### PR TITLE
Use table mappings for FromSql

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -104,7 +104,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                     _sqlExpressionFactory.Select(
                         fromSqlQueryRootExpression.EntityType,
                         new FromSqlExpression(
-                            fromSqlQueryRootExpression.EntityType.GetDefaultMappings().Single().Table,
+                            fromSqlQueryRootExpression.EntityType.GetTableMappings().SingleOrDefault()?.Table
+                            ?? fromSqlQueryRootExpression.EntityType.GetDefaultMappings().Single().Table,
                             fromSqlQueryRootExpression.Sql,
                             fromSqlQueryRootExpression.Argument)));
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -483,8 +483,8 @@ WHERE EXISTS (
         SELECT "OrderID", "ProductID", "UnitPrice", "Quantity", "Discount"
         FROM "Order Details"
         WHERE "OrderID" < 10300
-    ) AS [m]
-    WHERE [m].[OrderID] = [o].[OrderID] AND [m].[ProductID] = [o].[ProductID])
+    ) AS [o0]
+    WHERE [o0].[OrderID] = [o].[OrderID] AND [o0].[ProductID] = [o].[ProductID])
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -786,17 +786,17 @@ WHERE [d].[SmallDateTime] IN (
             Assert.Equal(Context19206.TestType19206.Integration, item.t2.Type);
 
             AssertSql(
-"""
+                """
 p0='0'
 p1='1'
 
-SELECT [m].[Id], [m].[Type], [m0].[Id], [m0].[Type]
+SELECT [t].[Id], [t].[Type], [t0].[Id], [t0].[Type]
 FROM (
     Select * from Tests Where Type = @p0
-) AS [m]
+) AS [t]
 CROSS JOIN (
     Select * from Tests Where Type = @p1
-) AS [m0]
+) AS [t0]
 """);
         }
     }
@@ -1083,10 +1083,10 @@ p0='1'
 SELECT [d].[Id] AS [Key], COUNT(*) AS [Aggregate]
 FROM [DemoEntities] AS [d]
 WHERE [d].[Id] IN (
-    SELECT [m].[Id]
+    SELECT [d0].[Id]
     FROM (
         SELECT * FROM DemoEntities WHERE Id = @p0
-    ) AS [m]
+    ) AS [d0]
 )
 GROUP BY [d].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1290,18 +1290,18 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Date], [m].[Name], [m].[OneToMany_Optional_Self_Inverse1Id], [m].[OneToMany_Required_Self_Inverse1Id], [m].[OneToOne_Optional_Self1Id], [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id], [t].[Id0], [t].[Level2_Optional_Id], [t].[Level2_Required_Id], [t].[Name0], [t].[OneToMany_Optional_Inverse3Id], [t].[OneToMany_Optional_Self_Inverse3Id], [t].[OneToMany_Required_Inverse3Id], [t].[OneToMany_Required_Self_Inverse3Id], [t].[OneToOne_Optional_PK_Inverse3Id], [t].[OneToOne_Optional_Self3Id]
+SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id], [t].[Id0], [t].[Level2_Optional_Id], [t].[Level2_Required_Id], [t].[Name0], [t].[OneToMany_Optional_Inverse3Id], [t].[OneToMany_Optional_Self_Inverse3Id], [t].[OneToMany_Required_Inverse3Id], [t].[OneToMany_Required_Self_Inverse3Id], [t].[OneToOne_Optional_PK_Inverse3Id], [t].[OneToOne_Optional_Self3Id]
 FROM (
     SELECT * FROM [LevelOne]
-) AS [m]
-LEFT JOIN [LevelTwo] AS [l] ON [m].[Id] = [l].[Level1_Optional_Id]
-LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
+) AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
+LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 LEFT JOIN (
-    SELECT [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id], [l2].[Id] AS [Id0], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name] AS [Name0], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id]
-    FROM [LevelTwo] AS [l1]
-    LEFT JOIN [LevelThree] AS [l2] ON [l1].[Id] = [l2].[Level2_Optional_Id]
-) AS [t] ON [m].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [m].[Id], [l].[Id], [l0].[Id], [t].[Id]
+    SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l3].[Id] AS [Id0], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name] AS [Name0], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id]
+    FROM [LevelTwo] AS [l2]
+    LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[Level2_Optional_Id]
+) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.ComplexTypeModel;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class ComplexTypeQuerySqlServerTest : ComplexTypeQueryRelationalTestBase<
@@ -741,6 +743,134 @@ FROM [ValuedCustomer] AS [v0]
 
         AssertSql();
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_complex_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+WHERE [c].[ShippingAddress_ZipCode] = 7728
+"""),
+            ss => ss.Set<Customer>().Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_nested_complex_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+WHERE [c].[ShippingAddress_Country_Code] = N'DE'
+"""),
+            ss => ss.Set<Customer>().Where(c => c.ShippingAddress.Country.Code == "DE"));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_complex_type_after_subquery_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSql(
+                $"""
+                SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_Tags], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_Tags], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+                FROM (
+                    SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                    FROM [Customer] AS [c]
+                    ORDER BY [c].[Id]
+                    OFFSET {1} ROWS
+                ) AS [t]
+                WHERE [t].[ShippingAddress_ZipCode] = 7728
+                """),
+            ss => ss.Set<Customer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct()
+                .Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Load_complex_type_after_subquery_on_entity_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSql(
+                $"""
+                SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_Tags], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_Tags], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+                FROM (
+                    SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                    FROM [Customer] AS [c]
+                    ORDER BY [c].[Id]
+                    OFFSET {1} ROWS
+                ) AS [t]
+                """),
+            ss => ss.Set<Customer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_complex_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+                SELECT [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                FROM [Customer] AS [c]
+                """).Select(c => c.ShippingAddress),
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_nested_complex_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+                SELECT [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                FROM [Customer] AS [c]
+                """).Select(c => c.ShippingAddress.Country),
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress.Country));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_single_property_on_nested_complex_type_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+                SELECT [c].[ShippingAddress_Country_FullName]
+                FROM [Customer] AS [c]
+                """).Select(c => c.ShippingAddress.Country.FullName),
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress.Country.FullName));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_complex_type_Where_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+                SELECT [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                FROM [Customer] AS [c]
+                """).Select(c => c.ShippingAddress).Where(a => a.ZipCode == 07728),
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress).Where(a => a.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_complex_type_Distinct_with_FromSql(bool async)
+        => AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>()).FromSqlRaw(
+                """
+                SELECT [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+                FROM [Customer] AS [c]
+                """).Select(c => c.ShippingAddress).Distinct(),
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress).Distinct());
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -52,11 +52,11 @@ SELECT "Region", "PostalCode", "PostalCode" AS "Foo", "Phone", "Fax", "CustomerI
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -66,7 +66,7 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
 
         
@@ -74,8 +74,8 @@ FROM (
 
     SELECT
     * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -85,11 +85,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -101,11 +101,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
             """
 customer='CONSH' (Nullable = false) (Size = 5)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @customer
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -117,11 +117,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
             """
 p0='CONSH' (Nullable = false) (Size = 5)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @p0
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -131,11 +131,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = N'CONSH'
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -148,10 +148,10 @@ WHERE [m].[ContactName] LIKE N'%z%'
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [o].[CustomerID]
     FROM (
         SELECT * FROM "Orders"
-    ) AS [m]
+    ) AS [o]
 )
 """);
     }
