### PR TITLE
Introduce liftable constants to shaper to prepare for precompilation

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -302,6 +302,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Includable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=liftable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lite_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializers/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -63,6 +63,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             { typeof(IQuerySqlGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IModificationCommandFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ISqlAliasManagerFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IRelationalLiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ICommandBatchPreparer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalSqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -189,6 +190,9 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IQueryCompilationContextFactory, RelationalQueryCompilationContextFactory>();
         TryAdd<IAdHocMapper, RelationalAdHocMapper>();
         TryAdd<ISqlAliasManagerFactory, SqlAliasManagerFactory>();
+        TryAdd<ILiftableConstantFactory>(p => p.GetRequiredService<IRelationalLiftableConstantFactory>());
+        TryAdd<IRelationalLiftableConstantFactory, RelationalLiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, RelationalLiftableConstantProcessor>();
 
         ServiceCollectionMap.GetInfrastructure()
             .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()

--- a/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface IRelationalLiftableConstantFactory : ILiftableConstantFactory
+{
+    LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -653,7 +653,8 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
         return new ProjectionBindingExpression(_selectExpression, existingIndex, type);
     }
 
-    private static T GetParameterValue<T>(QueryContext queryContext, string parameterName)
+    // Public because can get referenced by precompiled shaper code
+    public static T GetParameterValue<T>(QueryContext queryContext, string parameterName)
 #pragma warning restore IDE0052 // Remove unread private members
         => (T)queryContext.ParameterValues[parameterName]!;
 

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -6,6 +6,28 @@ using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
+public static class SingleQueryingEnumerable
+{
+    public static SingleQueryingEnumerable<T> Create<T>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            shaper,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class RelationalLiftableConstantFactory : LiftableConstantFactory, IRelationalLiftableConstantFactory
+{
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(resolverExpression, variableName, type);
+}

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#pragma warning disable EF1001 // LiftableConstantProcessor is internal
+
+public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
+{
+    private RelationalMaterializerLiftableConstantContext _relationalMaterializerLiftableConstantContext;
+
+    public RelationalLiftableConstantProcessor(
+        ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
+        : base(dependencies)
+        => _relationalMaterializerLiftableConstantContext = new(dependencies, relationalDependencies);
+
+    protected override ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<RelationalMaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_relationalMaterializerLiftableConstantContext);
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        return base.InlineConstant(liftableConstant);
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
+++ b/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public record RelationalMaterializerLiftableConstantContext(
+        ShapedQueryCompilingExpressionVisitorDependencies Dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies)
+    : MaterializerLiftableConstantContext(Dependencies);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -11,7 +11,14 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
-    private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
         private static readonly MethodInfo ThrowReadValueExceptionMethod =
             typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ThrowReadValueException))!;
@@ -160,7 +167,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void InitializeIncludeCollection<TParent, TNavigationEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InitializeIncludeCollection<TParent, TNavigationEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -201,7 +215,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             resultCoordinator.SetSingleQueryCollectionContext(collectionId, collectionMaterializationContext);
         }
 
-        private static void PopulateIncludeCollection<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateIncludeCollection<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -209,9 +230,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             Func<QueryContext, DbDataReader, object[]> parentIdentifier,
             Func<QueryContext, DbDataReader, object[]> outerIdentifier,
             Func<QueryContext, DbDataReader, object[]> selfIdentifier,
-            IReadOnlyList<ValueComparer> parentIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> outerIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> selfIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> parentIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> outerIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> selfIdentifierValueComparers,
+            // IReadOnlyList<ValueComparer> parentIdentifierValueComparers,
+            // IReadOnlyList<ValueComparer> outerIdentifierValueComparers,
+            // IReadOnlyList<ValueComparer> selfIdentifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TIncludedEntity> innerShaper,
             INavigationBase? inverseNavigation,
             Action<TIncludingEntity, TIncludedEntity> fixup,
@@ -229,14 +253,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     return;
                 }
 
