### PR TITLE
[release/8.x] Produce uncorrelated IN for Contains with nullable item (#32575)

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
@@ -113,4 +115,36 @@ public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
     /// </summary>
     protected override bool PreferExistsToInWithCoalesce
         => true;
+
+#pragma warning disable EF1001
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override bool IsCollectionTable(TableExpressionBase table, [NotNullWhen(true)] out Expression? collection)
+    {
+        if (table is SqlServerOpenJsonExpression { Arguments: [var argument] })
+        {
+            collection = argument;
+            return true;
+        }
+
+        return base.IsCollectionTable(table, out collection);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override TableExpressionBase UpdateParameterCollection(
+        TableExpressionBase table,
+        SqlParameterExpression newCollectionParameter)
+        => table is SqlServerOpenJsonExpression { Arguments: [SqlParameterExpression] } openJsonExpression
+            ? openJsonExpression.Update(newCollectionParameter, path: null)
+            : base.UpdateParameterCollection(table, newCollectionParameter);
+#pragma warning restore EF1001
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlNullabilityProcessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlNullabilityProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.SqlExpressions.Internal;
 
@@ -83,4 +84,36 @@ public class SqliteSqlNullabilityProcessor : SqlNullabilityProcessor
 
         return regexpExpression.Update(match, pattern);
     }
+
+#pragma warning disable EF1001
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override bool IsCollectionTable(TableExpressionBase table, [NotNullWhen(true)] out Expression? collection)
+    {
+        if (table is TableValuedFunctionExpression { Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var argument] })
+        {
+            collection = argument;
+            return true;
+        }
+
+        return base.IsCollectionTable(table, out collection);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override TableExpressionBase UpdateParameterCollection(
+        TableExpressionBase table,
+        SqlParameterExpression newCollectionParameter)
+        => table is TableValuedFunctionExpression { Arguments: [SqlParameterExpression] } jsonEachExpression
+            ? jsonEachExpression.Update(new[] { newCollectionParameter })
+            : base.UpdateParameterCollection(table, newCollectionParameter);
+#pragma warning restore EF1001
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1244,6 +1244,8 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     #endregion Contains with subquery
 
+    // For more tests on Contains with parameterized collections, see PrimitiveCollectionsqueryTestBase
+
     #region Contains with inline collection
 
     [ConditionalTheory]
@@ -1260,7 +1262,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_non_nullable_values_with_null(bool async)
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()
@@ -1272,7 +1274,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values(bool async)
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()
@@ -1284,7 +1286,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values_with_null(bool async)
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()
@@ -1308,7 +1310,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values_with_null(bool async)
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()
@@ -1320,7 +1322,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_nullable_values(bool async)
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()
@@ -1332,7 +1334,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_nullable_values_with_null(bool async)
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
     {
         await AssertQueryScalar(
             async, ss => ss.Set<NullSemanticsEntity1>()

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -167,58 +167,117 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Parameter_collection_of_ints_Contains(bool async)
+    public virtual async Task Parameter_collection_of_ints_Contains_int(bool async)
     {
         var ints = new[] { 10, 999 };
 
-        return AssertQuery(
+        await AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ints.Contains(c.Int)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !ints.Contains(c.Int)));
     }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    public virtual async Task Parameter_collection_of_ints_Contains_nullable_int(bool async)
+    {
+        var ints = new int?[] { 10, 999 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ints.Contains(c.NullableInt)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !ints.Contains(c.NullableInt)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
     {
         var nullableInts = new int?[] { 10, 999 };
 
-        return AssertQuery(
+        await AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.Int)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.Int)));
     }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    public virtual async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
     {
         var nullableInts = new int?[] { null, 999 };
 
-        return AssertQuery(
+        await AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.NullableInt)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.NullableInt)));
     }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Parameter_collection_of_strings_Contains_non_nullable_string(bool async)
+    public virtual async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
         var strings = new[] { "10", "999" };
 
-        return AssertQuery(
+        await AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => strings.Contains(c.String)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !strings.Contains(c.String)));
     }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Parameter_collection_of_strings_Contains_nullable_string(bool async)
+    public virtual async Task Parameter_collection_of_strings_Contains_nullable_string(bool async)
+    {
+        var strings = new[] { "10", "999" };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => strings.Contains(c.NullableString)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !strings.Contains(c.NullableString)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_of_nullable_strings_Contains_string(bool async)
+    {
+        var strings = new[] { "10", null };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => strings.Contains(c.String)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !strings.Contains(c.String)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_of_nullable_strings_Contains_nullable_string(bool async)
     {
         var strings = new[] { "999", null };
 
-        return AssertQuery(
+        await AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => strings.Contains(c.NullableString)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !strings.Contains(c.NullableString)));
     }
+
+    // See more nullability-related tests in NullSemanticsQueryTestBase
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -1223,10 +1223,10 @@ END, [l].[Id], [l0].[Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Req
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [l0].[Id]
 """);
     }
@@ -2336,19 +2336,19 @@ SELECT [t].[Date], [t0].[Id]
 FROM (
     SELECT [l].[Date]
     FROM [LevelOne] AS [l]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l].[Name] IN (
+        SELECT [v].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-        WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+    )
     GROUP BY [l].[Date]
 ) AS [t]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date]
     FROM [LevelOne] AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l0].[Name] IN (
+        SELECT [v0].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
-        WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
+    )
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -2874,10 +2874,10 @@ LEFT JOIN (
 ) AS [t1] ON CASE
     WHEN [t0].[OneToOne_Required_PK_Date] IS NOT NULL AND [t0].[Level1_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t0].[Id0]
 END = [t1].[OneToMany_Required_Inverse3Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]
 """);
     }