@@ -165,10 +165,10 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI' AND [c].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [o].[CustomerID]
     FROM (
         SELECT * FROM "Orders"
-    ) AS [m]
+    ) AS [o]
 )
 """);
     }
@@ -179,14 +179,14 @@ WHERE [c].[CustomerID] = N'ALFKI' AND [c].[CustomerID] IN (
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders"
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -199,14 +199,14 @@ WHERE [m].[CustomerID] = [m0].[CustomerID]
 p0='1997-01-01T00:00:00.0000000'
 p1='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p0 AND @p1
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -220,14 +220,14 @@ p0='London' (Size = 4000)
 p1='1997-01-01T00:00:00.0000000'
 p2='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """,
             //
             """
@@ -235,14 +235,14 @@ p0='Berlin' (Size = 4000)
 p1='1998-04-01T00:00:00.0000000'
 p2='1998-05-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -264,12 +264,12 @@ WHERE "City" = 'London'
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT *
     FROM "Customers"
-) AS [m]
-WHERE [m].[City] = N'London'
+) AS [c]
+WHERE [c].[City] = N'London'
 """);
     }
 
@@ -362,14 +362,14 @@ p0='London' (Size = 4000)
 p1='1997-01-01T00:00:00.0000000'
 p2='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """,
             //
             """
@@ -377,14 +377,14 @@ p0='Berlin' (Size = 4000)
 p1='1998-04-01T00:00:00.0000000'
 p2='1998-05-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -399,14 +399,14 @@ p0='London' (Size = 4000)
 p1='1997-01-01T00:00:00.0000000'
 p2='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """,
             //
             """
@@ -414,14 +414,14 @@ p0='Berlin' (Size = 4000)
 p1='1998-04-01T00:00:00.0000000'
 p2='1998-05-01T00:00:00.0000000'
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -446,11 +446,11 @@ SELECT * FROM "Employees" WHERE "ReportsTo" = @p0 OR ("ReportsTo" IS NULL AND @p
 p0='London' (Size = 4000)
 @__contactTitle_1='Sales Representative' (Size = 30)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
-WHERE [m].[ContactTitle] = @__contactTitle_1
+) AS [c]
+WHERE [c].[ContactTitle] = @__contactTitle_1
 """);
 
         return null;
@@ -506,13 +506,13 @@ SELECT * FROM "Customers"
 
         AssertSql(
             """
-SELECT [m].[ProductName]
+SELECT [p].[ProductName]
 FROM (
     SELECT *
     FROM "Products"
     WHERE "Discontinued" <> CAST(1 AS bit)
     AND (("UnitsInStock" + "UnitsOnOrder") < "ReorderLevel")
-) AS [m]
+) AS [p]
 """);
     }
 
@@ -522,12 +522,12 @@ FROM (
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-LEFT JOIN [Orders] AS [o] ON [m].[CustomerID] = [o].[CustomerID]
-ORDER BY [m].[CustomerID]
+) AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]
 """);
     }
 
@@ -537,13 +537,13 @@ ORDER BY [m].[CustomerID]
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-LEFT JOIN [Orders] AS [o] ON [m].[CustomerID] = [o].[CustomerID]
-WHERE [m].[City] = N'London'
-ORDER BY [m].[CustomerID]
+) AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[City] = N'London'
+ORDER BY [c].[CustomerID]
 """);
     }
 
