### PR TITLE
Move all pruning code to the pruner and make it an immutable visitor 

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1552,6 +1552,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
+        ///     SelectExpression.Update() is not supported while the expression is in mutable state.
+        /// </summary>
+        public static string SelectExpressionUpdateNotSupportedWhileMutable
+            => GetString("SelectExpressionUpdateNotSupportedWhileMutable");
+
+        /// <summary>
         ///     Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').
         /// </summary>
         public static string SetOperationOverDifferentStructuralTypes(object? type1, object? type2)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1017,6 +1017,9 @@
   <data name="SetOperationOverDifferentStructuralTypes" xml:space="preserve">
     <value>Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').</value>
   </data>
+  <data name="SelectExpressionUpdateNotSupportedWhileMutable" xml:space="preserve">
+    <value>SelectExpression.Update() is not supported while the expression is in mutable state.</value>
+  </data>
   <data name="SetOperationsNotAllowedAfterClientEvaluation" xml:space="preserve">
     <value>Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.</value>
   </data>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -527,7 +527,7 @@ public sealed partial class SelectExpression
                                     CreateColumnExpression(projection, setOperationAlias), projection.Alias));
                         }
 
-                        generatedSelectExpression._mutable = false;
+                        generatedSelectExpression.IsMutable = false;
                         result = generatedSelectExpression;
                     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
@@ -104,7 +104,7 @@ public sealed class UpdateExpression : Expression, IPrintableExpression
 
         return selectExpression == SelectExpression && table == Table && columnValueSetters is null
             ? this
-            : new UpdateExpression(Table, selectExpression, columnValueSetters ?? ColumnValueSetters);
+            : new UpdateExpression(table, selectExpression, columnValueSetters ?? ColumnValueSetters);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -251,7 +251,6 @@ public class SqlNullabilityProcessor
     /// <returns>An optimized select expression.</returns>
     protected virtual SelectExpression Visit(SelectExpression selectExpression)
     {
-        var changed = false;
         var projections = (List<ProjectionExpression>)selectExpression.Projection;
         for (var i = 0; i < selectExpression.Projection.Count; i++)
         {
@@ -265,8 +264,6 @@ public class SqlNullabilityProcessor
                 {
                     projections.Add(selectExpression.Projection[j]);
                 }
-
-                changed = true;
             }
 
             if (projections != selectExpression.Projection)
@@ -288,8 +285,6 @@ public class SqlNullabilityProcessor
                 {
                     tables.Add(selectExpression.Tables[j]);
                 }
-
-                changed = true;
             }
 
             if (tables != selectExpression.Tables)
@@ -299,12 +294,10 @@ public class SqlNullabilityProcessor
         }
 
         var predicate = Visit(selectExpression.Predicate, allowOptimizedExpansion: true, out _);
-        changed |= predicate != selectExpression.Predicate;
 
         if (IsTrue(predicate))
         {
             predicate = null;
-            changed = true;
         }
 
         var groupBy = (List<SqlExpression>)selectExpression.GroupBy;
@@ -320,8 +313,6 @@ public class SqlNullabilityProcessor
                 {
                     groupBy.Add(selectExpression.GroupBy[j]);
                 }
-
-                changed = true;
             }
 
             if (groupBy != selectExpression.GroupBy)
@@ -331,12 +322,10 @@ public class SqlNullabilityProcessor
         }
 
         var having = Visit(selectExpression.Having, allowOptimizedExpansion: true, out _);
-        changed |= having != selectExpression.Having;
 
         if (IsTrue(having))
         {
             having = null;
-            changed = true;
         }
 
         var orderings = (List<OrderingExpression>)selectExpression.Orderings;
@@ -352,8 +341,6 @@ public class SqlNullabilityProcessor
                 {
                     orderings.Add(selectExpression.Orderings[j]);
                 }
-
-                changed = true;
             }
 
             if (orderings != selectExpression.Orderings)
@@ -363,15 +350,10 @@ public class SqlNullabilityProcessor
         }
 
         var offset = Visit(selectExpression.Offset, out _);