@@ -3020,19 +3020,19 @@ SELECT [t].[Date], [t0].[Id]
 FROM (
     SELECT [l].[Date]
     FROM [Level1] AS [l]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l].[Name] IN (
+        SELECT [v].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-        WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+    )
     GROUP BY [l].[Date]
 ) AS [t]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date]
     FROM [Level1] AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l0].[Name] IN (
+        SELECT [v0].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
-        WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
+    )
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -3195,10 +3195,10 @@ SELECT CASE
 END, [l].[Id], [l0].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [l0].[Id]
 """,
             //
@@ -3209,10 +3209,10 @@ SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Na
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [l0].[Id]
 """);
     }
@@ -3748,10 +3748,10 @@ ORDER BY [l].[Id], [t].[Date], [t0].[Name], [t0].[Date]
 
 SELECT [l].[Date]
 FROM [LevelOne] AS [l]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 GROUP BY [l].[Date]
 ORDER BY [l].[Date]
 """,
@@ -3763,19 +3763,19 @@ SELECT [t0].[Id], [t].[Date]
 FROM (
     SELECT [l].[Date]
     FROM [LevelOne] AS [l]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l].[Name] IN (
+        SELECT [v].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-        WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+    )
     GROUP BY [l].[Date]
 ) AS [t]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Date]
     FROM [LevelOne] AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l0].[Name] IN (
+        SELECT [v0].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
-        WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
+    )
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3085,10 +3085,10 @@ WHERE [l0].[Id] IS NOT NULL
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [l0].[Name] NOT IN (
+    SELECT [n].[value]
     FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
-    WHERE [n].[value] = [l0].[Name] OR ([n].[value] IS NULL AND [l0].[Name] IS NULL))
+) OR [l0].[Name] IS NULL
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -5433,10 +5433,10 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [t].[Level2_Name] NOT IN (
+    SELECT [n].[value]
     FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
-    WHERE [n].[value] = [t].[Level2_Name] OR ([n].[value] IS NULL AND [t].[Level2_Name] IS NULL))
+) OR [t].[Level2_Name] IS NULL
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -214,10 +214,10 @@ FROM [Tags] AS [t]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [t].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -238,10 +238,10 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [c].[Location] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -261,10 +261,10 @@ FROM [Tags] AS [t]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [t].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -2102,10 +2102,10 @@ WHERE [c].[Location] = @__value_0
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE EXISTS (
-    SELECT 1
+WHERE [c].[Location] IN (
+    SELECT [c0].[value]
     FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
-    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+)
 """);
     }
 
@@ -3623,15 +3623,15 @@ ORDER BY [g].[Nickname], [t].[Nickname]
 
         AssertSql(
             """
-@__cities_0='["Ephyra",null]' (Size = 4000)
+@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE [g].[SquadId] < 2 AND EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
-    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+WHERE [g].[SquadId] < 2 AND ([c].[Name] IN (
+    SELECT [c0].[value]
+    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+) OR [c].[Name] IS NULL)
 """);
     }
 
@@ -5919,10 +5919,10 @@ SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [g].[Nickname] IN (
+        SELECT [n].[value]
         FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
-        WHERE [n].[value] = [g].[Nickname]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
 """);
@@ -8137,15 +8137,15 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__types_0='[null,1]' (Size = 4000)
+@__types_0_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-WHERE [w0].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
-    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
 
@@ -10184,18 +10184,14 @@ END IN (
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [w].[Name]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) IN (
+    SELECT [w0].[value]
     FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w0]
-    WHERE [w0].[value] = (
-        SELECT TOP(1) [w].[Name]
-        FROM [Weapons] AS [w]
-        WHERE [g].[FullName] = [w].[OwnerFullName]
-        ORDER BY [w].[Id]) OR ([w0].[value] IS NULL AND (
-        SELECT TOP(1) [w].[Name]
-        FROM [Weapons] AS [w]
-        WHERE [g].[FullName] = [w].[OwnerFullName]
-        ORDER BY [w].[Id]) IS NULL))
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -1585,10 +1585,10 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Customers] AS [c0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [c0].[City] IN (
+        SELECT [i].[value]
         FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
-        WHERE [i].[value] = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
+    ) AND [c0].[CustomerID] = [c].[CustomerID])
 """,
             //
             """
@@ -1599,10 +1599,10 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Customers] AS [c0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [c0].[City] IN (
+        SELECT [i].[value]
         FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
-        WHERE [i].[value] = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
+    ) AND [c0].[CustomerID] = [c].[CustomerID])
 """);
     }
 