@@ -568,11 +568,11 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] = [m].[CompanyName]
+) AS [c]
+WHERE [c].[ContactName] = [c].[CompanyName]
 """);
     }
 
@@ -643,15 +643,15 @@ SELECT * FROM "Customers" WHERE "CustomerID" = @id
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = 'ALFKI'
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Customers" WHERE "CustomerID" = 'AROUT'
-) AS [m0]
-LEFT JOIN [Orders] AS [o] ON [m0].[CustomerID] = [o].[CustomerID]
-ORDER BY [m].[CustomerID], [m0].[CustomerID]
+) AS [c0]
+LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [c0].[CustomerID]
 """);
     }
 
@@ -661,15 +661,15 @@ ORDER BY [m].[CustomerID], [m0].[CustomerID]
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region], [m0].[OrderID], [m0].[CustomerID], [m0].[EmployeeID], [m0].[OrderDate], [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = 'ALFKI'
-) AS [m]
+) AS [c]
 INNER JOIN (
     SELECT * FROM "Orders" WHERE "OrderID" <> 1
-) AS [m0] ON [m].[CustomerID] = [m0].[CustomerID]
-LEFT JOIN [Order Details] AS [o] ON [m0].[OrderID] = [o].[OrderID]
-ORDER BY [m].[CustomerID], [m0].[OrderID], [o].[OrderID]
+) AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]
 """);
     }
 
@@ -729,10 +729,10 @@ SELECT * FROM "Customers" WHERE "CustomerID" = @somename
             """
 p0='10300'
 
-SELECT [m].[OrderID]
+SELECT [o].[OrderID]
 FROM (
     SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-) AS [m]
+) AS [o]
 """,
             //
             """
@@ -742,10 +742,10 @@ p0='10300'
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] <= @__max_0 AND [o].[OrderID] IN (
-    SELECT [m].[OrderID]
+    SELECT [o0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-    ) AS [m]
+    ) AS [o0]
 )
 """,
             //
@@ -756,10 +756,10 @@ p0='10300'
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] <= @__max_0 AND [o].[OrderID] IN (
-    SELECT [m].[OrderID]
+    SELECT [o0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-    ) AS [m]
+    ) AS [o0]
 )
 """);
     }
@@ -782,11 +782,11 @@ SELECT * FROM "Orders" WHERE "OrderID" < @p0
 
         AssertSql(
             """
-SELECT [m].[OrderID], [m].[CustomerID], [m].[EmployeeID], [m].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-LEFT JOIN [Customers] AS [c] ON [m].[CustomerID] = [c].[CustomerID]
+) AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [c].[CustomerID] = N'VINET'
 """);
     }
@@ -797,15 +797,15 @@ WHERE [c].[CustomerID] = N'VINET'
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = 'London'
-) AS [m]
+) AS [c]
 UNION ALL
-SELECT [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region]
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = 'Berlin'
-) AS [m0]
+) AS [c0]
 """);
     }
 
@@ -815,12 +815,12 @@ FROM (
 
         AssertSql(
             """
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT
     * FROM "Customers"
-) AS [m]
-WHERE [m].[City] = N'Seattle'
+) AS [c]
+WHERE [c].[City] = N'Seattle'
 """);
     }
 
@@ -832,34 +832,34 @@ WHERE [m].[City] = N'Seattle'
             """
 customerID='ALFKI' (Nullable = false) (Size = 5)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @customerID
-) AS [m]
-ORDER BY [m].[CustomerID]
+) AS [c]
+ORDER BY [c].[CustomerID]
 """,
             //
             """
 customerID='ALFKI' (Nullable = false) (Size = 5)
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [m].[CustomerID]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @customerID
-) AS [m]
-INNER JOIN [Orders] AS [o] ON [m].[CustomerID] = [o].[CustomerID]
-ORDER BY [m].[CustomerID], [o].[OrderID]
+) AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [o].[OrderID]
 """,
             //
             """
 customerID='ALFKI' (Nullable = false) (Size = 5)
 
-SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [m].[CustomerID], [o].[OrderID]
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[CustomerID], [o].[OrderID]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @customerID
-) AS [m]
-INNER JOIN [Orders] AS [o] ON [m].[CustomerID] = [o].[CustomerID]
+) AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-ORDER BY [m].[CustomerID], [o].[OrderID]
+ORDER BY [c].[CustomerID], [o].[OrderID]
 """);
     }
 
@@ -874,10 +874,10 @@ ORDER BY [m].[CustomerID], [o].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city
-    ) AS [m]
+    ) AS [c]
 )
 """);
     }
@@ -893,10 +893,10 @@ p0='London' (Nullable = false) (Size = 6)
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @p0
-    ) AS [m]
+    ) AS [c]
 )
 """);
     }
@@ -912,10 +912,10 @@ WHERE [o].[CustomerID] IN (
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city
-    ) AS [m]
+    ) AS [c]
 )
 """);
     }
@@ -932,10 +932,10 @@ p0='London' (Size = 4000)
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @p0 AND "ContactTitle" = @title
-    ) AS [m]
+    ) AS [c]
 )
 """,
             //
@@ -946,10 +946,10 @@ p1='Sales Representative' (Size = 4000)
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
-    SELECT [m].[CustomerID]
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
-    ) AS [m]
+    ) AS [c]
 )
 """);
     }
@@ -962,15 +962,15 @@ WHERE [o].[CustomerID] IN (
             """
 city='Seattle' (Nullable = false) (Size = 7)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @city
-) AS [m]
+) AS [c]
 INTERSECT
-SELECT [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region]
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @city
-) AS [m0]
+) AS [c0]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -64,11 +64,11 @@ WHERE [d].[Discriminator] = 3
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[CountryId], [m].[Discriminator], [m].[Name], [m].[Species], [m].[EagleId], [m].[IsFlightless], [m].[Group], [m].[FoundOn]
+SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM (
     select * from "Animals"
-) AS [m]
-WHERE [m].[Discriminator] IN (N'Eagle', N'Kiwi')
+) AS [a]
+WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 """);
     }
 
