### PR TITLE
Make TableExpressionBase.Alias immutable 

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -68,6 +68,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 complexType);
 
         /// <summary>
+        ///     Join expressions have no aliases; set the alias on the enclosed table expression.
+        /// </summary>
+        public static string CannotSetAliasOnJoin
+            => GetString("CannotSetAliasOnJoin");
+
+        /// <summary>
         ///     The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.
         /// </summary>
         public static string CannotTranslateNonConstantNewArrayExpression(object? newArrayExpression)
@@ -1340,6 +1346,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NoActiveTransaction");
 
         /// <summary>
+        ///     No alias is defined on table: '{table}'
+        /// </summary>
+        public static string NoAliasOnTable(object? table)
+            => string.Format(
+                GetString("NoAliasOnTable", nameof(table)),
+                table);
+
+        /// <summary>
         ///     Cannot create a DbCommand for a non-relational query.
         /// </summary>
         public static string NoDbCommand
@@ -2046,7 +2060,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -136,6 +136,9 @@
   <data name="CannotProjectNullableComplexType" xml:space="preserve">
     <value>You are attempting to project out complex type '{complexType}' via an optional navigation; that is currently not supported. Either project out the complex type in a non-optional context, or project the containing entity type along with the complex type.</value>
   </data>
+  <data name="CannotSetAliasOnJoin" xml:space="preserve">
+    <value>Join expressions have no aliases; set the alias on the enclosed table expression.</value>
+  </data>
   <data name="CannotTranslateNonConstantNewArrayExpression" xml:space="preserve">
     <value>The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.</value>
   </data>
@@ -926,6 +929,9 @@
   </data>
   <data name="NoActiveTransaction" xml:space="preserve">
     <value>The connection does not have any active transactions.</value>
+  </data>
+  <data name="NoAliasOnTable" xml:space="preserve">
+    <value>No alias is defined on table: '{table}'.</value>
   </data>
   <data name="NoDbCommand" xml:space="preserve">
     <value>Cannot create a DbCommand for a non-relational query.</value>

--- a/src/EFCore.Relational/Query/Internal/TpcTablesExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TpcTablesExpression.cs
@@ -34,7 +34,7 @@ public sealed class TpcTablesExpression : TableExpressionBase
         string? alias,
         IEntityType entityType,
         IReadOnlyList<SelectExpression> subSelectExpressions,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, annotations)
     {
         EntityType = entityType;
@@ -47,12 +47,8 @@ public sealed class TpcTablesExpression : TableExpressionBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [NotNull]
-    public override string? Alias
-    {
-        get => base.Alias!;
-        internal set => base.Alias = value;
-    }
+    public override string Alias
+        => base.Alias!;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -86,7 +82,7 @@ public sealed class TpcTablesExpression : TableExpressionBase
 
         Check.DebugAssert(subSelectExpressions.Count > 0, "TPC must have at least 1 table selected.");
 
-        return new TpcTablesExpression(Alias, EntityType, subSelectExpressions, GetAnnotations());
+        return new TpcTablesExpression(Alias, EntityType, subSelectExpressions, Annotations);
     }
 
     /// <summary>