@@ -2076,10 +2076,10 @@ WHERE [c].[CustomerID] IN (
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [c].[CustomerID] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
-    WHERE [i].[value] = [c].[CustomerID])
+)
 """);
     }
 
@@ -2683,10 +2683,10 @@ WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [c].[CustomerID] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
-    WHERE [i].[value] = [c].[CustomerID])
+)
 """);
     }
 
@@ -2712,10 +2712,10 @@ WHERE [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [c].[CustomerID] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
-    WHERE [i].[value] = [c].[CustomerID])
+)
 """);
     }
 
@@ -2729,10 +2729,10 @@ WHERE NOT EXISTS (
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = N'México D.F.' AND NOT EXISTS (
-    SELECT 1
+WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
-    WHERE [i].[value] = [c].[CustomerID])
+)
 """,
             //
             """
@@ -2740,10 +2740,10 @@ WHERE [c].[City] = N'México D.F.' AND NOT EXISTS (
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = N'México D.F.' AND NOT EXISTS (
-    SELECT 1
+WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
-    WHERE [i].[value] = [c].[CustomerID])
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
@@ -621,19 +621,19 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -969,19 +969,19 @@ ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1365,19 +1365,19 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1844,19 +1844,19 @@ ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
@@ -175,19 +175,19 @@ ORDER BY [c].[CustomerID], [t].[OrderID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -457,19 +457,19 @@ WHERE [o].[OrderID] % 23 = 13
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2058,19 +2058,19 @@ LEFT JOIN (
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2092,19 +2092,19 @@ ORDER BY [t].[c], [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -1508,19 +1508,19 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1542,19 +1542,19 @@ ORDER BY [t].[c], [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1576,19 +1576,19 @@ ORDER BY [t].[c], [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1610,19 +1610,19 @@ ORDER BY [t].[c], [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5087,10 +5087,10 @@ FROM (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -5107,10 +5107,10 @@ END
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
-    WHEN NOT EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] NOT IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -113,10 +113,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN NOT EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] NOT IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -129,19 +129,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1110,10 +1110,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1126,19 +1126,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1557,10 +1557,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1573,19 +1573,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1736,10 +1736,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN NOT EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] NOT IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1752,19 +1752,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -2052,10 +2052,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2068,19 +2068,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2103,10 +2103,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN NOT EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] NOT IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2119,19 +2119,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2154,10 +2154,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2170,19 +2170,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2205,10 +2205,10 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
-    WHEN NOT EXISTS (
-        SELECT 1
+    WHEN [c].[CustomerID] NOT IN (
+        SELECT [l].[value]
         FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2221,19 +2221,19 @@ OFFSET @__p_1 ROWS
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
@@ -621,19 +621,19 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -969,19 +969,19 @@ ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1365,19 +1365,19 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1844,19 +1844,19 @@ ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY CASE
-        WHEN NOT EXISTS (
-            SELECT 1
+        WHEN [c].[CustomerID] NOT IN (
+            SELECT [l].[value]
             FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
-            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
+        ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -2074,10 +2074,10 @@ WHERE [o].[OrderID] = 10274
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE EXISTS (
-    SELECT 1
+WHERE [c].[City] IN (
+    SELECT [c0].[value]
     FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
-    WHERE [c0].[value] = [c].[City] OR ([c0].[value] IS NULL AND [c].[City] IS NULL))
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -910,14 +910,14 @@ INNER JOIN [Entities2] AS [e0] ON [e].[NullableIntA] = [e0].[NullableIntB]
 
         AssertSql(
             """
-@__ids_0='["Foo",null]' (Size = 4000)
+@__ids_0_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
-    WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
+WHERE [e].[NullableStringA] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+) OR [e].[NullableStringA] IS NULL
 """);
     }
 
@@ -927,14 +927,14 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__ids_0='["Foo",null]' (Size = 4000)
+@__ids_0_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
-    WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
+WHERE [e].[NullableStringA] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+) AND [e].[NullableStringA] IS NOT NULL
 """);
     }
 
@@ -948,10 +948,10 @@ WHERE NOT EXISTS (
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [e].[NullableStringA] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
-    WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
+) OR [e].[NullableStringA] IS NULL
 """);
     }
 
@@ -961,14 +961,14 @@ WHERE NOT EXISTS (
 
         AssertSql(
             """
