### PR TITLE
Fix complex assignment operator handling in LinqToCSharpSyntaxTranslator

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -662,6 +662,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 name);
 
         /// <summary>
+        ///     The same ParameterExpression instance with name '{parameter}' was used as a variable declaration in a block and a nested block inside it. This is not allowed - use different ParameterExpression instances.
+        /// </summary>
+        public static string SameParameterExpressionDeclaredAsVariableInNestedBlocks(object? parameter)
+            => string.Format(
+                GetString("SameParameterExpressionDeclaredAsVariableInNestedBlocks", nameof(parameter)),
+                parameter);
+
+        /// <summary>
         ///     To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
         /// </summary>
         public static string SensitiveInformationWarning

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -380,6 +380,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="RevertMigration" xml:space="preserve">
     <value>The migration '{name}' has already been applied to the database. Revert it and try again. If the migration has been applied to other databases, consider reverting its changes using a new migration instead.</value>
   </data>
+  <data name="SameParameterExpressionDeclaredAsVariableInNestedBlocks" xml:space="preserve">
+    <value>The same ParameterExpression instance with name '{parameter}' was used as a variable declaration in a block and a nested block inside it. This is not allowed - use different ParameterExpression instances.</value>
+  </data>
   <data name="SensitiveInformationWarning" xml:space="preserve">
     <value>To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.</value>
     <comment>Localize the URL if we have localized docs.</comment>

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.EntityFrameworkCore.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using ConditionalExpression = System.Linq.Expressions.ConditionalExpression;
 using E = System.Linq.Expressions.Expression;
@@ -469,7 +470,12 @@ public class LinqToCSharpSyntaxTranslator : ExpressionVisitor, ILinqToCSharpSynt
                 }
                 else
                 {
-                    variables.Add(parameter, uniquifiedName);
+                    if (!variables.TryAdd(parameter, uniquifiedName))
+                    {
+                        throw new InvalidOperationException(
+                            DesignStrings.SameParameterExpressionDeclaredAsVariableInNestedBlocks(parameter.Name ?? "<null>"));
+                    }
+
                     variableNames.Add(uniquifiedName);
                 }
             }

--- a/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
@@ -70,11 +70,24 @@ public class LinqToCSharpTranslatorTest
     [Theory]
     [InlineData(ExpressionType.Add, "+")]
     [InlineData(ExpressionType.Subtract, "-")]
-    // TODO: Complete
+    [InlineData(ExpressionType.Assign, "=")]
+    [InlineData(ExpressionType.AddAssign, "+=")]
+    [InlineData(ExpressionType.AddAssignChecked, "+=")]
+    [InlineData(ExpressionType.MultiplyAssign, "*=")]
+    [InlineData(ExpressionType.MultiplyAssignChecked, "*=")]
+    [InlineData(ExpressionType.DivideAssign, "/=")]
+    [InlineData(ExpressionType.ModuloAssign, "%=")]
+    [InlineData(ExpressionType.SubtractAssign, "-=")]
+    [InlineData(ExpressionType.SubtractAssignChecked, "-=")]
+    [InlineData(ExpressionType.AndAssign, "&=")]
+    [InlineData(ExpressionType.OrAssign, "|=")]
+    [InlineData(ExpressionType.LeftShiftAssign, "<<=")]
+    [InlineData(ExpressionType.RightShiftAssign, ">>=")]
+    [InlineData(ExpressionType.ExclusiveOrAssign, "^=")]
     public void Binary_numeric(ExpressionType expressionType, string op)
         => AssertExpression(
-            MakeBinary(expressionType, Constant(2), Constant(3)),
-            $"2 {op} 3");
+            MakeBinary(expressionType, Parameter(typeof(int), "i"), Constant(3)),
+            $"i {op} 3");
 
     [Fact]
     public void Binary_ArrayIndex()
@@ -93,6 +106,33 @@ public class LinqToCSharpTranslatorTest
         => AssertExpression(
             PowerAssign(Parameter(typeof(double), "d"), Constant(3.0)),
             "d = Math.Pow(d, 3D)");
+
+    [Fact]
+    public void Private_instance_field_SimpleAssign()
+        => AssertExpression(
+            Assign(
+                Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+                Constant(3)),
+            """typeof(LinqToCSharpTranslatorTest.Blog).GetField("_privateField", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(blog, 3)""");
+
+    [Theory]
+    [InlineData(ExpressionType.AddAssign, "+")]
+    [InlineData(ExpressionType.MultiplyAssign, "*")]
+    [InlineData(ExpressionType.DivideAssign, "/")]
+    [InlineData(ExpressionType.ModuloAssign, "%")]
+    [InlineData(ExpressionType.SubtractAssign, "-")]
+    [InlineData(ExpressionType.AndAssign, "&")]
+    [InlineData(ExpressionType.OrAssign, "|")]
+    [InlineData(ExpressionType.LeftShiftAssign, "<<")]
+    [InlineData(ExpressionType.RightShiftAssign, ">>")]
+    [InlineData(ExpressionType.ExclusiveOrAssign, "^")]
+    public void Private_instance_field_AssignOperators(ExpressionType expressionType, string op)
+        => AssertExpression(
+            MakeBinary(
+                expressionType,
+                Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+                Constant(3)),
+            $"""typeof(LinqToCSharpTranslatorTest.Blog).GetField("_privateField", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(blog, typeof(LinqToCSharpTranslatorTest.Blog).GetField("_privateField", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(blog) {op} 3)""");
 
     [Theory]
     [InlineData(ExpressionType.Negate, "-i")]


### PR DESCRIPTION
Part of #32659
