### PR TITLE
Don't keep join table around because a ForeignKeyAttribute used to reference it

### DIFF
--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -182,11 +182,30 @@ public class ForeignKey : ConventionAnnotatable, IMutableForeignKey, IConvention
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+        => UpdateConfigurationSource(configurationSource, configurationSource, configurationSource);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void UpdateConfigurationSource(
+        ConfigurationSource configurationSource,
+        ConfigurationSource? principalConfigurationSource,
+        ConfigurationSource? dependentConfigurationSource)
     {
         _configurationSource = _configurationSource.Max(configurationSource);
 
-        DeclaringEntityType.UpdateConfigurationSource(configurationSource);
-        PrincipalEntityType.UpdateConfigurationSource(configurationSource);
+        if (dependentConfigurationSource.HasValue)
+        {
+            DeclaringEntityType.UpdateConfigurationSource(dependentConfigurationSource.Value);
+        }
+
+        if (principalConfigurationSource.HasValue)
+        {
+            PrincipalEntityType.UpdateConfigurationSource(principalConfigurationSource.Value);
+        }
     }
 
     /// <summary>

--- a/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -73,7 +73,8 @@ public class ForeignKeyTest
         Assert.Same(entityType.FindPrimaryKey(), foreignKey.PrincipalKey);
         Assert.Equal(ConfigurationSource.Convention, foreignKey.GetConfigurationSource());
 
-        ((ForeignKey)foreignKey).UpdateConfigurationSource(ConfigurationSource.DataAnnotation);
+        ((ForeignKey)foreignKey).UpdateConfigurationSource(
+            ConfigurationSource.DataAnnotation, ConfigurationSource.DataAnnotation, ConfigurationSource.DataAnnotation);
 
         Assert.Equal(ConfigurationSource.DataAnnotation, foreignKey.GetConfigurationSource());
     }


### PR DESCRIPTION
Fixes #27990

The issue here was a skip navigation with a `ForeignKeyAttribute`. At first I thought that this was not valid, but it turns out we decided that this configuration specified the name of the FK property in the join table.

However, this by-convention join type was then discarded and replaced with an explicitly configured join type. This normally removes the old join type from the model, but this doesn't happen here because the `ForeignKeyAttribute` resulted in the join type having a "data annotation" configuration source. This is not really correct; the FK attribute just says that the FK properties should have a given name, not anything about the type, so the entity type configuration source should not be changed here.

This allows the by-convention join type to be removed like it should, and hence we don't have two join tables mapped that differ only by case.