-@__ids_0='[null,"Foo",null,null]' (Size = 4000)
+@__ids_0_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
-    WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
+WHERE [e].[NullableStringA] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+) OR [e].[NullableStringA] IS NULL
 """);
     }
 
@@ -1783,10 +1783,10 @@ END = COALESCE([e0].[NullableBoolA], [e0].[BoolC])
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
+WHERE [e].[NullableIntA] IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+)
 """,
             //
             """
@@ -1794,32 +1794,32 @@ WHERE EXISTS (
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [e].[NullableIntA] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0='[1,2,null]' (Size = 4000)
+@__ids2_0_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+WHERE [e].[NullableIntA] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0='[1,2,null]' (Size = 4000)
+@__ids2_0_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+WHERE [e].[NullableIntA] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+) AND [e].[NullableIntA] IS NOT NULL
 """,
             //
             """
@@ -1857,10 +1857,10 @@ WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
+WHERE [e].[NullableIntA] IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+)
 """,
             //
             """
@@ -1868,32 +1868,32 @@ WHERE EXISTS (
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [e].[NullableIntA] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0='[null]' (Size = 4000)
+@__ids2_0_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+WHERE [e].[NullableIntA] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0='[null]' (Size = 4000)
+@__ids2_0_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+WHERE [e].[NullableIntA] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+) AND [e].[NullableIntA] IS NOT NULL
 """,
             //
             """
@@ -2036,9 +2036,9 @@ WHERE [e].[IntA] NOT IN (1, 2)
 """);
     }
 
-    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_non_nullable_values_with_null(bool async)
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
     {
-        await base.Null_semantics_contains_with_non_nullable_item_and_inline_non_nullable_values_with_null(async);
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(async);
 
         AssertSql(
             """
@@ -2054,9 +2054,9 @@ WHERE [e].[IntA] NOT IN (1, 2)
 """);
     }
 
-    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values(bool async)
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
     {
-        await base.Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values(async);
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(async);
 
         AssertSql(
             """
@@ -2072,9 +2072,9 @@ WHERE [e].[IntA] NOT IN (1, 2) AND ([e].[IntA] <> [e].[NullableIntB] OR [e].[Nul
 """);
     }
 
-    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values_with_null(bool async)
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
     {
-        await base.Null_semantics_contains_with_non_nullable_item_and_inline_nullable_values_with_null(async);
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(async);
 
         AssertSql(
             """
@@ -2108,9 +2108,9 @@ WHERE [e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL
 """);
     }
 
-    public override async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values_with_null(bool async)
+    public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
     {
-        await base.Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values_with_null(async);
+        await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_null(async);
 
         AssertSql(
             """
@@ -2126,9 +2126,9 @@ WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL
 """);
     }
 
-    public override async Task Null_semantics_contains_with_nullable_item_and_inline_nullable_values(bool async)
+    public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
     {
-        await base.Null_semantics_contains_with_nullable_item_and_inline_nullable_values(async);
+        await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(async);
 
         AssertSql(
             """
@@ -2144,9 +2144,9 @@ WHERE ([e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL) AND ([e].
 """);
     }
 
-    public override async Task Null_semantics_contains_with_nullable_item_and_inline_nullable_values_with_null(bool async)
+    public override async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
     {
-        await base.Null_semantics_contains_with_nullable_item_and_inline_nullable_values_with_null(async);
+        await base.Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(async);
 
         AssertSql(
             """
@@ -2264,14 +2264,14 @@ WHERE [e].[IntA] IN (
 """,
             //
             """
-@__ids_0='[1,2,null]' (Size = 4000)
+@__ids_0_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[IntA])
+WHERE [e].[IntA] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+)
 """,
             //
             """
@@ -2290,10 +2290,10 @@ WHERE [e].[IntA] IN (
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [e].[IntA] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[IntA])
+)
 """,
             //
             """
@@ -2312,10 +2312,10 @@ WHERE [e].[IntA] IN (
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
+WHERE [e].[IntA] NOT IN (
+    SELECT [i].[value]
     FROM OPENJSON(@__ids3_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[IntA])
+)
 """,
             //
             """
@@ -2330,14 +2330,14 @@ WHERE [e].[IntA] IN (
 """,
             //
             """
-@__ids4_0='[null]' (Size = 4000)
+@__ids4_0_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__ids4_0) WITH ([value] int '$') AS [i]
-    WHERE [i].[value] = [e].[IntA])
+WHERE [e].[IntA] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids4_0_without_nulls) AS [i]
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -241,15 +241,39 @@ WHERE [p].[Id] NOT IN (2, 999)
     public override Task Parameter_collection_Count(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_Count(async));
 
-    public override async Task Parameter_collection_of_ints_Contains(bool async)
+    public override async Task Parameter_collection_of_ints_Contains_int(bool async)
     {
-        await base.Parameter_collection_of_ints_Contains(async);
+        await base.Parameter_collection_of_ints_Contains_int(async);
 
         AssertSql(
             """
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (10, 999)
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (10, 999)
+""");
+    }
+
+    public override async Task Parameter_collection_of_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (10, 999)
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (10, 999) OR [p].[NullableInt] IS NULL
 """);
     }
 
@@ -262,6 +286,12 @@ WHERE [p].[Int] IN (10, 999)
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (10, 999)
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (10, 999)
 """);
     }
 
@@ -274,18 +304,30 @@ WHERE [p].[Int] IN (10, 999)
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NOT NULL AND [p].[NullableInt] <> 999
 """);
     }
 
-    public override async Task Parameter_collection_of_strings_Contains_non_nullable_string(bool async)
+    public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
-        await base.Parameter_collection_of_strings_Contains_non_nullable_string(async);
+        await base.Parameter_collection_of_strings_Contains_string(async);
 
         AssertSql(
             """
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (N'10', N'999')
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] NOT IN (N'10', N'999')
 """);
     }
 
