### PR TITLE
Allow to configure Cosmos without specifying connection details.

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
@@ -17,6 +17,47 @@ namespace Microsoft.EntityFrameworkCore;
 public static class CosmosDbContextOptionsExtensions
 {
     /// <summary>
+    ///     Configures the context to connect to an Azure Cosmos database. The connection details need to be specified in a separate call.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <typeparam name="TContext">The type of context to be configured.</typeparam>
+    /// <param name="optionsBuilder">The builder being used to configure the context.</param>
+    /// <param name="cosmosOptionsAction">An action to allow Cosmos-specific configuration.</param>
+    /// <returns>The options builder so that further configuration can be chained.</returns>
+    public static DbContextOptionsBuilder<TContext> UseCosmos<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseCosmos(
+            (DbContextOptionsBuilder)optionsBuilder,
+            cosmosOptionsAction);
+
+    /// <summary>
+    ///     Configures the context to connect to an Azure Cosmos database. The connection details need to be specified in a separate call.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="optionsBuilder">The builder being used to configure the context.</param>
+    /// <param name="cosmosOptionsAction">An action to allow Cosmos-specific configuration.</param>
+    /// <returns>The options builder so that further configuration can be chained.</returns>
+    public static DbContextOptionsBuilder UseCosmos(
+        this DbContextOptionsBuilder optionsBuilder,
+        Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction)
+    {
+        Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+        Check.NotNull(cosmosOptionsAction, nameof(cosmosOptionsAction));
+
+        cosmosOptionsAction.Invoke(new CosmosDbContextOptionsBuilder(optionsBuilder));
+
+        return optionsBuilder;
+    }
+
+    /// <summary>
     ///     Configures the context to connect to an Azure Cosmos database.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -102,14 +102,13 @@ public class CosmosOptionsExtension : IDbContextOptionsExtension
     /// </summary>
     public virtual CosmosOptionsExtension WithAccountEndpoint(string? accountEndpoint)
     {
-        if (_connectionString != null)
-        {
-            throw new InvalidOperationException(CosmosStrings.ConnectionStringConflictingConfiguration);
-        }
-
         var clone = Clone();
 
         clone._accountEndpoint = accountEndpoint;
+        if (accountEndpoint is not null)
+        {
+            clone._connectionString = null;
+        }
 
         return clone;
     }
@@ -131,14 +130,14 @@ public class CosmosOptionsExtension : IDbContextOptionsExtension
     /// </summary>
     public virtual CosmosOptionsExtension WithAccountKey(string? accountKey)
     {
-        if (accountKey is not null && _connectionString is not null)
-        {
-            throw new InvalidOperationException(CosmosStrings.ConnectionStringConflictingConfiguration);
-        }
-
         var clone = Clone();
 
         clone._accountKey = accountKey;
+        if (accountKey is not null)
+        {
+            clone._connectionString = null;
+            clone._tokenCredential = null;
+        }
 
         return clone;
     }
@@ -160,14 +159,14 @@ public class CosmosOptionsExtension : IDbContextOptionsExtension
     /// </summary>
     public virtual CosmosOptionsExtension WithTokenCredential(TokenCredential? tokenCredential)
     {
-        if (tokenCredential is not null && _connectionString is not null)
-        {
-            throw new InvalidOperationException(CosmosStrings.ConnectionStringConflictingConfiguration);
-        }
-
         var clone = Clone();
 
         clone._tokenCredential = tokenCredential;
+        if (tokenCredential is not null)
+        {
+            clone._connectionString = null;
+            clone._accountKey = null;
+        }
 
         return clone;
     }
@@ -189,14 +188,15 @@ public class CosmosOptionsExtension : IDbContextOptionsExtension
     /// </summary>
     public virtual CosmosOptionsExtension WithConnectionString(string? connectionString)
     {
-        if (connectionString is not null && (_accountEndpoint != null || _accountKey != null || _tokenCredential != null))
-        {
-            throw new InvalidOperationException(CosmosStrings.ConnectionStringConflictingConfiguration);
-        }
-
         var clone = Clone();
 
         clone._connectionString = connectionString;
+        if (connectionString is not null)
+        {
+            clone._accountEndpoint = null;
+            clone._accountKey = null;
+            clone._tokenCredential = null;
+        }
 
         return clone;
     }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -46,10 +46,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 newArrayExpression);
 
         /// <summary>
-        ///     Both the connection string and CredentialToken, account key or account endpoint were specified. Specify only one set of connection details.
+        ///     None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.
         /// </summary>
-        public static string ConnectionStringConflictingConfiguration
-            => GetString("ConnectionStringConflictingConfiguration");
+        public static string ConnectionInfoMissing
+            => GetString("ConnectionInfoMissing");
 
         /// <summary>
         ///     The entity type '{entityType}' is mapped to the container '{container}' but it is also configured as being contained in property '{property}'.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -126,8 +126,8 @@
   <data name="CannotTranslateNonConstantNewArrayExpression" xml:space="preserve">
     <value>The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.</value>
   </data>
