### PR TITLE
Stop stripping new lines from migration script literals

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1377,11 +1377,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         var batchBuilder = new StringBuilder();
         foreach (var line in preBatched)
         {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
-
             var trimmed = line.TrimStart();
             if (trimmed.StartsWith("GO", StringComparison.OrdinalIgnoreCase)
                 && (trimmed.Length == 2

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -72,7 +72,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
             x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
             x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
-            x => Assert.Equal("00000000000004_Migration4", x.MigrationId));
+            x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -144,7 +145,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
             x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
             x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
-            x => Assert.Equal("00000000000004_Migration4", x.MigrationId));
+            x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -346,6 +348,7 @@ public abstract class
     public class Foo
     {
         public int Id { get; set; }
+        public string Description { get; set; }
     }
 
     [DbContext(typeof(MigrationsContext))]
@@ -359,7 +362,7 @@ public abstract class
             migrationBuilder
                 .CreateTable(
                     name: "Table1",
-                    columns: x => new { Id = x.Column<int>(), Foo = x.Column<int>() })
+                    columns: x => new { Id = x.Column<int>(), Foo = x.Column<int>(), Description = x.Column<string>() })
                 .PrimaryKey(
                     name: "PK_Table1",
                     columns: x => x.Id);
@@ -439,6 +442,27 @@ public abstract class
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+        }
+    }
+
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("00000000000005_Migration5")]
+    private class Migration5 : Migration
+    {
+        public const string TestValue = """
+            Value With
+
+            Empty Lines
+            """;
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', '{TestValue}')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -73,7 +73,31 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
             x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
             x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
-            x => Assert.Equal("00000000000005_Migration5", x.MigrationId));
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
+            x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
+            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
+    }
+
+    [ConditionalFact]
+    public virtual void Can_apply_range_of_migrations()
+    {
+        using var db = Fixture.CreateContext();
+        db.Database.EnsureDeleted();
+
+        GiveMeSomeTime(db);
+
+        var migrator = db.GetService<IMigrator>();
+        migrator.Migrate("Migration6");
+
+        var history = db.GetService<IHistoryRepository>();
+        Assert.Collection(
+            history.GetAppliedMigrations(),
+            x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+            x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
+            x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
+            x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
+            x => Assert.Equal("00000000000006_Migration6", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -101,9 +125,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
 
         GiveMeSomeTime(db);
 
-        db.Database.Migrate();
-
         var migrator = db.GetService<IMigrator>();
+        migrator.Migrate("Migration5");
         migrator.Migrate(Migration.InitialDatabase);
 
         var history = db.GetService<IHistoryRepository>();
@@ -118,15 +141,17 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
 
         GiveMeSomeTime(db);
 
-        db.Database.Migrate();
-
         var migrator = db.GetService<IMigrator>();
-        migrator.Migrate("Migration1");
+        migrator.Migrate("Migration5");
+        migrator.Migrate("Migration4");
 
         var history = db.GetService<IHistoryRepository>();
         Assert.Collection(
             history.GetAppliedMigrations(),
-            x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
+            x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+            x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
+            x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
+            x => Assert.Equal("00000000000004_Migration4", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -146,7 +171,9 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
             x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
             x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
-            x => Assert.Equal("00000000000005_Migration5", x.MigrationId));
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
+            x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
+            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -458,6 +485,53 @@ public abstract class
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', '{TestValue}')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("00000000000006_Migration6")]
+    private class Migration6 : Migration
+    {
+        public const string TestValue = """
+            GO
+            Value With
+
+            Empty Lines
+            """;
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', '{TestValue}')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("00000000000007_Migration7")]
+    private class Migration7 : Migration
+    {
+        public const string TestValue = """
+            GO
+            Value With
+
+            GO
+
+            Empty Lines
+            GO
+            """;
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', '{TestValue}')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Identity30.Data;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     public class MigrationsInfrastructureSqlServerTest(MigrationsInfrastructureSqlServerTest.MigrationsInfrastructureSqlServerFixture fixture)
         : MigrationsInfrastructureTestBase<MigrationsInfrastructureSqlServerTest.MigrationsInfrastructureSqlServerFixture>(fixture)
     {
+        public override void Can_apply_all_migrations() // Issue #32826
+            => Assert.Throws<SqlException>(() => base.Can_apply_all_migrations());
+
+        public override Task Can_apply_all_migrations_async() // Issue #32826
+            => Assert.ThrowsAsync<SqlException>(() => base.Can_apply_all_migrations_async());
+
         public override void Can_generate_migration_from_initial_database_to_initial()
         {
             base.Can_generate_migration_from_initial_database_to_initial();
@@ -166,6 +173,42 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+Value With
+
+Empty Lines')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000006_Migration6', N'7.0.0-test');
+GO
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+Value With
+
+GO
+
+
+Empty Lines
+GO')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+GO
+
+COMMIT;
+GO
+
 
 """,
                 Sql,
@@ -250,6 +293,30 @@ GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000005_Migration5', N'7.0.0-test');
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+Value With
+
+Empty Lines')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000006_Migration6', N'7.0.0-test');
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+Value With
+
+GO
+
+
+Empty Lines
+GO')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000007_Migration7', N'7.0.0-test');
 GO
 
 
@@ -484,6 +551,72 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000006_Migration6'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+    Value With
+
+    Empty Lines')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000006_Migration6'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000006_Migration6', N'7.0.0-test');
+END;
+GO
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+    Value With
+
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+
+    Empty Lines
+    GO')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+END;
+GO
+
+COMMIT;
+GO
+
 
 """,
                 Sql,
@@ -633,6 +766,60 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000005_Migration5', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000006_Migration6'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+    Value With
+
+    Empty Lines')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000006_Migration6'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000006_Migration6', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+    Value With
+
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+
+    Empty Lines
+    GO')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000007_Migration7'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000007_Migration7', N'7.0.0-test');
 END;
 GO
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -78,6 +78,7 @@ GO
 CREATE TABLE [Table1] (
     [Id] int NOT NULL,
     [Foo] int NOT NULL,
+    [Description] nvarchar(max) NOT NULL,
     CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
 );
 GO
@@ -145,6 +146,21 @@ GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+GO
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+Empty Lines')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 GO
 
 COMMIT;
@@ -175,6 +191,7 @@ GO
 CREATE TABLE [Table1] (
     [Id] int NOT NULL,
     [Foo] int NOT NULL,
+    [Description] nvarchar(max) NOT NULL,
     CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
 );
 GO
@@ -224,6 +241,15 @@ GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+GO
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+Empty Lines')
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 GO
 
 
@@ -309,6 +335,7 @@ BEGIN
     CREATE TABLE [Table1] (
         [Id] int NOT NULL,
         [Foo] int NOT NULL,
+        [Description] nvarchar(max) NOT NULL,
         CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
     );
 END;
@@ -424,6 +451,33 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+END;
+GO
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000005_Migration5'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+    Empty Lines')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000005_Migration5'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 END;
 GO
 
@@ -460,6 +514,7 @@ BEGIN
     CREATE TABLE [Table1] (
         [Id] int NOT NULL,
         [Foo] int NOT NULL,
+        [Description] nvarchar(max) NOT NULL,
         CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
     );
 END;
@@ -557,6 +612,27 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000005_Migration5'
+)
+BEGIN
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+    Empty Lines')
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000005_Migration5'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 END;
 GO
 

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -102,6 +102,33 @@ VALUES ('00000000000005_Migration5', '7.0.0-test');
 
 COMMIT;
 
+BEGIN TRANSACTION;
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+Value With
+
+Empty Lines')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000006_Migration6', '7.0.0-test');
+
+COMMIT;
+
+BEGIN TRANSACTION;
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+Value With
+
+GO
+
+Empty Lines
+GO')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000007_Migration7', '7.0.0-test');
+
+COMMIT;
+
 
 """,
                 Sql,
@@ -145,6 +172,25 @@ Empty Lines')
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000005_Migration5', '7.0.0-test');
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+Value With
+
+Empty Lines')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000006_Migration6', '7.0.0-test');
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+Value With
+
+GO
+
+Empty Lines
+GO')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000007_Migration7', '7.0.0-test');
 
 
 """,

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -59,7 +59,8 @@ BEGIN TRANSACTION;
 
 CREATE TABLE "Table1" (
     "Id" INTEGER NOT NULL CONSTRAINT "PK_Table1" PRIMARY KEY,
-    "Foo" INTEGER NOT NULL
+    "Foo" INTEGER NOT NULL,
+    "Description" TEXT NOT NULL
 );
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
@@ -87,6 +88,17 @@ BEGIN TRANSACTION;
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
+
+COMMIT;
+
+BEGIN TRANSACTION;
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+Empty Lines')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000005_Migration5', '7.0.0-test');
 
 COMMIT;
 
@@ -109,7 +121,8 @@ CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
 
 CREATE TABLE "Table1" (
     "Id" INTEGER NOT NULL CONSTRAINT "PK_Table1" PRIMARY KEY,
-    "Foo" INTEGER NOT NULL
+    "Foo" INTEGER NOT NULL,
+    "Description" TEXT NOT NULL
 );
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
@@ -125,6 +138,13 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+
+Empty Lines')
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000005_Migration5', '7.0.0-test');
 
 
 """,


### PR DESCRIPTION
Fixes #32730

Will port to 8.0 for patch after merge.
