### PR TITLE
Don't keep join entity type around because a ForeignKeyAttribute used to reference it. Instead, remove it and reattach the configuration.

### DIFF
--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -407,6 +407,7 @@ public class CollectionCollectionBuilder
 
         var existingJoinEntityType = (EntityType?)(LeftNavigation.JoinEntityType ?? RightNavigation.JoinEntityType);
         EntityType? newJoinEntityType = null;
+        EntityType.Snapshot? entityTypeSnapshot = null;
         if (existingJoinEntityType != null)
         {
             if ((joinEntityType == null || existingJoinEntityType.ClrType == joinEntityType)
@@ -416,7 +417,13 @@ public class CollectionCollectionBuilder
             }
             else
             {
-                ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType);
+                ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType, configurationSource: ConfigurationSource.DataAnnotation);
+
+                entityTypeSnapshot = InternalEntityTypeBuilder.DetachAllMembers(existingJoinEntityType);
+                if (entityTypeSnapshot != null)
+                {
+                    ModelBuilder.HasNoEntityType(existingJoinEntityType, ConfigurationSource.Explicit);
+                }
             }
         }
 
@@ -440,15 +447,36 @@ public class CollectionCollectionBuilder
             }
         }
 
-        var rightForeignKey = configureRight != null
-            ? configureRight(newJoinEntityType)
-            : GetOrCreateSkipNavigationForeignKey((SkipNavigation)RightNavigation, newJoinEntityType);
-        var leftForeignKey = configureLeft != null
-            ? configureLeft(newJoinEntityType)
-            : GetOrCreateSkipNavigationForeignKey((SkipNavigation)LeftNavigation, newJoinEntityType);
+        if (entityTypeSnapshot != null)
+        {
+            entityTypeSnapshot.Attach(newJoinEntityType.Builder);
+        }
 
+        IMutableForeignKey? rightForeignKey;
+        if (configureRight != null)
+        {
+            newJoinEntityType.SetAnnotation(CoreAnnotationNames.SkipNavigationBeingConfigured, RightNavigation);
+            rightForeignKey = configureRight(newJoinEntityType);
+            newJoinEntityType.RemoveAnnotation(CoreAnnotationNames.SkipNavigationBeingConfigured);
+        }
+        else
+        {
+            rightForeignKey = GetOrCreateSkipNavigationForeignKey((SkipNavigation)RightNavigation, newJoinEntityType);
+        }
         ((SkipNavigation)RightNavigation).Builder
             .HasForeignKey((ForeignKey)rightForeignKey, ConfigurationSource.Explicit);
+
+        IMutableForeignKey? leftForeignKey;
+        if (configureLeft != null)
+        {
+            newJoinEntityType.SetAnnotation(CoreAnnotationNames.SkipNavigationBeingConfigured, LeftNavigation);
+            leftForeignKey = configureLeft(newJoinEntityType);
+            newJoinEntityType.RemoveAnnotation(CoreAnnotationNames.SkipNavigationBeingConfigured);
+        }
+        else
+        {
+            leftForeignKey = GetOrCreateSkipNavigationForeignKey((SkipNavigation)LeftNavigation, newJoinEntityType);
+        }
         ((SkipNavigation)LeftNavigation).Builder
             .HasForeignKey((ForeignKey)leftForeignKey, ConfigurationSource.Explicit);
 

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -1055,8 +1055,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
         Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
         var relatedEntityType = FindRelatedEntityType(relatedTypeName, navigationName);