-  <data name="ConnectionStringConflictingConfiguration" xml:space="preserve">
-    <value>Both the connection string and CredentialToken, account key or account endpoint were specified. Specify only one set of connection details.</value>
+  <data name="ConnectionInfoMissing" xml:space="preserve">
+    <value>None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.</value>
   </data>
   <data name="ContainerContainingPropertyConflict" xml:space="preserve">
     <value>The entity type '{entityType}' is mapped to the container '{container}' but it is also configured as being contained in property '{property}'.</value>

--- a/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 
@@ -108,7 +109,9 @@ public class SingletonCosmosClientWrapper : ISingletonCosmosClientWrapper
     public virtual CosmosClient Client
         => _client ??= string.IsNullOrEmpty(_connectionString)
             ? _tokenCredential == null
-                ? new CosmosClient(_endpoint, _key, _options)
+                ? _endpoint == null
+                    ? throw new InvalidOperationException(CosmosStrings.ConnectionInfoMissing)
+                    : new CosmosClient(_endpoint, _key, _options)
                 : new CosmosClient(_endpoint, _tokenCredential, _options)
             : new CosmosClient(_connectionString, _options);
 

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -94,6 +94,10 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._connectionString = connectionString;
+        if (connectionString is not null)
+        {
+            clone._connection = null;
+        }
 
         return clone;
     }
@@ -136,6 +140,10 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
 
         clone._connection = connection;
         clone._connectionOwned = owned;
+        if (connection is not null)
+        {
+            clone._connectionString = null;
+        }
 
         return clone;
     }

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -68,10 +68,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
             _connection = relationalOptions.Connection;
             _connectionOwned = relationalOptions.IsConnectionOwned;
 
-            if (_connectionString != null)
-            {
-                _connection.ConnectionString = _connectionString;
-            }
+            Check.DebugAssert(_connectionString == null, "ConnectionString is not null");
         }
         else
         {

--- a/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
@@ -130,6 +130,7 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
     private DbContextOptions CreateOptions(CosmosTestStore testDatabase, Action<DbContextOptionsBuilder> configure = null)
     {
         var builder = Fixture.AddOptions(testDatabase.AddProviderOptions(new DbContextOptionsBuilder()))
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .EnableDetailedErrors();
         configure?.Invoke(builder);
         return builder.Options;

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
@@ -260,6 +260,7 @@ public class CosmosConcurrencyTest : IClassFixture<CosmosConcurrencyTest.CosmosF
 
     private DbContextOptions CreateOptions(CosmosTestStore testDatabase)
         => testDatabase.AddProviderOptions(new DbContextOptionsBuilder())
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .EnableDetailedErrors()
             .Options;
 

--- a/test/EFCore.SqlServer.Tests/Extensions/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Extensions/SqlServerDbContextOptionsExtensionsTest.cs
@@ -88,6 +88,38 @@ public class SqlServerDbContextOptionsExtensionsTest
     }
 
     [ConditionalFact]
+    public void Connection_overrides_connection_string()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+        var connection = new SqlConnection();
+
+        optionsBuilder.UseSqlServer("Database=Whisper");
+        optionsBuilder.UseSqlServer(connection);
+
+        var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
+
+        Assert.Same(connection, extension.Connection);
+        Assert.False(extension.IsConnectionOwned);
+        Assert.Null(extension.ConnectionString);
+    }
+
+    [ConditionalFact]
+    public void Connection_string_overrides_connection()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+        var connection = new SqlConnection();
+
+        optionsBuilder.UseSqlServer(connection);
+        optionsBuilder.UseSqlServer("Database=Whisper");
+
+        var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
+
+        Assert.False(extension.IsConnectionOwned);
+        Assert.Null(extension.Connection);
+        Assert.Equal("Database=Whisper", extension.ConnectionString);
+    }
+
+    [ConditionalFact]
     public void Can_add_extension_with_connection_using_generic_options()
     {
         var optionsBuilder = new DbContextOptionsBuilder<DbContext>();

--- a/test/EFCore.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -100,6 +100,38 @@ public class SqliteDbContextOptionsBuilderExtensionsTest
     }
 
     [ConditionalFact]
+    public void Connection_overrides_connection_string()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+        var connection = new SqliteConnection();
+
+        optionsBuilder.UseSqlite("Database=Whisper");
+        optionsBuilder.UseSqlite(connection);
+
+        var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+        Assert.Same(connection, extension.Connection);
+        Assert.False(extension.IsConnectionOwned);
+        Assert.Null(extension.ConnectionString);
+    }
+
+    [ConditionalFact]
+    public void Connection_string_overrides_connection()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+        var connection = new SqliteConnection();
+
+        optionsBuilder.UseSqlite(connection);
+        optionsBuilder.UseSqlite("Database=Whisper");
+
+        var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+        Assert.False(extension.IsConnectionOwned);
+        Assert.Null(extension.Connection);
+        Assert.Equal("Database=Whisper", extension.ConnectionString);
+    }
+
+    [ConditionalFact]
     public void Can_add_extension_with_connection_using_generic_options()
     {
         var optionsBuilder = new DbContextOptionsBuilder<DbContext>();


### PR DESCRIPTION
Ensure that configuring connection details again overrides previous configuration.