### PR TITLE
[release/8.0] Preserve unicodeness and fixed-lengthiness in compiled model.

### DIFF
--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -2149,7 +2149,15 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
             && relationalTypeMapping.Scale != defaultInstance.Scale;
         var dbTypeDifferent = relationalTypeMapping.DbType != null
             && relationalTypeMapping.DbType != defaultInstance.DbType;
-        if (storeTypeDifferent || sizeDifferent || precisionDifferent || scaleDifferent || dbTypeDifferent)
+        var isUnicodeDifferent = relationalTypeMapping.IsUnicode != defaultInstance.IsUnicode;
+        var isFixedLengthDifferent = relationalTypeMapping.IsFixedLength != defaultInstance.IsFixedLength;
+        if (storeTypeDifferent
+            || sizeDifferent
+            || precisionDifferent
+            || scaleDifferent
+            || dbTypeDifferent
+            || isUnicodeDifferent
+            || isFixedLengthDifferent)
         {
             AddNamespace(typeof(RelationalTypeMappingInfo), parameters.Namespaces);
             mainBuilder.AppendLine(",")
@@ -2167,6 +2175,18 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
             {
                 GenerateArgument(
                     "size", code.Literal(relationalTypeMapping.Size), mainBuilder, ref firstParameter);
+            }
+
+            if (isUnicodeDifferent)
+            {
+                GenerateArgument(
+                    "unicode", code.Literal(relationalTypeMapping.IsUnicode), mainBuilder, ref firstParameter);
+            }
+
+            if (isFixedLengthDifferent)
+            {
+                GenerateArgument(
+                    "fixedLength", code.Literal(relationalTypeMapping.IsFixedLength), mainBuilder, ref firstParameter);
             }
 
             if (precisionDifferent)

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -68,9 +68,7 @@ public class SqlServerStringTypeMapping : StringTypeMapping
     private static string GetDefaultStoreName(bool unicode, bool fixedLength)
         => unicode
             ? fixedLength ? "nchar" : "nvarchar"
-            : fixedLength
-                ? "char"
-                : "varchar";
+            : fixedLength ? "char" : "varchar";
 
     private static DbType? GetDbType(bool unicode, bool fixedLength)
         => unicode


### PR DESCRIPTION
Fixes #32617
Port of #32662

### Description

In EF 8 we augmented the generated compiled model with type mappings, however some aspects weren't preserved, in particular whether a given string property accepts Unicode and whether it has a fixed length.

### Customer impact

When using a compiled model with unicode properties queries involving those properties will use non-unicode behavior, potentially resulting in data corruption.

### How found

Customer report on 8.0.

### Regression

Yes.

### Testing

Tests added.

### Risk

Low.