### PR TITLE
Translate to NULLIF

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
@@ -56,4 +56,17 @@ public static class RelationalDbFunctionsExtensions
         this DbFunctions _,
         [NotParameterized] params T[] values)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Greatest)));
+
+    /// <summary>
+    ///     Returns <see langword="null"/> if <paramref name="expression"/> equals <paramref name="matchExpression"/>, otherwise returns <paramref name="expression"/>. Usually corresponds to the <c>NULLIF</c> SQL function.
+    /// </summary>
+    /// <typeparam name="T">The type</typeparam>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="expression">The expression.</param>
+    /// <param name="matchExpression">The matching expression.</param>
+    public static T? NullIf<T>(
+        this DbFunctions _,
+        T expression,
+        T matchExpression)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Collate)));
 }

--- a/src/EFCore.Relational/Query/Internal/NullIfTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/NullIfTranslator.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class NullIfTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo MethodInfo
+        = typeof(RelationalDbFunctionsExtensions).GetMethod(nameof(RelationalDbFunctionsExtensions.NullIf))!;
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public NullIfTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        => method.IsGenericMethod
+            && Equals(method.GetGenericMethodDefinition(), MethodInfo)
+                ? _sqlExpressionFactory.Function(
+                    "NULLIF",
+                    new[] { arguments[1], arguments[2] },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true },
+                    method.ReturnType)
+                : null;
+}

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -37,7 +37,8 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
                 new GetValueOrDefaultTranslator(sqlExpressionFactory),
                 new ComparisonTranslator(sqlExpressionFactory),
                 new ByteArraySequenceEqualTranslator(sqlExpressionFactory),
-                new RandomTranslator(sqlExpressionFactory)
+                new RandomTranslator(sqlExpressionFactory),
+                new NullIfTranslator(sqlExpressionFactory)
             });
         _sqlExpressionFactory = sqlExpressionFactory;
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -92,6 +92,16 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
                     ss => ss.Set<OrderDetail>().Where(od => EF.Functions.Greatest(arr) == 10251)));
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task NullIf(bool async)
+        => AssertCount(
+            async,
+            ss => ss.Set<Customer>(),
+            ss => ss.Set<Customer>(),
+            c => EF.Functions.NullIf(c.ContactName, "maria anders") == null,
+            c => c.ContactName == null);
+
     protected abstract string CaseInsensitiveCollation { get; }
     protected abstract string CaseSensitiveCollation { get; }
 }


### PR DESCRIPTION
Adding ```NullIf``` to ```DbFunctions``` (Related issue #31682)

I created a new Translator to handle the ```NullIf``` method. 
It's similar to the ```RandomTranslator```.