@@ -297,7 +339,49 @@ WHERE [p].[String] IN (N'10', N'999')
             """
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] IN (N'10', N'999')
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] NOT IN (N'10', N'999') OR [p].[NullableString] IS NULL
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_string(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] = N'10'
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] <> N'10'
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_nullable_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_nullable_string(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IS NULL OR [p].[NullableString] = N'999'
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] IS NOT NULL AND [p].[NullableString] <> N'999'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -247,9 +247,9 @@ WHERE (
 """);
     }
 
-    public override async Task Parameter_collection_of_ints_Contains(bool async)
+    public override async Task Parameter_collection_of_ints_Contains_int(bool async)
     {
-        await base.Parameter_collection_of_ints_Contains(async);
+        await base.Parameter_collection_of_ints_Contains_int(async);
 
         AssertSql(
             """
@@ -261,6 +261,45 @@ WHERE [p].[Int] IN (
     SELECT [i].[value]
     FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
 )
+""",
+            //
+            """
+@__ints_0='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@__ints_0='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+)
+""",
+            //
+            """
+@__ints_0='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+) OR [p].[NullableInt] IS NULL
 """);
     }
 
@@ -278,6 +317,17 @@ WHERE [p].[Int] IN (
     SELECT [n].[value]
     FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
 )
+""",
+            //
+            """
+@__nullableInts_0='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+)
 """);
     }
 
@@ -287,20 +337,31 @@ WHERE [p].[Int] IN (
 
         AssertSql(
             """
-@__nullableInts_0='[null,999]' (Size = 4000)
+@__nullableInts_0_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
-    WHERE [n].[value] = [p].[NullableInt] OR ([n].[value] IS NULL AND [p].[NullableInt] IS NULL))
+WHERE [p].[NullableInt] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+) OR [p].[NullableInt] IS NULL
+""",
+            //
+            """
+@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+) AND [p].[NullableInt] IS NOT NULL
 """);
     }
 
-    public override async Task Parameter_collection_of_strings_Contains_non_nullable_string(bool async)
+    public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
-        await base.Parameter_collection_of_strings_Contains_non_nullable_string(async);
+        await base.Parameter_collection_of_strings_Contains_string(async);
 
         AssertSql(
             """
@@ -309,6 +370,17 @@ WHERE EXISTS (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+)
+""",
+            //
+            """
+@__strings_0='["10","999"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] NOT IN (
     SELECT [s].[value]
     FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
 )
@@ -321,14 +393,81 @@ WHERE [p].[String] IN (
 
         AssertSql(
             """
-@__strings_0='["999",null]' (Size = 4000)
+@__strings_0='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE EXISTS (
-    SELECT 1
+WHERE [p].[NullableString] IN (
+    SELECT [s].[value]
     FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
-    WHERE [s].[value] = [p].[NullableString] OR ([s].[value] IS NULL AND [p].[NullableString] IS NULL))
+)
+""",
+            //
+            """
+@__strings_0='["10","999"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] NOT IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+) OR [p].[NullableString] IS NULL
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_string(async);
+
+        AssertSql(
+            """
+@__strings_0='["10",null]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+)
+""",
+            //
+            """
+@__strings_0_without_nulls='["10"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[String] NOT IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_nullable_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_nullable_string(async);
+
+        AssertSql(
+            """
+@__strings_0_without_nulls='["999"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+) OR [p].[NullableString] IS NULL
+""",
+            //
+            """
+@__strings_0_without_nulls='["999"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableString] NOT IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+) AND [p].[NullableString] IS NOT NULL
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2307,19 +2307,19 @@ SELECT [t].[Date], [t0].[Id]
 FROM (
     SELECT [l].[Date]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l].[Name] IN (
+        SELECT [v].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-        WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+    )
     GROUP BY [l].[Date]
 ) AS [t]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l0].[Name] IN (
+        SELECT [v0].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
-        WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
+    )
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
 """);
@@ -2627,10 +2627,10 @@ END, [l].[Id], [l0].[Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Req
 FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [l0].[Id]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -1876,10 +1876,10 @@ LEFT JOIN (
 ) AS [t1] ON CASE
     WHEN [t0].[OneToOne_Required_PK_Date] IS NOT NULL AND [t0].[Level1_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [t0].[PeriodEnd0] IS NOT NULL AND [t0].[PeriodStart0] IS NOT NULL THEN [t0].[Id0]
 END = [t1].[OneToMany_Required_Inverse3Id]
-WHERE EXISTS (
-    SELECT 1
+WHERE [l].[Name] IN (
+    SELECT [v].[value]
     FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-    WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+)
 ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]
 """);
     }
@@ -3040,19 +3040,19 @@ SELECT [t].[Date], [t0].[Id]
 FROM (
     SELECT [l].[Date]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l].[Name] IN (
+        SELECT [v].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
-        WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
+    )
     GROUP BY [l].[Date]
 ) AS [t]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [l0].[Name] IN (
+        SELECT [v0].[value]
         FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
-        WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
+    )
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -66,10 +66,10 @@ FROM [Tags] AS [t]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [t].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -93,10 +93,10 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [c].[Location] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -119,10 +119,10 @@ FROM [Tags] AS [t]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
-WHERE [t].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
     FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
-    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+)
 """);
     }
 
@@ -1739,15 +1739,15 @@ WHERE [s].[Name] = N'Kilo'
 
         AssertSql(
             """
-@__cities_0='["Ephyra",null]' (Size = 4000)
+@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE [g].[SquadId] < 2 AND EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
-    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+WHERE [g].[SquadId] < 2 AND ([c].[Name] IN (
+    SELECT [c0].[value]
+    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+) OR [c].[Name] IS NULL)
 """);
     }
 
@@ -5582,15 +5582,15 @@ WHERE COALESCE([c].[Location], N'') + N'Added' LIKE N'%Add%'
 
         AssertSql(
             """
-@__types_0='[null,1]' (Size = 4000)
+@__types_0_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-WHERE [w0].[Id] IS NOT NULL AND EXISTS (
-    SELECT 1
-    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
-    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
 
@@ -6666,10 +6666,10 @@ WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 
 SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodStart]
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
-WHERE EXISTS (
-    SELECT 1
+WHERE [c].[Location] IN (
+    SELECT [c0].[value]
     FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
-    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+)
 """);
     }
 
