### PR TITLE
[release/8.0] Don't discover DbFunctions when building ad-hoc model

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -185,6 +186,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IRelationalParameterBasedSqlProcessorFactory, RelationalParameterBasedSqlProcessorFactory>();
         TryAdd<IRelationalQueryStringFactory, RelationalQueryStringFactory>();
         TryAdd<IQueryCompilationContextFactory, RelationalQueryCompilationContextFactory>();
+        TryAdd<IAdHocMapper, RelationalAdHocMapper>();
 
         ServiceCollectionMap.GetInfrastructure()
             .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()

--- a/src/EFCore.Relational/Metadata/Internal/RelationalAdHocMapper.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalAdHocMapper.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+#pragma warning disable EF1001 // AdHocMapper should be made public
+public class RelationalAdHocMapper : AdHocMapper
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RelationalAdHocMapper(
+        IModel model,
+        ModelCreationDependencies modelCreationDependencies)
+        : base(model, modelCreationDependencies)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override ConventionSet BuildConventionSet()
+    {
+        var conventionSet = base.BuildConventionSet();
+        conventionSet.Remove(typeof(RelationalDbFunctionAttributeConvention));
+        conventionSet.Remove(typeof(TableNameFromDbSetConvention));
+        conventionSet.Remove(typeof(TableValuedDbFunctionConvention));
+        return conventionSet;
+    }
+}
+#pragma warning restore EF1001

--- a/src/EFCore.Relational/Metadata/Internal/RelationalAdHocMapper.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalAdHocMapper.cs
@@ -12,6 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 #pragma warning disable EF1001 // AdHocMapper should be made public
 public class RelationalAdHocMapper : AdHocMapper
 {
+    private static readonly bool UseOldBehavior32680 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32680", out var enabled32680) && enabled32680;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -33,6 +36,11 @@ public class RelationalAdHocMapper : AdHocMapper
     /// </summary>
     public override ConventionSet BuildConventionSet()
     {
+        if (UseOldBehavior32680)
+        {
+            return base.BuildConventionSet();
+        }
+
         var conventionSet = base.BuildConventionSet();
         conventionSet.Remove(typeof(RelationalDbFunctionAttributeConvention));
         conventionSet.Remove(typeof(TableNameFromDbSetConvention));

--- a/src/EFCore/Metadata/Internal/AdHocMapper.cs
+++ b/src/EFCore/Metadata/Internal/AdHocMapper.cs
@@ -29,43 +29,46 @@ public class AdHocMapper : IAdHocMapper
         _modelCreationDependencies = modelCreationDependencies;
     }
 
-    private ConventionSet ConventionSet
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ConventionSet BuildConventionSet()
     {
-        get
-        {
-            if (_conventionSet == null)
-            {
-                _conventionSet = _modelCreationDependencies.ConventionSetBuilder.CreateConventionSet();
-                _conventionSet.Remove(typeof(DbSetFindingConvention));
-                _conventionSet.Remove(typeof(RelationshipDiscoveryConvention));
-                _conventionSet.Remove(typeof(KeyDiscoveryConvention));
-                _conventionSet.Remove(typeof(CascadeDeleteConvention));
-                _conventionSet.Remove(typeof(ChangeTrackingStrategyConvention));
-                _conventionSet.Remove(typeof(DeleteBehaviorAttributeConvention));
-                _conventionSet.Remove(typeof(ForeignKeyAttributeConvention));
-                _conventionSet.Remove(typeof(ForeignKeyIndexConvention));
-                _conventionSet.Remove(typeof(ForeignKeyPropertyDiscoveryConvention));
-                _conventionSet.Remove(typeof(IndexAttributeConvention));
-                _conventionSet.Remove(typeof(KeyAttributeConvention));
-                _conventionSet.Remove(typeof(KeylessAttributeConvention));
-                _conventionSet.Remove(typeof(ManyToManyJoinEntityTypeConvention));
-                _conventionSet.Remove(typeof(RequiredNavigationAttributeConvention));
-                _conventionSet.Remove(typeof(NavigationBackingFieldAttributeConvention));
-                _conventionSet.Remove(typeof(InversePropertyAttributeConvention));
-                _conventionSet.Remove(typeof(NavigationEagerLoadingConvention));
-                _conventionSet.Remove(typeof(NonNullableNavigationConvention));
-                _conventionSet.Remove(typeof(NotMappedTypeAttributeConvention));
-                _conventionSet.Remove(typeof(OwnedAttributeConvention));
-                _conventionSet.Remove(typeof(QueryFilterRewritingConvention));
-                _conventionSet.Remove(typeof(ServicePropertyDiscoveryConvention));
-                _conventionSet.Remove(typeof(ValueGenerationConvention));
-                _conventionSet.Remove(typeof(BaseTypeDiscoveryConvention));
-                _conventionSet.Remove(typeof(DiscriminatorConvention));
-            }
+        var conventionSet = _modelCreationDependencies.ConventionSetBuilder.CreateConventionSet();
+        conventionSet.Remove(typeof(DbSetFindingConvention));
+        conventionSet.Remove(typeof(RelationshipDiscoveryConvention));
+        conventionSet.Remove(typeof(KeyDiscoveryConvention));
+        conventionSet.Remove(typeof(CascadeDeleteConvention));
+        conventionSet.Remove(typeof(ChangeTrackingStrategyConvention));
+        conventionSet.Remove(typeof(DeleteBehaviorAttributeConvention));
+        conventionSet.Remove(typeof(ForeignKeyAttributeConvention));
+        conventionSet.Remove(typeof(ForeignKeyIndexConvention));
+        conventionSet.Remove(typeof(ForeignKeyPropertyDiscoveryConvention));
+        conventionSet.Remove(typeof(IndexAttributeConvention));
+        conventionSet.Remove(typeof(KeyAttributeConvention));
+        conventionSet.Remove(typeof(KeylessAttributeConvention));
+        conventionSet.Remove(typeof(ManyToManyJoinEntityTypeConvention));
+        conventionSet.Remove(typeof(RequiredNavigationAttributeConvention));
+        conventionSet.Remove(typeof(NavigationBackingFieldAttributeConvention));
+        conventionSet.Remove(typeof(InversePropertyAttributeConvention));
+        conventionSet.Remove(typeof(NavigationEagerLoadingConvention));
+        conventionSet.Remove(typeof(NonNullableNavigationConvention));
+        conventionSet.Remove(typeof(NotMappedTypeAttributeConvention));
+        conventionSet.Remove(typeof(OwnedAttributeConvention));
+        conventionSet.Remove(typeof(QueryFilterRewritingConvention));
+        conventionSet.Remove(typeof(ServicePropertyDiscoveryConvention));
+        conventionSet.Remove(typeof(ValueGenerationConvention));
+        conventionSet.Remove(typeof(BaseTypeDiscoveryConvention));
+        conventionSet.Remove(typeof(DiscriminatorConvention));
 
-            return _conventionSet;
-        }
+        return conventionSet;
     }
+
+    private ConventionSet ConventionSet
+        => (_conventionSet ??= BuildConventionSet());
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to


### PR DESCRIPTION
Fixes #32680
Port of #32790

### Description

Raw SQL queries for unmapped types will fail if a DbFunction is registered on the DbContext and the referenced entity type does not map by convention.

### Customer impact

Raw SQL queries will throw in this scenario.

### How found

Customer reported on 8.

### Regression

No. Raw SQL queries for unmapped types is a new feature in 8.0.

### Testing

Tests added.

### Risk

Low. Quirked.