-                if (!CompareIdentifiers(
+                if (!CompareIdentifiers2(
                         outerIdentifierValueComparers,
                         outerIdentifier(queryContext, dbDataReader), collectionMaterializationContext.OuterIdentifier))
                 {
                     // Outer changed so collection has ended. Materialize last element.
                     GenerateCurrentElementIfPending();
                     // If parent also changed then this row is now pointing to element of next collection
-                    if (!CompareIdentifiers(
+                    if (!CompareIdentifiers2(
                             parentIdentifierValueComparers,
                             parentIdentifier(queryContext, dbDataReader), collectionMaterializationContext.ParentIdentifier))
                     {
@@ -255,7 +279,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                 if (collectionMaterializationContext.SelfIdentifier != null)
                 {
-                    if (CompareIdentifiers(selfIdentifierValueComparers, innerKey, collectionMaterializationContext.SelfIdentifier))
+                    if (CompareIdentifiers2(selfIdentifierValueComparers, innerKey, collectionMaterializationContext.SelfIdentifier))
                     {
                         // repeated row for current element
                         // If it is pending materialization then it may have nested elements
@@ -319,7 +343,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader parentDataReader,
@@ -358,7 +389,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             resultCoordinator.SetSplitQueryCollectionContext(collectionId, splitQueryCollectionContext);
         }
 
-        private static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -367,7 +405,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
+            // IReadOnlyList<ValueComparer> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -414,7 +453,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 while (dataReaderContext.HasNext ?? dbDataReader.Read())
                 {
-                    if (!CompareIdentifiers(
+                    if (!CompareIdentifiers2(
                             identifierValueComparers,
                             splitQueryCollectionContext.ParentIdentifier, childIdentifier(queryContext, dbDataReader)))
                     {
@@ -451,7 +490,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
+            // IReadOnlyList<ValueComparer> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -506,7 +546,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 while (dataReaderContext.HasNext ?? await dbDataReader.ReadAsync(queryContext.CancellationToken).ConfigureAwait(false))
                 {
-                    if (!CompareIdentifiers(
+                    if (!CompareIdentifiers2(
                             identifierValueComparers,
                             splitQueryCollectionContext.ParentIdentifier, childIdentifier(queryContext, dbDataReader)))
                     {
@@ -538,7 +578,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static TCollection InitializeCollection<TElement, TCollection>(
+        [EntityFrameworkInternal]
+        public static TCollection InitializeCollection<TElement, TCollection>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -560,7 +601,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return (TCollection)collection;
         }
 
-        private static void PopulateCollection<TCollection, TElement, TRelatedEntity>(
+        [EntityFrameworkInternal]
+        public static void PopulateCollection<TCollection, TElement, TRelatedEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -1064,6 +1106,20 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 await taskFactories[i]().ConfigureAwait(false);
             }
+        }
+
+        private static bool CompareIdentifiers2(IReadOnlyList<Func<object, object, bool>> valueComparers, object[] left, object[] right)
+        {
+            // Ignoring size check on all for perf as they should be same unless bug in code.
+            for (var i = 0; i < left.Length; i++)
+            {
+                if (!valueComparers[i](left[i], right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool CompareIdentifiers(IReadOnlyList<ValueComparer> valueComparers, object[] left, object[] right)

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -14,7 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
-    private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
         /// <summary>
         ///     Reading database values
@@ -76,6 +82,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
         private static readonly MethodInfo EnumParseMethodInfo
             = typeof(Enum).GetMethod(nameof(Enum.Parse), [typeof(Type), typeof(string)])!;
+
+        private static readonly MethodInfo ReadColumnCreateMethod
+            = typeof(ReaderColumn).GetMethod(nameof(ReaderColumn.Create))!;
 
         private readonly RelationalShapedQueryCompilingExpressionVisitor _parentVisitor;
         private readonly ISet<string>? _tags;
@@ -249,8 +258,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
         public LambdaExpression ProcessRelationalGroupingResult(
             RelationalGroupByResultExpression relationalGroupByResultExpression,
-            out RelationalCommandCache relationalCommandCache,
-            out IReadOnlyList<ReaderColumn?>? readerColumns,
+            out Expression relationalCommandCache,
+            out Func<Expression> readerColumns,
+            // out IReadOnlyList<ReaderColumn?>? readerColumns,
             out LambdaExpression keySelector,
             out LambdaExpression keyIdentifier,
             out LambdaExpression? relatedDataLoaders,
@@ -279,8 +289,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
         public LambdaExpression ProcessShaper(
             Expression shaperExpression,
-            out RelationalCommandCache? relationalCommandCache,
-            out IReadOnlyList<ReaderColumn?>? readerColumns,
+            out Expression relationalCommandCache,
+            out Func<Expression> readerColumns,
+            // out IReadOnlyList<ReaderColumn?>? readerColumns,
             out LambdaExpression? relatedDataLoaders,
             ref int collectionId)
         {
@@ -293,13 +304,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 _expressions.Add(result);
                 result = Block(_variables, _expressions);
 
-                relationalCommandCache = new RelationalCommandCache(
-                    _parentVisitor.Dependencies.MemoryCache,
-                    _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                    _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                    _selectExpression,
-                    _parentVisitor._useRelationalNulls);
-                readerColumns = _readerColumns;
+                relationalCommandCache = _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression);
+                readerColumns = CreateReaderColumnsExpression();
 
                 return Lambda(
                     result,
@@ -320,14 +326,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 result = Block(_variables, _expressions);
 
                 relationalCommandCache = _generateCommandCache
-                    ? new RelationalCommandCache(
-                        _parentVisitor.Dependencies.MemoryCache,
-                        _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                        _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                        _selectExpression,
-                        _parentVisitor._useRelationalNulls)
-                    : null;
-                readerColumns = _readerColumns;
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
+                    : Expression.Constant(null, typeof(RelationalCommandCache));
+                readerColumns = CreateReaderColumnsExpression();
 
                 return Lambda(
                     result,
@@ -408,14 +409,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
 
                 relationalCommandCache = _generateCommandCache
-                    ? new RelationalCommandCache(
-                        _parentVisitor.Dependencies.MemoryCache,
-                        _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                        _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                        _selectExpression,
-                        _parentVisitor._useRelationalNulls)
-                    : null;
-                readerColumns = _readerColumns;
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
+                    : Expression.Constant(null, typeof(RelationalCommandCache));;
+                readerColumns = CreateReaderColumnsExpression();
 
                 collectionId = _collectionId;
 
@@ -452,8 +448,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 ? value
                                 : propertyMap.Values.Max() + 1;
 
-                        var updatedExpression = newExpression.Update(
-                            new[] { Constant(ValueBuffer.Empty), newExpression.Arguments[1] });
+                    var updatedExpression = newExpression.Update(
+                        new[]
+                        {
+                            _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                _ => ValueBuffer.Empty,
+                                "emptyValueBuffer",
+                                typeof(ValueBuffer)),
+                            newExpression.Arguments[1]
+                        });
 
                         return Assign(binaryExpression.Left, updatedExpression);
                     }
@@ -597,7 +600,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         }
                         else
                         {
-                            var entityParameter = Parameter(shaper.Type);
+                            var entityParameter = Parameter(shaper.Type, "entity");
                             _variables.Add(entityParameter);
                             if (shaper.StructuralType is IEntityType entityType
                                 && entityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
@@ -718,7 +721,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     var projection = _selectExpression.Projection[projectionIndex];
                     var nullable = IsNullableProjection(projection);
 
-                    var valueParameter = Parameter(projectionBindingExpression.Type);
+                    var valueParameter = Parameter(projectionBindingExpression.Type, "value" + (_variables.Count + 1));
                     _variables.Add(valueParameter);
 
                     _expressions.Add(
@@ -769,13 +772,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 _readerColumns)
                             .ProcessShaper(relationalCollectionShaperExpression.InnerShaper, out _, out _, out _, ref _collectionId);
 
-                        var entityType = entity.Type;
+                        var entityClrType = entity.Type;
                         var navigation = includeExpression.Navigation;
-                        var includingEntityType = navigation.DeclaringEntityType.ClrType;
-                        if (includingEntityType != entityType
-                            && includingEntityType.IsAssignableFrom(entityType))
+                        var includingEntityClrType = navigation.DeclaringEntityType.ClrType;
+                        if (includingEntityClrType != entityClrType
+                            && includingEntityClrType.IsAssignableFrom(entityClrType))
                         {
-                            includingEntityType = entityType;
+                            includingEntityClrType = entityClrType;
                         }
 
                         _inline = true;
@@ -799,51 +802,68 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         _includeExpressions.Add(
                             Call(
-                                InitializeIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityType),
+                                InitializeIncludeCollectionMethodInfo.MakeGenericMethod(entityClrType, includingEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
                                 entity,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(outerIdentifierLambda.Compile()),
-                                Constant(navigation),
-                                Constant(
-                                    navigation.IsShadowProperty()
-                                        ? null
-                                        : navigation.GetCollectionAccessor(), typeof(IClrCollectionAccessor)),
+                                parentIdentifierLambda,
+                                outerIdentifierLambda,
+                                // Constant(navigation),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
+                                    navigation.Name + "Navigation",
+                                    typeof(INavigationBase)),
+                                // Constant(navigation.IsShadowProperty()
+                                //     ? null
+                                //     : navigation.GetCollectionAccessor(), typeof(IClrCollectionAccessor)),
+                                navigation.IsShadowProperty()
+                                    ? Constant(null, typeof(IClrCollectionAccessor))
+                                    : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
+                                            .GetCollectionAccessor()!,
+                                        navigation.Name + "NavigationCollectionAccessor",
+                                        typeof(IClrCollectionAccessor)),
                                 Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
                                 Constant(includeExpression.SetLoaded)));
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-                        var relatedEntityType = innerShaper.ReturnType;
+                        var relatedEntityClrType = innerShaper.ReturnType;
                         var inverseNavigation = navigation.Inverse;
 
                         _collectionPopulatingExpressions!.Add(
                             Call(
-                                PopulateIncludeCollectionMethodInfo.MakeGenericMethod(includingEntityType, relatedEntityType),
+                                PopulateIncludeCollectionMethodInfo.MakeGenericMethod(includingEntityClrType, relatedEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(outerIdentifierLambda.Compile()),
-                                Constant(selfIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalCollectionShaperExpression.ParentIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.OuterIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.SelfIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile()),
-                                Constant(inverseNavigation, typeof(INavigationBase)),
-                                Constant(
-                                    GenerateFixup(
-                                        includingEntityType, relatedEntityType, navigation, inverseNavigation).Compile()),
+                                parentIdentifierLambda,
+                                outerIdentifierLambda,
+                                selfIdentifierLambda,
+                                NewArrayInit(typeof(Func<object, object, bool>), relationalCollectionShaperExpression.ParentIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(typeof(Func<object, object, bool>), relationalCollectionShaperExpression.OuterIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(typeof(Func<object, object, bool>), relationalCollectionShaperExpression.SelfIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                // Expression.Constant(
+                                //     relationalCollectionShaperExpression.ParentIdentifierValueComparers,
+                                //     typeof(IReadOnlyList<ValueComparer>)),
+                                // Expression.Constant(
+                                //     relationalCollectionShaperExpression.OuterIdentifierValueComparers,
+                                //     typeof(IReadOnlyList<ValueComparer>)),
+                                // Expression.Constant(
+                                //     relationalCollectionShaperExpression.SelfIdentifierValueComparers,
+                                //     typeof(IReadOnlyList<ValueComparer>)),
+                                innerShaper,
+                                // Expression.Constant(inverseNavigation, typeof(INavigationBase)),
+                                inverseNavigation is null
+                                    ? Constant(null, typeof(INavigationBase))
+                                    : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        c => c.Dependencies.Model.FindEntityType(inverseNavigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
+                                        navigation.Name + "InverseNavigation",
+                                        typeof(INavigationBase)),
+                                GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Constant(_isTracking)));
                     }
                     else if (includeExpression.NavigationExpression is RelationalSplitCollectionShaperExpression
@@ -862,11 +882,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         var entityType = entity.Type;
                         var navigation = includeExpression.Navigation;
-                        var includingEntityType = navigation.DeclaringEntityType.ClrType;
-                        if (includingEntityType != entityType
-                            && includingEntityType.IsAssignableFrom(entityType))
+                        var includingEntityClrType = navigation.DeclaringEntityType.ClrType;
+                        if (includingEntityClrType != entityType
+                            && includingEntityClrType.IsAssignableFrom(entityType))
                         {
-                            includingEntityType = entityType;
+                            includingEntityClrType = entityType;
                         }
 
                         _inline = true;
@@ -889,48 +909,66 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         _includeExpressions.Add(
                             Call(
-                                InitializeSplitIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityType),
+                                InitializeSplitIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
                                 entity,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(navigation),
-                                Constant(navigation.GetCollectionAccessor()),
+                                parentIdentifierLambda,
+                                // Expression.Constant(navigation),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
+                                    navigation.Name + "Navigation",
+                                    typeof(INavigationBase)),
+                                // Expression.Constant(navigation.GetCollectionAccessor()),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
+                                        .GetCollectionAccessor()!,
+                                    navigation.Name + "NavigationCollectionAccessor",
+                                    typeof(IClrCollectionAccessor)),
                                 Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
                                 Constant(includeExpression.SetLoaded)));
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-                        var relatedEntityType = innerShaper.ReturnType;
+                        var relatedEntityClrType = innerShaper.ReturnType;
                         var inverseNavigation = navigation.Inverse;
 
                         _collectionPopulatingExpressions!.Add(
                             Call(
                                 (_isAsync ? PopulateSplitIncludeCollectionAsyncMethodInfo : PopulateSplitIncludeCollectionMethodInfo)
-                                .MakeGenericMethod(includingEntityType, relatedEntityType),
+                                .MakeGenericMethod(includingEntityClrType, relatedEntityClrType),
                                 collectionIdConstant,
                                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
                                 _executionStrategyParameter!,
-                                Constant(relationalCommandCache),
-                                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                                relationalCommandCache,
+                                readerColumns(),
                                 Constant(_detailedErrorsEnabled),
                                 _resultCoordinatorParameter,
-                                Constant(childIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalSplitCollectionShaperExpression.IdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile()),
-                                Constant(
-                                    relatedDataLoaders?.Compile(),
+                                childIdentifierLambda,
+                                // Constant(
+                                //     relationalSplitCollectionShaperExpression.IdentifierValueComparers,
+                                //     typeof(IReadOnlyList<ValueComparer>)),
+                                NewArrayInit(typeof(Func<object, object, bool>), relationalSplitCollectionShaperExpression.IdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                innerShaper,
+                                // Constant(
+                                //     relatedDataLoaders?.Compile(),
+                                //     _isAsync
+                                //         ? typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>)
+                                //         : typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>)),
+                                relatedDataLoaders ?? (Expression)Expression.Constant(null,
                                     _isAsync
                                         ? typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>)
                                         : typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>)),
-                                Constant(inverseNavigation, typeof(INavigationBase)),
-                                Constant(
-                                    GenerateFixup(
-                                        includingEntityType, relatedEntityType, navigation, inverseNavigation).Compile()),
+                                // Constant(inverseNavigation, typeof(INavigationBase)),
+                                inverseNavigation is null
+                                    ? Constant(null, typeof(INavigationBase))
+                                    : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        c => c.Dependencies.Model.FindEntityType(inverseNavigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
+                                        navigation.Name + "InverseNavigation",
+                                        typeof(INavigationBase)),
+                                GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Constant(_isTracking)));
                     }
                     else
@@ -1170,6 +1208,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                 case GroupByShaperExpression:
                     throw new InvalidOperationException(RelationalStrings.ClientGroupByNotSupported);
+
+                case LiftableConstantExpression:
+                    return extensionExpression;
             }
 
             return base.VisitExtension(extensionExpression);
@@ -2326,7 +2367,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static LambdaExpression GenerateFixup(
+        private LambdaExpression GenerateFixup(
             Type entityType,
             Type relatedEntityType,
             INavigationBase navigation,
@@ -2422,12 +2463,22 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     prm);
         }
 
-        private static Expression AddToCollectionNavigation(
+        private Expression AddToCollectionNavigation(
             ParameterExpression entity,
             ParameterExpression relatedEntity,
             INavigationBase navigation)
             => Call(
-                Constant(navigation.GetCollectionAccessor()),
+                // Constant(navigation.GetCollectionAccessor()),
+
+                // // TODO: Very temporary hack. This is bad for perf.
+                // Call(Expression.Constant(navigation), typeof(INavigationBase).GetMethod(nameof(INavigationBase.GetCollectionAccessor), Array.Empty<Type>())!),
+
+                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                        c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
+                            .GetCollectionAccessor()!,
+                        navigation.Name + "NavigationCollectionAccessor",
+                        typeof(IClrCollectionAccessor)),
+
                 CollectionAccessorAddMethodInfo,
                 entity,
                 relatedEntity,
@@ -2495,7 +2546,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         Lambda(
                             bufferedReaderLambdaExpression,
                             dbDataReader,
-                            _indexMapParameter ?? Parameter(typeof(int[]))).Compile());
+                            _indexMapParameter ?? Parameter(typeof(int[]), "indexMap")));
                 }
 
                 valueExpression = Call(
@@ -2628,6 +2679,51 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             return resultExpression;
         }
+
+        // TODO: No, this must be a lifted constant, otherwise we re-instantiate on each query
+        private Func<Expression> CreateReaderColumnsExpression()
+            => () =>
+            {
+                if (_readerColumns is null)
+                {
+                    return Expression.Constant(null, typeof(ReaderColumn?[]));
+                }
+
+                var materializerLiftableConstantContextParameter = Expression.Parameter(typeof(MaterializerLiftableConstantContext));
+
+                return _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                    Expression.Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                        Expression.NewArrayInit(
+                            typeof(ReaderColumn),
+                            _readerColumns.Select(rc =>
+                                rc is null
+                                    ? (Expression)Expression.Constant(null, typeof(ReaderColumn))
+                                    : Expression.New(
+                                        ReaderColumn.GetConstructor(rc.Type),
+                                        Expression.Constant(rc.IsNullable),
+                                        Expression.Constant(rc.Name, typeof(string)),
+                                        GetPropertyExpression(rc),
+                                        rc.GetFieldValueExpression))),
+                        materializerLiftableConstantContextParameter),
+                    "readerColumns",
+                    typeof(ReaderColumn[]));
+
+                Expression GetPropertyExpression(ReaderColumn readerColumn)
+                {
+                    if (readerColumn.Property is null)
+                    {
+                        return Expression.Constant(null, typeof(IProperty));
+                    }
+
+                    Expression<Func<MaterializerLiftableConstantContext, object?>> wrapper = c
+                        => c.Dependencies.Model
+                            .FindEntityType(readerColumn.Property.DeclaringType.Name)!
+                            .FindProperty(readerColumn.Property.Name)!;
+
+                    return ReplacingExpressionVisitor.Replace(
+                        wrapper.Parameters[0], materializerLiftableConstantContextParameter, wrapper.Body);
+                }
+            };
 
         private sealed class CollectionShaperFindingExpressionVisitor : ExpressionVisitor
         {

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -70,17 +70,19 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                 break;
         }
 
-        var relationalCommandCache = new RelationalCommandCache(
-            Dependencies.MemoryCache,
-            RelationalDependencies.QuerySqlGeneratorFactory,
-            RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-            innerExpression,
-            _useRelationalNulls);
+        // var relationalCommandCache = new RelationalCommandCache(
+        //     Dependencies.MemoryCache,
+        //     RelationalDependencies.QuerySqlGeneratorFactory,
+        //     RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
+        //     innerExpression,
+        //     _useRelationalNulls);
+
+        var relationalCommandCache = CreateRelationalCommandCacheExpression(innerExpression);
 
         return Call(
             QueryCompilationContext.IsAsync ? NonQueryAsyncMethodInfo : NonQueryMethodInfo,
             Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-            Constant(relationalCommandCache),
+            relationalCommandCache,
             Constant(_contextType),
             Constant(nonQueryExpression.CommandSource),
             Constant(_threadSafetyChecksEnabled));
@@ -96,7 +98,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
             .GetDeclaredMethods(nameof(NonQueryResultAsync))
             .Single(mi => mi.GetParameters().Length == 5);
 
-    private static int NonQueryResult(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static int NonQueryResult(
         RelationalQueryContext relationalQueryContext,
         RelationalCommandCache relationalCommandCache,
         Type contextType,
@@ -167,7 +176,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
         }
     }
 
-    private static Task<int> NonQueryResultAsync(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static Task<int> NonQueryResultAsync(
         RelationalQueryContext relationalQueryContext,
         RelationalCommandCache relationalCommandCache,
         Type contextType,
@@ -318,9 +334,10 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
         else
         {
             var nonComposedFromSql = selectExpression.IsNonComposedFromSql();
-            var shaper = new ShaperProcessingExpressionVisitor(this, selectExpression, _tags, splitQuery, nonComposedFromSql).ProcessShaper(
-                shapedQueryExpression.ShaperExpression,
-                out var relationalCommandCache, out var readerColumns, out var relatedDataLoaders, ref collectionCount);
+            var shaper = new ShaperProcessingExpressionVisitor(this, selectExpression, _tags, splitQuery, nonComposedFromSql)
+                .ProcessShaper(
+                    shapedQueryExpression.ShaperExpression, out var relationalCommandCache, out var readerColumns,
+                    out var relatedDataLoaders, ref collectionCount);
 
             if (querySplittingBehavior == null
                 && collectionCount > 1)
@@ -334,7 +351,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                     typeof(FromSqlQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
                     Constant(relationalCommandCache),
-                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                    readerColumns(),
                     Constant(
                         selectExpression.Projection.Select(pe => ((ColumnExpression)pe.Expression).Name).ToList(),
                         typeof(IReadOnlyList<string>)),
@@ -348,20 +365,30 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
 
             if (splitQuery)
             {
-                var relatedDataLoadersParameter = Constant(
-                    QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
-                    typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
+                var relatedDataLoadersParameter =
+                    QueryCompilationContext.IsAsync || relatedDataLoaders is null
+                        ? Expression.Constant(null, typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>))
+                        : (Expression)relatedDataLoaders;
 
-                var relatedDataLoadersAsyncParameter = Constant(
-                    QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
-                    typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
+                // var relatedDataLoadersParameter = Constant(
+                //     QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
+                //     typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
+
+                var relatedDataLoadersAsyncParameter =
+                    QueryCompilationContext.IsAsync && relatedDataLoaders is not null
+                        ? (Expression)relatedDataLoaders
+                        : Expression.Constant(null, typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
+
+                // var relatedDataLoadersAsyncParameter = Constant(
+                //     QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
+                //     typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
                 return New(
                     typeof(SplitQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors().Single(),
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Constant(relationalCommandCache),
-                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Constant(shaper.Compile()),
+                    relationalCommandCache,
+                    readerColumns(),
+                    shaper,
                     relatedDataLoadersParameter,
                     relatedDataLoadersAsyncParameter,
                     Constant(_contextType),
@@ -371,12 +398,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                     Constant(_threadSafetyChecksEnabled));
             }
 
-            return New(
-                typeof(SingleQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
+            // TODO: Do the same for the other QueryingEnumerables
+            return Call(
+                typeof(SingleQueryingEnumerable).GetMethods()
+                    .Single(m => m.Name == nameof(SingleQueryingEnumerable.Create))
+                    .MakeGenericMethod(shaper.ReturnType),
                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                Constant(relationalCommandCache),
-                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                Constant(shaper.Compile()),
+                relationalCommandCache,
+                readerColumns(),
+                shaper,
                 Constant(_contextType),
                 Constant(
                     QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
@@ -384,4 +414,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                 Constant(_threadSafetyChecksEnabled));
         }
     }
+
+    private LiftableConstantExpression CreateRelationalCommandCacheExpression(Expression queryExpression)
+        => RelationalDependencies.RelationalLiftableConstantFactory.CreateLiftableConstant(
+            c => new RelationalCommandCache(
+                c.Dependencies.MemoryCache,
+                c.RelationalDependencies.QuerySqlGeneratorFactory,
+                c.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
+                queryExpression,
+                _useRelationalNulls),
+            "relationalCommandCache",
+            typeof(RelationalCommandCache));
 }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -47,10 +47,12 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     [EntityFrameworkInternal]
     public RelationalShapedQueryCompilingExpressionVisitorDependencies(
         IQuerySqlGeneratorFactory querySqlGeneratorFactory,
-        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory)
+        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory,
+        IRelationalLiftableConstantFactory relationalLiftableConstantFactory)
     {
         QuerySqlGeneratorFactory = querySqlGeneratorFactory;
         RelationalParameterBasedSqlProcessorFactory = relationalParameterBasedSqlProcessorFactory;
+        RelationalLiftableConstantFactory = relationalLiftableConstantFactory;
     }
 
     /// <summary>
@@ -62,4 +64,9 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     ///     The SQL processor based on parameter values.
     /// </summary>
     public IRelationalParameterBasedSqlProcessorFactory RelationalParameterBasedSqlProcessorFactory { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public IRelationalLiftableConstantFactory RelationalLiftableConstantFactory { get; init; }
 }

--- a/src/EFCore.Relational/Storage/ReaderColumn.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn.cs
@@ -29,12 +29,14 @@ public abstract class ReaderColumn
     /// <param name="nullable">A value indicating if the column is nullable.</param>
     /// <param name="name">The name of the column.</param>
     /// <param name="property">The property being read if any, null otherwise.</param>
-    protected ReaderColumn(Type type, bool nullable, string? name, IPropertyBase? property)
+    /// <param name="getFieldValueExpression">A lambda expression to get field value for the column from the reader.</param>
+    protected ReaderColumn(Type type, bool nullable, string? name, IPropertyBase? property, LambdaExpression getFieldValueExpression)
     {
         Type = type;
         IsNullable = nullable;
         Name = name;
         Property = property;
+        GetFieldValueExpression = getFieldValueExpression;
     }
 
     /// <summary>
@@ -58,6 +60,11 @@ public abstract class ReaderColumn
     public virtual IPropertyBase? Property { get; }
 
     /// <summary>
+    ///     A lambda expression to get field value for the column from the reader.
+    /// </summary>
+    public virtual LambdaExpression GetFieldValueExpression { get; }
+
+    /// <summary>
     ///     Creates an instance of <see cref="ReaderColumn{T}" />.
     /// </summary>
     /// <param name="type">The type of the column.</param>
@@ -73,10 +80,17 @@ public abstract class ReaderColumn
         bool nullable,
         string? columnName,
         IPropertyBase? property,
-        object readFunc)
+        LambdaExpression readFunc)
         => (ReaderColumn)GetConstructor(type).Invoke([nullable, columnName, property, readFunc]);
 
-    private static ConstructorInfo GetConstructor(Type type)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static ConstructorInfo GetConstructor(Type type)
         => Constructors.GetOrAdd(
             type, t => typeof(ReaderColumn<>).MakeGenericType(t).GetConstructors().First(ci => ci.GetParameters().Length == 4));
 }

--- a/src/EFCore.Relational/Storage/ReaderColumn`.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn`.cs
@@ -24,15 +24,15 @@ public class ReaderColumn<T> : ReaderColumn
     /// <param name="nullable">A value indicating if the column is nullable.</param>
     /// <param name="name">The name of the column.</param>
     /// <param name="property">The property being read if any, null otherwise.</param>
-    /// <param name="getFieldValue">A function to get field value for the column from the reader.</param>
+    /// <param name="getFieldValueExpression">A lambda expression to get field value for the column from the reader.</param>
     public ReaderColumn(
         bool nullable,
         string? name,
         IPropertyBase? property,
-        Func<DbDataReader, int[], T> getFieldValue)
-        : base(typeof(T), nullable, name, property)
+        Expression<Func<DbDataReader, int[], T>> getFieldValueExpression)
+        : base(typeof(T), nullable, name, property, getFieldValueExpression)
     {
-        GetFieldValue = getFieldValue;
+        GetFieldValue = getFieldValueExpression.Compile();
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -353,7 +353,14 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         }
     }
 
-    private static string? ConstructLikePatternParameter(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal] // Can be referenced in shaper code
+    public static string? ConstructLikePatternParameter(
         QueryContext queryContext,
         string baseParameterName,
         StartsEndsWithContains methodType)
@@ -376,10 +383,36 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
             _ => throw new UnreachableException()
         };
 
-    private enum StartsEndsWithContains
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>    [EntityFrameworkInternal] // Can be referenced in shaper code
+    public enum StartsEndsWithContains
     {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         StartsWith,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         EndsWith,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         Contains
     }
 

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -155,6 +155,8 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
     /// </summary>
     public virtual LambdaExpression EqualsExpression { get; }
 
+    public abstract LambdaExpression ObjectEqualsExpression { get; }
+
     /// <summary>
     ///     The hash code expression.
     /// </summary>

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -248,6 +248,29 @@ public class ValueComparer
         return v1Null || v2Null ? v1Null && v2Null : Equals((T?)left, (T?)right);
     }
 
+    public override LambdaExpression ObjectEqualsExpression
+    {
+        get
+        {
+            // TODO: Cache this
+            var left = Expression.Parameter(typeof(object), "left");
+            var right = Expression.Parameter(typeof(object), "right");
+
+            return Expression.Lambda<Func<object?, object?, bool>>(
+                Expression.Condition(
+                    Expression.Equal(left, Expression.Constant(null)),
+                    Expression.Equal(right, Expression.Constant(null)),
+                    Expression.AndAlso(
+                        Expression.NotEqual(right, Expression.Constant(null)),
+                        Expression.Invoke(
+                            EqualsExpression,
+                            Expression.Convert(left, typeof(T)),
+                            Expression.Convert(right, typeof(T))))),
+                left,
+                right);
+        }
+    }
+
     /// <summary>
     ///     Returns the hash code for the given instance.
     /// </summary>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -83,6 +83,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IMemoryCache), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(INavigationExpansionExtensibilityHelper), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(ILiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IExceptionDetector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IJsonValueReaderWriterSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IProviderConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -125,6 +126,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IShapedQueryCompilingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IDbContextLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IAdHocMapper), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+            { typeof(ILiftableConstantProcessor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Transient) },
             { typeof(ILazyLoaderFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
@@ -309,6 +311,8 @@ public class EntityFrameworkServicesBuilder
         TryAdd<IExceptionDetector, ExceptionDetector>();
         TryAdd<IAdHocMapper, AdHocMapper>();
         TryAdd<IJsonValueReaderWriterSource, JsonValueReaderWriterSource>();
+        TryAdd<ILiftableConstantFactory, LiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, LiftableConstantProcessor>();
 
         TryAdd(
             p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.DbContextLogger
@@ -329,7 +333,6 @@ public class EntityFrameworkServicesBuilder
             .AddDependencySingleton<ModelCacheKeyFactoryDependencies>()
             .AddDependencySingleton<ValueConverterSelectorDependencies>()
             .AddDependencySingleton<EntityMaterializerSourceDependencies>()
-            .AddDependencySingleton<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencySingleton<EvaluatableExpressionFilterDependencies>()
             .AddDependencySingleton<RuntimeModelDependencies>()
             .AddDependencySingleton<ModelRuntimeInitializerDependencies>()
@@ -344,6 +347,7 @@ public class EntityFrameworkServicesBuilder
             .AddDependencyScoped<QueryableMethodTranslatingExpressionVisitorDependencies>()
             .AddDependencyScoped<QueryTranslationPreprocessorDependencies>()
             .AddDependencyScoped<QueryTranslationPostprocessorDependencies>()
+            .AddDependencyScoped<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencyScoped<ValueGeneratorSelectorDependencies>()
             .AddDependencyScoped<DatabaseDependencies>()
             .AddDependencyScoped<ModelDependencies>()

--- a/src/EFCore/Query/ILiftableConstantFactory.cs
+++ b/src/EFCore/Query/ILiftableConstantFactory.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface ILiftableConstantFactory
+{
+    LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore/Query/ILiftableConstantProcessor.cs
+++ b/src/EFCore/Query/ILiftableConstantProcessor.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface ILiftableConstantProcessor
+{
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    /// </remarks>
+    Expression InlineConstants(Expression expression);
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the liftable constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Constant lifting is performed in the precompiled query pipeline flow.
+    /// </remarks>
+    Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames);
+}

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -295,7 +295,8 @@ public class EntityMaterializerSource : IEntityMaterializerSource
 
         if (bindingInfo.StructuralType is IEntityType)
         {
-            AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
+            // TODO: bindingInfo is used as a constant, needs to be liftable
+            //AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
         }
 
         blockExpressions.Add(instanceVariable);

--- a/src/EFCore/Query/Internal/ShaperPublicMethodVerifier.cs
+++ b/src/EFCore/Query/Internal/ShaperPublicMethodVerifier.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public sealed class ShaperPublicMethodVerifier : ExpressionVisitor
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCall)
+    {
+        var method = methodCall.Method;
+        if (!method.IsPublic)
+        {
+            throw new InvalidOperationException($"Method '{method.DeclaringType?.Name}.{method.Name}' isn't public and therefore cannot be invoked in shaper code (incompatible with precompiled queries)");
+        }
+
+        var currentType = method.DeclaringType;
+        while (currentType is not null)
+        {
+            if (currentType is { IsPublic: false, IsNestedPublic: false }
+                // Exclude anonymous types
+                && currentType.GetCustomAttribute(typeof(CompilerGeneratedAttribute), inherit: false) is null)
+            {
+                throw new InvalidOperationException($"Method '{method.DeclaringType?.Name}.{method.Name}' isn't public and therefore cannot be invoked in shaper code (incompatible with precompiled queries)");
+            }
+
+            currentType = currentType.DeclaringType;
+        }
+
+        return base.VisitMethodCall(methodCall);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitNew(NewExpression newExpression)
+    {
+        var constructor = newExpression.Constructor;
+        if (constructor is not null)
+        {
+            if (!constructor.IsPublic)
+            {
+                throw new InvalidOperationException($"The constructor for '{constructor.DeclaringType?.Name}' isn't public and therefore cannot be invoked in shaper code (incompatible with precompiled queries)");
+            }
+
+            var currentType = constructor.DeclaringType;
+            while (currentType is not null)
+            {
+                if (currentType is { IsPublic: false, IsNestedPublic: false }
+                    // Exclude anonymous types
+                    && currentType.GetCustomAttribute(typeof(CompilerGeneratedAttribute), inherit: false) is null)
+                {
+                    throw new InvalidOperationException($"Constructor for '{constructor.DeclaringType?.Name}' isn't public and therefore cannot be invoked in shaper code (incompatible with precompiled queries)");
+                }
+
+                currentType = currentType.DeclaringType;
+            }
+        }
+
+        return base.VisitNew(newExpression);
+    }
+
+    // Ignore liftable constant nodes - they contain literals only (not method/constructor invocations) and cause exceptions.
+    protected override Expression VisitExtension(Expression node)
+        => node is LiftableConstantExpression ? node : base.VisitExtension(node);
+}

--- a/src/EFCore/Query/LiftableConstantExpression.cs
+++ b/src/EFCore/Query/LiftableConstantExpression.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     A node containing an expression expressing how to obtain a constant value, which may get lifted out of an expression tree.
+/// </summary>
+/// <remarks>
+///     <para>
+///         When the expression tree is compiled, the constant value can simply be evaluated beforehand, and a
+///         <see cref="ConstantExpression" /> expression can directly reference the result.
+///     </para>
+///     <para>
+///         When the expression tree is translated to source code instead (in query pre-compilation), the expression can be rendered out
+///         separately, to be assigned to a variable, and this node is replaced by a reference to that variable.
+///     </para>
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class LiftableConstantExpression : Expression, IPrintableExpression
+{
+    public LiftableConstantExpression(
+        LambdaExpression resolverExpression,
+        string variableName,
+        Type type)
+    {
+        ResolverExpression = resolverExpression;
+        VariableName = char.ToLower(variableName[0]) + variableName[1..];
+        Type = type;
+    }
+
+    public LambdaExpression ResolverExpression { get; }
+
+    public string VariableName { get; }
+
+    public override Type Type { get; }
+
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    // TODO: Complete other expression stuff (equality, etc.)
+
+    /// <inheritdoc />
+    public void Print(ExpressionPrinter expressionPrinter)
+        => expressionPrinter.Append($"[Constant: {expressionPrinter.PrintExpression(ResolverExpression)}]");
+}

--- a/src/EFCore/Query/LiftableConstantFactory.cs
+++ b/src/EFCore/Query/LiftableConstantFactory.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class LiftableConstantFactory : ILiftableConstantFactory
+{
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(resolverExpression, variableName, type);
+}

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -1,0 +1,458 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+#pragma warning disable CS1591
+
+public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantProcessor
+{
+    private bool _inline;
+    private MaterializerLiftableConstantContext _materializerLiftableConstantContext;
+
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; private set; }
+        = Array.Empty<(ParameterExpression Parameter, Expression Expression)>();
+
+    private record LiftedConstant(ParameterExpression Parameter, Expression Expression, ParameterExpression? ReplacingParameter = null);
+
+    private readonly List<LiftedConstant> _liftedConstants = new();
+    private readonly LiftedExpressionProcessor _liftedExpressionProcessor = new();
+    private readonly LiftedConstantOptimizer _liftedConstantOptimizer = new();
+
+    private ParameterExpression? _contextParameter;
+
+    public LiftableConstantProcessor(ShapedQueryCompilingExpressionVisitorDependencies dependencies)
+    {
+        _materializerLiftableConstantContext = new(dependencies);
+
+        _liftedConstants.Clear();
+    }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     <para>
+    ///         Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
+    public virtual Expression InlineConstants(Expression expression)
+    {
+        _liftedConstants.Clear();
+        _inline = true;
+
+        return Visit(expression);
+    }
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the lifted constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    public virtual Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames)
+    {
+        _liftedConstants.Clear();
+
+        _inline = false;
+        _contextParameter = contextParameter;
+
+        var expressionAfterLifting = Visit(expression);
+
+        // All liftable constant nodes have been lifted out.
+        // We'll now optimize them, looking for greatest common denominator tree fragments, in cases where e.g. two lifted constants look up
+        // the same entity type.
+        _liftedConstantOptimizer.Optimize(_liftedConstants);
+
+        // Uniquify all variable names, taking into account possible remapping done in the optimization phase above
+        var replacedParameters = new Dictionary<ParameterExpression, ParameterExpression>();
+        // var (originalParameters, newParameters) = (new List<Expression>(), new List<Expression>());
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+
+            if (liftedConstant.ReplacingParameter is not null)
+            {
+                // This lifted constant is being removed, since it's a duplicate of another with the same expression.
+                // We still need to remap the parameter in the expression, but no uniquification etc.
+                replacedParameters.Add(liftedConstant.Parameter,
+                    replacedParameters.TryGetValue(liftedConstant.ReplacingParameter, out var replacedReplacingParameter)
+                        ? replacedReplacingParameter
+                        : liftedConstant.ReplacingParameter);
+                _liftedConstants.RemoveAt(i--);
+                continue;
+            }
+
+            var name = liftedConstant.Parameter.Name ?? "unknown";
+            var baseName = name;
+            for (var j = 0; variableNames.Contains(name); j++)
+            {
+                name = baseName + j;
+            }
+
+            variableNames.Add(name);
+
+            if (name != liftedConstant.Parameter.Name)
+            {
+                var newParameter = Expression.Parameter(liftedConstant.Parameter.Type, name);
+                _liftedConstants[i] = liftedConstant with { Parameter = newParameter };
+                replacedParameters.Add(liftedConstant.Parameter, newParameter);
+            }
+        }
+
+        // Finally, apply all remapping (optimization, uniquification) to both the expression tree and to the lifted constant variable
+        // themselves.
+
+        // var (originalParametersArray, newParametersArray) = (originalParameters.ToArray(), newParameters.ToArray());
+        // var remappedExpression = ReplacingExpressionVisitor.Replace(originalParametersArray, newParametersArray, expressionAfterLifting);
+        var originalParameters = new Expression[replacedParameters.Count];
+        var newParameters = new Expression[replacedParameters.Count];
+        var index = 0;
+        foreach (var (originalParameter, newParameter) in replacedParameters)
+        {
+            originalParameters[index] = originalParameter;
+            newParameters[index] = newParameter;
+            index++;
+        }
+        var remappedExpression = ReplacingExpressionVisitor.Replace(originalParameters, newParameters, expressionAfterLifting);
+
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+            var remappedLiftedConstantExpression =
+                ReplacingExpressionVisitor.Replace(originalParameters, newParameters, liftedConstant.Expression);
+
+            if (remappedLiftedConstantExpression != liftedConstant.Expression)
+            {
+                _liftedConstants[i] = liftedConstant with { Expression = remappedLiftedConstantExpression };
+            }
+        }
+
+        LiftedConstants = _liftedConstants.Select(c => (c.Parameter, c.Expression)).ToArray();
+        return remappedExpression;
+    }
+
+    protected override Expression VisitExtension(Expression node)
+    {
+        if (node is LiftableConstantExpression liftedConstant)
+        {
+            return _inline
+                ? InlineConstant(liftedConstant)
+                : LiftConstant(liftedConstant);
+        }
+
+        return base.VisitExtension(node);
+    }
+
+    protected virtual ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<MaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_materializerLiftableConstantContext);
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        throw new InvalidOperationException(
+            $"Unknown resolved expression of type {liftableConstant.ResolverExpression.GetType().Name} found on liftable constant expression");
+    }
+
+    protected virtual ParameterExpression LiftConstant(LiftableConstantExpression liftableConstant)
+    {
+        var resolverLambda = liftableConstant.ResolverExpression;
+        var parameter = resolverLambda.Parameters[0];
+
+        // Extract the lambda body, replacing the lambda parameter with our lifted constant context parameter, and also inline any captured
+        // literals
+        var body = _liftedExpressionProcessor.Process(resolverLambda.Body, parameter, _contextParameter!);
+
+        // If the lambda returns a value type, a Convert to object node gets needed that we need to unwrap
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } convertNode
+            && convertNode.Type == typeof(object))
+        {
+            body = convertNode.Operand;
+        }
+
+        // Register the lifted constant; note that the name will be uniquified later
+        var variableParameter = Expression.Parameter(liftableConstant.Type, liftableConstant.VariableName);
+        _liftedConstants.Add(new(variableParameter, body));
+
+        return variableParameter;
+    }
+
+    private class LiftedConstantOptimizer : ExpressionVisitor
+    {
+        private List<LiftedConstant> _liftedConstants = null!;
+
+        private record ExpressionInfo(ExpressionStatus Status, ParameterExpression? Parameter = null, string? PreferredName = null);
+        private readonly Dictionary<Expression, ExpressionInfo> _indexedExpressions = new(ExpressionEqualityComparer.Instance);
+        private LiftedConstant _currentLiftedConstant = null!;
+        private bool _firstPass;
+        private int _index;
+
+        public void Optimize(List<LiftedConstant> liftedConstants)
+        {
+            _liftedConstants = liftedConstants;
+            _indexedExpressions.Clear();
+
+            _firstPass = true;
+
+            // Phase 1: recursively seek out tree fragments which appear more than once across the lifted constants. These will be extracted
+            // out to separate variables.
+            foreach (var liftedConstant in liftedConstants)
+            {
+                _currentLiftedConstant = liftedConstant;
+                Visit(liftedConstant.Expression);
+            }
+
+            // Filter out fragments which don't appear at least once
+            foreach (var (expression, expressionInfo) in _indexedExpressions)
+            {
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce)
+                {
+                    _indexedExpressions.Remove(expression);
+                    continue;
+                }
+
+                Check.DebugAssert(expressionInfo.Status == ExpressionStatus.SeenMultipleTimes,
+                    "expressionInfo.Status == ExpressionStatus.SeenMultipleTimes");
+            }
+
+            // Second pass: extract common denominator tree fragments to separate variables
+            _firstPass = false;
+            for (_index = 0; _index < liftedConstants.Count; _index++)
+            {
+                _currentLiftedConstant = _liftedConstants[_index];
+                if (_indexedExpressions.TryGetValue(_currentLiftedConstant.Expression, out var expressionInfo)
+                    && expressionInfo.Status == ExpressionStatus.Extracted)
+                {
+                    // This entire lifted constant has already been extracted before, so we no longer need it as a separate variable.
+                    _liftedConstants[_index] = _currentLiftedConstant with { ReplacingParameter = expressionInfo.Parameter };
+
+                    continue;
+                }
+
+                var optimizedExpression = Visit(_currentLiftedConstant.Expression);
+                if (optimizedExpression != _currentLiftedConstant.Expression)
+                {
+                    _liftedConstants[_index] = _currentLiftedConstant with { Expression = optimizedExpression };
+                }
+            }
+        }
+
+        [return: NotNullIfNotNull(nameof(node))]
+        public override Expression? Visit(Expression? node)
+        {
+            if (node is null)
+            {
+                return null;
+            }
+
+            if (node is ParameterExpression or ConstantExpression || node.Type.IsAssignableTo(typeof(LambdaExpression)))
+            {
+                return node;
+            }
+
+            if (_firstPass)
+            {
+                var preferredName = ReferenceEquals(node, _currentLiftedConstant.Expression)
+                    ? _currentLiftedConstant.Parameter.Name
+                    : null;
+
+                if (!_indexedExpressions.TryGetValue(node, out var expressionInfo))
+                {
+                    // Unseen expression, add it to the dictionary with a null value, to indicate it's only a candidate at this point.
+                    _indexedExpressions[node] = new(ExpressionStatus.SeenOnce, PreferredName: preferredName);
+                    return base.Visit(node);
+                }
+
+                // We've already seen this expression.
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce
+                    || expressionInfo.PreferredName is null && preferredName is not null)
+                {
+                    // This is the 2nd time we're seeing the expression - mark it as a common denominator
+                    _indexedExpressions[node] = _indexedExpressions[node] with
+                    {
+                        Status = ExpressionStatus.SeenMultipleTimes,
+                        PreferredName = preferredName
+                    };
+                }
+
+                // We've already seen and indexed this expression, no need to do it again
+                return node;
+            }
+            else
+            {
+                // 2nd pass
+                if (_indexedExpressions.TryGetValue(node, out var expressionInfo) && expressionInfo.Status != ExpressionStatus.SeenOnce)
+                {
+                    // This fragment is common across multiple lifted constants.
+                    if (expressionInfo.Status == ExpressionStatus.SeenMultipleTimes)
+                    {
+                        // This fragment hasn't yet been extracted out to its own variable in the 2nd pass.
+
+                        // If this happens to be a top-level node in the lifted constant, no need to extract an additional variable - just
+                        // use that as the "extracted" parameter further down.
+                        if (ReferenceEquals(node, _currentLiftedConstant.Expression))
+                        {
+                            _indexedExpressions[node] = new(ExpressionStatus.Extracted, _currentLiftedConstant.Parameter);
+                            return base.Visit(node);
+                        }
+
+                        // Otherwise, we need to extract a new variable, integrating it just before this one.
+                        var parameter = Expression.Parameter(node.Type, node switch
+                        {
+                            _ when expressionInfo.PreferredName is not null => expressionInfo.PreferredName,
+                            MemberExpression me => char.ToLowerInvariant(me.Member.Name[0]) + me.Member.Name[1..],
+                            MethodCallExpression mce => char.ToLowerInvariant(mce.Method.Name[0]) + mce.Method.Name[1..],
+                            _ => "unknown"
+                        });
+
+                        var visitedNode = base.Visit(node);
+                        _liftedConstants.Insert(_index++, new(parameter, visitedNode));
+
+                        // Mark this node as having been extracted, to prevent it from getting extracted again
+                        expressionInfo = _indexedExpressions[node] = new(ExpressionStatus.Extracted, parameter);
+                    }
+
+                    Check.DebugAssert(expressionInfo.Parameter is not null, "expressionInfo.Parameter is not null");
+
+                    return expressionInfo.Parameter;
+                }
+
+                // This specific fragment only appears once across the lifted constants; keep going down.
+                return base.Visit(node);
+            }
+        }
+
+        private enum ExpressionStatus
+        {
+            SeenOnce,
+            SeenMultipleTimes,
+            Extracted
+        }
+    }
+
+    private class LiftedExpressionProcessor : ExpressionVisitor
+    {
+        private ParameterExpression _originalParameter = null!;
+        private ParameterExpression _replacingParameter = null!;
+
+        public Expression Process(Expression expression, ParameterExpression originalParameter, ParameterExpression replacingParameter)
+        {
+            _originalParameter = originalParameter;
+            _replacingParameter = replacingParameter;
+
+            return Visit(expression);
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            // The expression to be lifted may contain a captured variable; for limited literal scenarios, inline that variable into the
+            // expression so we can render it out to C#.
+
+            // TODO: For the general case, this needs to be a full blown "evaluatable" identifier (like ParameterExtractingEV), which can
+            // identify any fragments of the tree which don't depend on the lambda parameter, and evaluate them.
+            // But for now we're doing a reduced version.
+
+            var visited = base.VisitMember(node);
+
+            if (visited is MemberExpression
+                {
+                    Expression: ConstantExpression { Value: { } constant },
+                    Member: var member
+                })
+            {
+                return member switch
+                {
+                    FieldInfo fi => Expression.Constant(fi.GetValue(constant), node.Type),
+                    PropertyInfo pi => Expression.Constant(pi.GetValue(constant), node.Type),
+                    _ => visited
+                };
+            }
+
+            return visited;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+            => ReferenceEquals(node, _originalParameter)
+                ? _replacingParameter
+                : base.VisitParameter(node);
+    }
+
+#if DEBUG
+    protected override Expression VisitConstant(ConstantExpression node)
+    {
+        return IsLiteral(node.Value)
+            ? node
+            : throw new InvalidOperationException(
+                $"Materializer expression contains a non-literal constant of type '{node.Value!.GetType().Name}'. " +
+                $"Use a {nameof(LiftableConstantExpression)} to reference any non-literal constants.");
+
+        static bool IsLiteral(object? value)
+        {
+            return value switch
+            {
+                int or long or uint or ulong or short or sbyte or ushort or byte or double or float or decimal
+                    => true,
+
+                string or bool or Type or Enum or null => true,
+
+                ITuple tuple
+                    when tuple.GetType() is { IsGenericType: true } tupleType
+                         && tupleType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal)
+                         && tupleType.Namespace == "System"
+                    => IsTupleLiteral(tuple),
+
+                _ => false
+            };
+
+            bool IsTupleLiteral(ITuple tuple)
+            {
+                for (var i = 0; i < tuple.Length; i++)
+                {
+                    if (!IsLiteral(tuple[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+#endif
+}

--- a/src/EFCore/Query/MaterializerLiftableConstantContext.cs
+++ b/src/EFCore/Query/MaterializerLiftableConstantContext.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public record MaterializerLiftableConstantContext(ShapedQueryCompilingExpressionVisitorDependencies Dependencies);

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -53,6 +53,8 @@ public sealed record QueryCompilationContextDependencies
         IQueryableMethodTranslatingExpressionVisitorFactory queryableMethodTranslatingExpressionVisitorFactory,
         IQueryTranslationPostprocessorFactory queryTranslationPostprocessorFactory,
         IShapedQueryCompilingExpressionVisitorFactory shapedQueryCompilingExpressionVisitorFactory,
+        // ShapedQueryCompilingExpressionVisitorDependencies shapedQueryCompilingExpressionVisitorDependencies,
+        ILiftableConstantProcessor liftableConstantProcessor,
         IExecutionStrategy executionStrategy,
         ICurrentDbContext currentContext,
         IDbContextOptions contextOptions,
@@ -65,6 +67,9 @@ public sealed record QueryCompilationContextDependencies
         QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
         QueryTranslationPostprocessorFactory = queryTranslationPostprocessorFactory;
         ShapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
+        // ShapedQueryCompilingExpressionVisitorDependencies = shapedQueryCompilingExpressionVisitorDependencies;
+        LiftableConstantProcessor = liftableConstantProcessor;
+        ShapedQueryCompilingExpressionVisitorDependencies = null!;
         IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
         ContextOptions = contextOptions;
         Logger = logger;
@@ -113,6 +118,16 @@ public sealed record QueryCompilationContextDependencies
     ///     The shaped-query compiling expression visitor factory.
     /// </summary>
     public IShapedQueryCompilingExpressionVisitorFactory ShapedQueryCompilingExpressionVisitorFactory { get; init; }
+
+    /// <summary>
+    ///     The shaped query compiling expression visitor dependencies.
+    /// </summary>
+    public ShapedQueryCompilingExpressionVisitorDependencies ShapedQueryCompilingExpressionVisitorDependencies { get; init; }
+
+    /// <summary>
+    ///     The liftable constant processor.
+    /// </summary>
+    public ILiftableConstantProcessor LiftableConstantProcessor { get; init; }
 
     /// <summary>
     ///     Whether the configured execution strategy can retry.

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -34,6 +34,16 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
         => new ReplacingExpressionVisitor(new[] { original }, new[] { replacement }).Visit(tree);
 
     /// <summary>
+    ///     Replaces one expression with another in given expression tree.
+    /// </summary>
+    /// <param name="originals">A list of original expressions to replace.</param>
+    /// <param name="replacements">A list of expressions to be used as replacements.</param>
+    /// <param name="tree">The expression tree in which replacement is going to be performed.</param>
+    /// <returns>An expression tree with replacements made.</returns>
+    public static Expression Replace(Expression[] originals, Expression[] replacements, Expression tree)
+        => new ReplacingExpressionVisitor(originals, replacements).Visit(tree);
+
+    /// <summary>
     ///     Creates a new instance of the <see cref="ReplacingExpressionVisitor" /> class.
     /// </summary>
     /// <param name="originals">A list of original expressions to replace.</param>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -51,12 +51,16 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
         IEntityMaterializerSource entityMaterializerSource,
         ITypeMappingSource typeMappingSource,
         IMemoryCache memoryCache,
-        ICoreSingletonOptions coreSingletonOptions)
+        ICoreSingletonOptions coreSingletonOptions,
+        IModel model,
+        ILiftableConstantFactory liftableConstantFactory)
     {
         EntityMaterializerSource = entityMaterializerSource;
         TypeMappingSource = typeMappingSource;
         MemoryCache = memoryCache;
         CoreSingletonOptions = coreSingletonOptions;
+        Model = model;
+        LiftableConstantFactory = liftableConstantFactory;
     }
 
     /// <summary>
@@ -78,4 +82,14 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
     ///     Core singleton options.
     /// </summary>
     public ICoreSingletonOptions CoreSingletonOptions { get; init; }
+
+    /// <summary>
+    ///     The model.
+    /// </summary>
+    public IModel Model { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public ILiftableConstantFactory LiftableConstantFactory { get; init; }
 }


### PR DESCRIPTION
This PR is one piece of the precompiled query puzzle (#25009) - making sure that our generated shaper code is compatible with outputting to C#. This is something that materializer enthusiasts can work on independently, so we can start parallelizing the work. Of course, the actual infra introduced here also needs to be reviewed.

The problem is mainly removing Constant expression nodes which don't refer to literals (int, string), and therefore can't be outputted to C#. The fix is the "LiftableConstantExpression" mechanism; instead of integrating constants directly into the tree, materializer generation code can use a factory to generate these nodes, providing them with an expression that determines how to resolve the "constant", given starting points (e.g. the model). So instead of referencing an IEntityType as a constant, you create a liftable constant node that resolves that entity type given the model. In normal mode a visitor simply resolves these nodes, replacing them with the correct constant before compiling the expression; but in precompilation we'll instead generate code out of these resolvers.

This PR makes us fail if any non-liftable constant is in the shaper, so making all the tests green here should in principle mean that all our shaper generation is precompilation-compatible. Note also that the materializer changes you see in this PR were done in prototype/hacky mode a year ago, and need to be cleaned up/reviewed (but the concepts/infra should be OK).

In addition, this introduces a DEBUG-only ShaperPublicMethodVerifier, which makes sure that all method/constructor calls in the shaper reference fully public members (otherwise they can't be referenced in generated C# code).

Categories of test errors:

1. "Materializer expression contains a non-literal constant of type X. Use a LiftableConstantExpression to reference any non-literal constants.". As the message says, we need to find the constant and replace it.
2. "must be reducible node" - this is because materializer generation code contains a Compile() over a tree that contains a LiftableConstantExpression. We cannot use Compile() in any case - anywhere - since we lose the expression tree and can't generate C# from it. So all invocations of Compile() must be removed (except the top-level one that's called only for non-precompiled queries).
3. "Method X isn't public and therefore cannot be invoked in shaper code" - this is the new ShaperPublicMethodVerifier. In principle it's sufficient to make sure that the method is public (with `[EntityFrameworkInternal]`!) - but also its declaring type, if it's on a nested type. But it might be an occasion to think a bit more widely about factoring etc., and maybe extract the method.