@@ -7980,10 +7980,10 @@ SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [g].[Nickname] IN (
+        SELECT [n].[value]
         FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
-        WHERE [n].[value] = [g].[Nickname]) THEN CAST(1 AS bit)
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
 """);
@@ -10092,18 +10092,14 @@ END IN (
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [w].[Name]
+    FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) IN (
+    SELECT [w0].[value]
     FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w0]
-    WHERE [w0].[value] = (
-        SELECT TOP(1) [w].[Name]
-        FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-        WHERE [g].[FullName] = [w].[OwnerFullName]
-        ORDER BY [w].[Id]) OR ([w0].[value] IS NULL AND (
-        SELECT TOP(1) [w].[Name]
-        FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-        WHERE [g].[FullName] = [w].[OwnerFullName]
-        ORDER BY [w].[Id]) IS NULL))
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -810,10 +810,10 @@ SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthNa
 FROM "Gears" AS "g"
 INNER JOIN "Cities" AS "c" ON "g"."CityOfBirthName" = "c"."Name"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
-WHERE "c"."Location" IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE "c"."Location" IS NOT NULL AND "t"."Id" IN (
+    SELECT "t0"."value"
     FROM json_each(@__tags_0) AS "t0"
-    WHERE "t0"."value" = "t"."Id" OR ("t0"."value" IS NULL AND "t"."Id" IS NULL))
+)
 """);
     }
 
@@ -1178,10 +1178,10 @@ FROM "Weapons" AS "w"
 
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE EXISTS (
-    SELECT 1
+WHERE "c"."Location" IN (
+    SELECT "c0"."value"
     FROM json_each(@__cities_0) AS "c0"
-    WHERE "c0"."value" = "c"."Location" OR ("c0"."value" IS NULL AND "c"."Location" IS NULL))
+)
 """);
     }
 
@@ -1902,10 +1902,10 @@ WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
 SELECT "g"."Nickname", "g"."SquadId", "w"."Name", "w"."Id"
 FROM "Gears" AS "g"
 LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName"
-ORDER BY COALESCE("g"."Nickname" IN (
+ORDER BY "g"."Nickname" IN (
     SELECT "n"."value"
     FROM json_each(@__nicknames_0) AS "n"
-), 0) DESC, "g"."Nickname", "g"."SquadId"
+) DESC, "g"."Nickname", "g"."SquadId"
 """);
     }
 
@@ -2744,15 +2744,15 @@ ORDER BY (
 
         AssertSql(
             """
-@__cities_0='["Ephyra",null]' (Size = 15)
+@__cities_0_without_nulls='["Ephyra"]' (Size = 10)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 LEFT JOIN "Cities" AS "c" ON "g"."AssignedCityName" = "c"."Name"
-WHERE "g"."SquadId" < 2 AND EXISTS (
-    SELECT 1
-    FROM json_each(@__cities_0) AS "c0"
-    WHERE "c0"."value" = "c"."Name" OR ("c0"."value" IS NULL AND "c"."Name" IS NULL))
+WHERE "g"."SquadId" < 2 AND ("c"."Name" IN (
+    SELECT "c0"."value"
+    FROM json_each(@__cities_0_without_nulls) AS "c0"
+) OR "c"."Name" IS NULL)
 """);
     }
 
@@ -3033,15 +3033,15 @@ WHERE COALESCE("w"."Id", 0) = 0
 
         AssertSql(
             """
-@__types_0='[null,1]' (Size = 8)
+@__types_0_without_nulls='[1]' (Size = 3)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
 LEFT JOIN "Weapons" AS "w0" ON "w"."SynergyWithId" = "w0"."Id"
-WHERE "w0"."Id" IS NOT NULL AND EXISTS (
-    SELECT 1
-    FROM json_each(@__types_0) AS "t"
-    WHERE "t"."value" = "w0"."AmmunitionType" OR ("t"."value" IS NULL AND "w0"."AmmunitionType" IS NULL))
+WHERE "w0"."Id" IS NOT NULL AND ("w0"."AmmunitionType" IN (
+    SELECT "t"."value"
+    FROM json_each(@__types_0_without_nulls) AS "t"
+) OR "w0"."AmmunitionType" IS NULL)
 """);
     }
 
