### PR TITLE
Generate more information when failing to load EntityTypeConfiguration types

### DIFF
--- a/src/EFCore/Diagnostics/AssemblyEventData.cs
+++ b/src/EFCore/Diagnostics/AssemblyEventData.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     A <see cref="DiagnosticSource" /> event payload class for assembly events.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class AssemblyEventData : EventData
+{
+    /// <summary>
+    ///     Constructs the event payload.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="assembly">The assembly from which types are being loaded.</param>
+    public AssemblyEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        Assembly assembly)
+        : base(eventDefinition, messageGenerator)
+    {
+        Assembly = assembly;
+    }
+
+    /// <summary>
+    ///     The assembly.
+    /// </summary>
+    public virtual Assembly Assembly { get; }
+}

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -122,6 +122,9 @@ public static class CoreEventId
         MappedNavigationIgnoredWarning,
         MappedPropertyIgnoredWarning,
         MappedComplexPropertyIgnoredWarning,
+        TypeLoadingErrorWarning,
+        SkippedEntityTypeConfigurationWarning,
+        NoEntityTypeConfigurationsWarning,
 
         // ChangeTracking events
         DetectChangesStarting = CoreBaseId + 800,
@@ -594,6 +597,57 @@ public static class CoreEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId MappedComplexPropertyIgnoredWarning = MakeModelId(Id.MappedComplexPropertyIgnoredWarning);
+
+    /// <summary>
+    ///     An error was ignored while loading types from an assembly.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="TypeLoadingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId TypeLoadingErrorWarning = MakeModelId(Id.TypeLoadingErrorWarning);
+
+    /// <summary>
+    ///     A type that implements <see cref="IEntityTypeConfiguration{TEntity}"/> could not be instantiated.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="TypeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId SkippedEntityTypeConfigurationWarning = MakeModelId(Id.SkippedEntityTypeConfigurationWarning);
+
+    /// <summary>
+    ///     A type that implements <see cref="IEntityTypeConfiguration{TEntity}"/> could not be instantiated.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="AssemblyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId NoEntityTypeConfigurationsWarning = MakeModelId(Id.NoEntityTypeConfigurationsWarning);
 
     /// <summary>
     ///     An index was not created as the properties are already covered.

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -717,43 +717,94 @@ public static class CoreLoggerExtensions
         }
     }
 
-    ///// <summary>
-    /////     Logs for the <see cref="CoreEventId.IncludeIgnoredWarning" /> event.
-    ///// </summary>
-    ///// <param name="diagnostics">The diagnostics logger to use.</param>
-    ///// <param name="includeResultOperator">The result operator for the Include.</param>
-    //public static void IncludeIgnoredWarning(
-    //    this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-    //    IncludeResultOperator includeResultOperator)
-    //{
-    //    var definition = CoreResources.LogIgnoredInclude(diagnostics);
+    /// <summary>
+    ///     Logs for the <see cref="CoreEventId.TypeLoadingErrorWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="assembly">The assembly that types are being loaded from.</param>
+    /// <param name="exceptionMessage">The exception message from the loading error.</param>
+    public static void TypeLoadingErrorWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        Assembly assembly,
+        string exceptionMessage)
+    {
+        var definition = CoreResources.LogTypeLoadingErrorWarning(diagnostics);
 
-    //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-    //    if (warningBehavior != WarningBehavior.Ignore)
-    //    {
-    //        definition.Log(
-    //            diagnostics,
-    //            warningBehavior,
-    //            includeResultOperator.DisplayString());
-    //    }
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, assembly.ToString(), exceptionMessage);
+        }
 
-    //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-    //    {
-    //        diagnostics.DiagnosticSource.Write(
-    //            definition.EventId.Name,
-    //            new IncludeEventData(
-    //                definition,
-    //                IncludeIgnoredWarning,
-    //                includeResultOperator));
-    //    }
-    //}
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new TypeLoadingEventData(
+                definition,
+                TypeLoadingErrorWarning,
+                assembly,
+                exceptionMessage);
 