@@ -78,11 +78,11 @@ WHERE [m].[Discriminator] IN (N'Eagle', N'Kiwi')
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[CountryId], [m].[Discriminator], [m].[Name], [m].[Species], [m].[EagleId], [m].[IsFlightless], [m].[Group]
+SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group]
 FROM (
     select * from "Animals"
-) AS [m]
-WHERE [m].[Discriminator] = N'Eagle'
+) AS [a]
+WHERE [a].[Discriminator] = N'Eagle'
 """);
     }
 
@@ -558,11 +558,11 @@ ORDER BY [a].[Name]
 
         AssertSql(
             """
-SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [m].[CountryId], [m].[Discriminator], [m].[Name], [m].[EagleId], [m].[IsFlightless], [m].[Group], [m].[FoundOn]
+SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
 FROM [Animals] AS [a]
 INNER JOIN (
     Select * from "Animals"
-) AS [m] ON [a].[Name] = [m].[Name]
+) AS [a0] ON [a].[Name] = [a0].[Name]
 WHERE [a].[Discriminator] = N'Eagle'
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -2733,10 +2733,10 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.StringYNConvertedToBool') AS bit) = CA
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[EntityBasicId], [m].[Name], [m].[OwnedCollectionRoot], [m].[OwnedReferenceRoot]
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
-) AS [m]
+) AS [j]
 """);
     }
 
@@ -2756,10 +2756,10 @@ FROM (
             """
 prm='1'
 
-SELECT [m].[Id], [m].[EntityBasicId], [m].[Name], [m].[OwnedCollectionRoot], [m].[OwnedReferenceRoot]
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j WHERE "j"."Id" = @prm
-) AS [m]
+) AS [j]
 """);
     }
 
@@ -2771,10 +2771,10 @@ FROM (
 
         AssertSql(
             """
-SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [m].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
-) AS [m]
+) AS [j]
 """);
     }
 
@@ -2786,10 +2786,10 @@ FROM (
 
         AssertSql(
             """
-SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [m].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
-) AS [m]
+) AS [j]
 """);
     }
 
@@ -2801,10 +2801,10 @@ FROM (
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Discriminator], [m].[Name], [m].[Fraction], [m].[CollectionOnBase], [m].[ReferenceOnBase], [m].[CollectionOnDerived], [m].[ReferenceOnDerived]
+SELECT [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
-) AS [m]
+) AS [j]
 """);
     }
 
@@ -2816,11 +2816,11 @@ FROM (
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Discriminator], [m].[Name], [m].[Fraction], [m].[CollectionOnBase], [m].[ReferenceOnBase], [m].[CollectionOnDerived], [m].[ReferenceOnDerived]
+SELECT [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
-) AS [m]
-WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
+) AS [j]
+WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
 """);
     }
 
@@ -2832,11 +2832,11 @@ WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
 
         AssertSql(
             """
-SELECT [m].[ReferenceOnBase], [m].[Id]
+SELECT [j].[ReferenceOnBase], [j].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
-) AS [m]
-ORDER BY [m].[Id]
+) AS [j]
+ORDER BY [j].[Id]
 """);
     }
 
@@ -2848,12 +2848,12 @@ ORDER BY [m].[Id]
 
         AssertSql(
             """
-SELECT [m].[CollectionOnDerived], [m].[Id]
+SELECT [j].[CollectionOnDerived], [j].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
-) AS [m]
-WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
-ORDER BY [m].[Id]
+) AS [j]
+WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
+ORDER BY [j].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -264,11 +264,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
             """
 @__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     select * from Customers
-) AS [m]
-WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+) AS [c]
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -286,15 +286,15 @@ WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
             """
 @__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
-SELECT [m].[OrderID], [m].[CustomerID], [m].[EmployeeID], [m].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     select * from Orders
-) AS [m]
+) AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
     WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