-        changed |= offset != selectExpression.Offset;
 
         var limit = Visit(selectExpression.Limit, out _);
-        changed |= limit != selectExpression.Limit;
 
-        return changed
-            ? selectExpression.Update(
-                projections, tables, predicate, groupBy, having, orderings, limit, offset)
-            : selectExpression;
+        return selectExpression.Update(projections, tables, predicate, groupBy, having, orderings, limit, offset);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlTreePruner.cs
+++ b/src/EFCore.Relational/Query/SqlTreePruner.cs
@@ -21,9 +21,7 @@ public class SqlTreePruner : ExpressionVisitor
     /// <summary>
     /// Maps table aliases to the list of column aliases found referenced on them.
     /// </summary>
-    // TODO: Make this protected after SelectExpression.Prune is moved into this visitor
-    [EntityFrameworkInternal]
-    public virtual IReadOnlyDictionary<string, HashSet<string>> ReferencedColumnMap => _referencedColumnMap;
+    protected virtual IReadOnlyDictionary<string, HashSet<string>> ReferencedColumnMap => _referencedColumnMap;
 
     /// <summary>
     ///     When visiting a nested <see cref="TableExpressionBase" /> (e.g. a select within a set operation), this holds the table alias
@@ -36,9 +34,7 @@ public class SqlTreePruner : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </remarks>
-    // TODO: Make this protected after SelectExpression.Prune is moved into this visitor
-    [EntityFrameworkInternal]
-    public virtual string? CurrentTableAlias { get; set; }
+    protected virtual string? CurrentTableAlias { get; set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -62,7 +58,7 @@ public class SqlTreePruner : ExpressionVisitor
             case ShapedQueryExpression shapedQueryExpression:
                 _referencedColumnMap.Clear();
                 return shapedQueryExpression.Update(
-                    ((SelectExpression)shapedQueryExpression.QueryExpression).PruneToplevel(this),
+                    PruneToplevelSelect((SelectExpression)shapedQueryExpression.QueryExpression),
                     Visit(shapedQueryExpression.ShaperExpression));
 
             case RelationalSplitCollectionShaperExpression relationalSplitCollectionShaperExpression:
@@ -70,20 +66,18 @@ public class SqlTreePruner : ExpressionVisitor
                 return relationalSplitCollectionShaperExpression.Update(
                     relationalSplitCollectionShaperExpression.ParentIdentifier,
                     relationalSplitCollectionShaperExpression.ChildIdentifier,
-                    relationalSplitCollectionShaperExpression.SelectExpression.PruneToplevel(this),
+                    PruneToplevelSelect(relationalSplitCollectionShaperExpression.SelectExpression),
                     Visit(relationalSplitCollectionShaperExpression.InnerShaper));
 
             case DeleteExpression deleteExpression:
-                return deleteExpression.Update(deleteExpression.Table, deleteExpression.SelectExpression.PruneToplevel(this));
+                return deleteExpression.Update(deleteExpression.Table, PruneToplevelSelect(deleteExpression.SelectExpression));
 
             case UpdateExpression updateExpression:
                 // Note that we must visit the setters before we visit the select, since the setters can reference tables inside it.
                 var visitedSetters = updateExpression.ColumnValueSetters
                     .Select(e => e with { Value = (SqlExpression)Visit(e.Value) })
                     .ToList();
-                return updateExpression.Update(
-                    updateExpression.SelectExpression.PruneToplevel(this),
-                    visitedSetters);
+                return updateExpression.Update(PruneToplevelSelect(updateExpression.SelectExpression), visitedSetters);
 
             // The following remaining cases deal with recursive visitation (i.e. non-top-level things)
 
@@ -96,8 +90,7 @@ public class SqlTreePruner : ExpressionVisitor
             // Note that this only handles nested selects, and *not* the top-level select - that was already handled above in the first
             // cases.
             case SelectExpression select:
-                select.Prune(this, pruneProjection: true);
-                return select;
+                return PruneSelect(select, preserveProjection: false);
 
             // PredicateJoinExpressionBase.VisitChildren visits the table before the predicate, but we must visit the predicate first
             // since it can contain columns referencing the table's projection (which we shouldn't prune).
@@ -109,14 +102,13 @@ public class SqlTreePruner : ExpressionVisitor
             // Never prune the projection of a scalar subquery. Note that there are never columns referencing scalar subqueries, since
             // they're not tables.
             case ScalarSubqueryExpression scalarSubquery:
-                scalarSubquery.Subquery.Prune(this, pruneProjection: false);
-                return scalarSubquery;
+                return scalarSubquery.Update(PruneSelect(scalarSubquery.Subquery, preserveProjection: true));
 
             // Same for subqueries inside InExpression
             case InExpression { Subquery: SelectExpression subquery } inExpression:
-                var item = (SqlExpression)Visit(inExpression.Item);
-                subquery.Prune(this, pruneProjection: false);
-                return inExpression.Update(item, subquery);
+                var visitedItem = (SqlExpression)Visit(inExpression.Item);
+                var visitedSubquery = PruneSelect(subquery, preserveProjection: true);
+                return inExpression.Update(visitedItem, visitedSubquery);
 
             // If the set operation is distinct (union/intersect/except, but not concat), we cannot prune the projection since that would
             // affect which rows come out.
@@ -126,9 +118,9 @@ public class SqlTreePruner : ExpressionVisitor
             case SetOperationBase { Source1: var source1, Source2: var source2 } setOperation
                 when setOperation.IsDistinct || source1.IsDistinct || source2.IsDistinct:
             {
-                source1.Prune(this, pruneProjection: false);
-                source2.Prune(this, pruneProjection: false);
-                return setOperation;
+                return setOperation.Update(
+                    PruneSelect(source1, preserveProjection: true),
+                    PruneSelect(source2, preserveProjection: true));
             }
 
             default:
@@ -137,5 +129,136 @@ public class SqlTreePruner : ExpressionVisitor
 
         void RegisterTable(string tableAlias, ColumnExpression column)
             => _referencedColumnMap.GetOrAddNew(tableAlias).Add(column.Name);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual SelectExpression PruneToplevelSelect(SelectExpression select)
+    {
+        // TODO: This doesn't belong in pruning, take a deeper look at how we manage TPC, #32873
+        select = select.RemoveTpcTableExpression();
+        return PruneSelect(select, preserveProjection: true);
+    }
+
+    /// <summary>
+    ///     Prunes a <see cref="SelectExpression" />, removes tables inside it which aren't referenced, and optionally also projections
+    ///     which aren't referenced from outside it.
+    /// </summary>
+    /// <param name="select">The <see cref="SelectExpression" /> to prune.</param>
+    /// <param name="preserveProjection">Whether to prune projections if they aren't referenced from the outside.</param>
+    /// <returns>A pruned copy of <paramref name="select" />, or the same instance of nothing was pruned.</returns>
+    protected virtual SelectExpression PruneSelect(SelectExpression select, bool preserveProjection)
+    {
+        Check.DebugAssert(!select.IsMutable, "Mutable SelectExpression found when pruning");
+
+        var referencedColumnMap = ReferencedColumnMap;
+
+        // When visiting the select's tables, we track the alias so that we know it when processing nested table expressions (e.g. within
+        // set operations); make sure that when visiting other clauses (e.g. predicate), the tracked table alias is null.
+        var currentSelectAlias = select.Alias ?? CurrentTableAlias;
+        var parentTableAlias = CurrentTableAlias;
+        CurrentTableAlias = null;
+
+        // First visit all the non-table clauses of the SelectExpression - this will populate referencedColumnMap with all columns
+        // referenced on all tables.
+
+        // Go over the projections, prune any that isn't referenced from the outside and visiting those that are.
+        // We avoid pruning projections when:
+        // 1. The caller requests we don't (top-level select, scalar subquery, select within a set operation where the other is distinct -
+        //     projection must be preserved as-is)
+        // 2. The select has distinct (removing a projection changes which rows get projected out)
+        preserveProjection |= select.IsDistinct || currentSelectAlias is null;
+        List<ProjectionExpression>? projections = null;
+
+        var referencedProjectionAliases = currentSelectAlias is not null ? referencedColumnMap.GetValueOrDefault(currentSelectAlias) : null;
+
+        for (var i = 0; i < select.Projection.Count; i++)
+        {
+            var projection = select.Projection[i];
+
+            var visitedProjection = preserveProjection || referencedProjectionAliases?.Contains(projection.Alias) == true
+                ? (ProjectionExpression)Visit(projection)
+                : null; // "visited" in the sense of pruned
+
+            if (visitedProjection != projection && projections is null)
+            {
+                projections = new(select.Projection.Count);
+                for (var j = 0; j < i; j++)
+                {
+                    projections.Add(select.Projection[j]);
+                }
+            }
+
+            if (projections is not null && visitedProjection is not null)
+            {
+                projections.Add(visitedProjection);
+            }
+        }
+
+        var predicate = (SqlExpression?)Visit(select.Predicate);
+        var groupBy = this.VisitAndConvert(select.GroupBy);
+        var having = (SqlExpression?)Visit(select.Having);
+        var orderings = this.VisitAndConvert(select.Orderings);
+        var offset = (SqlExpression?)Visit(select.Offset);
+        var limit = (SqlExpression?)Visit(select.Limit);
+
+        // Note that we don't visit/copy _identifier, _childIdentifier and _tpcDiscriminatorValues; these have already been applied
+        // and are no longer needed.
+
+        // We've visited the entire select expression except for the table, and now have referencedColumnMap fully populated with column
+        // references to all its tables.
+        // Go over the tables, removing any which aren't referenced anywhere (and are prunable).
+        // We do this in backwards order, so that later joins referencing earlier tables in the predicate don't cause the earlier tables
+        // to be preserved.
+        List<TableExpressionBase>? tables = null;
+        for (var i = select.Tables.Count - 1; i >= 0; i--)
+        {
+            var table = select.Tables[i];
+            var alias = table.GetRequiredAlias();
+            TableExpressionBase? visitedTable;
+
+            if (!referencedColumnMap.ContainsKey(alias)
+                && table is JoinExpressionBase { IsPrunable: true })
+            {
+                // If no column references the table, prune it.
+                // Note that we only prune joins; pruning the main is more complex because other tables need to unwrap joins to be main.
+                // We also only prune joins explicitly marked as prunable; otherwise e.g. an inner join may be needed to filter out rows
+                // even if no column references it.
+                visitedTable = null;
+            }
+            else
+            {
+                // The table wasn't pruned - visit it. This may add references to a previous table, causing it to be preserved (e.g. if it's
+                // referenced from the join predicate), or just prune something inside (e.g. a subquery table).
+                // Note that we track the table's alias in CurrentTableAlias, in case it contains nested selects (i.e. within set
+                // operations), which don't have their own alias.
+                CurrentTableAlias = alias;
+                visitedTable = (TableExpressionBase)Visit(table);
+            }
+
+            if (visitedTable != table && tables is null)
+            {
+                tables = new List<TableExpressionBase>(select.Tables.Count);
+                for (var j = i + 1; j < select.Tables.Count; j++)
+                {
+                    tables.Add(select.Tables[j]);
+                }
+            }
+
+            if (tables is not null && visitedTable is not null)
+            {
+                tables.Insert(0, visitedTable);
+            }
+        }
+
+        CurrentTableAlias = parentTableAlias;
+
+        return select.Update(
+            projections ?? select.Projection, tables ?? select.Tables, predicate, groupBy, having, orderings, limit, offset);
     }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -281,64 +281,25 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
     /// </summary>
     protected override Expression VisitSelect(SelectExpression selectExpression)
     {
-        var changed = false;
         var parentSearchCondition = _isSearchCondition;
 
-        var projections = new List<ProjectionExpression>();
         _isSearchCondition = false;
-        foreach (var item in selectExpression.Projection)
-        {
-            var updatedProjection = (ProjectionExpression)Visit(item);
-            projections.Add(updatedProjection);
-            changed |= updatedProjection != item;
-        }
 
-        var tables = new List<TableExpressionBase>();
-        foreach (var table in selectExpression.Tables)
-        {
-            var newTable = (TableExpressionBase)Visit(table);
-            changed |= newTable != table;
-            tables.Add(newTable);
-        }
-
-        _isSearchCondition = true;
-        var predicate = (SqlExpression?)Visit(selectExpression.Predicate);
-        changed |= predicate != selectExpression.Predicate;
-
-        var groupBy = new List<SqlExpression>();
-        _isSearchCondition = false;
-        foreach (var groupingKey in selectExpression.GroupBy)
-        {
-            var newGroupingKey = (SqlExpression)Visit(groupingKey);
-            changed |= newGroupingKey != groupingKey;
-            groupBy.Add(newGroupingKey);
-        }
-
-        _isSearchCondition = true;
-        var havingExpression = (SqlExpression?)Visit(selectExpression.Having);
-        changed |= havingExpression != selectExpression.Having;
-
-        var orderings = new List<OrderingExpression>();
-        _isSearchCondition = false;
-        foreach (var ordering in selectExpression.Orderings)
-        {
-            var orderingExpression = (SqlExpression)Visit(ordering.Expression);
-            changed |= orderingExpression != ordering.Expression;
-            orderings.Add(ordering.Update(orderingExpression));
-        }
-
+        var projections = this.VisitAndConvert(selectExpression.Projection);
+        var tables = this.VisitAndConvert(selectExpression.Tables);
+        var groupBy = this.VisitAndConvert(selectExpression.GroupBy);
+        var orderings = this.VisitAndConvert(selectExpression.Orderings);
         var offset = (SqlExpression?)Visit(selectExpression.Offset);
-        changed |= offset != selectExpression.Offset;
-
         var limit = (SqlExpression?)Visit(selectExpression.Limit);
-        changed |= limit != selectExpression.Limit;
+
+        _isSearchCondition = true;
+
+        var predicate = (SqlExpression?)Visit(selectExpression.Predicate);
+        var havingExpression = (SqlExpression?)Visit(selectExpression.Having);
 
         _isSearchCondition = parentSearchCondition;
 
-        return changed
-            ? selectExpression.Update(
-                projections, tables, predicate, groupBy, havingExpression, orderings, limit, offset)
-            : selectExpression;
+        return selectExpression.Update(projections, tables, predicate, groupBy, havingExpression, orderings, limit, offset);
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTreePruner.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTreePruner.cs
@@ -27,9 +27,7 @@ public class SqlServerSqlTreePruner : SqlTreePruner
             case SqlServerOpenJsonExpression { ColumnInfos: IReadOnlyList<ColumnInfo> columnInfos } openJson:
                 var visitedJson = (SqlExpression)Visit(openJson.JsonExpression);
 
-#pragma warning disable EF1001 // ReferencedColumnMap is pubternal; should be made protected
                 if (ReferencedColumnMap.TryGetValue(openJson.Alias, out var referencedAliases))
-#pragma warning restore EF1001
                 {
                     List<ColumnInfo>? newColumnInfos = null;
 


### PR DESCRIPTION
**NOTE: This is based on top of #32815, review the last commit only**

* As planned, this moves all pruning code out of SelectExpression and into the SqlTreePruner, which is now completely self-contained (except for am unimportant TPC-related exception).
* In addition, the pruner was reimplemented to be a standard visitor, returning a copy rather than mutating anything.
* This has important consequences beyond just cleaning up the pruner; since the pruner now treats SelectExpression as an actual immutable expression, any node that gets referenced multiple times gets duplicated if any change is done inside it. This exposed various places further down the pipeline where reference identity was assumed, but now we have distinct instances which are structurally equal instead.
* SelectExpression.Update() was optimized, and all usages of it cleaned up for much terser code.

Fixes #31276