@@ -105,8 +101,12 @@ public sealed class TpcTablesExpression : TableExpressionBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new TpcTablesExpression(Alias, EntityType, SelectExpressions, annotations);
+    protected override TpcTablesExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, EntityType, SelectExpressions, annotations);
+
+    /// <inheritdoc />
+    public override TpcTablesExpression WithAlias(string newAlias)
+        => new(newAlias, EntityType, SelectExpressions, Annotations);
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -191,14 +191,17 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     {
         var selectExpression = deleteExpression.SelectExpression;
 
-        if (selectExpression.Offset == null
-            && selectExpression.Limit == null
-            && selectExpression.Having == null
-            && selectExpression.Orderings.Count == 0
-            && selectExpression.GroupBy.Count == 0
-            && selectExpression.Tables.Count == 1
-            && selectExpression.Tables[0] == deleteExpression.Table
-            && selectExpression.Projection.Count == 0)
+        if (selectExpression is
+            {
+                Tables: [var table],
+                GroupBy: [],
+                Having: null,
+                Projection: [],
+                Orderings: [],
+                Offset: null,
+                Limit: null
+            }
+            && table.Equals(deleteExpression.Table))
         {
             _relationalCommandBuilder.Append("DELETE FROM ");
             Visit(deleteExpression.Table);
@@ -1349,12 +1352,15 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     {
         var selectExpression = updateExpression.SelectExpression;
 
-        if (selectExpression.Offset == null
-            && selectExpression.Limit == null
-            && selectExpression.Having == null
-            && selectExpression.Orderings.Count == 0
-            && selectExpression.GroupBy.Count == 0
-            && selectExpression.Projection.Count == 0
+        if (selectExpression is
+            {
+                Offset: null,
+                Limit: null,
+                Having: null,
+                Orderings: [],
+                GroupBy: [],
+                Projection: [],
+            }
             && (selectExpression.Tables.Count == 1
                 || !ReferenceEquals(selectExpression.Tables[0], updateExpression.Table)
                 || selectExpression.Tables[1] is InnerJoinExpression

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -23,7 +23,7 @@ public class CrossApplyExpression : JoinExpressionBase
     {
     }
 
-    private CrossApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
+    private CrossApplyExpression(TableExpressionBase table, IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(table, prunable: false, annotations)
     {
     }
@@ -40,12 +40,12 @@ public class CrossApplyExpression : JoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override CrossApplyExpression Update(TableExpressionBase table)
         => table != Table
-            ? new CrossApplyExpression(table, GetAnnotations())
+            ? new CrossApplyExpression(table, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new CrossApplyExpression(Table, GetAnnotations());
+    protected override CrossApplyExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Table, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
@@ -23,7 +23,7 @@ public class CrossJoinExpression : JoinExpressionBase
     {
     }
 
-    private CrossJoinExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
+    private CrossJoinExpression(TableExpressionBase table, IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(table, prunable: false, annotations)
     {
     }
@@ -40,12 +40,12 @@ public class CrossJoinExpression : JoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override CrossJoinExpression Update(TableExpressionBase table)
         => table != Table
-            ? new CrossJoinExpression(table, GetAnnotations())
+            ? new CrossJoinExpression(table, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new CrossJoinExpression(Table, annotations);
+    protected override CrossJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Table, Annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
@@ -64,20 +64,21 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
         var selectExpression = (SelectExpression)visitor.Visit(SelectExpression);
-
-        return Update(selectExpression);
+        var table = (TableExpression)visitor.Visit(Table);
+        return Update(table, selectExpression);
     }
 
     /// <summary>
     ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
     ///     return this expression.
     /// </summary>
+    /// <param name="table">The <see cref="Table" /> property of the result.</param>
     /// <param name="selectExpression">The <see cref="SelectExpression" /> property of the result.</param>
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
-    public DeleteExpression Update(SelectExpression selectExpression)
-        => selectExpression != SelectExpression
-            ? new DeleteExpression(Table, selectExpression, Tags)
-            : this;
+    public DeleteExpression Update(TableExpression table, SelectExpression selectExpression)
+        => table == Table && selectExpression == SelectExpression
+            ? this
+            : new DeleteExpression(table, selectExpression, Tags);
 
     /// <inheritdoc />
     public void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -35,7 +35,7 @@ public class ExceptExpression : SetOperationBase
         SelectExpression source1,
         SelectExpression source2,
         bool distinct,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, source1, source2, distinct, annotations)
     {
     }
@@ -58,12 +58,12 @@ public class ExceptExpression : SetOperationBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override ExceptExpression Update(SelectExpression source1, SelectExpression source2)
         => source1 != Source1 || source2 != Source2
-            ? new ExceptExpression(Alias, source1, source2, IsDistinct, GetAnnotations())
+            ? new ExceptExpression(Alias, source1, source2, IsDistinct, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new ExceptExpression(Alias, Source1, Source2, IsDistinct, annotations);
+    protected override ExceptExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, Source1, Source2, IsDistinct, annotations);
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
@@ -72,6 +72,10 @@ public class ExceptExpression : SetOperationBase
             (SelectExpression)cloningExpressionVisitor.Visit(Source1),
             (SelectExpression)cloningExpressionVisitor.Visit(Source2),
             IsDistinct);
+
+    /// <inheritdoc />
+    public override ExceptExpression WithAlias(string newAlias)
+        => new(newAlias, Source1, Source2, IsDistinct);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -54,7 +54,7 @@ public class FromSqlExpression : TableExpressionBase, ITableBasedExpression
         ITableBase? tableBase,
         string sql,
         Expression arguments,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, annotations)
     {
         Table = tableBase;
@@ -65,12 +65,8 @@ public class FromSqlExpression : TableExpressionBase, ITableBasedExpression
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>
-    [NotNull]
-    public override string? Alias
-    {
-        get => base.Alias!;
-        internal set => base.Alias = value;
-    }
+    public override string Alias
+        => base.Alias!;
 
     /// <summary>
     ///     The user-provided custom SQL for the table source.
@@ -95,12 +91,16 @@ public class FromSqlExpression : TableExpressionBase, ITableBasedExpression
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public virtual FromSqlExpression Update(Expression arguments)
         => arguments != Arguments
-            ? new FromSqlExpression(Alias, Table, Sql, arguments, GetAnnotations())
+            ? new FromSqlExpression(Alias, Table, Sql, arguments, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new FromSqlExpression(Alias, Table, Sql, Arguments, annotations);
+    protected override FromSqlExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, Table, Sql, Arguments, annotations);
+
+    /// <inheritdoc />
+    public override FromSqlExpression WithAlias(string newAlias)
+        => new(newAlias, Table, Sql, Arguments, Annotations);
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -108,7 +108,7 @@ public class FromSqlExpression : TableExpressionBase, ITableBasedExpression
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningVisitor)
-        => new FromSqlExpression(alias!, Table, Sql, Arguments, GetAnnotations());
+        => new FromSqlExpression(alias!, Table, Sql, Arguments, Annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -29,7 +29,7 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
         TableExpressionBase table,
         SqlExpression joinPredicate,
         bool prunable,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(table, joinPredicate, prunable, annotations)
     {
     }
@@ -43,7 +43,7 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override InnerJoinExpression Update(TableExpressionBase table, SqlExpression joinPredicate)
         => table != Table || joinPredicate != JoinPredicate
-            ? new InnerJoinExpression(table, joinPredicate, IsPrunable, GetAnnotations())
+            ? new InnerJoinExpression(table, joinPredicate, IsPrunable, Annotations)
             : this;
 
     /// <summary>
@@ -54,12 +54,12 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override InnerJoinExpression Update(TableExpressionBase table)
         => table != Table
-            ? new InnerJoinExpression(table, JoinPredicate, IsPrunable, GetAnnotations())
+            ? new InnerJoinExpression(table, JoinPredicate, IsPrunable, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new InnerJoinExpression(Table, JoinPredicate, IsPrunable, annotations);
+    protected override InnerJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Table, JoinPredicate, IsPrunable, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -35,7 +35,7 @@ public class IntersectExpression : SetOperationBase
         SelectExpression source1,
         SelectExpression source2,
         bool distinct,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, source1, source2, distinct, annotations)
     {
     }
@@ -58,12 +58,12 @@ public class IntersectExpression : SetOperationBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override IntersectExpression Update(SelectExpression source1, SelectExpression source2)
         => source1 != Source1 || source2 != Source2
-            ? new IntersectExpression(Alias, source1, source2, IsDistinct, GetAnnotations())
+            ? new IntersectExpression(Alias, source1, source2, IsDistinct, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new IntersectExpression(Alias, Source1, Source2, IsDistinct, annotations);
+    protected override IntersectExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, Source1, Source2, IsDistinct, annotations);
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
@@ -72,6 +72,10 @@ public class IntersectExpression : SetOperationBase
             (SelectExpression)cloningExpressionVisitor.Visit(Source1),
             (SelectExpression)cloningExpressionVisitor.Visit(Source2),
             IsDistinct);
+
+    /// <inheritdoc />
+    public override IntersectExpression WithAlias(string newAlias)
+        => new(newAlias, Source1, Source2, IsDistinct);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/JoinExpressionBase.cs
@@ -20,7 +20,7 @@ public abstract class JoinExpressionBase : TableExpressionBase
     /// <param name="table">A table source to join with.</param>
     /// <param name="prunable">Whether this join expression may be pruned if nothing references a column on it.</param>
     /// <param name="annotations">A collection of annotations associated with this expression.</param>
-    protected JoinExpressionBase(TableExpressionBase table, bool prunable, IEnumerable<IAnnotation>? annotations = null)
+    protected JoinExpressionBase(TableExpressionBase table, bool prunable, IReadOnlyDictionary<string, IAnnotation>? annotations = null)
         : base(alias: null, annotations)
     {
         Table = table;
@@ -51,6 +51,13 @@ public abstract class JoinExpressionBase : TableExpressionBase
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
         => (TableExpressionBase)VisitChildren(cloningExpressionVisitor);
+
+    /// <summary>
+    ///     The implementation of <see cref="WithAlias" /> for join expressions always throws, since the alias on joins is always
+    ///     <see langword="null" />. Set the alias on the enclosed table expression instead.
+    /// </summary>
+    public override TableExpressionBase WithAlias(string newAlias)
+        => throw new InvalidOperationException(RelationalStrings.CannotSetAliasOnJoin);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -29,7 +29,7 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
         TableExpressionBase table,
         SqlExpression joinPredicate,
         bool prunable,
-        IEnumerable<IAnnotation>? annotations = null)
+        IReadOnlyDictionary<string, IAnnotation>? annotations = null)
         : base(table, joinPredicate, prunable, annotations)
     {
     }
@@ -43,7 +43,7 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override LeftJoinExpression Update(TableExpressionBase table, SqlExpression joinPredicate)
         => table != Table || joinPredicate != JoinPredicate
-            ? new LeftJoinExpression(table, joinPredicate, IsPrunable, GetAnnotations())
+            ? new LeftJoinExpression(table, joinPredicate, IsPrunable, Annotations)
             : this;
 
     /// <summary>
@@ -54,12 +54,12 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override LeftJoinExpression Update(TableExpressionBase table)
         => table != Table
-            ? new LeftJoinExpression(table, JoinPredicate, IsPrunable, GetAnnotations())
+            ? new LeftJoinExpression(table, JoinPredicate, IsPrunable, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new LeftJoinExpression(Table, JoinPredicate, IsPrunable, annotations);
+    protected override LeftJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Table, JoinPredicate, IsPrunable, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -23,7 +23,7 @@ public class OuterApplyExpression : JoinExpressionBase
     {
     }
 
-    private OuterApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
+    private OuterApplyExpression(TableExpressionBase table, IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(table, prunable: false, annotations)
     {
     }
@@ -40,12 +40,12 @@ public class OuterApplyExpression : JoinExpressionBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override OuterApplyExpression Update(TableExpressionBase table)
         => table != Table
-            ? new OuterApplyExpression(table, GetAnnotations())
+            ? new OuterApplyExpression(table, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new OuterApplyExpression(Table, annotations);
+    protected override OuterApplyExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Table, annotations);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/PredicateJoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/PredicateJoinExpressionBase.cs
@@ -25,7 +25,7 @@ public abstract class PredicateJoinExpressionBase : JoinExpressionBase
         TableExpressionBase table,
         SqlExpression joinPredicate,
         bool prunable,
-        IEnumerable<IAnnotation>? annotations = null)
+        IReadOnlyDictionary<string, IAnnotation>? annotations = null)
         : base(table, prunable, annotations)
     {
         JoinPredicate = joinPredicate;

--- a/src/EFCore.Relational/Query/SqlExpressions/SetOperationBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SetOperationBase.cs
@@ -45,7 +45,7 @@ public abstract class SetOperationBase : TableExpressionBase
         SelectExpression source1,
         SelectExpression source2,
         bool distinct,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, annotations)
     {
         IsDistinct = distinct;
@@ -56,12 +56,8 @@ public abstract class SetOperationBase : TableExpressionBase
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>
-    [NotNull]
-    public override string? Alias
-    {
-        get => base.Alias!;
-        internal set => base.Alias = value;
-    }
+    public override string Alias
+        => base.Alias!;
 
     /// <summary>
     ///     The bool value indicating whether result will remove duplicate rows.

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 /// <summary>
@@ -15,13 +17,16 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public abstract class TableExpressionBase : Expression, IPrintableExpression
 {
-    private readonly IReadOnlyDictionary<string, IAnnotation>? _annotations;
+    /// <summary>
+    ///     An indexed collection of annotations associated with this table expression.
+    /// </summary>
+    protected virtual IReadOnlyDictionary<string, IAnnotation>? Annotations { get; }
 
     /// <summary>
     ///     Creates a new instance of the <see cref="TableExpressionBase" /> class.
     /// </summary>
     /// <param name="alias">A string alias for the table source.</param>
-    /// <param name="annotations">A collection of annotations associated with this expression.</param>
+    /// <param name="annotations">A collection of annotations associated with this table expression.</param>
     protected TableExpressionBase(string? alias, IEnumerable<IAnnotation>? annotations = null)
     {
         Alias = alias;
@@ -34,14 +39,25 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
                 dictionary[annotation.Name] = annotation;
             }
 
-            _annotations = dictionary;
+            Annotations = dictionary;
         }
+    }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="TableExpressionBase" /> class.
+    /// </summary>
+    /// <param name="alias">A string alias for the table source.</param>
+    /// <param name="annotations">A collection of annotations associated with this expression.</param>
+    protected TableExpressionBase(string? alias, IReadOnlyDictionary<string, IAnnotation>? annotations)
+    {
+        Alias = alias;
+        Annotations = annotations;
     }
 
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>
-    public virtual string? Alias { get; internal set; }
+    public virtual string? Alias { get; }
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -62,6 +78,12 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     /// <param name="cloningExpressionVisitor">The cloning expression for further visitation of nested nodes.</param>
     /// <returns>A new object that is a copy of this instance.</returns>
     public abstract TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor);
+
+    /// <summary>
+    ///     Returns a copy of the current <see cref="TableExpressionBase" /> with the new provided alias.
+    /// </summary>
+    /// <param name="newAlias">The alias to apply to the returned <see cref="TableExpressionBase" />.</param>
+    public abstract TableExpressionBase WithAlias(string newAlias);
 
     /// <summary>
     ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter" />.
@@ -100,7 +122,7 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
 
     /// <inheritdoc />
     public override int GetHashCode()
-        => 0;
+        => Alias?.GetHashCode() ?? 0;
 
     /// <summary>
     ///     Adds an annotation to this object. Throws if an annotation with the specified name already exists.
@@ -118,9 +140,20 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
                 : throw new InvalidOperationException(CoreStrings.DuplicateAnnotation(name, this.Print()));
         }
 
-        var annotation = new Annotation(name, value);
 
-        return CreateWithAnnotations(new[] { annotation }.Concat(GetAnnotations()));
+        var annotations = new SortedDictionary<string, IAnnotation>();
+
+        if (Annotations is not null)
+        {
+            foreach (var annotation in Annotations.Values)
+            {
+                annotations[annotation.Name] = annotation;
+            }
+        }
+
+        annotations[name] = new Annotation(name, value);
+
+        return WithAnnotations(annotations);
     }
 
     /// <summary>
@@ -128,7 +161,7 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     /// </summary>
     /// <param name="annotations">The annotations to be applied.</param>
     /// <returns>The new expression with given annotations.</returns>
-    protected abstract TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations);
+    protected abstract TableExpressionBase WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations);
 
     /// <summary>
     ///     Gets the annotation with the given name, returning <see langword="null" /> if it does not exist.
