### PR TITLE
Add --disable-build-servers to bundle command

### DIFF
--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -175,6 +175,8 @@ internal partial class MigrationsBundleCommand
                 publishArgs.Add(configuration!);
             }
 
+            publishArgs.Add("--disable-build-servers");
+
             var exitCode = Exe.Run("dotnet", publishArgs, directory, interceptOutput: true);
             if (exitCode != 0)
             {


### PR DESCRIPTION
Attempt to help with #25555.

Note that this code is in `dotnet-ef`, so a new tool version is needed to get this change.

Tested with locally built tool package and didn't see any issues.