-        var foreignKey = HasOneBuilder(
-            MemberIdentity.Create(navigationName), relatedEntityType);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder(
             Builder.Metadata,
@@ -1098,8 +1097,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
         Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
         var relatedEntityType = FindRelatedEntityType(relatedType, navigationName);
-        var foreignKey = HasOneBuilder(
-            MemberIdentity.Create(navigationName), relatedEntityType);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder(
             Builder.Metadata,
@@ -1145,6 +1143,17 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
         MemberIdentity navigationId,
         EntityType relatedEntityType)
     {
+        if (Metadata[CoreAnnotationNames.SkipNavigationBeingConfigured] is SkipNavigation skipNavigation
+            && skipNavigation.DeclaringEntityType == relatedEntityType
+            && skipNavigation.ForeignKey?.DeclaringEntityType == Builder.Metadata)
+        {
+            return navigationId.MemberInfo != null
+                ? skipNavigation.ForeignKey.Builder.HasNavigation(navigationId.MemberInfo, pointsToPrincipal: true, ConfigurationSource.Explicit)
+                    !.Metadata
+                : skipNavigation.ForeignKey.Builder.HasNavigation(navigationId.Name, pointsToPrincipal: true, ConfigurationSource.Explicit)
+                    !.Metadata;
+        }
+
         ForeignKey foreignKey;
         if (navigationId.MemberInfo != null)
         {

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -1336,8 +1336,7 @@ public class EntityTypeBuilder<[DynamicallyAccessedMembers(IEntityType.Dynamical
         where TRelatedEntity : class
     {
         var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationName);
-        var foreignKey = HasOneBuilder(
-            MemberIdentity.Create(navigationName), relatedEntityType);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
             Builder.Metadata,
@@ -1381,8 +1380,7 @@ public class EntityTypeBuilder<[DynamicallyAccessedMembers(IEntityType.Dynamical
     {
         var navigationMember = navigationExpression?.GetMemberAccess();
         var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationMember?.GetSimpleMemberName());
-        var foreignKey = HasOneBuilder(
-            MemberIdentity.Create(navigationMember), relatedEntityType);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationMember), relatedEntityType);
 
         return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
             Builder.Metadata,

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -861,14 +861,13 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
         Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
         var relatedEntityType = FindRelatedEntityType(relatedTypeName, navigationName);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder(
             DependentEntityType,
             relatedEntityType,
             navigationName,
-            DependentEntityType.Builder.HasRelationship(
-                relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
+            foreignKey);
     }
 
     /// <summary>
@@ -936,14 +935,41 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
         Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
         var relatedEntityType = FindRelatedEntityType(relatedType, navigationName);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder(
             DependentEntityType,
             relatedEntityType,
             navigationName,
-            DependentEntityType.Builder.HasRelationship(
-                relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
+            foreignKey);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual ForeignKey HasOneBuilder(
+        MemberIdentity navigationId,
+        EntityType relatedEntityType)
+    {
+        ForeignKey foreignKey;
+        if (navigationId.MemberInfo != null)
+        {
+            foreignKey = DependentEntityType.Builder.HasRelationship(
+                relatedEntityType, navigationId.MemberInfo, ConfigurationSource.Explicit,
+                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata;
+        }
+        else
+        {
+            foreignKey = DependentEntityType.Builder.HasRelationship(
+                relatedEntityType, navigationId.Name, ConfigurationSource.Explicit,
+                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata;
+        }
+
+        return foreignKey;
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -1104,14 +1104,13 @@ public class OwnedNavigationBuilder<
         where TNewRelatedEntity : class
     {
         var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigationName);
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationName), relatedEntityType);
 
         return new ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
             DependentEntityType,
             relatedEntityType,
             navigationName,
-            DependentEntityType.Builder.HasRelationship(
-                relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
+            foreignKey);
     }
 
     /// <summary>
@@ -1147,16 +1146,15 @@ public class OwnedNavigationBuilder<
             Expression<Func<TDependentEntity, TNewRelatedEntity?>>? navigationExpression = null)
         where TNewRelatedEntity : class
     {
-        var navigation = navigationExpression?.GetMemberAccess();
-        var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigation?.GetSimpleMemberName());
+        var navigationMember = navigationExpression?.GetMemberAccess();
+        var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigationMember?.GetSimpleMemberName());
+        var foreignKey = HasOneBuilder(MemberIdentity.Create(navigationMember), relatedEntityType);
 
         return new ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
             DependentEntityType,
             relatedEntityType,
-            navigation,
-            DependentEntityType.Builder.HasRelationship(
-                relatedEntityType, navigation, ConfigurationSource.Explicit,
-                targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
+            navigationMember,
+            foreignKey);
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -279,7 +279,8 @@ public class KeyDiscoveryConvention :
         IConventionContext<IReadOnlyList<IConventionProperty>> context)
     {
         var foreignKey = relationshipBuilder.Metadata;
-        if (foreignKey.IsOwnership
+        if ((foreignKey.IsOwnership
+            || foreignKey.GetReferencingSkipNavigations().Any(n => n.IsCollection))
             && !foreignKey.Properties.SequenceEqual(oldDependentProperties)
             && relationshipBuilder.Metadata.IsInModel)
         {

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -354,6 +354,14 @@ public static class CoreAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public const string SkipNavigationBeingConfigured = "SkipNavigationBeingConfigured";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public static readonly ISet<string> AllNames = new HashSet<string>
     {
         MaxLength,
@@ -399,6 +407,7 @@ public static class CoreAnnotationNames
         FullChangeTrackingNotificationsRequired,
         AdHocModel,
         JsonValueReaderWriterType,
-        ElementType
+        ElementType,
+        SkipNavigationBeingConfigured
     };
 }

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -385,16 +385,13 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual InternalModelBuilder? RemoveImplicitJoinEntity(EntityType joinEntityType)
-    {
-        Check.NotNull(joinEntityType, nameof(joinEntityType));
-
-        return !joinEntityType.IsInModel
+    public virtual InternalModelBuilder? RemoveImplicitJoinEntity(
+        EntityType joinEntityType, ConfigurationSource configurationSource = ConfigurationSource.Convention)
+        => !Check.NotNull(joinEntityType, nameof(joinEntityType)).IsInModel
             ? this
             : !joinEntityType.IsImplicitlyCreatedJoinEntityType
                 ? null
-                : HasNoEntityType(joinEntityType, ConfigurationSource.Convention);
-    }
+                : HasNoEntityType(joinEntityType, configurationSource);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
@@ -68,7 +68,7 @@ public class InternalSkipNavigationBuilder :
             && oldForeignKey != foreignKey
             && oldForeignKey.ReferencingSkipNavigations?.Any() != true)
         {
-            oldForeignKey.DeclaringEntityType.Builder.HasNoRelationship(oldForeignKey, ConfigurationSource.Convention);
+            oldForeignKey.DeclaringEntityType.Builder.HasNoRelationship(oldForeignKey, ConfigurationSource.Explicit);
         }
 
         return this;

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosModelAsserter.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosModelAsserter.cs
@@ -19,8 +19,8 @@ public class CosmosModelAsserter : ModelAsserter
         bool assertOrder = false,
         bool compareAnnotations = false)
     {
-        expectedProperties = expectedProperties.Where(p => p.Name != "__jObject" && p.Name != "__id");
-        actualProperties = actualProperties.Where(p => p.Name != "__jObject" && p.Name != "__id");
+        expectedProperties = expectedProperties.Where(p => p.Name != "__jObject" && p.Name != "__id" && p.Name != "Discriminator");
+        actualProperties = actualProperties.Where(p => p.Name != "__jObject" && p.Name != "__id" && p.Name != "Discriminator");
 
         base.AssertEqual(expectedProperties, actualProperties, assertOrder, compareAnnotations);
     }

--- a/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
+++ b/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 
 // ReSharper disable InconsistentNaming
@@ -708,7 +710,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
     public abstract class RelationalOneToManyTestBase : OneToManyTestBase
     {
-        public RelationalOneToManyTestBase(RelationalModelBuilderFixture fixture)
+        protected RelationalOneToManyTestBase(RelationalModelBuilderFixture fixture)
             : base(fixture)
         {
         }
@@ -716,7 +718,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
     public abstract class RelationalManyToOneTestBase : ManyToOneTestBase
     {
-        public RelationalManyToOneTestBase(RelationalModelBuilderFixture fixture)
+        protected RelationalManyToOneTestBase(RelationalModelBuilderFixture fixture)
             : base(fixture)
         {
         }
@@ -724,7 +726,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
     public abstract class RelationalOneToOneTestBase : OneToOneTestBase
     {
-        public RelationalOneToOneTestBase(RelationalModelBuilderFixture fixture)
+        protected RelationalOneToOneTestBase(RelationalModelBuilderFixture fixture)
             : base(fixture)
         {
         }
@@ -732,15 +734,149 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
     public abstract class RelationalManyToManyTestBase : ManyToManyTestBase
     {
-        public RelationalManyToManyTestBase(RelationalModelBuilderFixture fixture)
+        protected RelationalManyToManyTestBase(RelationalModelBuilderFixture fixture)
             : base(fixture)
         {
         }
+
+        [ConditionalFact] // Issue #27990
+        public virtual void Can_use_ForeignKeyAttribute_with_InversePropertyAttribute()
+        {
+            var modelBuilder = CreateModelBuilder();
+                    
+            modelBuilder.Entity<MotorArt>(
+                entity =>
+                {
+                    entity.HasMany(d => d.MotorBauArt)
+                        .WithMany(p => p.MotorArt)
+                        .UsingEntity<Dictionary<string, object>>("MotorArtXMotorBauart");
+                });
+
+            var model = modelBuilder.FinalizeModel();
+
+            Assert.Collection(model.GetEntityTypes(),
+                e =>
+                {
+                    Assert.Equal("FuelTypeMotorArt", e.ShortName());
+                    Assert.Collection(e.GetProperties(), p => Assert.Equal("FuelTypeId", p.Name), p => Assert.Equal("MotorArtId", p.Name));
+                    Assert.Collection(e.GetKeys(), k =>Assert.Collection(k.Properties,
+                        p => Assert.Equal("FuelTypeId", p.Name),
+                        p => Assert.Equal("MotorArtId", p.Name)));
+                    Assert.Collection(e.GetForeignKeys(), k =>
+                    {
+                        Assert.Equal("FuelType", k.PrincipalEntityType.ShortName());
+                        Assert.Collection(k.Properties, p => Assert.Equal("FuelTypeId", p.Name));
+                        Assert.Collection(k.PrincipalKey.Properties, p => Assert.Equal("FuelTypeId", p.Name));
+                    }, k =>
+                    {
+                        Assert.Equal("MotorArt", k.PrincipalEntityType.ShortName());
+                        Assert.Collection(k.Properties, p => Assert.Equal("MotorArtId", p.Name));
+                        Assert.Collection(k.PrincipalKey.Properties, p => Assert.Equal("MotorArtId", p.Name));
+                    });
+                    Assert.Empty(e.GetNavigations());
+                    Assert.Empty(e.GetSkipNavigations());
+                },
+                e =>
+                {
+                    Assert.Equal("FuelType", e.ShortName());
+                    Assert.Collection(e.GetKeys(), k =>Assert.Collection(k.Properties, p => Assert.Equal("FuelTypeId", p.Name)));
+                    Assert.Collection(e.GetProperties(), p => Assert.Equal("FuelTypeId", p.Name), p => Assert.Equal("Bezeichnung", p.Name));
+                    Assert.Empty(e.GetForeignKeys());
+                    Assert.Empty(e.GetNavigations());
+                    Assert.Collection(e.GetSkipNavigations(), n => Assert.Equal("MotorArt", n.Name));
+                },
+                e =>
+                {
+                    Assert.Equal("MotorArt", e.ShortName());
+                    Assert.Collection(e.GetKeys(), k =>Assert.Collection(k.Properties, p => Assert.Equal("MotorArtId", p.Name)));
+                    Assert.Collection(e.GetProperties(), p => Assert.Equal("MotorArtId", p.Name));
+                    Assert.Empty(e.GetForeignKeys());
+                    Assert.Empty(e.GetNavigations());
+                    Assert.Collection(e.GetSkipNavigations(),
+                        n => Assert.Equal("FuelType", n.Name),
+                        n => Assert.Equal("MotorBauArt", n.Name));
+                },
+                e =>
+                {
+                    Assert.Equal("MotorBauart", e.ShortName());
+                    Assert.Collection(e.GetKeys(), k =>Assert.Collection(k.Properties, p => Assert.Equal("MotorBauartId", p.Name)));
+                    Assert.Collection(e.GetProperties(), p => Assert.Equal("MotorBauartId", p.Name));
+                    Assert.Empty(e.GetForeignKeys());
+                    Assert.Empty(e.GetNavigations());
+                    Assert.Collection(e.GetSkipNavigations(), n => Assert.Equal("MotorArt", n.Name));
+                },
+                e =>
+                {
+                    Assert.Equal("MotorArtXMotorBauart", e.ShortName());
+                    Assert.Collection(e.GetProperties(),
+                        p => Assert.Equal("MotorArtId", p.Name),
+                        p => Assert.Equal("MotorBauArtId", p.Name));
+                    Assert.Collection(e.GetKeys(), k =>Assert.Collection(k.Properties,
+                        p => Assert.Equal("MotorArtId", p.Name),
+                        p => Assert.Equal("MotorBauArtId", p.Name)));
+                    Assert.Collection(e.GetForeignKeys(), k =>
+                    {
+                        Assert.Equal("MotorArt", k.PrincipalEntityType.ShortName());
+                        Assert.Collection(k.Properties, p => Assert.Equal("MotorArtId", p.Name));
+                        Assert.Collection(k.PrincipalKey.Properties, p => Assert.Equal("MotorArtId", p.Name));
+                    }, k =>
+                    {
+                        Assert.Equal("MotorBauart", k.PrincipalEntityType.ShortName());
+                        Assert.Collection(k.Properties, p => Assert.Equal("MotorBauArtId", p.Name));
+                        Assert.Collection(k.PrincipalKey.Properties, p => Assert.Equal("MotorBauartId", p.Name));
+                    });
+                    Assert.Empty(e.GetNavigations());
+                    Assert.Empty(e.GetSkipNavigations());
+                });
+        }
+
+        [Table("FuelType", Schema = "dbo")]
+        [Index("Bezeichnung", Name = "Key_Fueltype", IsUnique = true)]
+        protected class FuelType
+        {
+            [Key]
+            public int FuelTypeId { get; set; }
+
+            [StringLength(255)]
+            public string Bezeichnung { get; set; } = null!;
+
+            [ForeignKey("FuelTypeId")]
+            [InverseProperty("FuelType")]
+            public virtual ICollection<MotorArt> MotorArt { get; set; } = new HashSet<MotorArt>();
+        }
+
+        [Table("MotorArt", Schema = "Bib")]
+        protected class MotorArt
+        {
+            [Key]
+            public int MotorArtId { get; set; }
+
+            [StringLength(255)]
+            [ForeignKey("MotorArtId")]
+            [InverseProperty("MotorArt")]
+            public virtual ICollection<FuelType> FuelType { get; set; } = new HashSet<FuelType>();
+
+            [ForeignKey("MotorArtId")]
+            [InverseProperty("MotorArt")]
+            public virtual ICollection<MotorBauart> MotorBauArt { get; set; } = new HashSet<MotorBauart>();
+        }
+
+        [Table("MotorBauart", Schema = "Bib")]
+        protected class MotorBauart
+        {
+            [Key]
+            public int MotorBauartId { get; set; }
+
+            [ForeignKey("MotorBauArtId")]
+            [InverseProperty("MotorBauArt")]
+            public virtual ICollection<MotorArt> MotorArt { get; set; } = new HashSet<MotorArt>();
+        }
+
     }
 
     public abstract class RelationalOwnedTypesTestBase : OwnedTypesTestBase
     {
-        public RelationalOwnedTypesTestBase(RelationalModelBuilderFixture fixture)
+        protected RelationalOwnedTypesTestBase(RelationalModelBuilderFixture fixture)
             : base(fixture)
         {
         }


### PR DESCRIPTION
Also, reuse the FKs that already were configured instead of creating new ones.

Fixes #27990
Fixes #26555