@@ -138,17 +171,13 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     ///     The existing annotation if an annotation with the specified name already exists. Otherwise, <see langword="null" />.
     /// </returns>
     public virtual IAnnotation? FindAnnotation(string name)
-        => _annotations == null
-            ? null
-            : _annotations.TryGetValue(name, out var annotation)
-                ? annotation
-                : null;
+        => Annotations?.GetValueOrDefault(name);
 
     /// <summary>
     ///     Gets all annotations on the current object.
     /// </summary>
     public virtual IEnumerable<IAnnotation> GetAnnotations()
-        => _annotations?.Values ?? Enumerable.Empty<IAnnotation>();
+        => Annotations?.Values ?? Enumerable.Empty<IAnnotation>();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -158,5 +187,5 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     /// </summary>
     [EntityFrameworkInternal]
     public virtual string GetRequiredAlias()
-        => Alias ?? throw new InvalidOperationException($"No alias is defined on table: {ExpressionPrinter.Print(this)}");
+        => Alias ?? throw new InvalidOperationException(RelationalStrings.NoAliasOnTable(ExpressionPrinter.Print(this)));
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -35,7 +35,7 @@ public class UnionExpression : SetOperationBase
         SelectExpression source1,
         SelectExpression source2,
         bool distinct,
-        IEnumerable<IAnnotation>? annotations)
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
         : base(alias, source1, source2, distinct, annotations)
     {
     }
