### PR TITLE
Track prunability of inner joins on the expression itself 

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -315,6 +315,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluralizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poolable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=prunable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pushdown/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=queryables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=remapper/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -24,7 +24,7 @@ public class CrossApplyExpression : JoinExpressionBase
     }
 
     private CrossApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
-        : base(table, annotations)
+        : base(table, prunable: false, annotations)
     {
     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
@@ -24,7 +24,7 @@ public class CrossJoinExpression : JoinExpressionBase
     }
 
     private CrossJoinExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
-        : base(table, annotations)
+        : base(table, prunable: false, annotations)
     {
     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -19,16 +19,18 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// </summary>
     /// <param name="table">A table source to INNER JOIN with.</param>
     /// <param name="joinPredicate">A predicate to use for the join.</param>
-    public InnerJoinExpression(TableExpressionBase table, SqlExpression joinPredicate)
-        : this(table, joinPredicate, annotations: null)
+    /// <param name="prunable">Whether this join expression may be pruned if nothing references a column on it.</param>
+    public InnerJoinExpression(TableExpressionBase table, SqlExpression joinPredicate, bool prunable = false)
+        : this(table, joinPredicate, prunable, annotations: null)
     {
     }
 
     private InnerJoinExpression(
         TableExpressionBase table,
         SqlExpression joinPredicate,
+        bool prunable,
         IEnumerable<IAnnotation>? annotations)
-        : base(table, joinPredicate, annotations)
+        : base(table, joinPredicate, prunable, annotations)
     {
     }
 
@@ -41,7 +43,7 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override InnerJoinExpression Update(TableExpressionBase table, SqlExpression joinPredicate)
         => table != Table || joinPredicate != JoinPredicate
-            ? new InnerJoinExpression(table, joinPredicate, GetAnnotations())
+            ? new InnerJoinExpression(table, joinPredicate, IsPrunable, GetAnnotations())
             : this;
 
     /// <summary>
@@ -52,12 +54,12 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override InnerJoinExpression Update(TableExpressionBase table)
         => table != Table
-            ? new InnerJoinExpression(table, JoinPredicate, GetAnnotations())
+            ? new InnerJoinExpression(table, JoinPredicate, IsPrunable, GetAnnotations())
             : this;
 
     /// <inheritdoc />
     protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new InnerJoinExpression(Table, JoinPredicate, annotations);
+        => new InnerJoinExpression(Table, JoinPredicate, IsPrunable, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/JoinExpressionBase.cs
@@ -18,26 +18,25 @@ public abstract class JoinExpressionBase : TableExpressionBase
     ///     Creates a new instance of the <see cref="JoinExpressionBase" /> class.
     /// </summary>
     /// <param name="table">A table source to join with.</param>
-    protected JoinExpressionBase(TableExpressionBase table)
-        : this(table, annotations: null)
-    {
-    }
-
-    /// <summary>
-    ///     Creates a new instance of the <see cref="JoinExpressionBase" /> class.
-    /// </summary>
-    /// <param name="table">A table source to join with.</param>
+    /// <param name="prunable">Whether this join expression may be pruned if nothing references a column on it.</param>
     /// <param name="annotations">A collection of annotations associated with this expression.</param>
-    protected JoinExpressionBase(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
+    protected JoinExpressionBase(TableExpressionBase table, bool prunable, IEnumerable<IAnnotation>? annotations = null)
         : base(alias: null, annotations)
     {
         Table = table;
+        IsPrunable = prunable;
     }
 
     /// <summary>
     ///     Gets the underlying table source to join with.
     /// </summary>
     public virtual TableExpressionBase Table { get; }
+
+    /// <summary>
+    ///     Whether this join expression may be pruned if nothing references a column on it. This isn't the case, for example, when an
+    ///     INNER JOIN is used to filter out rows.
+    /// </summary>
+    public virtual bool IsPrunable { get; }
 
     /// <summary>
     ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -19,16 +19,18 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// </summary>
     /// <param name="table">A table source to LEFT JOIN with.</param>
     /// <param name="joinPredicate">A predicate to use for the join.</param>
-    public LeftJoinExpression(TableExpressionBase table, SqlExpression joinPredicate)
-        : this(table, joinPredicate, annotations: null)
+    /// <param name="prunable">Whether this join expression may be pruned if nothing references a column on it.</param>
+    public LeftJoinExpression(TableExpressionBase table, SqlExpression joinPredicate, bool prunable = false)
+        : this(table, joinPredicate, prunable, annotations: null)
     {
     }
 
     private LeftJoinExpression(
         TableExpressionBase table,
         SqlExpression joinPredicate,
-        IEnumerable<IAnnotation>? annotations)
-        : base(table, joinPredicate, annotations)
+        bool prunable,
+        IEnumerable<IAnnotation>? annotations = null)
+        : base(table, joinPredicate, prunable, annotations)
     {
     }
 
@@ -41,7 +43,7 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override LeftJoinExpression Update(TableExpressionBase table, SqlExpression joinPredicate)
         => table != Table || joinPredicate != JoinPredicate
-            ? new LeftJoinExpression(table, joinPredicate, GetAnnotations())
+            ? new LeftJoinExpression(table, joinPredicate, IsPrunable, GetAnnotations())
             : this;
 
     /// <summary>
@@ -52,12 +54,12 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override LeftJoinExpression Update(TableExpressionBase table)
         => table != Table
-            ? new LeftJoinExpression(table, JoinPredicate, GetAnnotations())
+            ? new LeftJoinExpression(table, JoinPredicate, IsPrunable, GetAnnotations())
             : this;
 
     /// <inheritdoc />
     protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new LeftJoinExpression(Table, JoinPredicate, annotations);
+        => new LeftJoinExpression(Table, JoinPredicate, IsPrunable, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -24,7 +24,7 @@ public class OuterApplyExpression : JoinExpressionBase
     }
 
     private OuterApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
-        : base(table, annotations)
+        : base(table, prunable: false, annotations)
     {
     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/PredicateJoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/PredicateJoinExpressionBase.cs
@@ -19,22 +19,14 @@ public abstract class PredicateJoinExpressionBase : JoinExpressionBase
     /// </summary>
     /// <param name="table">A table source to join with.</param>
     /// <param name="joinPredicate">A predicate to use for the join.</param>
-    protected PredicateJoinExpressionBase(TableExpressionBase table, SqlExpression joinPredicate)
-        : this(table, joinPredicate, annotations: null)
-    {
-    }
-
-    /// <summary>
-    ///     Creates a new instance of the <see cref="PredicateJoinExpressionBase" /> class.
-    /// </summary>
-    /// <param name="table">A table source to join with.</param>
-    /// <param name="joinPredicate">A predicate to use for the join.</param>
+    /// <param name="prunable">Whether this join expression may be pruned if nothing references a column on it.</param>
     /// <param name="annotations">A collection of annotations associated with this expression.</param>
     protected PredicateJoinExpressionBase(
         TableExpressionBase table,
         SqlExpression joinPredicate,
-        IEnumerable<IAnnotation>? annotations)
-        : base(table, annotations)
+        bool prunable,
+        IEnumerable<IAnnotation>? annotations = null)
+        : base(table, prunable, annotations)
     {
         JoinPredicate = joinPredicate;
     }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -804,8 +804,6 @@ public sealed partial class SelectExpression
                         _mutable = selectExpression._mutable
                     };
 
-                    newSelectExpression._removableJoinTables.AddRange(selectExpression._removableJoinTables);
-
                     foreach (var kvp in selectExpression._tpcDiscriminatorValues)
                     {
                         newSelectExpression._tpcDiscriminatorValues[tpcTablesMap[kvp.Key]] = kvp.Value;

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -21,18 +21,8 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     ///     Creates a new instance of the <see cref="TableExpressionBase" /> class.
     /// </summary>
     /// <param name="alias">A string alias for the table source.</param>
-    protected TableExpressionBase(string? alias)
-        : this(alias, annotations: null)
-    {
-        Alias = alias;
-    }
-
-    /// <summary>
-    ///     Creates a new instance of the <see cref="TableExpressionBase" /> class.
-    /// </summary>
-    /// <param name="alias">A string alias for the table source.</param>
     /// <param name="annotations">A collection of annotations associated with this expression.</param>
-    protected TableExpressionBase(string? alias, IEnumerable<IAnnotation>? annotations)
+    protected TableExpressionBase(string? alias, IEnumerable<IAnnotation>? annotations = null)
     {
         Alias = alias;
 


### PR DESCRIPTION
When a join is added to a select, it's optionally marked as removable, i.e. eligible for pruning if not referenced by any column; this is checked while pruning to prevent removing joins which are important for preserving correct data even when not referenced (e.g. an inner join can be used to filter).

In line with the current architecture, this information is stored on a private list on SelectExpression; this means that all code that accesses it must be on SelectExpression itself (and not on an external visitor, where it can be overridden e.g. by a provider); it also means we must take care to always copy it when duplicating selects, and generally causes unnecessary bookkeeping.

This PR is a pure refactor which moves the information to the tables themselves, where it can be accessed freely from anywhere. This is part of a larger effort to remove private state from SelectExpression and simplify the pipeline.

Part of #31049