### PR TITLE
Allow generated class members to have same name as generated classes when casing differs

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 public class CSharpUniqueNamer<T> : CSharpNamer<T>
     where T : notnull
 {
-    private readonly HashSet<string> _usedNames = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _usedNames;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,8 +23,9 @@ public class CSharpUniqueNamer<T> : CSharpNamer<T>
     public CSharpUniqueNamer(
         Func<T, string> nameGetter,
         ICSharpUtilities cSharpUtilities,
-        Func<string, string>? singularizePluralizer)
-        : this(nameGetter, null, cSharpUtilities, singularizePluralizer)
+        Func<string, string>? singularizePluralizer,
+        bool caseSensitive)
+        : this(nameGetter, null, cSharpUtilities, singularizePluralizer, caseSensitive)
     {
     }
 
@@ -38,9 +39,11 @@ public class CSharpUniqueNamer<T> : CSharpNamer<T>
         Func<T, string> nameGetter,
         IEnumerable<string>? usedNames,
         ICSharpUtilities cSharpUtilities,
-        Func<string, string>? singularizePluralizer)
+        Func<string, string>? singularizePluralizer,
+        bool caseSensitive)
         : base(nameGetter, cSharpUtilities, singularizePluralizer)
     {
+        _usedNames = new(caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
         if (usedNames != null)
         {
             foreach (var name in usedNames)

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -73,7 +73,8 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             _cSharpUtilities,
             options.NoPluralize
                 ? null
-                : _pluralizer.Singularize);
+                : _pluralizer.Singularize,
+            caseSensitive: false);
         _dbSetNamer = new CSharpUniqueNamer<DatabaseTable>(
             options.UseDatabaseNames
                 ? (t => t.Name)
@@ -81,7 +82,8 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             _cSharpUtilities,
             options.NoPluralize
                 ? null
-                : _pluralizer.Pluralize);
+                : _pluralizer.Pluralize,
+            caseSensitive: true);
         _columnNamers = new Dictionary<DatabaseTable, CSharpUniqueNamer<DatabaseColumn>>();
         _options = options;
 
@@ -133,7 +135,8 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
                         c => c.Name,
                         usedNames,
                         _cSharpUtilities,
-                        singularizePluralizer: null));
+                        singularizePluralizer: null,
+                        caseSensitive: true));
             }
             else
             {
@@ -143,7 +146,8 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
                         c => _candidateNamingService.GenerateCandidateIdentifier(c),
                         usedNames,
                         _cSharpUtilities,
-                        singularizePluralizer: null));
+                        singularizePluralizer: null,
+                        caseSensitive: true));
             }
         }
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
@@ -11,7 +11,7 @@ public class CSharpUniqueNamerTest
     [ConditionalFact]
     public void Returns_unique_name_for_type()
     {
-        var namer = new CSharpUniqueNamer<DatabaseColumn>(s => s.Name, new CSharpUtilities(), null);
+        var namer = new CSharpUniqueNamer<DatabaseColumn>(s => s.Name, new CSharpUtilities(), null, true);
         var table = new DatabaseTable { Database = new DatabaseModel(), Name = "foo" };
         var input1 = new DatabaseColumn
         {
@@ -35,7 +35,7 @@ public class CSharpUniqueNamerTest
     [ConditionalFact]
     public void Uses_comparer()
     {
-        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), null);
+        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), null, true);
         var database = new DatabaseModel();
         var table1 = new DatabaseTable { Database = database, Name = "A B C" };
         var table2 = new DatabaseTable { Database = database, Name = "A_B_C" };
@@ -49,7 +49,7 @@ public class CSharpUniqueNamerTest
     public void Singularizes_names(string input, string output)
     {
         var pluralizer = new HumanizerPluralizer();
-        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), pluralizer.Singularize);
+        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), pluralizer.Singularize, true);
         var table = new DatabaseTable { Database = new DatabaseModel(), Name = input };
         Assert.Equal(output, namer.GetName(table));
     }
@@ -60,7 +60,7 @@ public class CSharpUniqueNamerTest
     public void Pluralizes_names(string input, string output)
     {
         var pluralizer = new HumanizerPluralizer();
-        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), pluralizer.Pluralize);
+        var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), pluralizer.Pluralize, true);
         var table = new DatabaseTable { Database = new DatabaseModel(), Name = input };
         Assert.Equal(output, namer.GetName(table));
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -789,6 +789,43 @@ CREATE TABLE [Blogs] (
             "DROP TABLE [Blogs]");
 
     [ConditionalFact]
+    public void Class_members_can_have_same_name_as_classes_when_casing_differs() // Issue #30237
+        => Test(
+            @"
+CREATE TABLE [dbo].[UIText]
+(
+	[UiKey] VARCHAR(100) NOT NULL PRIMARY KEY,
+	[UiText] NVARCHAR(1000) NOT NULL
+)",
+            Enumerable.Empty<string>(),
+            Enumerable.Empty<string>(),
+            (dbModel, scaffoldingFactory) =>
+            {
+                Assert.Collection(dbModel.Tables,
+                    t =>
+                    {
+                        Assert.Equal("UIText", t.Name);
+                        Assert.Collection(
+                            t.Columns,
+                            c => Assert.Equal("UiKey", c.Name),
+                            c => Assert.Equal("UiText", c.Name));
+                    });
+
+                var model = scaffoldingFactory.Create(dbModel, new());
+
+                Assert.Collection(model.GetEntityTypes(),
+                    e =>
+                    {
+                        Assert.Equal("Uitext", e.Name);
+                        Assert.Collection(
+                            e.GetProperties(),
+                            p => Assert.Equal("UiKey", p.Name),
+                            p => Assert.Equal("UiText", p.Name));
+                    });
+            },
+            "DROP TABLE [UIText]");
+
+    [ConditionalFact]
     public void Create_columns()
         => Test(
             @"


### PR DESCRIPTION
Fixes #30237