@@ -58,12 +58,12 @@ public class UnionExpression : SetOperationBase
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public override UnionExpression Update(SelectExpression source1, SelectExpression source2)
         => source1 != Source1 || source2 != Source2
-            ? new UnionExpression(Alias, source1, source2, IsDistinct, GetAnnotations())
+            ? new UnionExpression(Alias, source1, source2, IsDistinct, Annotations)
             : this;
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new UnionExpression(Alias, Source1, Source2, IsDistinct, annotations);
+    protected override UnionExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, Source1, Source2, IsDistinct, annotations);
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
@@ -72,6 +72,10 @@ public class UnionExpression : SetOperationBase
             (SelectExpression)cloningExpressionVisitor.Visit(Source1),
             (SelectExpression)cloningExpressionVisitor.Visit(Source2),
             IsDistinct);
+
+    /// <inheritdoc />
+    public override UnionExpression WithAlias(string newAlias)
+        => new(newAlias, Source1, Source2, IsDistinct);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
@@ -86,7 +86,7 @@ public sealed class UpdateExpression : Expression, IPrintableExpression
             var newValue = (SqlExpression)visitor.Visit(columnValueSetter.Value);
             if (columnValueSetters != null)
             {
-                columnValueSetters.Add(new ColumnValueSetter(columnValueSetter.Column, newValue));
+                columnValueSetters.Add(columnValueSetter with { Value = newValue });
             }
             else if (!ReferenceEquals(newValue, columnValueSetter.Value))
             {
@@ -96,14 +96,15 @@ public sealed class UpdateExpression : Expression, IPrintableExpression
                     columnValueSetters.Add(ColumnValueSetters[j]);
                 }
 
