### PR TITLE
Test migration path generation

### DIFF
--- a/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
@@ -19,12 +19,14 @@ public interface IMigrationsScaffolder
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="subNamespace">The migration's sub-namespace.</param>
     /// <param name="language">The project's language.</param>
+    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
     /// <returns>The scaffolded migration.</returns>
     ScaffoldedMigration ScaffoldMigration(
         string migrationName,
         string? rootNamespace,
         string? subNamespace = null,
-        string? language = null);
+        string? language = null,
+        bool dryRun = false);
 
     /// <summary>
     ///     Removes the previous migration.
@@ -33,12 +35,14 @@ public interface IMigrationsScaffolder
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="force">Don't check to see if the migration has been applied to the database.</param>
     /// <param name="language">The project's language.</param>
+    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
     /// <returns>The removed migration files.</returns>
     MigrationFiles RemoveMigration(
         string projectDir,
         string? rootNamespace,
         bool force,
-        string? language);
+        string? language,
+        bool dryRun);
 
     /// <summary>
     ///     Saves a scaffolded migration to files.
@@ -46,9 +50,11 @@ public interface IMigrationsScaffolder
     /// <param name="projectDir">The project's root directory.</param>
     /// <param name="migration">The scaffolded migration.</param>
     /// <param name="outputDir">The directory to put files in. Paths are relative to the project directory.</param>
+    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
     /// <returns>The saved migrations files.</returns>
     MigrationFiles Save(
         string projectDir,
         ScaffoldedMigration migration,
-        string? outputDir);
+        string? outputDir,
+        bool dryRun);
 }

--- a/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
@@ -19,7 +19,7 @@ public interface IMigrationsScaffolder
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="subNamespace">The migration's sub-namespace.</param>
     /// <param name="language">The project's language.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The scaffolded migration.</returns>
     ScaffoldedMigration ScaffoldMigration(
         string migrationName,
@@ -35,14 +35,14 @@ public interface IMigrationsScaffolder
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="force">Don't check to see if the migration has been applied to the database.</param>
     /// <param name="language">The project's language.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The removed migration files.</returns>
     MigrationFiles RemoveMigration(
         string projectDir,
         string? rootNamespace,
         bool force,
         string? language,
-        bool dryRun);
+        bool dryRun = false);
 
     /// <summary>
     ///     Saves a scaffolded migration to files.
@@ -50,11 +50,11 @@ public interface IMigrationsScaffolder
     /// <param name="projectDir">The project's root directory.</param>
     /// <param name="migration">The scaffolded migration.</param>
     /// <param name="outputDir">The directory to put files in. Paths are relative to the project directory.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The saved migrations files.</returns>
     MigrationFiles Save(
         string projectDir,
         ScaffoldedMigration migration,
         string? outputDir,
-        bool dryRun);
+        bool dryRun = false);
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationFiles.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationFiles.cs
@@ -11,18 +11,24 @@ public class MigrationFiles
     /// <summary>
     ///     Gets or sets the path to the migration file.
     /// </summary>
-    /// <value> The path to the migration file. </value>
+    /// <value>The path to the migration file.</value>
     public virtual string? MigrationFile { get; set; }
 
     /// <summary>
     ///     Gets or sets the path to the migration metadata file.
     /// </summary>
-    /// <value> The path to the migration metadata file. </value>
+    /// <value>The path to the migration metadata file.</value>
     public virtual string? MetadataFile { get; set; }
 
     /// <summary>
     ///     Gets or sets the path to the model snapshot file.
     /// </summary>
-    /// <value> The path to the model snapshot file. </value>
+    /// <value>The path to the model snapshot file.</value>
     public virtual string? SnapshotFile { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the scaffolded migration.
+    /// </summary>
+    /// <value>The scaffolded migration.</value>
+    public virtual ScaffoldedMigration? Migration { get; set; }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -61,7 +61,7 @@ public class MigrationsScaffolder : IMigrationsScaffolder
     ///     the sub-namespace should not both be empty.
     /// </param>
     /// <param name="language">The project's language.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The scaffolded migration.</returns>
     public virtual ScaffoldedMigration ScaffoldMigration(
         string migrationName,
@@ -224,7 +224,7 @@ public class MigrationsScaffolder : IMigrationsScaffolder
     /// <param name="projectDir">The project's root directory.</param>
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="force">Don't check to see if the migration has been applied to the database.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The removed migration files.</returns>
     public virtual MigrationFiles RemoveMigration(string projectDir, string rootNamespace, bool force, bool dryRun)
         => RemoveMigration(projectDir, rootNamespace, force, language: null, dryRun: false);
@@ -236,9 +236,8 @@ public class MigrationsScaffolder : IMigrationsScaffolder
     /// <param name="rootNamespace">The project's root namespace.</param>
     /// <param name="force">Don't check to see if the migration has been applied to the database.</param>
     /// <param name="language">The project's language.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The removed migration files.</returns>
-    // TODO: DRY (file names)
     public virtual MigrationFiles RemoveMigration(
         string projectDir,
         string? rootNamespace,
@@ -396,7 +395,7 @@ public class MigrationsScaffolder : IMigrationsScaffolder
     /// <param name="projectDir">The project's root directory.</param>
     /// <param name="migration">The scaffolded migration.</param>
     /// <param name="outputDir">The directory to put files in. Paths are relative to the project directory.</param>
-    /// <param name="dryRun">If true, then nothing is actually written to disk.</param>
+    /// <param name="dryRun">If <see langword="true" />, then nothing is actually written to disk.</param>
     /// <returns>The saved migrations files.</returns>
     public virtual MigrationFiles Save(string projectDir, ScaffoldedMigration migration, string? outputDir, bool dryRun)
     {


### PR DESCRIPTION
Part of #32738

There are no functional product changes here, Instead this PR adds code to allow migrations to be generated without actually creating the files. This allows testing of the current behavior such that we can make changes and have confidence that we know what the impact is.