-) AS [t] ON [m].[CustomerID] = [t].[CustomerID]
+) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1553,11 +1553,11 @@ WHERE @__p_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[BoolA], [m].[BoolB], [m].[BoolC], [m].[IntA], [m].[IntB], [m].[IntC], [m].[NullableBoolA], [m].[NullableBoolB], [m].[NullableBoolC], [m].[NullableIntA], [m].[NullableIntB], [m].[NullableIntC], [m].[NullableStringA], [m].[NullableStringB], [m].[NullableStringC], [m].[StringA], [m].[StringB], [m].[StringC]
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM (
     SELECT * FROM "Entities1"
-) AS [m]
-WHERE [m].[StringA] = [m].[StringB]
+) AS [e]
+WHERE [e].[StringA] = [e].[StringB]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1340,20 +1340,20 @@ ORDER BY [o].[PersonAddress_PlaceType], [o].[Id], [t].[ClientId], [t].[Id], [t].
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Discriminator], [m].[Name], [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [t].[ClientId], [t].[Id], [t].[OrderDate], [t].[OrderClientId], [t].[OrderId], [t].[Id0], [t].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o1].[LeafBAddress_LeafBType], [o1].[LeafBAddress_PlaceType], [o1].[LeafBAddress_Country_Name], [o1].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o0].[Id], [o1].[Id], [o2].[Id], [o3].[Id], [t].[ClientId], [t].[Id], [t].[OrderDate], [t].[OrderClientId], [t].[OrderId], [t].[Id0], [t].[Detail], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o1].[BranchAddress_BranchName], [o1].[BranchAddress_PlaceType], [o1].[BranchAddress_Country_Name], [o1].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o3].[LeafAAddress_LeafType], [o3].[LeafAAddress_PlaceType], [o3].[LeafAAddress_Country_Name], [o3].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT * FROM "OwnedPerson"
-) AS [m]
-LEFT JOIN [OwnedPerson] AS [o] ON [m].[Id] = [o].[Id]
-LEFT JOIN [OwnedPerson] AS [o0] ON [m].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [m].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [m].[Id] = [o2].[Id]
+) AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
+LEFT JOIN [OwnedPerson] AS [o1] ON [o].[Id] = [o1].[Id]
+LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
+LEFT JOIN [OwnedPerson] AS [o3] ON [o].[Id] = [o3].[Id]
 LEFT JOIN (
-    SELECT [o3].[ClientId], [o3].[Id], [o3].[OrderDate], [o4].[OrderClientId], [o4].[OrderId], [o4].[Id] AS [Id0], [o4].[Detail]
-    FROM [Order] AS [o3]
-    LEFT JOIN [OrderDetail] AS [o4] ON [o3].[ClientId] = [o4].[OrderClientId] AND [o3].[Id] = [o4].[OrderId]
-) AS [t] ON [m].[Id] = [t].[ClientId]
-ORDER BY [m].[Id], [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]
+    SELECT [o4].[ClientId], [o4].[Id], [o4].[OrderDate], [o5].[OrderClientId], [o5].[OrderId], [o5].[Id] AS [Id0], [o5].[Detail]
+    FROM [Order] AS [o4]
+    LEFT JOIN [OrderDetail] AS [o5] ON [o4].[ClientId] = [o5].[OrderClientId] AND [o4].[Id] = [o5].[OrderId]
+) AS [t] ON [o].[Id] = [t].[ClientId]
+ORDER BY [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [o3].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SqlQuerySqlServerTest.cs
@@ -49,11 +49,11 @@ SELECT "Region", "PostalCode", "PostalCode" AS "Foo", "Phone", "Fax", "CustomerI
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -63,7 +63,7 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
 
         
@@ -71,8 +71,8 @@ FROM (
 
     SELECT
     * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -82,11 +82,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -98,11 +98,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
             """
 customer='CONSH' (Nullable = false) (Size = 5)
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @customer
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -114,11 +114,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
             """
 p0='CONSH' (Nullable = false) (Size = 5)
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = @p0
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -128,11 +128,11 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "CustomerID" = N'CONSH'
-) AS [m]
-WHERE [m].[ContactName] LIKE N'%z%'
+) AS [c]
+WHERE [c].[ContactName] LIKE N'%z%'
 """);
     }
 
@@ -142,15 +142,15 @@ WHERE [m].[ContactName] LIKE N'%z%'
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [o].[CustomerID]
     FROM (
         SELECT * FROM "Orders"
-    ) AS [m0]
+    ) AS [o]
 )
 """);
     }
@@ -161,14 +161,14 @@ WHERE [m].[CustomerID] IN (
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders"
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -181,14 +181,14 @@ WHERE [m].[CustomerID] = [m0].[CustomerID]
 p0='1997-01-01T00:00:00.0000000'
 p1='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p0 AND @p1
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -202,14 +202,14 @@ p0='London' (Size = 4000)
 p1='1997-01-01T00:00:00.0000000'
 p2='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """,
             //
             """
@@ -217,14 +217,14 @@ p0='Berlin' (Size = 4000)
 p1='1998-04-01T00:00:00.0000000'
 p2='1998-05-01T00:00:00.0000000'
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -246,12 +246,12 @@ WHERE "City" = 'London'
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT *
     FROM "Customers"
-) AS [m]
-WHERE [m].[City] = N'London'
+) AS [c]
+WHERE [c].[City] = N'London'
 """);
     }
 
@@ -318,14 +318,14 @@ p0='London' (Size = 4000)
 p1='1997-01-01T00:00:00.0000000'
 p2='1998-01-01T00:00:00.0000000'
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """,
             //
             """
@@ -333,14 +333,14 @@ p0='Berlin' (Size = 4000)
 p1='1998-04-01T00:00:00.0000000'
 p2='1998-05-01T00:00:00.0000000'
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode], [m0].[CustomerID], [m0].[EmployeeID], [m0].[Freight], [m0].[OrderDate], [m0].[OrderID], [m0].[RequiredDate], [m0].[ShipAddress], [m0].[ShipCity], [m0].[ShipCountry], [m0].[ShipName], [m0].[ShipPostalCode], [m0].[ShipRegion], [m0].[ShipVia], [m0].[ShippedDate]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode], [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
+) AS [c]
 CROSS JOIN (
     SELECT * FROM "Orders" WHERE "OrderDate" BETWEEN @p1 AND @p2
-) AS [m0]
-WHERE [m].[CustomerID] = [m0].[CustomerID]
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
@@ -365,11 +365,11 @@ SELECT * FROM "Employees" WHERE "ReportsTo" = @p0 OR ("ReportsTo" IS NULL AND @p
 p0='London' (Size = 4000)
 @__contactTitle_1='Sales Representative' (Size = 30)
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
-) AS [m]
-WHERE [m].[ContactTitle] = @__contactTitle_1
+) AS [c]
+WHERE [c].[ContactTitle] = @__contactTitle_1
 """);
 
         return null;
@@ -425,13 +425,13 @@ SELECT * FROM "Customers"
 
         AssertSql(
             """