@@ -3668,10 +3668,10 @@ FROM "Tags" AS "t"
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
-WHERE "t"."Id" IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE "t"."Id" IS NOT NULL AND "t"."Id" IN (
+    SELECT "t0"."value"
     FROM json_each(@__tags_0) AS "t0"
-    WHERE "t0"."value" = "t"."Id" OR ("t0"."value" IS NULL AND "t"."Id" IS NULL))
+)
 """);
     }
 
@@ -4835,10 +4835,10 @@ FROM "Tags" AS "t"
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank", "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Gears" AS "g"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
-WHERE "t"."Id" IS NOT NULL AND EXISTS (
-    SELECT 1
+WHERE "t"."Id" IS NOT NULL AND "t"."Id" IN (
+    SELECT "t0"."value"
     FROM json_each(@__tags_0) AS "t0"
-    WHERE "t0"."value" = "t"."Id" OR ("t0"."value" IS NULL AND "t"."Id" IS NULL))
+)
 """);
     }
 
@@ -9553,20 +9553,15 @@ END IN (
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE EXISTS (
-    SELECT 1
+WHERE (
+    SELECT "w"."Name"
+    FROM "Weapons" AS "w"
+    WHERE "g"."FullName" = "w"."OwnerFullName"
+    ORDER BY "w"."Id"
+    LIMIT 1) IN (
+    SELECT "w0"."value"
     FROM json_each(@__weapons_0) AS "w0"
-    WHERE "w0"."value" = (
-        SELECT "w"."Name"
-        FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName"
-        ORDER BY "w"."Id"
-        LIMIT 1) OR ("w0"."value" IS NULL AND (
-        SELECT "w"."Name"
-        FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName"
-        ORDER BY "w"."Id"
-        LIMIT 1) IS NULL))
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -81,10 +81,10 @@ public class NorthwindAggregateOperatorsQuerySqliteTest : NorthwindAggregateOper
 @__cities_0='["London","Berlin"]' (Size = 19)
 
 SELECT COUNT(CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN "c"."City" IN (
+        SELECT "c0"."value"
         FROM json_each(@__cities_0) AS "c0"
-        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ) THEN 1
 END)
 FROM "Customers" AS "c"
 GROUP BY "c"."Country"
@@ -100,10 +100,10 @@ GROUP BY "c"."Country"
 @__cities_0='["London","Berlin"]' (Size = 19)
 
 SELECT AVG(CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN "c"."City" IN (
+        SELECT "c0"."value"
         FROM json_each(@__cities_0) AS "c0"
-        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1.0
+    ) THEN 1.0
     ELSE 0.0
 END)
 FROM "Customers" AS "c"
@@ -119,10 +119,10 @@ FROM "Customers" AS "c"
 @__cities_0='["London","Berlin"]' (Size = 19)
 
 SELECT COALESCE(SUM(CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN "c"."City" IN (
+        SELECT "c0"."value"
         FROM json_each(@__cities_0) AS "c0"
-        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ) THEN 1
     ELSE 0
 END), 0)
 FROM "Customers" AS "c"
@@ -139,10 +139,10 @@ FROM "Customers" AS "c"
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE EXISTS (
-    SELECT 1
+WHERE "c"."City" IN (
+    SELECT "c0"."value"
     FROM json_each(@__cities_0) AS "c0"
-    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+)
 """);
     }
 
@@ -156,10 +156,10 @@ WHERE EXISTS (
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE EXISTS (
-    SELECT 1
+WHERE "c"."City" IN (
+    SELECT "c0"."value"
     FROM json_each(@__cities_0) AS "c0"
-    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+)
 """);
     }
 
@@ -172,10 +172,10 @@ WHERE EXISTS (
 @__cities_0='["London","Berlin"]' (Size = 19)
 
 SELECT MAX(CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN "c"."City" IN (
+        SELECT "c0"."value"
         FROM json_each(@__cities_0) AS "c0"
-        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ) THEN 1
     ELSE 0
 END)
 FROM "Customers" AS "c"
@@ -191,10 +191,10 @@ FROM "Customers" AS "c"
 @__cities_0='["London","Berlin"]' (Size = 19)
 
 SELECT MIN(CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN "c"."City" IN (
+        SELECT "c0"."value"
         FROM json_each(@__cities_0) AS "c0"
-        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ) THEN 1
     ELSE 0
 END)
 FROM "Customers" AS "c"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -248,9 +248,9 @@ WHERE (
 """);
     }
 
-    public override async Task Parameter_collection_of_ints_Contains(bool async)
+    public override async Task Parameter_collection_of_ints_Contains_int(bool async)
     {
-        await base.Parameter_collection_of_ints_Contains(async);
+        await base.Parameter_collection_of_ints_Contains_int(async);
 
         AssertSql(
             """
@@ -262,6 +262,45 @@ WHERE "p"."Int" IN (
     SELECT "i"."value"
     FROM json_each(@__ints_0) AS "i"
 )
+""",
+            //
+            """
+@__ints_0='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" NOT IN (
+    SELECT "i"."value"
+    FROM json_each(@__ints_0) AS "i"
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@__ints_0='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" IN (
+    SELECT "i"."value"
+    FROM json_each(@__ints_0) AS "i"
+)
+""",
+            //
+            """
+@__ints_0='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" NOT IN (
+    SELECT "i"."value"
+    FROM json_each(@__ints_0) AS "i"
+) OR "p"."NullableInt" IS NULL
 """);
     }
 
@@ -279,6 +318,17 @@ WHERE "p"."Int" IN (
     SELECT "n"."value"
     FROM json_each(@__nullableInts_0) AS "n"
 )
+""",
+            //
+            """
+@__nullableInts_0='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" NOT IN (
+    SELECT "n"."value"
+    FROM json_each(@__nullableInts_0) AS "n"
+)
 """);
     }
 