-                columnValueSetters.Add(new ColumnValueSetter(columnValueSetter.Column, newValue));
+                columnValueSetters.Add(columnValueSetter with { Value = newValue });
             }
         }
 
-        return selectExpression != SelectExpression
-            || columnValueSetters != null
-                ? new UpdateExpression(Table, selectExpression, columnValueSetters ?? ColumnValueSetters)
-                : this;
+        var table = (TableExpression)visitor.Visit(Table);
+
+        return selectExpression == SelectExpression && table == Table && columnValueSetters is null
+            ? this
+            : new UpdateExpression(Table, selectExpression, columnValueSetters ?? ColumnValueSetters);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
@@ -48,15 +48,26 @@ public class ValuesExpression : TableExpressionBase
         ColumnNames = columnNames;
     }
 
+    private ValuesExpression(
+        string? alias,
+        IReadOnlyList<RowValueExpression> rowValues,
+        IReadOnlyList<string> columnNames,
+        IReadOnlyDictionary<string, IAnnotation>? annotations)
+        : base(alias, annotations)
+    {
+        Check.DebugAssert(
+            rowValues.All(rv => rv.Values.Count == columnNames.Count),
+            "All row values must have a value count matching the number of column names");
+
+        RowValues = rowValues;
+        ColumnNames = columnNames;
+    }
+
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>
-    [NotNull]
-    public override string? Alias
-    {
-        get => base.Alias!;
-        internal set => base.Alias = value;
-    }
+    public override string Alias
+        => base.Alias!;
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -75,8 +86,12 @@ public class ValuesExpression : TableExpressionBase
             : new ValuesExpression(Alias, rowValues, ColumnNames);
 
     /// <inheritdoc />