-SELECT [m].[ProductName]
+SELECT [u].[ProductName]
 FROM (
     SELECT *
     FROM "Products"
     WHERE "Discontinued" <> CAST(1 AS bit)
     AND (("UnitsInStock" + "UnitsOnOrder") < "ReorderLevel")
-) AS [m]
+) AS [u]
 """);
     }
 
@@ -454,12 +454,12 @@ SELECT * FROM "Customers"
         await base.SqlQueryRaw_composed_with_predicate(async);
 
         AssertSql(
-"""
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+            """
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE SUBSTRING([m].[ContactName], 0 + 1, 1) = SUBSTRING([m].[CompanyName], 0 + 1, 1)
+) AS [c]
+WHERE SUBSTRING([c].[ContactName], 0 + 1, 1) = SUBSTRING([c].[CompanyName], 0 + 1, 1)
 """);
     }
 
@@ -469,11 +469,11 @@ WHERE SUBSTRING([m].[ContactName], 0 + 1, 1) = SUBSTRING([m].[CompanyName], 0 + 
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers"
-) AS [m]
-WHERE [m].[ContactName] = [m].[CompanyName]
+) AS [c]
+WHERE [c].[ContactName] = [c].[CompanyName]
 """);
     }
 
@@ -570,25 +570,25 @@ SELECT * FROM "Customers" WHERE "CustomerID" = @somename
             """
 p0='10300'
 
-SELECT [m].[OrderID]
+SELECT [o].[OrderID]
 FROM (
     SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-) AS [m]
+) AS [o]
 """,
             //
             """
 @__max_1='10400'
 p0='10300'
 
-SELECT [m].[OrderID]
+SELECT [o].[OrderID]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
-    SELECT [m0].[OrderID]
+) AS [o]
+WHERE [o].[OrderID] <= @__max_1 AND [o].[OrderID] IN (
+    SELECT [o0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-    ) AS [m0]
+    ) AS [o0]
 )
 """,
             //
@@ -596,15 +596,15 @@ WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
 @__max_1='10400'
 p0='10300'
 
-SELECT [m].[OrderID]
+SELECT [o].[OrderID]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
-    SELECT [m0].[OrderID]
+) AS [o]
+WHERE [o].[OrderID] <= @__max_1 AND [o].[OrderID] IN (
+    SELECT [o0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
-    ) AS [m0]
+    ) AS [o0]
 )
 """);
     }
@@ -627,15 +627,15 @@ SELECT * FROM "Orders" WHERE "OrderID" < @p0
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = 'London'
-) AS [m]
+) AS [c]
 UNION ALL
-SELECT [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[CustomerID], [m0].[Fax], [m0].[Phone], [m0].[Region], [m0].[PostalCode]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[Region], [c0].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = 'Berlin'
-) AS [m0]
+) AS [c0]
 """);
     }
 
@@ -645,12 +645,12 @@ FROM (
 
         AssertSql(
             """
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT
     * FROM "Customers"
-) AS [m]
-WHERE [m].[City] = N'Seattle'
+) AS [c]
+WHERE [c].[City] = N'Seattle'
 """);
     }
 
@@ -662,15 +662,15 @@ WHERE [m].[City] = N'Seattle'
             """
 @city='London' (Nullable = false) (Size = 6)
 
-SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
+SELECT [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [o]
+WHERE [o].[CustomerID] IN (
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city
-    ) AS [m0]
+    ) AS [c]
 )
 """);
     }
@@ -683,15 +683,15 @@ WHERE [m].[CustomerID] IN (
             """
 p0='London' (Nullable = false) (Size = 6)
 
-SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
+SELECT [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [o]
+WHERE [o].[CustomerID] IN (
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @p0
-    ) AS [m0]
+    ) AS [c]
 )
 """);
     }
@@ -704,15 +704,15 @@ WHERE [m].[CustomerID] IN (
             """
 @city='London' (Nullable = false) (Size = 6)
 
-SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
+SELECT [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [o]
+WHERE [o].[CustomerID] IN (
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city
-    ) AS [m0]
+    ) AS [c]
 )
 """);
     }
@@ -726,15 +726,15 @@ WHERE [m].[CustomerID] IN (
 p0='London' (Size = 4000)
 @title='Sales Representative' (Nullable = false) (Size = 20)
 
-SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
+SELECT [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [o]
+WHERE [o].[CustomerID] IN (
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @p0 AND "ContactTitle" = @title
-    ) AS [m0]
+    ) AS [c]
 )
 """,
             //
@@ -742,15 +742,15 @@ WHERE [m].[CustomerID] IN (
 @city='London' (Nullable = false) (Size = 6)
 p1='Sales Representative' (Size = 4000)
 
-SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
+SELECT [o].[CustomerID], [o].[EmployeeID], [o].[Freight], [o].[OrderDate], [o].[OrderID], [o].[RequiredDate], [o].[ShipAddress], [o].[ShipCity], [o].[ShipCountry], [o].[ShipName], [o].[ShipPostalCode], [o].[ShipRegion], [o].[ShipVia], [o].[ShippedDate]
 FROM (
     SELECT * FROM "Orders"
-) AS [m]
-WHERE [m].[CustomerID] IN (
-    SELECT [m0].[CustomerID]
+) AS [o]
+WHERE [o].[CustomerID] IN (
+    SELECT [c].[CustomerID]
     FROM (
         SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
-    ) AS [m0]
+    ) AS [c]
 )
 """);
     }
@@ -763,15 +763,15 @@ WHERE [m].[CustomerID] IN (
             """
 city='Seattle' (Nullable = false) (Size = 7)
 
-SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[Region], [c].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @city
-) AS [m]
+) AS [c]
 INTERSECT
-SELECT [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[CustomerID], [m0].[Fax], [m0].[Phone], [m0].[Region], [m0].[PostalCode]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[Region], [c0].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @city
-) AS [m0]
+) AS [c0]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPHInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPHInheritanceQuerySqlServerTest.cs
@@ -71,11 +71,11 @@ select * from "Animals"
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[CountryId], [m].[Discriminator], [m].[Name], [m].[Species], [m].[EagleId], [m].[IsFlightless], [m].[Group]
+SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group]
 FROM (
     select * from "Animals"
-) AS [m]
-WHERE [m].[Discriminator] = N'Eagle'
+) AS [a]
+WHERE [a].[Discriminator] = N'Eagle'
 """);
     }
 
@@ -531,11 +531,11 @@ ORDER BY [a].[Name]
 
         AssertSql(
             """
-SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [m].[CountryId], [m].[Discriminator], [m].[Name], [m].[EagleId], [m].[IsFlightless], [m].[Group], [m].[FoundOn]
+SELECT [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
 FROM [Animals] AS [a]
 INNER JOIN (
     Select * from "Animals"
-) AS [m] ON [a].[Name] = [m].[Name]
+) AS [a0] ON [a].[Name] = [a0].[Name]
 WHERE [a].[Discriminator] = N'Eagle'
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -1351,20 +1351,20 @@ ORDER BY [o].[PersonAddress_PlaceType], [o].[Id], [t].[ClientId], [t].[Id], [t].
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Discriminator], [m].[Name], [m].[PeriodEnd], [m].[PeriodStart], [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [t].[ClientId], [t].[Id], [t].[OrderDate], [t].[PeriodEnd], [t].[PeriodStart], [t].[OrderClientId], [t].[OrderId], [t].[Id0], [t].[Detail], [t].[PeriodEnd0], [t].[PeriodStart0], [o].[PersonAddress_AddressLine], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o1].[LeafBAddress_LeafBType], [o1].[PeriodEnd], [o1].[PeriodStart], [o1].[LeafBAddress_PlaceType], [o1].[LeafBAddress_Country_Name], [o1].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[PeriodEnd], [o2].[PeriodStart], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o0].[Id], [o1].[Id], [o2].[Id], [o3].[Id], [t].[ClientId], [t].[Id], [t].[OrderDate], [t].[PeriodEnd], [t].[PeriodStart], [t].[OrderClientId], [t].[OrderId], [t].[Id0], [t].[Detail], [t].[PeriodEnd0], [t].[PeriodStart0], [o0].[PersonAddress_AddressLine], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o1].[BranchAddress_BranchName], [o1].[PeriodEnd], [o1].[PeriodStart], [o1].[BranchAddress_PlaceType], [o1].[BranchAddress_Country_Name], [o1].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[PeriodEnd], [o2].[PeriodStart], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o3].[LeafAAddress_LeafType], [o3].[PeriodEnd], [o3].[PeriodStart], [o3].[LeafAAddress_PlaceType], [o3].[LeafAAddress_Country_Name], [o3].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT * FROM "OwnedPerson"
-) AS [m]
-LEFT JOIN [OwnedPerson] AS [o] ON [m].[Id] = [o].[Id]
-LEFT JOIN [OwnedPerson] AS [o0] ON [m].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [m].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [m].[Id] = [o2].[Id]
+) AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
+LEFT JOIN [OwnedPerson] AS [o1] ON [o].[Id] = [o1].[Id]
+LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
+LEFT JOIN [OwnedPerson] AS [o3] ON [o].[Id] = [o3].[Id]
 LEFT JOIN (
-    SELECT [o3].[ClientId], [o3].[Id], [o3].[OrderDate], [o3].[PeriodEnd], [o3].[PeriodStart], [o4].[OrderClientId], [o4].[OrderId], [o4].[Id] AS [Id0], [o4].[Detail], [o4].[PeriodEnd] AS [PeriodEnd0], [o4].[PeriodStart] AS [PeriodStart0]
-    FROM [Order] AS [o3]
-    LEFT JOIN [OrderDetail] AS [o4] ON [o3].[ClientId] = [o4].[OrderClientId] AND [o3].[Id] = [o4].[OrderId]
-) AS [t] ON [m].[Id] = [t].[ClientId]
-ORDER BY [m].[Id], [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]
+    SELECT [o4].[ClientId], [o4].[Id], [o4].[OrderDate], [o4].[PeriodEnd], [o4].[PeriodStart], [o5].[OrderClientId], [o5].[OrderId], [o5].[Id] AS [Id0], [o5].[Detail], [o5].[PeriodEnd] AS [PeriodEnd0], [o5].[PeriodStart] AS [PeriodStart0]
+    FROM [Order] AS [o4]
+    LEFT JOIN [OrderDetail] AS [o5] ON [o4].[ClientId] = [o5].[OrderClientId] AND [o4].[Id] = [o5].[OrderId]
+) AS [t] ON [o].[Id] = [t].[ClientId]
+ORDER BY [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [o3].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -481,8 +481,8 @@ WHERE EXISTS (
         SELECT "OrderID", "ProductID", "UnitPrice", "Quantity", "Discount"
         FROM "Order Details"
         WHERE "OrderID" < 10300
-    ) AS "m"
-    WHERE "m"."OrderID" = "o"."OrderID" AND "m"."ProductID" = "o"."ProductID")
+    ) AS "o0"
+    WHERE "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -19,11 +19,11 @@ public class FromSqlQuerySqliteTest : FromSqlQueryTestBase<NorthwindQuerySqliteF
 
         AssertSql(
             """
-SELECT "m"."CustomerID", "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."Fax", "m"."Phone", "m"."PostalCode", "m"."Region"
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM (
     SELECT * FROM "Customers"
-) AS "m"
-WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
+) AS "c"
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'z') > 0
 """);
     }
 
