### PR TITLE
Ensure connection and commands can be disposed in either order

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -338,9 +338,10 @@ namespace Microsoft.Data.Sqlite
 
             Transaction?.Dispose();
 
-            for (var i = _commands.Count - 1; i >= 0; i--)
+            var commands = _commands;
+            for (var i = commands.Count - 1; i >= 0; i--)
             {
-                var reference = _commands[i];
+                var reference = commands[i];
                 if (reference.TryGetTarget(out var command))
                 {
                     // NB: Calls RemoveCommand()
@@ -348,12 +349,13 @@ namespace Microsoft.Data.Sqlite
                 }
                 else
                 {
-                    _commands.RemoveAt(i);
+                    _commands.Remove(reference);
                 }
             }
 
             Debug.Assert(_commands.Count == 0);
 
+            _commands.Clear();
             _innerConnection!.Close();
             _innerConnection = null;
 


### PR DESCRIPTION
Fixes #22921

Note that the reports here seem to be caused by incorrect use by the same connection concurrently. This is invalid. However, made the code a bit more robust here anyway.
