### PR TITLE
Fix incremental builds

### DIFF
--- a/src/dotnet-ef/Project.cs
+++ b/src/dotnet-ef/Project.cs
@@ -53,16 +53,22 @@ internal class Project
 
         Directory.CreateDirectory(buildExtensionsDir);
 
+        byte[] efTargets;
+        using (var input = typeof(Resources).Assembly.GetManifestResourceStream(
+                   "Microsoft.EntityFrameworkCore.Tools.Resources.EntityFrameworkCore.targets")!)
+        {
+            efTargets = new byte[input.Length];
+            input.Read(efTargets);
+        }
+
         var efTargetsPath = Path.Combine(
             buildExtensionsDir,
             Path.GetFileName(file) + ".EntityFrameworkCore.targets");
-        using (var input = typeof(Resources).Assembly.GetManifestResourceStream(
-                   "Microsoft.EntityFrameworkCore.Tools.Resources.EntityFrameworkCore.targets")!)
-        using (var output = File.OpenWrite(efTargetsPath))
+        // Avoid touching the targets file, if it matches what we need, to enable incremental builds
+        if (!File.Exists(efTargetsPath) || !File.ReadAllBytes(efTargetsPath).SequenceEqual(efTargets))
         {
-            // NB: Copy always in case it changes
             Reporter.WriteVerbose(Resources.WritingFile(efTargetsPath));
-            input.CopyTo(output);
+            File.WriteAllBytes(efTargetsPath, efTargets);
         }
 
         IDictionary<string, string> metadata;

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestFixture.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestFixture.cs
@@ -12,14 +12,14 @@ public class ModelCodeGeneratorTestFixture : IDisposable
 
         using (var input = typeof(ModelCodeGeneratorTestBase).Assembly.GetManifestResourceStream(
                    "Microsoft.EntityFrameworkCore.Resources.CSharpDbContextGenerator.tt"))
-        using (var output = File.OpenWrite(Path.Combine(templatesDir, "DbContext.t4")))
+        using (var output = File.Create(Path.Combine(templatesDir, "DbContext.t4")))
         {
             input.CopyTo(output);
         }
 
         using (var input = typeof(ModelCodeGeneratorTestBase).Assembly.GetManifestResourceStream(
                    "Microsoft.EntityFrameworkCore.Resources.CSharpEntityTypeGenerator.tt"))
-        using (var output = File.OpenWrite(Path.Combine(templatesDir, "EntityType.t4")))
+        using (var output = File.Create(Path.Combine(templatesDir, "EntityType.t4")))
         {
             input.CopyTo(output);
         }

--- a/test/EFCore.Specification.Tests/TestUtilities/BuildSource.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/BuildSource.cs
@@ -60,7 +60,7 @@ public class BuildSource
 
         var targetPath = Path.Combine(TargetDir ?? Path.GetTempPath(), projectName + ".dll");
 
-        using (var stream = File.OpenWrite(targetPath))
+        using (var stream = File.Create(targetPath))
         {
             var result = compilation.Emit(stream);
             if (!result.Success)


### PR DESCRIPTION
- Avoid writing to the obj directory unnecessarily to avoid tripping up the up-to-date check
- Also fixes a subtle bug around file writing: `File.OpenWrite` will open an existing file and not truncate it, so if we ever write fewer bytes to that file than it currently contains, those additional bytes will remain at the end, corrupting the file. Using `File.Create` or `File.WriteAllBytes` ensures the contents of the files are fully replaced.

I hope this passes the "not too clever" bar and also improves reliability and performance.

Fixes #32801