-    //private static string IncludeIgnoredWarning(EventDefinitionBase definition, EventData payload)
-    //{
-    //    var d = (EventDefinition<string>)definition;
-    //    var p = (IncludeEventData)payload;
-    //    return d.GenerateMessage(p.IncludeResultOperator.DisplayString());
-    //}
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string TypeLoadingErrorWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string>)definition;
+        var p = (TypeLoadingEventData)payload;
+        return d.GenerateMessage(p.Assembly.ToString(), p.ExceptionMessage);
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="CoreEventId.SkippedEntityTypeConfigurationWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="type">The <see cref="IEntityTypeConfiguration{TEntity}"/> type.</param>
+    public static void SkippedEntityTypeConfigurationWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        Type type)
+    {
+        var definition = CoreResources.LogSkippedEntityTypeConfigurationWarning(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, type.DisplayName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new TypeEventData(definition, SkippedEntityTypeConfigurationWarning, type);
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string SkippedEntityTypeConfigurationWarning(EventDefinitionBase definition, EventData payload)
+        => ((EventDefinition<string>)definition).GenerateMessage(((TypeEventData)payload).ClrType.DisplayName());
+
+    /// <summary>
+    ///     Logs for the <see cref="CoreEventId.NoEntityTypeConfigurationsWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="assembly">The assembly from which types are being loaded.</param>
+    public static void NoEntityTypeConfigurationsWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        Assembly assembly)
+    {
+        var definition = CoreResources.LogNoEntityTypeConfigurationsWarning(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, assembly.ToString());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new AssemblyEventData(definition, NoEntityTypeConfigurationsWarning, assembly);
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string NoEntityTypeConfigurationsWarning(EventDefinitionBase definition, EventData payload)
+        => ((EventDefinition<string>)definition).GenerateMessage(((AssemblyEventData)payload).Assembly.ToString());
 
     /// <summary>
     ///     Logs for the <see cref="CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning" /> event.

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -365,6 +365,33 @@ public abstract class LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogTypeLoadingErrorWarning;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? SkippedEntityTypeConfigurationWarning;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? NoEntityTypeConfigurationsWarning;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogSaveChangesStarting;
 
     /// <summary>

--- a/src/EFCore/Diagnostics/TypeLoadingEventData.cs
+++ b/src/EFCore/Diagnostics/TypeLoadingEventData.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     A <see cref="DiagnosticSource" /> event payload class for type loading errors.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class TypeLoadingEventData : AssemblyEventData
+{
+    /// <summary>
+    ///     Constructs the event payload.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="assembly">The assembly from which types are being loaded.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    public TypeLoadingEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        Assembly assembly,
+        string exceptionMessage)
+        : base(eventDefinition, messageGenerator, assembly)
+    {
+        ExceptionMessage = exceptionMessage;
+    }
+
+    /// <summary>
+    ///     The exception message.
+    /// </summary>
+    public virtual string ExceptionMessage { get; }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -4192,6 +4192,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     No instantiatable types implementing `IEntityTypeConfiguration` were found while while scanning assembly '{assemblyName}'.
+        /// </summary>
+        public static EventDefinition<string> LogNoEntityTypeConfigurationsWarning(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).NoEntityTypeConfigurationsWarning;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).NoEntityTypeConfigurationsWarning,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.NoEntityTypeConfigurationsWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.NoEntityTypeConfigurationsWarning",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.NoEntityTypeConfigurationsWarning,
+                            _resourceManager.GetString("LogNoEntityTypeConfigurationsWarning")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
         ///     The navigation '{targetEntityType}.{inverseNavigation}' specified in the [InverseProperty] attribute cannot be used as the inverse of '{ownedEntityType}.{navigation}' because it's not the ownership navigation '{ownershipNavigation}'.
         /// </summary>
         public static EventDefinition<string, string?, string, string?, string?> LogNonOwnershipInverseNavigation(IDiagnosticsLogger logger)
@@ -4917,6 +4942,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     The type '{entityTypeConfig}' was found while scanning assemblies but could not instantiated because it does not have a parameterless constructor.
+        /// </summary>
+        public static EventDefinition<string> LogSkippedEntityTypeConfigurationWarning(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).SkippedEntityTypeConfigurationWarning;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).SkippedEntityTypeConfigurationWarning,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.SkippedEntityTypeConfigurationWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.SkippedEntityTypeConfigurationWarning",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.SkippedEntityTypeConfigurationWarning,
+                            _resourceManager.GetString("LogSkippedEntityTypeConfigurationWarning")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
         ///     Context '{contextType}' started tracking '{entityType}' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<string, string> LogStartedTracking(IDiagnosticsLogger logger)