@@ -32,14 +32,17 @@ WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
         var queryString = await base.FromSqlRaw_queryable_with_parameters_and_closure(async);
 
         Assert.Equal(
-            @".param set p0 'London'
-.param set @__contactTitle_1 'Sales Representative'
+            """
+            .param set p0 'London'
+            .param set @__contactTitle_1 'Sales Representative'
 
-SELECT ""m"".""CustomerID"", ""m"".""Address"", ""m"".""City"", ""m"".""CompanyName"", ""m"".""ContactName"", ""m"".""ContactTitle"", ""m"".""Country"", ""m"".""Fax"", ""m"".""Phone"", ""m"".""PostalCode"", ""m"".""Region""
-FROM (
-    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
-) AS ""m""
-WHERE ""m"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEndingDifferences: true);
+            SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+            FROM (
+                SELECT * FROM "Customers" WHERE "City" = @p0
+            ) AS "c"
+            WHERE "c"."ContactTitle" = @__contactTitle_1
+            """,
+            queryString, ignoreLineEndingDifferences: true);
 
         return queryString;
     }
@@ -66,14 +69,14 @@ WHERE ""m"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEnding
 
         AssertSql(
             """
-SELECT "m"."CustomerID", "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."Fax", "m"."Phone", "m"."PostalCode", "m"."Region"
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM (
     WITH "Customers2" AS (
         SELECT * FROM "Customers"
     )
     SELECT * FROM "Customers2"
-) AS "m"
-WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
+) AS "c"
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'z') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -199,10 +199,10 @@ WHERE EXISTS (
             """
 prm='1' (DbType = String)
 
-SELECT "m"."Id", "m"."EntityBasicId", "m"."Name", "m"."OwnedCollectionRoot", "m"."OwnedReferenceRoot"
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j WHERE "j"."Id" = @prm
-) AS "m"
+) AS "j"
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
@@ -19,11 +19,11 @@ public class SqlQuerySqliteTest : SqlQueryTestBase<NorthwindQuerySqliteFixture<N
 
         AssertSql(
             """
-SELECT "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."CustomerID", "m"."Fax", "m"."Phone", "m"."Region", "m"."PostalCode"
+SELECT "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."CustomerID", "c"."Fax", "c"."Phone", "c"."Region", "c"."PostalCode"
 FROM (
     SELECT * FROM "Customers"
-) AS "m"
-WHERE instr("m"."ContactName", 'z') > 0
+) AS "c"
+WHERE instr("c"."ContactName", 'z') > 0
 """);
     }
 
@@ -32,14 +32,17 @@ WHERE instr("m"."ContactName", 'z') > 0
         var queryString = await base.SqlQueryRaw_queryable_with_parameters_and_closure(async);
 
         Assert.Equal(
-            @".param set p0 'London'
-.param set @__contactTitle_1 'Sales Representative'
+            """
+            .param set p0 'London'
+            .param set @__contactTitle_1 'Sales Representative'
 
-SELECT ""m"".""Address"", ""m"".""City"", ""m"".""CompanyName"", ""m"".""ContactName"", ""m"".""ContactTitle"", ""m"".""Country"", ""m"".""CustomerID"", ""m"".""Fax"", ""m"".""Phone"", ""m"".""Region"", ""m"".""PostalCode""
-FROM (
-    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
-) AS ""m""
-WHERE ""m"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEndingDifferences: true);
+            SELECT "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."CustomerID", "c"."Fax", "c"."Phone", "c"."Region", "c"."PostalCode"
+            FROM (
+                SELECT * FROM "Customers" WHERE "City" = @p0
+            ) AS "c"
+            WHERE "c"."ContactTitle" = @__contactTitle_1
+            """,
+            queryString, ignoreLineEndingDifferences: true);
 
         return queryString;
     }
@@ -66,14 +69,14 @@ WHERE ""m"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEnding
 
         AssertSql(
             """
-SELECT "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."CustomerID", "m"."Fax", "m"."Phone", "m"."Region", "m"."PostalCode"
+SELECT "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."CustomerID", "c"."Fax", "c"."Phone", "c"."Region", "c"."PostalCode"
 FROM (
     WITH "Customers2" AS (
         SELECT * FROM "Customers"
     )
     SELECT * FROM "Customers2"
-) AS "m"
-WHERE instr("m"."ContactName", 'z') > 0
+) AS "c"
+WHERE instr("c"."ContactName", 'z') > 0
 """);
     }
 


### PR DESCRIPTION
The difference between the DbSet queries (work) and the FromSql queries (don't work) is that the DbSet queries use the table mappings, while the FromSql queries use the default mappings. The default mappings don't contain complex types. This may be an issue in of itself.

Fixes #32699
