### PR TITLE
Revert the nongeneric DbContextOptions registration

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -1137,7 +1137,7 @@ public static class EntityFrameworkServiceCollectionExtensions
         serviceCollection.TryAdd(
             new ServiceDescriptor(
                 typeof(DbContextOptions),
-                CreateDbContextOptions<TContextImplementation>,
+                p => p.GetRequiredService<DbContextOptions<TContextImplementation>>(),
                 optionsLifetime));
     }
 


### PR DESCRIPTION
This broke Identity tests because they were manipulated the service descriptors directly.