@@ -5089,6 +5139,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             }
 
             return (EventDefinition<string, object?, string, string>)definition;
+        }
+
+        /// <summary>
+        ///     Attempting to load types from '{assemblyName}' resulted in ignored error: '{exceptionMessage}'.
+        /// </summary>
+        public static EventDefinition<string, string> LogTypeLoadingErrorWarning(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogTypeLoadingErrorWarning;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogTypeLoadingErrorWarning,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.TypeLoadingErrorWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.TypeLoadingErrorWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CoreEventId.TypeLoadingErrorWarning,
+                            _resourceManager.GetString("LogTypeLoadingErrorWarning")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -935,6 +935,10 @@
     <value>The navigation '{entityType}.{navigation}' is being lazy-loaded.</value>
     <comment>Debug CoreEventId.NavigationLazyLoading string string</comment>
   </data>
+  <data name="LogNoEntityTypeConfigurationsWarning" xml:space="preserve">
+    <value>No instantiatable types implementing `IEntityTypeConfiguration` were found while while scanning assembly '{assemblyName}'.</value>
+    <comment>Warning CoreEventId.NoEntityTypeConfigurationsWarning string</comment>
+  </data>
   <data name="LogNonOwnershipInverseNavigation" xml:space="preserve">
     <value>The navigation '{targetEntityType}.{inverseNavigation}' specified in the [InverseProperty] attribute cannot be used as the inverse of '{ownedEntityType}.{navigation}' because it's not the ownership navigation '{ownershipNavigation}'.</value>
     <comment>Warning CoreEventId.NonOwnershipInverseNavigationWarning string string? string string? string?</comment>
@@ -1051,6 +1055,10 @@
     <value>{addedCount} entities were added and {removedCount} entities were removed from skip navigation '{entityType}.{property}' on entity with key '{keyValues}'.</value>
     <comment>Debug CoreEventId.SkipCollectionChangeDetected int int string string string</comment>
   </data>
+  <data name="LogSkippedEntityTypeConfigurationWarning" xml:space="preserve">
+    <value>The type '{entityTypeConfig}' was found while scanning assemblies but could not instantiated because it does not have a parameterless constructor.</value>
+    <comment>Warning CoreEventId.SkippedEntityTypeConfigurationWarning string</comment>
+  </data>
   <data name="LogStartedTracking" xml:space="preserve">
     <value>Context '{contextType}' started tracking '{entityType}' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.StartedTracking string string</comment>
@@ -1078,6 +1086,10 @@
   <data name="LogTempValueGeneratedSensitive" xml:space="preserve">
     <value>'{contextType}' generated temporary value '{keyValue}' for the property '{entityType}.{property}'.</value>
     <comment>Debug CoreEventId.ValueGenerated string object? string string</comment>
+  </data>
+  <data name="LogTypeLoadingErrorWarning" xml:space="preserve">
+    <value>Attempting to load types from '{assemblyName}' resulted in ignored error: '{exceptionMessage}'.</value>
+    <comment>Warning CoreEventId.TypeLoadingErrorWarning string string</comment>
   </data>
   <data name="LogValueGenerated" xml:space="preserve">
     <value>'{contextType}' generated a value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -413,12 +413,14 @@ internal static class SharedTypeExtensions
     }
 
     [RequiresUnreferencedCode("Gets all types from the given assembly - unsafe for trimming")]