-    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
-        => new ValuesExpression(Alias, RowValues, ColumnNames, annotations);
+    protected override ValuesExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new(Alias, RowValues, ColumnNames, annotations);
+
+    /// <inheritdoc />
+    public override ValuesExpression WithAlias(string newAlias)
+        => new(newAlias, RowValues, ColumnNames, Annotations);
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
@@ -88,7 +103,7 @@ public class ValuesExpression : TableExpressionBase
             newRowValues[i] = (RowValueExpression)cloningExpressionVisitor.Visit(RowValues[i]);
         }
 
-        return new ValuesExpression(alias, newRowValues, ColumnNames, GetAnnotations());
+        return new ValuesExpression(alias, newRowValues, ColumnNames, Annotations);
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -77,7 +77,7 @@ public class SqlNullabilityProcessor
         var result = queryExpression switch
         {
             SelectExpression selectExpression => (Expression)Visit(selectExpression),
-            DeleteExpression deleteExpression => deleteExpression.Update(Visit(deleteExpression.SelectExpression)),
+            DeleteExpression deleteExpression => deleteExpression.Update(deleteExpression.Table, Visit(deleteExpression.SelectExpression)),
             UpdateExpression updateExpression => VisitUpdate(updateExpression),
             _ => throw new InvalidOperationException(),
         };

