### PR TITLE
[release/8.0] Don't detect join table with other incoming references as a simple join table

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -27,7 +27,9 @@ public static class ScaffoldingModelExtensions
             var primaryKey = entityType.FindPrimaryKey();
             var properties = entityType.GetProperties().ToList();
             var foreignKeys = entityType.GetForeignKeys().ToList();
+            var referencingForeignKeys = entityType.GetReferencingForeignKeys().ToList();
             if (primaryKey is { Properties.Count: > 1 }
+                && referencingForeignKeys.Count == 0
                 && foreignKeys.Count == 2
                 && primaryKey.Properties.Count == properties.Count
                 && foreignKeys[0].Properties.Count + foreignKeys[1].Properties.Count == properties.Count

--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore;
 /// </summary>
 public static class ScaffoldingModelExtensions
 {
+    private static readonly bool UseOldBehavior28905 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue28905", out var enabled28905) && enabled28905;
+
     /// <summary>
     ///     Check whether an entity type could be considered a many-to-many join entity type.
     /// </summary>
@@ -27,7 +30,7 @@ public static class ScaffoldingModelExtensions
             var primaryKey = entityType.FindPrimaryKey();
             var properties = entityType.GetProperties().ToList();
             var foreignKeys = entityType.GetForeignKeys().ToList();
-            var referencingForeignKeys = entityType.GetReferencingForeignKeys().ToList();
+            var referencingForeignKeys = UseOldBehavior28905 ? new() : entityType.GetReferencingForeignKeys().ToList();
             if (primaryKey is { Properties.Count: > 1 }
                 && referencingForeignKeys.Count == 0
                 && foreignKeys.Count == 2


### PR DESCRIPTION
Fixes #28905
Port of #32627

### Description

A simple join table was being detected even though in the resulting model the join type has incoming navigations.

### Customer impact

Scaffolding of an invalid model that fails when used.

### How found

Multiple customer reports on 8.

### Regression

Yes, from 6 to 7, but being reported by people moving from 6 (LTS) to 8 (LTS).

### Testing

Tests added.

### Risk

Low. Quirked.
