### PR TITLE
Microsoft.Data.Sqlite.Core issue with multiple Blob colums

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Data.Sqlite
                     }
                 }
 
-                //Debug.Assert(rowIdForOrdinal!=null);
+                Debug.Assert(rowIdForOrdinal!=null);
             }
 
             if (rowIdForOrdinal == null)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -14,8 +14,21 @@ using static SQLitePCL.raw;
 
 namespace Microsoft.Data.Sqlite
 {
+    
     internal class SqliteDataRecord : SqliteValueReader, IDisposable
     {
+        internal class RowIdInfo
+        {
+            public int Ordinal { get; set; }
+            public string TableName { get; set; }
+
+            public RowIdInfo(int ordinal, string tableName)
+            {
+                Ordinal = ordinal;
+                TableName = tableName;
+            }
+        }
+
         private readonly SqliteConnection _connection;
         private readonly Action<int> _addChanges;
         private byte[][]? _blobCache;
@@ -23,7 +36,8 @@ namespace Microsoft.Data.Sqlite
         private Dictionary<string, int>? _columnNameOrdinalCache;
         private string[]? _columnNameCache;
         private bool _stepped;
-        private int? _rowidOrdinal;
+        readonly Dictionary<string, RowIdInfo> RowIds = new Dictionary<string, RowIdInfo>();
+
         private bool _alreadyThrown;
         private bool _alreadyAddedChanges;
 
@@ -310,11 +324,11 @@ namespace Microsoft.Data.Sqlite
             var blobDatabaseName = sqlite3_column_database_name(Handle, ordinal).utf8_to_string();
             var blobTableName = sqlite3_column_table_name(Handle, ordinal).utf8_to_string();
 
-            if (!_rowidOrdinal.HasValue)
+            RowIdInfo? rowIdForOrdinal = null;
+            string rowidkey = $"{blobDatabaseName}_{blobTableName}";
+            if (!RowIds.TryGetValue(rowidkey, out rowIdForOrdinal))
             {
-                _rowidOrdinal = -1;
                 var pkColumns = -1L;
-
                 for (var i = 0; i < FieldCount; i++)
                 {
                     if (i == ordinal)
@@ -337,7 +351,8 @@ namespace Microsoft.Data.Sqlite
                     var columnName = sqlite3_column_origin_name(Handle, i).utf8_to_string();
                     if (columnName == "rowid")
                     {
-                        _rowidOrdinal = i;
+                        rowIdForOrdinal = new RowIdInfo(i, tableName);
+                        RowIds.Add(rowidkey, rowIdForOrdinal);
                         break;
                     }
 
@@ -368,22 +383,23 @@ namespace Microsoft.Data.Sqlite
 
                         if (pkColumns == 1L)
                         {
-                            _rowidOrdinal = i;
+                            rowIdForOrdinal = new RowIdInfo(i, tableName);
+                            RowIds.Add(rowidkey, rowIdForOrdinal);
                             break;
                         }
                     }
                 }
 
-                Debug.Assert(_rowidOrdinal.HasValue);
+                //Debug.Assert(rowIdForOrdinal!=null);
             }
 
-            if (_rowidOrdinal.Value < 0)
+            if (rowIdForOrdinal == null)
             {
                 return new MemoryStream(GetCachedBlob(ordinal), false);
             }
 
             var blobColumnName = sqlite3_column_origin_name(Handle, ordinal).utf8_to_string();
-            var rowid = GetInt64(_rowidOrdinal.Value);
+            var rowid = GetInt64(rowIdForOrdinal.Ordinal);
 
             return new SqliteBlob(_connection, blobDatabaseName, blobTableName, blobColumnName, rowid, readOnly: true);
         }


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x ] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - SqliteDataRecord was able to handle only one rowid
        - added RowIdInfo containing both Ordinal and Table to wich the ordinal is referred to
		- in GetStream function rowid is cached but with reference to the referenced table
		- now it is possible to handle sql satements with joins and multiple rowids and tables
		- Test case added and verified

Fixes #32747
```
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Code follows the same patterns and style as existing code in this repo