--- a/src/EFCore.Relational/Query/SqlTreePruner.cs
+++ b/src/EFCore.Relational/Query/SqlTreePruner.cs
@@ -74,7 +74,7 @@ public class SqlTreePruner : ExpressionVisitor
                     Visit(relationalSplitCollectionShaperExpression.InnerShaper));
 
             case DeleteExpression deleteExpression:
-                return deleteExpression.Update(deleteExpression.SelectExpression.PruneToplevel(this));
+                return deleteExpression.Update(deleteExpression.Table, deleteExpression.SelectExpression.PruneToplevel(this));
 
             case UpdateExpression updateExpression:
                 // Note that we must visit the setters before we visit the select, since the setters can reference tables inside it.

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -167,7 +167,7 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitDelete(DeleteExpression deleteExpression)
-        => deleteExpression.Update((SelectExpression)Visit(deleteExpression.SelectExpression));
+        => deleteExpression.Update(deleteExpression.Table, (SelectExpression)Visit(deleteExpression.SelectExpression));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerOpenJsonExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerOpenJsonExpression.cs
@@ -168,6 +168,10 @@ public class SqlServerOpenJsonExpression : TableValuedFunctionExpression
         return clone;
     }
 
+    /// <inheritdoc />
+    public override SqlServerOpenJsonExpression WithAlias(string newAlias)
+        => new(newAlias, JsonExpression, Path, ColumnInfos);
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -63,11 +63,14 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
     {
         var selectExpression = deleteExpression.SelectExpression;
 
-        if (selectExpression.Offset == null
-            && selectExpression.Having == null
-            && selectExpression.Orderings.Count == 0
-            && selectExpression.GroupBy.Count == 0
-            && selectExpression.Projection.Count == 0)
+        if (selectExpression is
+            {
+                GroupBy: [],
+                Having: null,
+                Projection: [],
+                Orderings: [],
+                Offset: null
+            })
         {
             Sql.Append("DELETE ");
             GenerateTop(selectExpression);
@@ -122,11 +125,14 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
     {
         var selectExpression = updateExpression.SelectExpression;
 
-        if (selectExpression.Offset == null
-            && selectExpression.Having == null
-            && selectExpression.Orderings.Count == 0
-            && selectExpression.GroupBy.Count == 0
-            && selectExpression.Projection.Count == 0)
+        if (selectExpression is
+            {
+                GroupBy: [],
+                Having: null,
+                Projection: [],
+                Orderings: [],
+                Offset: null
+            })
         {
             Sql.Append("UPDATE ");
             GenerateTop(selectExpression);

--- a/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/JsonEachExpression.cs
+++ b/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/JsonEachExpression.cs
@@ -142,6 +142,10 @@ public class JsonEachExpression : TableValuedFunctionExpression
         return clone;
     }
 
+    /// <inheritdoc />
+    public override JsonEachExpression WithAlias(string newAlias)
+        => new(newAlias, JsonExpression, Path);
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in


### PR DESCRIPTION
~**NOTE: THIS IS BASED ON TOP OF #32812, REVIEW ONLY THE LAST COMMIT ONLY**~

This completes the immutability work done in #32812; that PR got rid of the mutable TableReferenceExpression, and this one makes TableExpressionBase.TableAlias immutable. After this, the only mutability we have in our SQL query tree is SelectExpression itself being in temporary mutable mode during translation.

Also did some cleanup around table annotations.

**Note:** as an alternative design, I considered extracting Alias out of TableExpressionBase altogether, and moving it out to a TableAliasExpression (or AsExpression) which would wrap the table, adding the `AS x` part; this is very similar to what we do in the prjection with ProjectionExpression. However, this would make it considerably harder to work with tables when **not** caring about their aliases - which is the majority of the time.