### PR TITLE
[release/8.0] Use the unpatched shared framework as the minimum requirement for tools.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,13 +7,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\testing\linker\trimmingTests.targets" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
 
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.NETCore.App"
-                        Condition="'$(TargetFramework)' == 'net8.0'"
-                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
-                        TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
-  </ItemGroup>
-
   <Target Name="GetCustomAssemblyAttributes"
           BeforeTargets="GetAssemblyAttributes"
           Condition=" '$(MSBuildProjectExtension)' == '.csproj' "


### PR DESCRIPTION
Fixes #32782

### Description

The `ef` tool no longer works on 8.0.100 SDK due to leftover code that allowed it to work on preview versions.

### Customer impact

Unable to use 8.0.1 EF tools on 8.0.100 .Net SDK

### How found

CTI testing on 8.0.1

### Regression

Yes, from 8.0.0.

### Testing

Tested manually.

### Risk

Low.

