### PR TITLE
Scaffolding Change -d option to -m, since -d no longer works

### DIFF
--- a/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
@@ -31,7 +31,7 @@ internal partial class DbContextScaffoldCommand : ProjectCommandBase
         _connection = command.Argument("<CONNECTION>", Resources.ConnectionDescription);
         _provider = command.Argument("<PROVIDER>", Resources.ProviderDescription);
 
-        _dataAnnotations = command.Option("-d|--data-annotations", Resources.DataAnnotationsDescription);
+        _dataAnnotations = command.Option("-m|--data-annotations", Resources.DataAnnotationsDescription);
         _context = command.Option("-c|--context <NAME>", Resources.ContextNameDescription);
         _contextDir = command.Option("--context-dir <PATH>", Resources.ContextDirDescription);
         _force = command.Option("-f|--force", Resources.DbContextScaffoldForceDescription);


### PR DESCRIPTION
This has been broken form 6 onwards. It's possible the tools will revert their break, but there doesn't seem much value in keeping -d at this point.

-m stands for "mapping attributes" ¯\_(``)_/¯

Fixes #26687