-    public static IEnumerable<TypeInfo> GetConstructibleTypes(this Assembly assembly)
-        => assembly.GetLoadableDefinedTypes().Where(
+    public static IEnumerable<TypeInfo> GetConstructibleTypes(
+        this Assembly assembly, IDiagnosticsLogger<DbLoggerCategory.Model>? logger = null)
+        => assembly.GetLoadableDefinedTypes(logger).Where(
             t => t is { IsAbstract: false, IsGenericTypeDefinition: false });
 
     [RequiresUnreferencedCode("Gets all types from the given assembly - unsafe for trimming")]
-    public static IEnumerable<TypeInfo> GetLoadableDefinedTypes(this Assembly assembly)
+    public static IEnumerable<TypeInfo> GetLoadableDefinedTypes(
+        this Assembly assembly, IDiagnosticsLogger<DbLoggerCategory.Model>? logger = null)
     {
         try
         {
@@ -426,6 +428,8 @@ internal static class SharedTypeExtensions
         }
         catch (ReflectionTypeLoadException ex)
         {
+            logger?.TypeLoadingErrorWarning(assembly, ex.Message);
+
             return ex.Types.Where(t => t != null).Select(IntrospectionExtensions.GetTypeInfo!);
         }
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/MockAssembly.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/MockAssembly.cs
@@ -5,6 +5,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class MockAssembly : Assembly
 {
+    private readonly IEnumerable<TypeInfo> _definedTypes;
+    private readonly ReflectionTypeLoadException _exception;
+
     public static Assembly Create(params Type[] definedTypes)
         => Create(
             definedTypes,
@@ -12,22 +15,24 @@ public class MockAssembly : Assembly
                 ? null
                 : new MockMethodInfo(definedTypes.First()));
 
-    public static Assembly Create(Type[] definedTypes, MethodInfo entryPoint)
+    public static Assembly Create(Type[] definedTypes, MethodInfo entryPoint, ReflectionTypeLoadException exception = null)
     {
         var definedTypeInfos = definedTypes.Select(t => t.GetTypeInfo()).ToArray();
 
-        return new MockAssembly(definedTypeInfos, entryPoint);
+        return new MockAssembly(definedTypeInfos, entryPoint, exception);
     }
 
-    public MockAssembly(IEnumerable<TypeInfo> definedTypes, MethodInfo entryPoint)
+    public MockAssembly(IEnumerable<TypeInfo> definedTypes, MethodInfo entryPoint, ReflectionTypeLoadException exception)
     {
-        DefinedTypes = definedTypes;
+        _definedTypes = definedTypes;
+        _exception = exception;
         EntryPoint = entryPoint;
     }
 
     public override MethodInfo EntryPoint { get; }
 
-    public override IEnumerable<TypeInfo> DefinedTypes { get; }
+    public override IEnumerable<TypeInfo> DefinedTypes
+        => _exception != null ? throw _exception : _definedTypes;
 
     public override AssemblyName GetName()
         => new(nameof(MockAssembly));

--- a/test/EFCore.Tests/Diagnostics/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Diagnostics/CoreEventIdTest.cs
@@ -75,7 +75,8 @@ public class CoreEventIdTest : EventIdTestBase
                 typeof(IList<IDictionary<string, string>>),
                 () => new List<IDictionary<string, string>> { new Dictionary<string, string> { { "A", "B" } } }
             },
-            { typeof(IDictionary<string, string>), () => new Dictionary<string, string>() }
+            { typeof(IDictionary<string, string>), () => new Dictionary<string, string>() },
+            { typeof(Assembly), () => MockAssembly.Create() }
         };
 
         TestEventLogging(


### PR DESCRIPTION
And allow non-public parameterless constructors.

Fixes #24748
Fixes #19691
