### PR TITLE
[release/8.0] Check value converter configuration source when setting element type.

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
@@ -306,7 +306,7 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
         }
     }
 
-    [ConditionalTheory]
+    [ConditionalTheory(Skip = "Issue #32611")]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Project_json_array_of_primitives_on_collection(bool async)
     {
@@ -426,33 +426,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
         {
             modelBuilder.Entity<MyEntityArrayOfPrimitives>().Property(x => x.Id).ValueGeneratedNever();
             modelBuilder.Entity<MyEntityArrayOfPrimitives>().OwnsOne(
-                x => x.Reference, b =>
-                {
-                    b.ToJson();
-                    b.Property(x => x.IntArray).HasConversion(
-                        x => string.Join(" ", x),
-                        x => x.Split(" ", StringSplitOptions.None).Select(v => int.Parse(v)).ToArray(),
-                        new ValueComparer<int[]>(true));
-
-                    b.Property(x => x.ListOfString).HasConversion(
-                        x => string.Join(" ", x),
-                        x => x.Split(" ", StringSplitOptions.None).ToList(),
-                        new ValueComparer<List<string>>(true));
-                });
+                x => x.Reference, b => b.ToJson());
 
             modelBuilder.Entity<MyEntityArrayOfPrimitives>().OwnsMany(
-                x => x.Collection, b =>
-                {
-                    b.ToJson();
-                    b.Property(x => x.IntArray).HasConversion(
-                        x => string.Join(" ", x),
-                        x => x.Split(" ", StringSplitOptions.None).Select(v => int.Parse(v)).ToArray(),
-                        new ValueComparer<int[]>(true));
-                    b.Property(x => x.ListOfString).HasConversion(
-                        x => string.Join(" ", x),
-                        x => x.Split(" ", StringSplitOptions.None).ToList(),
-                        new ValueComparer<List<string>>(true));
-                });
+                x => x.Collection, b => b.ToJson());
         }
     }
 

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -8,8 +8,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 public class ConventionDispatcherTest
 {
-    // TODO: Use public API to add conventions, issue #214
-
     [ConditionalFact]
     public void Infinite_recursion_throws()
     {
@@ -3710,7 +3708,7 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            Assert.Null(propertyBuilder.SetElementType(typeof(int), ConfigurationSource.Convention));
+            Assert.NotNull(propertyBuilder.SetElementType(typeof(int), ConfigurationSource.Convention));
             elementType = propertyBuilder.Metadata.GetElementType()!;
         }
         else

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -3256,6 +3256,45 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
+        public virtual void Conversion_on_base_property_prevents_primitive_collection()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<DerivedCollectionQuarks>();
+            modelBuilder.Entity<CollectionQuarks>(b =>
+            {
+                b.Property(c => c.Down).HasConversion(gs => string.Join(',', gs!),
+                    s => new ObservableCollection<string>(s.Split(',', StringSplitOptions.RemoveEmptyEntries)));
+            });
+
+            var model = modelBuilder.FinalizeModel();
+
+            var property = model.FindEntityType(typeof(CollectionQuarks))!.FindProperty(nameof(CollectionQuarks.Down))!;
+            Assert.False(property.IsPrimitiveCollection);
+            Assert.NotNull(property.GetValueConverter());
+        }
+
+        [ConditionalFact]
+        public virtual void Conversion_on_base_property_prevents_primitive_collection_when_base_first()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<CollectionQuarks>(b =>
+            {
+                b.Property(c => c.Down).HasConversion(gs => string.Join(',', gs!),
+                    s => new ObservableCollection<string>(s.Split(',', StringSplitOptions.RemoveEmptyEntries)));
+            });
+
+            var property = (IProperty)modelBuilder.Model.FindEntityType(typeof(CollectionQuarks))!.FindProperty(nameof(CollectionQuarks.Down))!;
+            Assert.False(property.IsPrimitiveCollection);
+
+            modelBuilder.Entity<DerivedCollectionQuarks>();
+
+            var model = modelBuilder.FinalizeModel();
+            property = model.FindEntityType(typeof(CollectionQuarks))!.FindProperty(nameof(CollectionQuarks.Down))!;
+            Assert.False(property.IsPrimitiveCollection);
+            Assert.NotNull(property.GetValueConverter());
+        }
+
+        [ConditionalFact]
         public virtual void Element_types_can_have_provider_type_set()
         {
             var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1652,6 +1652,7 @@ public abstract partial class ModelBuilderTest
 
             var departmentIdProperty = departmentType.FindProperty(nameof(Department.Id));
             Assert.NotNull(departmentIdProperty);
+            Assert.NotNull(departmentIdProperty.GetValueConverter());
             Assert.NotNull(departmentNestedType);
             Assert.NotNull(officeNestedType);
 

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -340,6 +340,10 @@ public abstract partial class ModelBuilderTest
 #pragma warning restore 67
     }
 
+    protected class DerivedCollectionQuarks : CollectionQuarks
+    {
+    }
+
     protected class Hob
     {
         public string? Id1 { get; set; }


### PR DESCRIPTION
Fixes #32430
Port of #32600

### Description

The convention added in EF 8 configures the matching properties as primitive collections regardless whether they were configured to use a value converter.

### Customer impact

When querying an exception is thrown in some cases, in other cases and when persisting data it is written in an incorrect format, possibly causing data corruption.

### How found

Customer report on 8.0.

### Regression

Yes.

### Testing

Tests added.

### Risk

Low and quirked.