@@ -288,20 +338,31 @@ WHERE "p"."Int" IN (
 
         AssertSql(
             """
-@__nullableInts_0='[null,999]' (Size = 10)
+@__nullableInts_0_without_nulls='[999]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE EXISTS (
-    SELECT 1
-    FROM json_each(@__nullableInts_0) AS "n"
-    WHERE "n"."value" = "p"."NullableInt" OR ("n"."value" IS NULL AND "p"."NullableInt" IS NULL))
+WHERE "p"."NullableInt" IN (
+    SELECT "n"."value"
+    FROM json_each(@__nullableInts_0_without_nulls) AS "n"
+) OR "p"."NullableInt" IS NULL
+""",
+            //
+            """
+@__nullableInts_0_without_nulls='[999]' (Size = 5)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" NOT IN (
+    SELECT "n"."value"
+    FROM json_each(@__nullableInts_0_without_nulls) AS "n"
+) AND "p"."NullableInt" IS NOT NULL
 """);
     }
 
-    public override async Task Parameter_collection_of_strings_Contains_non_nullable_string(bool async)
+    public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
-        await base.Parameter_collection_of_strings_Contains_non_nullable_string(async);
+        await base.Parameter_collection_of_strings_Contains_string(async);
 
         AssertSql(
             """
@@ -310,6 +371,17 @@ WHERE EXISTS (
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."String" IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0) AS "s"
+)
+""",
+            //
+            """
+@__strings_0='["10","999"]' (Size = 12)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."String" NOT IN (
     SELECT "s"."value"
     FROM json_each(@__strings_0) AS "s"
 )
@@ -322,14 +394,81 @@ WHERE "p"."String" IN (
 
         AssertSql(
             """
-@__strings_0='["999",null]' (Size = 12)
+@__strings_0='["10","999"]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE EXISTS (
-    SELECT 1
+WHERE "p"."NullableString" IN (
+    SELECT "s"."value"
     FROM json_each(@__strings_0) AS "s"
-    WHERE "s"."value" = "p"."NullableString" OR ("s"."value" IS NULL AND "p"."NullableString" IS NULL))
+)
+""",
+            //
+            """
+@__strings_0='["10","999"]' (Size = 12)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableString" NOT IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0) AS "s"
+) OR "p"."NullableString" IS NULL
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_string(async);
+
+        AssertSql(
+            """
+@__strings_0='["10",null]' (Size = 11)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."String" IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0) AS "s"
+)
+""",
+            //
+            """
+@__strings_0_without_nulls='["10"]' (Size = 6)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."String" NOT IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0_without_nulls) AS "s"
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_strings_Contains_nullable_string(bool async)
+    {
+        await base.Parameter_collection_of_nullable_strings_Contains_nullable_string(async);
+
+        AssertSql(
+            """
+@__strings_0_without_nulls='["999"]' (Size = 7)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableString" IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0_without_nulls) AS "s"
+) OR "p"."NullableString" IS NULL
+""",
+            //
+            """
+@__strings_0_without_nulls='["999"]' (Size = 7)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableString" NOT IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0_without_nulls) AS "s"
+) AND "p"."NullableString" IS NOT NULL
 """);
     }
 


### PR DESCRIPTION
Fixes #32574, backports #32575

### Description

As a result of the primitive collections changes in 8.0, when Contains is used with a nullable item over a parameterized list, a correlated EXISTS subquery is generated in the SQL. This changes the SQL to contain an uncorrelated IN subquery instead.

### Customer impact

The correlated subquery can be the cause of very serious perf regressions; for example, one user reported that a [query](https://github.com/dotnet/efcore/issues/32394#issuecomment-1843578244) that previously completed in milliseconds now times out.

### How found

Customer reported on 8.

### Regression

Yes, considerable perf regression from 7.

### Testing

The new SQL is asserted in tests.

### Risk

Medium, the change has been quirked.
