### PR TITLE
Clear _modificationCommandGraph when returning the context to pool

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -152,6 +151,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IRelationalCommandBuilderFactory, RelationalCommandBuilderFactory>();
         TryAdd<IRawSqlCommandBuilder, RawSqlCommandBuilder>();
         TryAdd<ICommandBatchPreparer, CommandBatchPreparer>();
+        TryAdd<IResettableService, ICommandBatchPreparer>(p => p.GetRequiredService<ICommandBatchPreparer>());
         TryAdd<IModificationCommandFactory, ModificationCommandFactory>();
         TryAdd<IMigrationsModelDiffer, MigrationsModelDiffer>();
         TryAdd<IMigrationsSqlGenerator, MigrationsSqlGenerator>();

--- a/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 ///         for more information and examples.
 ///     </para>
 /// </remarks>
-public interface ICommandBatchPreparer
+public interface ICommandBatchPreparer : IResettableService
 {
     /// <summary>
     ///     Creates the command batches needed to insert/update/delete the entities represented by the given

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -1334,6 +1334,17 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         }
     }
 
+    /// <inheritdoc/>
+    void IResettableService.ResetState() => _modificationCommandGraph.Clear();
+
+    /// <inheritdoc/>
+    Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
+    {
+        ((IResettableService)this).ResetState();
+
+        return Task.CompletedTask;
+    }
+
     private sealed record class CommandDependency
     {
         public CommandDependency(IAnnotatable metadata, bool breakable = false)

--- a/src/EFCore/Internal/DbContextLease.cs
+++ b/src/EFCore/Internal/DbContextLease.cs
@@ -60,7 +60,7 @@ public struct DbContextLease
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public bool IsActive
+    public readonly bool IsActive
         => _contextPool != null;
 
     /// <summary>

--- a/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
@@ -30,7 +30,7 @@ public static class ServiceCollectionExtensions
                     && mi.GetParameters()[1].ParameterType == typeof(Action<IServiceProvider, DbContextOptionsBuilder>)
                     && mi.GetGenericArguments().Length == 1);
 
-    public static IServiceCollection AddDbContextPool(
+    public static IServiceCollection AddPooledDbContextFactory(
         this IServiceCollection serviceCollection,
         Type contextType,
         Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)


### PR DESCRIPTION
Reset StateManager and DatabaseFacade more consistently.
Fix functional tests so they actually return the context to the pool.

Fixes #32652

