### PR TITLE
Cleanup of TPC handling

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
@@ -218,8 +218,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             subSelectExpressions.Add(SelectExpression.CreateImmutable(alias: null!, [tableExpression], projections));
                         }
 
-                        var tpcTableAlias = _sqlAliasManager.GenerateTableAlias("t");
-                        var tpcTables = new TpcTablesExpression(tpcTableAlias, entityType, subSelectExpressions);
+                        var tpcTableAlias = _sqlAliasManager.GenerateTableAlias("union");
 
                         var firstSelectExpression = subSelectExpressions[0];
                         var columns = new Dictionary<IProperty, ColumnExpression>();
@@ -236,18 +235,15 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                         }
 
                         var discriminatorColumn = CreateColumnExpression(firstSelectExpression.Projection[^1], tpcTableAlias);
-                        var tpcDiscriminatorValues = new Dictionary<TpcTablesExpression, (ColumnExpression, List<string>)>
-                        {
-                            [tpcTables] = (discriminatorColumn, discriminatorValues)
-                        };
+                        var tpcTables = new TpcTablesExpression(
+                            tpcTableAlias, entityType, subSelectExpressions, discriminatorColumn, discriminatorValues);
                         var tableMap = tables.ToDictionary(t => t, _ => tpcTableAlias);
 
                         return new SelectExpression(
                             [tpcTables],
                             new StructuralTypeProjectionExpression(entityType, columns, tableMap, nullable: false, discriminatorColumn),
                             identifier,
-                            _sqlAliasManager,
-                            tpcDiscriminatorValues);
+                            _sqlAliasManager);
                     }
                 }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -47,8 +47,8 @@ WHERE (
         UNION ALL
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [t].[CountryId] = 1 AND [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [u].[CountryId] = 1 AND [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -65,8 +65,8 @@ WHERE (
     FROM (
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [t].[CountryId] = 1 AND [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [u].[CountryId] = 1 AND [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -169,8 +169,8 @@ WHERE (
         UNION ALL
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [t].[CountryId] = 1 AND [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [u].[CountryId] = 1 AND [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -202,8 +202,8 @@ WHERE (
     FROM (
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [t].[CountryId] = 1 AND [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [u].[CountryId] = 1 AND [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
@@ -47,8 +47,8 @@ WHERE (
         UNION ALL
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -65,8 +65,8 @@ WHERE (
     FROM (
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -167,8 +167,8 @@ WHERE (
         UNION ALL
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 
@@ -199,8 +199,8 @@ WHERE (
     FROM (
         SELECT [k].[CountryId]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    WHERE [c].[Id] = [t].[CountryId] AND [t].[CountryId] > 0) > 0
+    ) AS [u]
+    WHERE [c].[Id] = [u].[CountryId] AND [u].[CountryId] > 0) > 0
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
@@ -222,15 +222,15 @@ WHERE ([d].[Id] IS NOT NULL OR [c].[Id] IS NOT NULL) AND [a].[Species] LIKE N'F%
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Species], [t].[Name], [t].[EdcuationLevel], [t].[FavoriteToy], [t].[Discriminator]
+SELECT [u].[Id], [u].[Species], [u].[Name], [u].[EdcuationLevel], [u].[FavoriteToy], [u].[Discriminator]
 FROM (
     SELECT [c].[Id], [c].[Species], [c].[Name], [c].[EdcuationLevel], NULL AS [FavoriteToy], N'Cat' AS [Discriminator]
     FROM [Cats] AS [c]
     UNION ALL
     SELECT [d].[Id], [d].[Species], [d].[Name], NULL AS [EdcuationLevel], [d].[FavoriteToy], N'Dog' AS [Discriminator]
     FROM [Dogs] AS [d]
-) AS [t]
-WHERE [t].[Species] LIKE N'F%'
+) AS [u]
+WHERE [u].[Species] LIKE N'F%'
 """);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
@@ -446,7 +446,7 @@ LEFT JOIN [OwnedReferencePart3] AS [o0] ON [l].[Id] = [o0].[LeafEntityId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseValue], [t].[MiddleValue], [t].[SiblingValue], [t].[LeafValue], [t].[Discriminator], [l0].[Id], [l0].[OwnedReference_Id], [l0].[OwnedReference_OwnedIntValue1], [l0].[OwnedReference_OwnedIntValue2], [o0].[OwnedIntValue3], [o].[OwnedIntValue4], [l0].[OwnedReference_OwnedStringValue1], [l0].[OwnedReference_OwnedStringValue2], [o0].[OwnedStringValue3], [o].[OwnedStringValue4]
+SELECT [u].[Id], [u].[BaseValue], [u].[MiddleValue], [u].[SiblingValue], [u].[LeafValue], [u].[Discriminator], [l0].[Id], [l0].[OwnedReference_Id], [l0].[OwnedReference_OwnedIntValue1], [l0].[OwnedReference_OwnedIntValue2], [o0].[OwnedIntValue3], [o].[OwnedIntValue4], [l0].[OwnedReference_OwnedStringValue1], [l0].[OwnedReference_OwnedStringValue2], [o0].[OwnedStringValue3], [o].[OwnedStringValue4]
 FROM (
     SELECT [b].[Id], [b].[BaseValue], NULL AS [MiddleValue], NULL AS [SiblingValue], NULL AS [LeafValue], N'BaseEntity' AS [Discriminator]
     FROM [BaseEntity] AS [b]
@@ -459,8 +459,8 @@ FROM (
     UNION ALL
     SELECT [l].[Id], [l].[BaseValue], [l].[MiddleValue], NULL AS [SiblingValue], [l].[LeafValue], N'LeafEntity' AS [Discriminator]
     FROM [LeafEntity] AS [l]
-) AS [t]
-LEFT JOIN [LeafEntity] AS [l0] ON [t].[Id] = [l0].[Id]
+) AS [u]
+LEFT JOIN [LeafEntity] AS [l0] ON [u].[Id] = [l0].[Id]
 LEFT JOIN [OwnedReferencePart4] AS [o] ON [l0].[Id] = [o].[LeafEntityId]
 LEFT JOIN [OwnedReferencePart3] AS [o0] ON [l0].[Id] = [o0].[LeafEntityId]
 """);
@@ -575,7 +575,7 @@ FROM [SiblingEntity] AS [s]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseValue], [t].[MiddleValue], [t].[SiblingValue], [t].[LeafValue], [t].[Discriminator], [o].[BaseEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
+SELECT [u].[Id], [u].[BaseValue], [u].[MiddleValue], [u].[SiblingValue], [u].[LeafValue], [u].[Discriminator], [o].[BaseEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
 FROM (
     SELECT [b].[Id], [b].[BaseValue], NULL AS [MiddleValue], NULL AS [SiblingValue], NULL AS [LeafValue], N'BaseEntity' AS [Discriminator]
     FROM [BaseEntity] AS [b]
@@ -588,8 +588,8 @@ FROM (
     UNION ALL
     SELECT [l].[Id], [l].[BaseValue], [l].[MiddleValue], NULL AS [SiblingValue], [l].[LeafValue], N'LeafEntity' AS [Discriminator]
     FROM [LeafEntity] AS [l]
-) AS [t]
-LEFT JOIN [OwnedReferencePart1] AS [o] ON [t].[Id] = [o].[BaseEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferencePart1] AS [o] ON [u].[Id] = [o].[BaseEntityId]
 LEFT JOIN [OwnedReferencePart4] AS [o0] ON [o].[BaseEntityId] = [o0].[BaseEntityId]
 LEFT JOIN [OwnedReferencePart3] AS [o1] ON [o].[BaseEntityId] = [o1].[BaseEntityId]
 """);
@@ -617,7 +617,7 @@ LEFT JOIN [OwnedReferencePart3] AS [o1] ON [o].[BaseEntityId] = [o1].[BaseEntity
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseValue], [t].[MiddleValue], [t].[SiblingValue], [t].[LeafValue], [t].[Discriminator], [o].[MiddleEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
+SELECT [u].[Id], [u].[BaseValue], [u].[MiddleValue], [u].[SiblingValue], [u].[LeafValue], [u].[Discriminator], [o].[MiddleEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
 FROM (
     SELECT [b].[Id], [b].[BaseValue], NULL AS [MiddleValue], NULL AS [SiblingValue], NULL AS [LeafValue], N'BaseEntity' AS [Discriminator]
     FROM [BaseEntity] AS [b]
@@ -630,8 +630,8 @@ FROM (
     UNION ALL
     SELECT [l].[Id], [l].[BaseValue], [l].[MiddleValue], NULL AS [SiblingValue], [l].[LeafValue], N'LeafEntity' AS [Discriminator]
     FROM [LeafEntity] AS [l]
-) AS [t]
-LEFT JOIN [OwnedReferencePart1] AS [o] ON [t].[Id] = [o].[MiddleEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferencePart1] AS [o] ON [u].[Id] = [o].[MiddleEntityId]
 LEFT JOIN [OwnedReferencePart4] AS [o0] ON [o].[MiddleEntityId] = [o0].[MiddleEntityId]
 LEFT JOIN [OwnedReferencePart3] AS [o1] ON [o].[MiddleEntityId] = [o1].[MiddleEntityId]
 """);
@@ -683,7 +683,7 @@ LEFT JOIN [OwnedReferencePart3] AS [o1] ON [o].[MiddleEntityId] = [o1].[MiddleEn
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseValue], [t].[MiddleValue], [t].[SiblingValue], [t].[LeafValue], [t].[Discriminator], [s0].[BaseEntityId], [s0].[Id], [s0].[OwnedIntValue1], [s0].[OwnedIntValue2], [s0].[OwnedIntValue3], [s0].[OwnedIntValue4], [s0].[OwnedStringValue1], [s0].[OwnedStringValue2], [s0].[OwnedStringValue3], [s0].[OwnedStringValue4]
+SELECT [u].[Id], [u].[BaseValue], [u].[MiddleValue], [u].[SiblingValue], [u].[LeafValue], [u].[Discriminator], [s0].[BaseEntityId], [s0].[Id], [s0].[OwnedIntValue1], [s0].[OwnedIntValue2], [s0].[OwnedIntValue3], [s0].[OwnedIntValue4], [s0].[OwnedStringValue1], [s0].[OwnedStringValue2], [s0].[OwnedStringValue3], [s0].[OwnedStringValue4]
 FROM (
     SELECT [b].[Id], [b].[BaseValue], NULL AS [MiddleValue], NULL AS [SiblingValue], NULL AS [LeafValue], N'BaseEntity' AS [Discriminator]
     FROM [BaseEntity] AS [b]
@@ -696,14 +696,14 @@ FROM (
     UNION ALL
     SELECT [l].[Id], [l].[BaseValue], [l].[MiddleValue], NULL AS [SiblingValue], [l].[LeafValue], N'LeafEntity' AS [Discriminator]
     FROM [LeafEntity] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [o].[BaseEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
     FROM [OwnedReferencePart1] AS [o]
     INNER JOIN [OwnedReferencePart4] AS [o0] ON [o].[BaseEntityId] = [o0].[BaseEntityId] AND [o].[Id] = [o0].[Id]
     INNER JOIN [OwnedReferencePart3] AS [o1] ON [o].[BaseEntityId] = [o1].[BaseEntityId] AND [o].[Id] = [o1].[Id]
-) AS [s0] ON [t].[Id] = [s0].[BaseEntityId]
-ORDER BY [t].[Id], [s0].[BaseEntityId]
+) AS [s0] ON [u].[Id] = [s0].[BaseEntityId]
+ORDER BY [u].[Id], [s0].[BaseEntityId]
 """);
     }
 
@@ -729,7 +729,7 @@ ORDER BY [t].[Id], [s0].[BaseEntityId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseValue], [t].[MiddleValue], [t].[SiblingValue], [t].[LeafValue], [t].[Discriminator], [s0].[MiddleEntityId], [s0].[Id], [s0].[OwnedIntValue1], [s0].[OwnedIntValue2], [s0].[OwnedIntValue3], [s0].[OwnedIntValue4], [s0].[OwnedStringValue1], [s0].[OwnedStringValue2], [s0].[OwnedStringValue3], [s0].[OwnedStringValue4]
+SELECT [u].[Id], [u].[BaseValue], [u].[MiddleValue], [u].[SiblingValue], [u].[LeafValue], [u].[Discriminator], [s0].[MiddleEntityId], [s0].[Id], [s0].[OwnedIntValue1], [s0].[OwnedIntValue2], [s0].[OwnedIntValue3], [s0].[OwnedIntValue4], [s0].[OwnedStringValue1], [s0].[OwnedStringValue2], [s0].[OwnedStringValue3], [s0].[OwnedStringValue4]
 FROM (
     SELECT [b].[Id], [b].[BaseValue], NULL AS [MiddleValue], NULL AS [SiblingValue], NULL AS [LeafValue], N'BaseEntity' AS [Discriminator]
     FROM [BaseEntity] AS [b]
@@ -742,14 +742,14 @@ FROM (
     UNION ALL
     SELECT [l].[Id], [l].[BaseValue], [l].[MiddleValue], NULL AS [SiblingValue], [l].[LeafValue], N'LeafEntity' AS [Discriminator]
     FROM [LeafEntity] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [o].[MiddleEntityId], [o].[Id], [o].[OwnedIntValue1], [o].[OwnedIntValue2], [o1].[OwnedIntValue3], [o0].[OwnedIntValue4], [o].[OwnedStringValue1], [o].[OwnedStringValue2], [o1].[OwnedStringValue3], [o0].[OwnedStringValue4]
     FROM [OwnedReferencePart1] AS [o]
     INNER JOIN [OwnedReferencePart4] AS [o0] ON [o].[MiddleEntityId] = [o0].[MiddleEntityId] AND [o].[Id] = [o0].[Id]
     INNER JOIN [OwnedReferencePart3] AS [o1] ON [o].[MiddleEntityId] = [o1].[MiddleEntityId] AND [o].[Id] = [o1].[Id]
-) AS [s0] ON [t].[Id] = [s0].[MiddleEntityId]
-ORDER BY [t].[Id], [s0].[MiddleEntityId]
+) AS [s0] ON [u].[Id] = [s0].[MiddleEntityId]
+ORDER BY [u].[Id], [s0].[MiddleEntityId]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
@@ -24,16 +24,16 @@ public class TPCFiltersInheritanceQuerySqlServerTest : TPCFiltersInheritanceQuer
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[CountryId] = 1
+ORDER BY [u].[Species]
 """);
     }
 
@@ -43,12 +43,12 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[CountryId] = 1
 """);
     }
 
@@ -58,15 +58,15 @@ WHERE [t].[CountryId] = 1
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1 AND [t].[Discriminator] = N'Kiwi' AND [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[CountryId] = 1 AND [u].[Discriminator] = N'Kiwi' AND [u].[CountryId] = 1
 """);
     }
 
@@ -77,7 +77,7 @@ WHERE [t].[CountryId] = 1 AND [t].[Discriminator] = N'Kiwi' AND [t].[CountryId] 
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
+    WHEN [u].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -86,8 +86,8 @@ FROM (
     UNION ALL
     SELECT [k].[CountryId], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[CountryId] = 1
 """);
     }
 
@@ -97,16 +97,16 @@ WHERE [t].[CountryId] = 1
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[CountryId] = 1
+ORDER BY [u].[Species]
 """);
     }
 
@@ -116,16 +116,16 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[CountryId] = 1
+ORDER BY [u].[Species]
 """);
     }
 
@@ -135,15 +135,15 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Name]
+SELECT [u].[Name]
 FROM (
     SELECT [e].[CountryId], [e].[Name]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[CountryId], [k].[Name]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[CountryId] = 1
 """);
     }
 
@@ -153,16 +153,16 @@ WHERE [t].[CountryId] = 1
 
         AssertSql(
             """
-SELECT TOP(1) [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT TOP(1) [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[CountryId] = 1
+ORDER BY [u].[Species]
 """);
     }
 
@@ -172,12 +172,12 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[CountryId] = 1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -27,14 +27,14 @@ public class TPCGearsOfWarQuerySqlServerTest : TPCGearsOfWarQueryRelationalTestB
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -45,7 +45,7 @@ WHERE 0 = 1
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -53,9 +53,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -65,7 +65,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -73,8 +73,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 """);
     }
 
@@ -84,23 +84,23 @@ LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [c].[Name] = [t0].[AssignedCityName]
-ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name], [t0].[Nickname]
+) AS [u0] ON [c].[Name] = [u0].[AssignedCityName]
+ORDER BY [u].[Nickname], [u].[SquadId], [c].[Name], [u0].[Nickname]
 """);
     }
 
@@ -110,24 +110,24 @@ ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [c].[Name] = [t0].[AssignedCityName]
-WHERE [t].[Nickname] = N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name], [t0].[Nickname]
+) AS [u0] ON [c].[Name] = [u0].[AssignedCityName]
+WHERE [u].[Nickname] = N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId], [c].[Name], [u0].[Nickname]
 """);
     }
 
@@ -137,17 +137,17 @@ ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-WHERE [t].[Nickname] = N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+WHERE [u].[Nickname] = N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -157,19 +157,19 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -179,19 +179,19 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -201,7 +201,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -209,8 +209,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] = N'Marcus'
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] = N'Marcus'
 """);
     }
 
@@ -220,16 +220,16 @@ WHERE [t0].[Nickname] = N'Marcus'
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[SquadId] = [t0].[GearSquadId] AND [t].[Nickname] = [t0].[GearNickName]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[SquadId] = [t].[GearSquadId] AND [u].[Nickname] = [t].[GearNickName]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 """);
     }
 
@@ -239,7 +239,7 @@ INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -247,8 +247,8 @@ INNER JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
-INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 """);
     }
 
@@ -258,17 +258,17 @@ INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[SquadId] = [t0].[GearSquadId] AND [t].[Nickname] = [t0].[GearNickName]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[SquadId] = [t].[GearSquadId] AND [u].[Nickname] = [t].[GearNickName]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [t].[Id]
 """);
     }
 
@@ -278,7 +278,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -286,9 +286,9 @@ INNER JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -305,18 +305,18 @@ FROM [Tags] AS [t]
             """
 @__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[Id] IS NOT NULL AND [t0].[Id] IN (
-    SELECT [t1].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -334,19 +334,19 @@ FROM [Tags] AS [t]
             """
 @__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [c].[Location] IS NOT NULL AND [t0].[Id] IN (
-    SELECT [t1].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -364,18 +364,18 @@ FROM [Tags] AS [t]
             """
 @__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[Id] IS NOT NULL AND [t0].[Id] IN (
-    SELECT [t1].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
+    SELECT [t0].[value]
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -386,24 +386,24 @@ WHERE [t0].[Id] IS NOT NULL AND [t0].[Id] IN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [t0].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], [t].[Id], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[SquadId] = [t0].[GearSquadId] AND [t].[Nickname] = [t0].[GearNickName]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[SquadId] = [t].[GearSquadId] AND [u].[Nickname] = [t].[GearNickName]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t1] ON [c].[Name] = [t1].[AssignedCityName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id], [c].[Name], [t1].[Nickname]
+) AS [u0] ON [c].[Name] = [u0].[AssignedCityName]
+ORDER BY [u].[Nickname], [u].[SquadId], [t].[Id], [c].[Name], [u0].[Nickname]
 """);
     }
 
@@ -413,13 +413,13 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id], [c].[Name], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
-INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 """);
     }
 
@@ -429,20 +429,20 @@ INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t1] ON [t0].[Nickname] = [t1].[LeaderNickname] AND [t0].[SquadId] = [t1].[LeaderSquadId]
-ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [t1].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[HasSoulPatch], [u].[Nickname] DESC, [t].[Id], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -452,14 +452,14 @@ ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [t
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[SquadId] = [t0].[GearSquadId] AND [t].[Nickname] = [t0].[GearNickName]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[SquadId] = [t].[GearSquadId] AND [u].[Nickname] = [t].[GearNickName]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [t].[Id]
 """);
     }
 
@@ -469,20 +469,20 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t1] ON [t0].[Nickname] = [t1].[LeaderNickname] AND [t0].[SquadId] = [t1].[LeaderSquadId]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -492,7 +492,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Weapons] AS [w]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -500,9 +500,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-LEFT JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
-WHERE [t].[Nickname] <> N'Paduk' OR [t].[Nickname] IS NULL
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+LEFT JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
+WHERE [u].[Nickname] <> N'Paduk' OR [u].[Nickname] IS NULL
 ORDER BY [c].[Name], [w].[Id]
 """);
     }
@@ -513,15 +513,15 @@ ORDER BY [c].[Name], [w].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] = 4
+) AS [u]
+WHERE [u].[Rank] = 4
 """);
     }
 
@@ -589,27 +589,27 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 2 > 0
+) AS [u]
+WHERE [u].[Rank] & 2 > 0
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 2 = 2
+) AS [u]
+WHERE [u].[Rank] & 2 = 2
 """);
     }
 
@@ -619,39 +619,39 @@ WHERE [t].[Rank] & 2 = 2
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 1 = 1
+) AS [u]
+WHERE [u].[Rank] & 1 = 1
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE CAST([t].[Rank] AS bigint) & CAST(1 AS bigint) = CAST(1 AS bigint)
+) AS [u]
+WHERE CAST([u].[Rank] AS bigint) & CAST(1 AS bigint) = CAST(1 AS bigint)
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE CAST([t].[Rank] AS smallint) & CAST(1 AS smallint) = CAST(1 AS smallint)
+) AS [u]
+WHERE CAST([u].[Rank] AS smallint) & CAST(1 AS smallint) = CAST(1 AS smallint)
 """);
     }
 
@@ -719,15 +719,15 @@ WHERE [w].[AmmunitionType] & NULL > 0
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] | 2 > 0
+) AS [u]
+WHERE [u].[Rank] | 2 > 0
 """);
     }
 
@@ -738,20 +738,20 @@ WHERE [t].[Rank] | 2 > 0
         AssertSql(
             """
 SELECT TOP(1) CASE
-    WHEN [t].[Rank] & 2 = 2 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] & 2 = 2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [BitwiseTrue], CASE
-    WHEN [t].[Rank] & 2 = 4 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] & 2 = 4 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END AS [BitwiseFalse], [t].[Rank] & 2 AS [BitwiseValue]
+END AS [BitwiseFalse], [u].[Rank] & 2 AS [BitwiseValue]
 FROM (
     SELECT [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 2 = 2
+) AS [u]
+WHERE [u].[Rank] & 2 = 2
 """);
     }
 
@@ -761,63 +761,63 @@ WHERE [t].[Rank] & 2 = 2
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 2 = 2
+) AS [u]
+WHERE [u].[Rank] & 2 = 2
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 18 = 18
+) AS [u]
+WHERE [u].[Rank] & 18 = 18
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 1 = 1
+) AS [u]
+WHERE [u].[Rank] & 1 = 1
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 1 = 1
+) AS [u]
+WHERE [u].[Rank] & 1 = 1
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE 2 & [t].[Rank] = [t].[Rank]
+) AS [u]
+WHERE 2 & [u].[Rank] = [u].[Rank]
 """);
     }
 
@@ -827,63 +827,63 @@ WHERE 2 & [t].[Rank] = [t].[Rank]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & COALESCE((
-    SELECT TOP(1) [t0].[Rank]
+) AS [u]
+WHERE [u].[Rank] & COALESCE((
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]), 0) = COALESCE((
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]), 0) = COALESCE((
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]), 0)
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]), 0)
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE 2 & COALESCE((
-    SELECT TOP(1) [t0].[Rank]
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]), 0) = COALESCE((
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]), 0) = COALESCE((
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]), 0)
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]), 0)
 """);
     }
 
@@ -892,82 +892,82 @@ WHERE 2 & COALESCE((
         await base.Where_enum_has_flag_subquery_with_pushdown(async);
 
         AssertSql(
-            """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+"""
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & (
-    SELECT TOP(1) [t0].[Rank]
+) AS [u]
+WHERE [u].[Rank] & (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) = (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) = (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) OR (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) OR (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) IS NULL
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) IS NULL
 """,
-            //
-            """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+                //
+                """
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE 2 & (
-    SELECT TOP(1) [t0].[Rank]
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) = (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) = (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) OR (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) OR (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) IS NULL
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) IS NULL
 """);
     }
 
@@ -977,42 +977,42 @@ WHERE 2 & (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & (
-    SELECT TOP(1) [t0].[Rank]
+) AS [u]
+WHERE [u].[Rank] & (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) = (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) = (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) OR (
-    SELECT TOP(1) [t0].[Rank]
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) OR (
+    SELECT TOP(1) [u0].[Rank]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    ORDER BY [t0].[Nickname], [t0].[SquadId]) IS NULL
+    ) AS [u0]
+    ORDER BY [u0].[Nickname], [u0].[SquadId]) IS NULL
 """);
     }
 
@@ -1024,15 +1024,15 @@ WHERE [t].[Rank] & (
             """
 @__parameter_0='2'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & @__parameter_0 = @__parameter_0
+) AS [u]
+WHERE [u].[Rank] & @__parameter_0 = @__parameter_0
 """);
     }
 
@@ -1044,15 +1044,15 @@ WHERE [t].[Rank] & @__parameter_0 = @__parameter_0
             """
 @__parameter_0='2' (Nullable = true)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & @__parameter_0 = @__parameter_0
+) AS [u]
+WHERE [u].[Rank] & @__parameter_0 = @__parameter_0
 """);
     }
 
@@ -1063,10 +1063,10 @@ WHERE [t].[Rank] & @__parameter_0 = @__parameter_0
         AssertSql(
             """
 SELECT TOP(1) CASE
-    WHEN [t].[Rank] & 2 = 2 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] & 2 = 2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [hasFlagTrue], CASE
-    WHEN [t].[Rank] & 4 = 4 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] & 4 = 4 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [hasFlagFalse]
 FROM (
@@ -1075,8 +1075,8 @@ FROM (
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & 2 = 2
+) AS [u]
+WHERE [u].[Rank] & 2 = 2
 """);
     }
 
@@ -1086,18 +1086,18 @@ WHERE [t].[Rank] & 2 = 2
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]) = 2
+    WHERE [u].[FullName] = [w].[OwnerFullName]) = 2
 """);
     }
 
@@ -1107,18 +1107,18 @@ WHERE (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName])
+    WHERE [u].[FullName] = [w].[OwnerFullName])
 """);
     }
 
@@ -1301,15 +1301,15 @@ FROM [Weapons] AS [w]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[LeaderNickname] = N'Marcus' AND [t].[LeaderNickname] IS NOT NULL
+) AS [u]
+WHERE [u].[LeaderNickname] = N'Marcus' AND [u].[LeaderNickname] IS NOT NULL
 """);
     }
 
@@ -1320,18 +1320,18 @@ WHERE [t].[LeaderNickname] = N'Marcus' AND [t].[LeaderNickname] IS NOT NULL
         // issue #16050
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[LeaderNickname] IS NULL THEN NULL
+    WHEN [u].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [t].[LeaderNickname] LIKE N'%us' AND [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
+        WHEN [u].[LeaderNickname] LIKE N'%us' AND [u].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
@@ -1345,17 +1345,17 @@ END = CAST(1 AS bit)
         // issue #16050
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN [t].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN [u].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1370,20 +1370,20 @@ END = CAST(1 AS bit)
         // issue #16050
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NULL THEN NULL
+    ELSE CAST(LEN([u].[LeaderNickname]) AS int)
 END = 5 AND CASE
-    WHEN [t].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NULL THEN NULL
+    ELSE CAST(LEN([u].[LeaderNickname]) AS int)
 END IS NOT NULL
 """);
     }
@@ -1395,19 +1395,19 @@ END IS NOT NULL
         // issue #16050
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
     ELSE NULL
 END = 5 AND CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
     ELSE NULL
 END IS NOT NULL
 """);
@@ -1420,19 +1420,19 @@ END IS NOT NULL
         // issue #16050
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
     ELSE NULL
 END = 5 AND CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(LEN([t].[LeaderNickname]) AS int)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
     ELSE NULL
 END IS NOT NULL
 """);
@@ -1446,7 +1446,7 @@ END IS NOT NULL
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN [t].[LeaderNickname] + [t].[LeaderNickname]
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN [u].[LeaderNickname] + [u].[LeaderNickname]
     ELSE NULL
 END
 FROM (
@@ -1455,7 +1455,7 @@ FROM (
     UNION ALL
     SELECT [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1465,14 +1465,14 @@ FROM (
 
         AssertSql(
             """
-SELECT COALESCE([t].[LeaderNickname], N'') + COALESCE([t].[LeaderNickname], N'')
+SELECT COALESCE([u].[LeaderNickname], N'') + COALESCE([u].[LeaderNickname], N'')
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1482,14 +1482,14 @@ FROM (
 
         AssertSql(
             """
-SELECT CAST(LEN([t].[FullName]) AS int)
+SELECT CAST(LEN([u].[FullName]) AS int)
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1500,8 +1500,8 @@ FROM (
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN CAST(LEN([t].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN CAST(LEN([u].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1512,7 +1512,7 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1523,7 +1523,7 @@ FROM (
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN [t0].[LeaderNickname]
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN [u0].[LeaderNickname]
     ELSE NULL
 END
 FROM (
@@ -1532,14 +1532,14 @@ FROM (
     UNION ALL
     SELECT [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[LeaderNickname]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[LeaderNickname]
     FROM [Officers] AS [o0]
-) AS [t0]
+) AS [u0]
 """);
     }
 
@@ -1549,9 +1549,9 @@ CROSS JOIN (
 
         AssertSql(
             """
-SELECT [t0].[Nickname], CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CASE
-        WHEN [t0].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
+SELECT [u0].[Nickname], CASE
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CASE
+        WHEN [u0].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1562,15 +1562,15 @@ FROM (
     UNION ALL
     SELECT [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[LeaderNickname]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[LeaderNickname]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t0].[Nickname]
+) AS [u0] ON [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u0].[Nickname]
 """);
     }
 
@@ -1581,24 +1581,24 @@ ORDER BY [t0].[Nickname]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname]
+END, [u0].[Nickname]
 FROM (
     SELECT [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t0].[Nickname]
+) AS [u0] ON [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u0].[Nickname]
 """);
     }
 
@@ -1609,24 +1609,24 @@ ORDER BY [t0].[Nickname]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname]
+END, [u0].[Nickname]
 FROM (
     SELECT [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t0].[Nickname]
+) AS [u0] ON [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u0].[Nickname]
 """);
     }
 
@@ -1637,8 +1637,8 @@ ORDER BY [t0].[Nickname]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN CAST(LEN([t].[LeaderNickname]) AS int) <> CAST(LEN([t].[LeaderNickname]) AS int) THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN CAST(LEN([u].[LeaderNickname]) AS int) <> CAST(LEN([u].[LeaderNickname]) AS int) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1649,7 +1649,7 @@ FROM (
     UNION ALL
     SELECT [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1660,7 +1660,7 @@ FROM (
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE NULL
 END
 FROM (
@@ -1669,7 +1669,7 @@ FROM (
     UNION ALL
     SELECT [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1690,9 +1690,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-LEFT JOIN [Cities] AS [c] ON [t0].[AssignedCityName] = [c].[Name]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
+LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
 """);
     }
 
@@ -1703,8 +1703,8 @@ LEFT JOIN [Cities] AS [c] ON [t0].[AssignedCityName] = [c].[Name]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
-        WHEN CAST(LEN([t].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
+        WHEN CAST(LEN([u].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, CAST(0 AS bit))
     ELSE NULL
@@ -1715,7 +1715,7 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -1725,7 +1725,7 @@ FROM (
 
         AssertSql(
             """
-SELECT [t0].[Nickname]
+SELECT [u].[Nickname]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -1733,7 +1733,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -1754,16 +1754,16 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Tags] AS [t1] ON ([t0].[Nickname] = [t1].[GearNickName] OR ([t0].[Nickname] IS NULL AND [t1].[GearNickName] IS NULL)) AND ([t0].[SquadId] = [t1].[GearSquadId] OR ([t0].[SquadId] IS NULL AND [t1].[GearSquadId] IS NULL))
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Tags] AS [t0] ON ([u].[Nickname] = [t0].[GearNickName] OR ([u].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND ([u].[SquadId] = [t0].[GearSquadId] OR ([u].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName]
     FROM [Officers] AS [o0]
-) AS [t2] ON [t1].[GearNickName] = [t2].[Nickname] AND [t1].[GearSquadId] = [t2].[SquadId]
-LEFT JOIN [Cities] AS [c] ON [t2].[AssignedCityName] = [c].[Name]
+) AS [u0] ON [t0].[GearNickName] = [u0].[Nickname] AND [t0].[GearSquadId] = [u0].[SquadId]
+LEFT JOIN [Cities] AS [c] ON [u0].[AssignedCityName] = [c].[Name]
 """);
     }
 
@@ -1774,17 +1774,17 @@ LEFT JOIN [Cities] AS [c] ON [t2].[AssignedCityName] = [c].[Name]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t].[HasSoulPatch]
+END, [u].[HasSoulPatch]
 FROM (
     SELECT [g].[Nickname], [g].[HasSoulPatch], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[HasSoulPatch], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1795,17 +1795,17 @@ ORDER BY [t].[Nickname]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t].[Nickname], [t].[FullName]
+END, [u].[Nickname], [u].[FullName]
 FROM (
     SELECT [g].[Nickname], [g].[FullName], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1815,16 +1815,16 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname], [g].[HasSoulPatch], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[HasSoulPatch], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[LeaderNickname] IS NULL
-ORDER BY [t].[Nickname]
+) AS [u]
+WHERE [u].[LeaderNickname] IS NULL
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1834,16 +1834,16 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname], [g].[HasSoulPatch], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[HasSoulPatch], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[LeaderNickname] IS NULL
-ORDER BY [t].[Nickname]
+) AS [u]
+WHERE [u].[LeaderNickname] IS NULL
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1853,15 +1853,15 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1871,15 +1871,15 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[LeaderNickname], [t].[FullName]
+SELECT [u].[LeaderNickname], [u].[FullName]
 FROM (
     SELECT [g].[Nickname], [g].[FullName], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -1896,15 +1896,15 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[LeaderNickname] = N'Marcus'
+) AS [u]
+WHERE [u].[LeaderNickname] = N'Marcus'
 """);
     }
 
@@ -1914,14 +1914,14 @@ WHERE [t].[LeaderNickname] = N'Marcus'
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -1941,15 +1941,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t1] ON [t].[GearNickName] = [t1].[Nickname] AND [t].[GearSquadId] = [t1].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
-WHERE [t1].[Nickname] = [t2].[Nickname] OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)
+) AS [u0] ON [t0].[GearNickName] = [u0].[Nickname] AND [t0].[GearSquadId] = [u0].[SquadId]
+WHERE [u].[Nickname] = [u0].[Nickname] OR ([u].[Nickname] IS NULL AND [u0].[Nickname] IS NULL)
 """);
     }
 
@@ -1959,7 +1959,7 @@ WHERE [t1].[Nickname] = [t2].[Nickname] OR ([t1].[Nickname] IS NULL AND [t2].[Ni
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -1967,8 +1967,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] = N'Marcus' AND ([t0].[CityOfBirthName] <> N'Ephyra' OR [t0].[CityOfBirthName] IS NULL)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] = N'Marcus' AND ([u].[CityOfBirthName] <> N'Ephyra' OR [u].[CityOfBirthName] IS NULL)
 """);
     }
 
@@ -1986,8 +1986,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] = N'Marcus'
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] = N'Marcus'
 """);
     }
 
@@ -2006,15 +2006,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t1] ON [t].[GearNickName] = [t1].[Nickname] AND [t].[GearSquadId] = [t1].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
-WHERE ([t1].[Nickname] = [t2].[Nickname] OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)) AND ([t1].[SquadId] = [t2].[SquadId] OR ([t1].[SquadId] IS NULL AND [t2].[SquadId] IS NULL))
+) AS [u0] ON [t0].[GearNickName] = [u0].[Nickname] AND [t0].[GearSquadId] = [u0].[SquadId]
+WHERE ([u].[Nickname] = [u0].[Nickname] OR ([u].[Nickname] IS NULL AND [u0].[Nickname] IS NULL)) AND ([u].[SquadId] = [u0].[SquadId] OR ([u].[SquadId] IS NULL AND [u0].[SquadId] IS NULL))
 """);
     }
 
@@ -2032,8 +2032,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] IS NULL OR [u].[SquadId] IS NULL
 """);
     }
 
@@ -2051,8 +2051,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] IS NULL OR [u].[SquadId] IS NULL
 """);
     }
 
@@ -2071,15 +2071,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t1] ON [t].[GearNickName] = [t1].[Nickname] AND [t].[GearSquadId] = [t1].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
-WHERE [t1].[Nickname] = [t2].[Nickname] OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)
+) AS [u0] ON [t0].[GearNickName] = [u0].[Nickname] AND [t0].[GearSquadId] = [u0].[SquadId]
+WHERE [u].[Nickname] = [u0].[Nickname] OR ([u].[Nickname] IS NULL AND [u0].[Nickname] IS NULL)
 """);
     }
 
@@ -2102,18 +2102,18 @@ ORDER BY [w].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), CAST(0 AS bit)) = CAST(1 AS bit)
 """);
     }
@@ -2124,18 +2124,18 @@ WHERE COALESCE((
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]) = CAST(1 AS bit)
 """);
     }
@@ -2146,20 +2146,20 @@ WHERE (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id]), CAST(0 AS bit)) = CAST(1 AS bit)
 """);
@@ -2171,20 +2171,20 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id]) = CAST(1 AS bit)
 """);
@@ -2196,23 +2196,23 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id]) = CAST(1 AS bit)
-ORDER BY [t].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2222,22 +2222,22 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
     ) AS [w0]), CAST(0 AS bit)) = CAST(1 AS bit)
-ORDER BY [t].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2247,19 +2247,19 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
     SELECT DISTINCT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'), CAST(0 AS bit)) = CAST(1 AS bit)
-ORDER BY [t].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'), CAST(0 AS bit)) = CAST(1 AS bit)
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2269,22 +2269,22 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
     ) AS [w0]) = CAST(1 AS bit)
-ORDER BY [t].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2294,23 +2294,23 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id] DESC) = CAST(0 AS bit)
-ORDER BY [t].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2320,23 +2320,23 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(0 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit) AND (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id] DESC) = CAST(1 AS bit)
-ORDER BY [t].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -2346,20 +2346,20 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id]), CAST(0 AS bit)) = CAST(1 AS bit)
 """);
@@ -2371,20 +2371,20 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND COALESCE((
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w0].[IsAutomatic]
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id]) = CAST(1 AS bit)
 """);
@@ -2396,26 +2396,26 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
-    SELECT TOP(1) [u].[IsAutomatic]
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
+    SELECT TOP(1) [u0].[IsAutomatic]
     FROM (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
         UNION
         SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
-    ) AS [u]
-    ORDER BY [u].[Id]) = CAST(1 AS bit)
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
+    ) AS [u0]
+    ORDER BY [u0].[Id]) = CAST(1 AS bit)
 """);
     }
 
@@ -2425,23 +2425,23 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     INNER JOIN (
         SELECT [w0].[Id]
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
     ) AS [w1] ON [w].[Id] = [w1].[Id]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]) = CAST(1 AS bit)
 """);
     }
@@ -2452,23 +2452,23 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [w0].[Id]
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
     ) AS [w1] ON [w].[Id] = [w1].[Id]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]) = CAST(1 AS bit)
 """);
     }
@@ -2479,26 +2479,26 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND (
-    SELECT TOP(1) [u].[IsAutomatic]
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND (
+    SELECT TOP(1) [u0].[IsAutomatic]
     FROM (
         SELECT [w].[Id], [w].[IsAutomatic]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
         UNION ALL
         SELECT [w0].[Id], [w0].[IsAutomatic]
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
-    ) AS [u]
-    ORDER BY [u].[Id]) = CAST(1 AS bit)
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
+    ) AS [u0]
+    ORDER BY [u0].[Id]) = CAST(1 AS bit)
 """);
     }
 
@@ -2521,7 +2521,7 @@ FROM (
     UNION ALL
     SELECT 1 AS empty
     FROM [Officers] AS [o0]
-) AS [u]
+) AS [u1]
 """);
     }
 
@@ -2544,7 +2544,7 @@ FROM (
     UNION ALL
     SELECT 1 AS empty
     FROM [Officers] AS [o0]
-) AS [u]
+) AS [u1]
 """);
     }
 
@@ -2563,7 +2563,7 @@ FROM (
         UNION ALL
         SELECT 1 AS empty
         FROM [Officers] AS [o]
-    ) AS [t]
+    ) AS [u]
     UNION ALL
     SELECT 1 AS empty
     FROM (
@@ -2572,8 +2572,8 @@ FROM (
         UNION ALL
         SELECT 1 AS empty
         FROM [Officers] AS [o0]
-    ) AS [t0]
-) AS [u]
+    ) AS [u0]
+) AS [u1]
 """);
     }
 
@@ -2608,20 +2608,20 @@ SELECT (
     FROM (
         SELECT 1 AS empty
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
         UNION ALL
         SELECT 1 AS empty
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
-    ) AS [u])
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
+    ) AS [u0])
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -2636,20 +2636,20 @@ SELECT (
     FROM (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
         UNION
         SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
         FROM [Weapons] AS [w0]
-        WHERE [t].[FullName] = [w0].[OwnerFullName]
-    ) AS [u])
+        WHERE [u].[FullName] = [w0].[OwnerFullName]
+    ) AS [u0])
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -2662,30 +2662,30 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
 SELECT (
     SELECT COUNT(*)
     FROM (
-        SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+        SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        WHERE [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
+        ) AS [u0]
+        WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
         UNION
-        SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+        SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
         FROM (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g0]
             UNION ALL
             SELECT [o1].[Nickname], [o1].[SquadId], [o1].[AssignedCityName], [o1].[CityOfBirthName], [o1].[FullName], [o1].[HasSoulPatch], [o1].[LeaderNickname], [o1].[LeaderSquadId], [o1].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o1]
-        ) AS [t1]
-        WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId]
-    ) AS [u])
+        ) AS [u1]
+        WHERE [u].[Nickname] = [u1].[LeaderNickname] AND [u].[SquadId] = [u1].[LeaderSquadId]
+    ) AS [u2])
 FROM (
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -2700,7 +2700,7 @@ SELECT (
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     ORDER BY [w0].[Id])
 FROM (
@@ -2709,8 +2709,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -2720,7 +2720,7 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t0].[CityOfBirthName] AS [B]
+SELECT [u].[CityOfBirthName] AS [B]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName]
@@ -2728,8 +2728,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[CityOfBirthName]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] = N'Marcus' AND ([t0].[CityOfBirthName] <> N'Ephyra' OR [t0].[CityOfBirthName] IS NULL)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Nickname] = N'Marcus' AND ([u].[CityOfBirthName] <> N'Ephyra' OR [u].[CityOfBirthName] IS NULL)
 """);
     }
 
@@ -2739,7 +2739,7 @@ WHERE [t0].[Nickname] = N'Marcus' AND ([t0].[CityOfBirthName] <> N'Ephyra' OR [t
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -2747,7 +2747,7 @@ INNER JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -2757,25 +2757,25 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [t].[FullName], [s].[Note]
+SELECT [u].[FullName], [s].[Note]
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
-    SELECT [t0].[Note], [t1].[FullName]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [u0].[FullName]
+    FROM [Tags] AS [t]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t0].[GearNickName] = [t1].[Nickname] AND [t0].[GearSquadId] = [t1].[SquadId]
-) AS [s] ON [t].[FullName] = [s].[FullName]
+    ) AS [u0] ON [t].[GearNickName] = [u0].[Nickname] AND [t].[GearSquadId] = [u0].[SquadId]
+) AS [s] ON [u].[FullName] = [s].[FullName]
 """);
     }
 
@@ -2785,25 +2785,25 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [t].[FullName], [s].[Note]
+SELECT [u].[FullName], [s].[Note]
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
-    SELECT [t0].[Note], [t1].[FullName]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [u0].[FullName]
+    FROM [Tags] AS [t]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t0].[GearNickName] = [t1].[Nickname] AND [t0].[GearSquadId] = [t1].[SquadId]
-) AS [s] ON [t].[FullName] = [s].[FullName]
+    ) AS [u0] ON [t].[GearNickName] = [u0].[Nickname] AND [t].[GearSquadId] = [u0].[SquadId]
+) AS [s] ON [u].[FullName] = [s].[FullName]
 """);
     }
 
@@ -2813,15 +2813,15 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [w].[Name], [t].[FullName]
+SELECT [w].[Name], [u].[FullName]
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
+) AS [u]
+INNER JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 """);
     }
 
@@ -2831,7 +2831,7 @@ INNER JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 
         AssertSql(
             """
-SELECT [w].[Name], [t].[FullName]
+SELECT [w].[Name], [u].[FullName]
 FROM [Squads] AS [s]
 INNER JOIN (
     SELECT [g].[SquadId], [g].[FullName]
@@ -2839,8 +2839,8 @@ INNER JOIN (
     UNION ALL
     SELECT [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t] ON [s].[Id] = [t].[SquadId]
-INNER JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
+) AS [u] ON [s].[Id] = [u].[SquadId]
+INNER JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 """);
     }
 
@@ -2850,13 +2850,13 @@ INNER JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t1].[Id], [t1].[GearNickName], [t1].[GearSquadId], [t1].[IssueDate], [t1].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
 FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearSquadId] = [t0].[SquadId] AND [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Tags] AS [t1] ON [t0].[Nickname] = [t1].[GearNickName] AND [t0].[SquadId] = [t1].[GearSquadId]
+) AS [u] ON [t].[GearSquadId] = [u].[SquadId] AND [t].[GearNickName] = [u].[Nickname]
+LEFT JOIN [Tags] AS [t0] ON [u].[Nickname] = [t0].[GearNickName] AND [u].[SquadId] = [t0].[GearSquadId]
 """);
     }
 
@@ -2866,13 +2866,13 @@ LEFT JOIN [Tags] AS [t1] ON [t0].[Nickname] = [t1].[GearNickName] AND [t0].[Squa
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t1].[Id], [t1].[GearNickName], [t1].[GearSquadId], [t1].[IssueDate], [t1].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[SquadId] = [t0].[GearSquadId] AND [t].[Nickname] = [t0].[GearNickName]
-LEFT JOIN [Tags] AS [t1] ON [t].[Nickname] = [t1].[GearNickName] AND [t].[SquadId] = [t1].[GearSquadId]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[SquadId] = [t].[GearSquadId] AND [u].[Nickname] = [t].[GearNickName]
+LEFT JOIN [Tags] AS [t0] ON [u].[Nickname] = [t0].[GearNickName] AND [u].[SquadId] = [t0].[GearSquadId]
 """);
     }
 
@@ -2947,8 +2947,8 @@ WHERE [c].[Location] = 'Unknown' AND (
         UNION ALL
         SELECT [o].[Nickname], [o].[CityOfBirthName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [c].[Name] = [t].[CityOfBirthName] AND [t].[Nickname] = N'Paduk') = 1
+    ) AS [u]
+    WHERE [c].[Name] = [u].[CityOfBirthName] AND [u].[Nickname] = N'Paduk') = 1
 """);
     }
 
@@ -2958,16 +2958,16 @@ WHERE [c].[Location] = 'Unknown' AND (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
-WHERE [t].[Nickname] = N'Marcus' AND [c].[Location] = 'Jacinto''s location'
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
+WHERE [u].[Nickname] = N'Marcus' AND [c].[Location] = 'Jacinto''s location'
 """);
     }
 
@@ -3002,23 +3002,23 @@ WHERE COALESCE([c].[Location], N'') + N'Added' LIKE N'%Add%'
         // Issue#16897
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -3029,23 +3029,23 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
         // Issue#16897
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -3056,24 +3056,24 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
         // Issue#16897
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id]
 """);
     }
 
@@ -3084,26 +3084,26 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
         // Issue#16897
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w1] ON [t0].[FullName] = [w1].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w2] ON [t].[FullName] = [w2].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id], [w0].[Id], [w1].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w1] ON [u0].[FullName] = [w1].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w2] ON [u].[FullName] = [w2].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id], [w0].[Id], [w1].[Id]
 """);
     }
 
@@ -3114,21 +3114,21 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
         // Issue#16897
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id]
 """);
     }
 
@@ -3140,26 +3140,26 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+END, [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id]
 """);
     }
 
@@ -3169,8 +3169,8 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId], CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId], CASE
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [w3].[Id], [w3].[AmmunitionType], [w3].[IsAutomatic], [w3].[Name], [w3].[OwnerFullName], [w3].[SynergyWithId], [w4].[Id], [w4].[AmmunitionType], [w4].[IsAutomatic], [w4].[Name], [w4].[OwnerFullName], [w4].[SynergyWithId]
 FROM (
@@ -3179,21 +3179,21 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w1] ON [t0].[FullName] = [w1].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w2] ON [t].[FullName] = [w2].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w3] ON [t0].[FullName] = [w3].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w4] ON [t].[FullName] = [w4].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id], [w0].[Id], [w1].[Id], [w2].[Id], [w3].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w1] ON [u0].[FullName] = [w1].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w2] ON [u].[FullName] = [w2].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w3] ON [u0].[FullName] = [w3].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w4] ON [u].[FullName] = [w4].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id], [w0].[Id], [w1].[Id], [w2].[Id], [w3].[Id]
 """);
     }
 
@@ -3249,8 +3249,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [t0].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -3268,8 +3268,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -3287,8 +3287,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -3306,10 +3306,10 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE [t0].[HasSoulPatch]
+    WHEN [u].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
+    ELSE [u].[HasSoulPatch]
 END = CAST(0 AS bit)
 """);
     }
@@ -3328,10 +3328,10 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t0].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
-    ELSE [t0].[HasSoulPatch]
+    WHEN [u].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
+    ELSE [u].[HasSoulPatch]
 END = CAST(0 AS bit)
 """);
     }
@@ -3350,9 +3350,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
+    WHEN [u].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -3372,8 +3372,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
 """);
     }
 
@@ -3384,7 +3384,7 @@ WHERE [t0].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] AS [t]
@@ -3394,7 +3394,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -3404,7 +3404,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t0].[SquadId]
+SELECT [u].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -3412,7 +3412,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 """);
     }
@@ -3423,7 +3423,7 @@ WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 
         AssertSql(
             """
-SELECT [t0].[SquadId]
+SELECT [u].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -3431,7 +3431,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 """);
     }
@@ -3442,7 +3442,7 @@ WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 
         AssertSql(
             """
-SELECT [t0].[SquadId] AS [Id]
+SELECT [u].[SquadId] AS [Id]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -3450,7 +3450,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 """);
     }
@@ -3461,7 +3461,7 @@ WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 
         AssertSql(
             """
-SELECT [t0].[SquadId], [t0].[SquadId] + 1
+SELECT [u].[SquadId], [u].[SquadId] + 1
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -3469,7 +3469,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 ORDER BY [t].[Note]
 """);
@@ -3481,7 +3481,7 @@ ORDER BY [t].[Note]
 
         AssertSql(
             """
-SELECT [t0].[SquadId]
+SELECT [u].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -3489,7 +3489,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 """);
     }
@@ -3508,9 +3508,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
-ORDER BY [t0].[SquadId]
+ORDER BY [u].[SquadId]
 """);
     }
 
@@ -3530,8 +3530,8 @@ SELECT CASE
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-        WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [t0].[HasSoulPatch] = CAST(0 AS bit)) THEN CAST(1 AS bit)
+        ) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+        WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [u].[HasSoulPatch] = CAST(0 AS bit)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -3551,8 +3551,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [t0].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -3570,8 +3570,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [t0].[SquadId] IN (
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [u].[SquadId] IN (
     SELECT [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
@@ -3601,22 +3601,22 @@ WHERE ([t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL) AND [t0].[SquadId] IN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [c].[Name], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [c].[Name], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[CityOfBirthName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[Name] <> N'Lancer' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 WHERE [c].[Name] IN (N'Ephyra', N'Hanover')
-ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name]
+ORDER BY [u].[Nickname], [u].[SquadId], [c].[Name]
 """);
     }
 
@@ -3626,23 +3626,23 @@ ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t0].[Nickname] <> N'Dom'
-) AS [t1] ON [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u0].[Nickname] <> N'Dom'
+) AS [u1] ON [u].[Nickname] = [u1].[LeaderNickname] AND [u].[SquadId] = [u1].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -3652,7 +3652,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -3660,8 +3660,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname]
+ORDER BY [t].[Note], [t].[Id], [u].[Nickname]
 """);
     }
 
@@ -3671,14 +3671,14 @@ ORDER BY [t].[Note], [t].[Id], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 """);
     }
@@ -3689,15 +3689,15 @@ INNER JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Weapons] AS [w] ON [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+INNER JOIN [Weapons] AS [w] ON [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -3707,14 +3707,14 @@ INNER JOIN [Weapons] AS [w] ON [t].[HasSoulPatch] = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 """);
     }
@@ -3725,14 +3725,14 @@ INNER JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 """);
     }
@@ -3743,15 +3743,15 @@ LEFT JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -3761,14 +3761,14 @@ LEFT JOIN [Weapons] AS [w] ON [t].[HasSoulPatch] = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN [Weapons] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 """);
     }
@@ -4007,8 +4007,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-WHERE [w].[Id] <> 50 AND [t].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+WHERE [w].[Id] <> 50 AND [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -4018,16 +4018,16 @@ WHERE [w].[Id] <> 50 AND [t].[HasSoulPatch] = CAST(0 AS bit)
 
         AssertSql(
             """
-SELECT DISTINCT [t].[HasSoulPatch]
+SELECT DISTINCT [u].[HasSoulPatch]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[Note] <> N'Foo' OR [t].[Note] IS NULL
 """);
     }
 
@@ -4037,16 +4037,16 @@ WHERE [t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL
 
         AssertSql(
             """
-SELECT COALESCE(SUM([t].[SquadId]), 0)
+SELECT COALESCE(SUM([u].[SquadId]), 0)
 FROM (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[Note] <> N'Foo' OR [t].[Note] IS NULL
 """);
     }
 
@@ -4063,9 +4063,9 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[Note] <> N'Foo' OR [t].[Note] IS NULL
 """);
     }
 
@@ -4083,7 +4083,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t] ON [s].[Id] = [t].[SquadId]
+) AS [u] ON [s].[Id] = [u].[SquadId]
 WHERE [s].[Name] = N'Kilo'
 """);
     }
@@ -4104,9 +4104,9 @@ WHERE NOT EXISTS (
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId]
         FROM [Officers] AS [o]
-    ) AS [t]
-    LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-    WHERE [s].[Id] = [t].[SquadId] AND [t0].[Note] = N'Dom''s Tag')
+    ) AS [u]
+    LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+    WHERE [s].[Id] = [u].[SquadId] AND [t].[Note] = N'Dom''s Tag')
 """);
     }
 
@@ -4125,9 +4125,9 @@ SELECT CASE
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId]
             FROM [Officers] AS [o]
-        ) AS [t]
-        LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-        WHERE [t0].[Note] = N'Foo' AND [t0].[Note] IS NOT NULL) THEN CAST(1 AS bit)
+        ) AS [u]
+        LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+        WHERE [t].[Note] = N'Foo' AND [t].[Note] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -4156,16 +4156,16 @@ WHERE [t].[Id] IN (
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t].[Rank]
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u].[Rank]
 """);
     }
 
@@ -4175,16 +4175,16 @@ ORDER BY [t].[Rank]
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[FullName]
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4194,16 +4194,16 @@ ORDER BY [t].[FullName]
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[FullName]
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4213,17 +4213,17 @@ ORDER BY [t].[FullName]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t].[FullName] <> N'Augustus Cole' AND [t].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[FullName]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [u].[FullName] <> N'Augustus Cole' AND [u].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4233,23 +4233,23 @@ ORDER BY [t].[FullName]
 
         AssertSql(
             """
-SELECT [t].[FullName] AS [Name1], [t0].[FullName] AS [Name2]
+SELECT [u].[FullName] AS [Name1], [u0].[FullName] AS [Name2]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[FullName], [g0].[HasSoulPatch]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[FullName], [o0].[HasSoulPatch]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t0].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[FullName]
+) AS [u0]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u0].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4259,17 +4259,17 @@ ORDER BY [t].[FullName]
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-CROSS JOIN [Tags] AS [t0]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t].[FullName]
+) AS [u]
+CROSS JOIN [Tags] AS [t]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4279,16 +4279,16 @@ ORDER BY [t].[FullName]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName]
-ORDER BY [t].[Nickname]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -4298,16 +4298,16 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName]
-ORDER BY [t].[Nickname]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -4317,18 +4317,18 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName]
-INNER JOIN [Tags] AS [t1] ON [t].[Nickname] = [t1].[GearNickName]
-WHERE [t0].[GearNickName] <> N'Cole Train' OR [t0].[GearNickName] IS NULL
-ORDER BY [t].[Nickname], [t1].[Id]
+) AS [u]
+INNER JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName]
+INNER JOIN [Tags] AS [t0] ON [u].[Nickname] = [t0].[GearNickName]
+WHERE [t].[GearNickName] <> N'Cole Train' OR [t].[GearNickName] IS NULL
+ORDER BY [u].[Nickname], [t0].[Id]
 """);
     }
 
@@ -4338,20 +4338,20 @@ ORDER BY [t].[Nickname], [t1].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 WHERE EXISTS (
     SELECT 1
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]) AND [t].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName]) AND [u].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -4361,23 +4361,23 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[FullName] AS [Name1], [t0].[FullName] AS [Name2]
+SELECT [u].[FullName] AS [Name1], [u0].[FullName] AS [Name2]
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[FullName], [g0].[HasSoulPatch]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[FullName], [o0].[HasSoulPatch]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t0].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[FullName]
+) AS [u0]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u0].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [u].[FullName]
 """);
     }
 
@@ -4389,20 +4389,20 @@ ORDER BY [t].[FullName]
             """
 @__p_0='2'
 
-SELECT [t0].[FullName]
+SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [t].[FullName], [t].[Rank]
+    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-    ORDER BY [t].[FullName]
-) AS [t0]
-ORDER BY [t0].[Rank]
+    ) AS [u]
+    WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+    ORDER BY [u].[FullName]
+) AS [u0]
+ORDER BY [u0].[Rank]
 """);
     }
 
@@ -4414,21 +4414,21 @@ ORDER BY [t0].[Rank]
             """
 @__p_0='1'
 
-SELECT [t0].[FullName]
+SELECT [u0].[FullName]
 FROM (
-    SELECT [t].[FullName], [t].[Rank]
+    SELECT [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-    ORDER BY [t].[FullName]
+    ) AS [u]
+    WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+    ORDER BY [u].[FullName]
     OFFSET @__p_0 ROWS
-) AS [t0]
-ORDER BY [t0].[Rank]
+) AS [u0]
+ORDER BY [u0].[Rank]
 """);
     }
 
@@ -4440,19 +4440,19 @@ ORDER BY [t0].[Rank]
             """
 @__p_0='999'
 
-SELECT [t0].[FullName]
+SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [t].[FullName], [t].[Rank]
+    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t0]
-ORDER BY [t0].[Rank]
+    ) AS [u]
+    WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u0]
+ORDER BY [u0].[Rank]
 """);
     }
 
@@ -4464,19 +4464,19 @@ ORDER BY [t0].[Rank]
             """
 @__p_0='999'
 
-SELECT [t0].[FullName]
+SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [t].[FullName], [t].[Rank]
+    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t0]
-ORDER BY [t0].[Rank]
+    ) AS [u]
+    WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u0]
+ORDER BY [u0].[Rank]
 """);
     }
 
@@ -4488,19 +4488,19 @@ ORDER BY [t0].[Rank]
             """
 @__p_0='999'
 
-SELECT [t0].[FullName]
+SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [t].[FullName], [t].[Rank]
+    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName], [o].[HasSoulPatch], [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t0]
-ORDER BY [t0].[FullName], [t0].[Rank]
+    ) AS [u]
+    WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u0]
+ORDER BY [u0].[FullName], [u0].[Rank]
 """);
     }
 
@@ -4636,8 +4636,8 @@ SELECT [l].[Name], (
         UNION ALL
         SELECT [l1].[LocustHordeId]
         FROM [LocustCommanders] AS [l1]
-    ) AS [t]
-    WHERE [l].[Id] = [t].[LocustHordeId]) AS [LeadersCount]
+    ) AS [u]
+    WHERE [l].[Id] = [u].[LocustHordeId]) AS [LeadersCount]
 FROM [LocustHordes] AS [l]
 ORDER BY [l].[Name]
 """);
@@ -4649,7 +4649,7 @@ ORDER BY [l].[Name]
 
         AssertSql(
             """
-SELECT [l].[Name], [t].[Name] AS [LeaderName]
+SELECT [l].[Name], [u].[Name] AS [LeaderName]
 FROM [LocustHordes] AS [l]
 INNER JOIN (
     SELECT [l0].[Name], [l0].[LocustHordeId]
@@ -4657,8 +4657,8 @@ INNER JOIN (
     UNION ALL
     SELECT [l1].[Name], [l1].[LocustHordeId]
     FROM [LocustCommanders] AS [l1]
-) AS [t] ON [l].[Id] = [t].[LocustHordeId]
-ORDER BY [t].[Name]
+) AS [u] ON [l].[Id] = [u].[LocustHordeId]
+ORDER BY [u].[Name]
 """);
     }
 
@@ -4668,7 +4668,7 @@ ORDER BY [t].[Name]
 
         AssertSql(
             """
-SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
@@ -4677,7 +4677,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [l2].[Name], [l2].[LocustHordeId], [l2].[ThreatLevel], [l2].[ThreatLevelByte], [l2].[ThreatLevelNullableByte], [l2].[DefeatedByNickname], [l2].[DefeatedBySquadId], [l2].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l2]
-) AS [t] ON [l].[Id] = [t].[LocustHordeId]
+) AS [u] ON [l].[Id] = [u].[LocustHordeId]
 ORDER BY [l].[Name], [l].[Id], [l0].[Name]
 """);
     }
@@ -4688,17 +4688,17 @@ ORDER BY [l].[Name], [l].[Id], [l0].[Name]
 
         AssertSql(
             """
-SELECT [t0].[HasSoulPatch]
+SELECT [u0].[HasSoulPatch]
 FROM (
-    SELECT DISTINCT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+    SELECT DISTINCT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
-) AS [t0]
+    ) AS [u]
+) AS [u0]
 """);
     }
 
@@ -4719,23 +4719,23 @@ FROM [LocustHordes] AS [l]
 
         AssertSql(
             """
-SELECT [t].[Nickname] AS [Nickname1], [t0].[Nickname] AS [Nickname2]
+SELECT [u].[Nickname] AS [Nickname1], [u0].[Nickname] AS [Nickname2]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
-ORDER BY [t].[Nickname]
+) AS [u0]
+WHERE [u].[Nickname] = [u0].[Nickname] AND [u].[SquadId] = [u0].[SquadId]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -4745,12 +4745,12 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [l].[Name], [t].[Nickname]
+SELECT [l].[Name], [u].[Nickname]
 FROM [LocustHordes] AS [l]
 CROSS JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -4758,8 +4758,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t0] ON [l0].[DefeatedByNickname] = [t0].[Nickname] AND [l0].[DefeatedBySquadId] = [t0].[SquadId]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t0].[Nickname] = [t].[Nickname] AND [t0].[SquadId] = [t].[SquadId]
+) AS [u0] ON [l0].[DefeatedByNickname] = [u0].[Nickname] AND [l0].[DefeatedBySquadId] = [u0].[SquadId]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u0].[Nickname] = [u].[Nickname] AND [u0].[SquadId] = [u].[SquadId]
 """);
     }
 
@@ -4769,20 +4769,20 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t0].[Nickname] = [t].[Nickname] A
 
         AssertSql(
             """
-SELECT [t].[Nickname] AS [Nickname1], [t0].[Nickname] AS [Nickname2]
+SELECT [u].[Nickname] AS [Nickname1], [u0].[Nickname] AS [Nickname2]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [o0].[Nickname], [o0].[SquadId]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
-ORDER BY [t].[Nickname], [t0].[Nickname]
+) AS [u0]
+WHERE [u].[Nickname] = [u0].[Nickname] AND [u].[SquadId] = [u0].[SquadId]
+ORDER BY [u].[Nickname], [u0].[Nickname]
 """);
     }
 
@@ -4794,16 +4794,16 @@ ORDER BY [t].[Nickname], [t0].[Nickname]
             """
 @__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
-WHERE [t].[SquadId] < 2 AND ([c].[Name] IN (
+) AS [u]
+LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
+WHERE [u].[SquadId] < 2 AND ([c].[Name] IN (
     SELECT [c0].[value]
     FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
 ) OR [c].[Name] IS NULL)
@@ -4824,8 +4824,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE [t0].[Discriminator] = N'Officer' AND (
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE [u].[Discriminator] = N'Officer' AND (
     SELECT COUNT(*)
     FROM (
         SELECT [g0].[Nickname], [g0].[LeaderNickname], [g0].[LeaderSquadId]
@@ -4833,8 +4833,8 @@ WHERE [t0].[Discriminator] = N'Officer' AND (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL AND [t0].[Nickname] = [t1].[LeaderNickname] AND [t0].[SquadId] = [t1].[LeaderSquadId] AND [t1].[Nickname] = N'Dom') > 0
+    ) AS [u0]
+    WHERE [u].[Nickname] IS NOT NULL AND [u].[SquadId] IS NOT NULL AND [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId] AND [u0].[Nickname] = N'Dom') > 0
 """);
     }
 
@@ -4872,7 +4872,7 @@ FROM [LocustHordes] AS [l]
 
         AssertSql(
             """
-SELECT [l].[Id], [l0].[Name], [l1].[Id], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [l].[Id], [l0].[Name], [l1].[Id], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN [LocustHordes] AS [l1] ON [l0].[Name] = [l1].[CommanderName]
@@ -4882,7 +4882,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [l3].[Name], [l3].[LocustHordeId], [l3].[ThreatLevel], [l3].[ThreatLevelByte], [l3].[ThreatLevelNullableByte], [l3].[DefeatedByNickname], [l3].[DefeatedBySquadId], [l3].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l3]
-) AS [t] ON [l1].[Id] = [t].[LocustHordeId]
+) AS [u] ON [l1].[Id] = [u].[LocustHordeId]
 ORDER BY [l].[Id], [l0].[Name], [l1].[Id]
 """);
     }
@@ -4893,7 +4893,7 @@ ORDER BY [l].[Id], [l0].[Name], [l1].[Id]
 
         AssertSql(
             """
-SELECT [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
@@ -4902,15 +4902,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t] ON [l0].[DefeatedByNickname] = [t].[Nickname] AND [l0].[DefeatedBySquadId] = [t].[SquadId]
+) AS [u] ON [l0].[DefeatedByNickname] = [u].[Nickname] AND [l0].[DefeatedBySquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON ([t].[Nickname] = [t0].[LeaderNickname] OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -4920,7 +4920,7 @@ ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
@@ -4929,15 +4929,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t] ON [l0].[DefeatedByNickname] = [t].[Nickname] AND [l0].[DefeatedBySquadId] = [t].[SquadId]
+) AS [u] ON [l0].[DefeatedByNickname] = [u].[Nickname] AND [l0].[DefeatedBySquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON ([t].[Nickname] = [t0].[LeaderNickname] OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -4947,21 +4947,21 @@ ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 """);
     }
 
@@ -4971,22 +4971,22 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u0].[SquadId] = [s].[Id]
 """);
     }
 
@@ -4996,33 +4996,33 @@ LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Name], [s].[Location], [s].[Nation]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Name], [s].[Location], [s].[Nation]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 LEFT JOIN (
-    SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
+    SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator], [c].[Name], [c].[Location], [c].[Nation]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    INNER JOIN [Cities] AS [c] ON [t1].[CityOfBirthName] = [c].[Name]
-) AS [s] ON ([t0].[Nickname] = [s].[LeaderNickname] OR ([t0].[Nickname] IS NULL AND [s].[LeaderNickname] IS NULL)) AND [t0].[SquadId] = [s].[LeaderSquadId]
-ORDER BY [t].[Name], [t0].[Nickname], [t0].[SquadId], [s].[Nickname], [s].[SquadId]
+    ) AS [u1]
+    INNER JOIN [Cities] AS [c] ON [u1].[CityOfBirthName] = [c].[Name]
+) AS [s] ON ([u0].[Nickname] = [s].[LeaderNickname] OR ([u0].[Nickname] IS NULL AND [s].[LeaderNickname] IS NULL)) AND [u0].[SquadId] = [s].[LeaderSquadId]
+ORDER BY [u].[Name], [u0].[Nickname], [u0].[SquadId], [s].[Nickname], [s].[SquadId]
 """);
     }
 
@@ -5032,21 +5032,21 @@ ORDER BY [t].[Name], [t0].[Nickname], [t0].[SquadId], [s].[Nickname], [s].[Squad
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 """);
     }
 
@@ -5056,21 +5056,21 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 """);
     }
 
@@ -5080,21 +5080,21 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 """);
     }
 
@@ -5104,22 +5104,22 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -5129,22 +5129,22 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -5154,22 +5154,22 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -5179,17 +5179,17 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [t].[Id]
 """);
     }
 
@@ -5199,7 +5199,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -5207,9 +5207,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5219,7 +5219,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
@@ -5228,15 +5228,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t] ON [l0].[DefeatedByNickname] = [t].[Nickname] AND [l0].[DefeatedBySquadId] = [t].[SquadId]
+) AS [u] ON [l0].[DefeatedByNickname] = [u].[Nickname] AND [l0].[DefeatedBySquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON ([t].[Nickname] = [t0].[LeaderNickname] OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -5246,32 +5246,32 @@ ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Nickname0], [s].[SquadId0], [s].[AssignedCityName0], [s].[CityOfBirthName0], [s].[FullName0], [s].[HasSoulPatch0], [s].[LeaderNickname0], [s].[LeaderSquadId0], [s].[Rank0], [s].[Discriminator0]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Nickname0], [s].[SquadId0], [s].[AssignedCityName0], [s].[CityOfBirthName0], [s].[FullName0], [s].[HasSoulPatch0], [s].[LeaderNickname0], [s].[LeaderSquadId0], [s].[Rank0], [s].[Discriminator0]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t1].[Nickname] AS [Nickname0], [t1].[SquadId] AS [SquadId0], [t1].[AssignedCityName] AS [AssignedCityName0], [t1].[CityOfBirthName] AS [CityOfBirthName0], [t1].[FullName] AS [FullName0], [t1].[HasSoulPatch] AS [HasSoulPatch0], [t1].[LeaderNickname] AS [LeaderNickname0], [t1].[LeaderSquadId] AS [LeaderSquadId0], [t1].[Rank] AS [Rank0], [t1].[Discriminator] AS [Discriminator0]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u1].[Nickname] AS [Nickname0], [u1].[SquadId] AS [SquadId0], [u1].[AssignedCityName] AS [AssignedCityName0], [u1].[CityOfBirthName] AS [CityOfBirthName0], [u1].[FullName] AS [FullName0], [u1].[HasSoulPatch] AS [HasSoulPatch0], [u1].[LeaderNickname] AS [LeaderNickname0], [u1].[LeaderSquadId] AS [LeaderSquadId0], [u1].[Rank] AS [Rank0], [u1].[Discriminator] AS [Discriminator0]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOfBirthName], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g1]
         UNION ALL
         SELECT [o1].[Nickname], [o1].[SquadId], [o1].[AssignedCityName], [o1].[CityOfBirthName], [o1].[FullName], [o1].[HasSoulPatch], [o1].[LeaderNickname], [o1].[LeaderSquadId], [o1].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o1]
-    ) AS [t1] ON [t0].[Nickname] = [t1].[LeaderNickname] AND [t0].[SquadId] = [t1].[LeaderSquadId]
-) AS [s] ON [t].[Nickname] = [s].[LeaderNickname] AND [t].[SquadId] = [s].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId], [s].[Nickname0]
+    ) AS [u1] ON [u0].[Nickname] = [u1].[LeaderNickname] AND [u0].[SquadId] = [u1].[LeaderSquadId]
+) AS [s] ON [u].[Nickname] = [s].[LeaderNickname] AND [u].[SquadId] = [s].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Nickname], [s].[SquadId], [s].[Nickname0]
 """);
     }
 
@@ -5284,21 +5284,21 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId], [s].[Nick
 SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [s].[Name], [s].[LocustHordeId], [s].[ThreatLevel], [s].[ThreatLevelByte], [s].[ThreatLevelNullableByte], [s].[DefeatedByNickname], [s].[DefeatedBySquadId], [s].[HighCommandId], [s].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator0]
 FROM [LocustHordes] AS [l]
 LEFT JOIN (
-    SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator] AS [Discriminator0]
+    SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator] AS [Discriminator0]
     FROM (
         SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
         FROM [LocustLeaders] AS [l0]
         UNION ALL
         SELECT [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], N'LocustCommander' AS [Discriminator]
         FROM [LocustCommanders] AS [l1]
-    ) AS [t]
+    ) AS [u]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+    ) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 ) AS [s] ON [l].[Id] = [s].[LocustHordeId]
 ORDER BY [l].[Id], [s].[Name], [s].[Nickname]
 """);
@@ -5310,7 +5310,7 @@ ORDER BY [l].[Id], [s].[Name], [s].[Nickname]
 
         AssertSql(
             """
-SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [l].[Id], [l].[CapitalName], [l].[Name], [l].[ServerAddress], [l].[CommanderName], [l].[Eradicated], [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 LEFT JOIN (
@@ -5319,15 +5319,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t] ON [l0].[DefeatedByNickname] = [t].[Nickname] AND [l0].[DefeatedBySquadId] = [t].[SquadId]
+) AS [u] ON [l0].[DefeatedByNickname] = [u].[Nickname] AND [l0].[DefeatedBySquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON ([t].[Nickname] = [t0].[LeaderNickname] OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [l].[Id], [l0].[Name], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -5337,27 +5337,27 @@ ORDER BY [l].[Id], [l0].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank], [s1].[Discriminator], [s1].[Id], [s1].[Banner], [s1].[Banner5], [s1].[InternalNumber], [s1].[Name], [s1].[SquadId0], [s1].[MissionId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank], [s1].[Discriminator], [s1].[Id], [s1].[Banner], [s1].[Banner5], [s1].[InternalNumber], [s1].[Name], [s1].[SquadId0], [s1].[MissionId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s0].[SquadId] AS [SquadId0], [s0].[MissionId]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s0].[SquadId] AS [SquadId0], [s0].[MissionId]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+    ) AS [u0]
+    INNER JOIN [Squads] AS [s] ON [u0].[SquadId] = [s].[Id]
     LEFT JOIN [SquadMissions] AS [s0] ON [s].[Id] = [s0].[SquadId]
-) AS [s1] ON [t].[Nickname] = [s1].[LeaderNickname] AND [t].[SquadId] = [s1].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[SquadId0]
+) AS [s1] ON [u].[Nickname] = [s1].[LeaderNickname] AND [u].[SquadId] = [s1].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[SquadId0]
 """);
     }
 
@@ -5368,7 +5368,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[I
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN [t0].[HasSoulPatch]
+    WHEN [u].[Nickname] IS NOT NULL AND [u].[SquadId] IS NOT NULL THEN [u].[HasSoulPatch]
     ELSE CAST(0 AS bit)
 END AS [Prop]
 FROM [Tags] AS [t]
@@ -5378,7 +5378,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -5388,15 +5388,15 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Rank]
+SELECT [u].[Rank]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[SquadId], [t].[Nickname]
+) AS [u]
+ORDER BY [u].[SquadId], [u].[Nickname]
 """);
     }
 
@@ -5406,17 +5406,17 @@ ORDER BY [t].[SquadId], [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5429,16 +5429,16 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 SELECT (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName])
+    WHERE [u].[FullName] = [w].[OwnerFullName])
 FROM (
     SELECT [g].[Nickname], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname]
+) AS [u]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -5448,17 +5448,17 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5468,21 +5468,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5492,21 +5492,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5516,21 +5516,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5540,21 +5540,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId], [w0].[Name] DESC
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId], [w0].[Name] DESC
 """);
     }
 
@@ -5564,24 +5564,24 @@ ORDER BY [t].[Nickname], [t].[SquadId], [w0].[Name] DESC
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t1].[Nickname], [t1].[FullName], [t1].[SquadId]
+SELECT [u].[Nickname], [u].[SquadId], [u1].[Nickname], [u1].[FullName], [u1].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[FullName], [t0].[SquadId], [t0].[LeaderNickname], [t0].[LeaderSquadId]
+    SELECT [u0].[Nickname], [u0].[FullName], [u0].[SquadId], [u0].[LeaderNickname], [u0].[LeaderSquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t1] ON [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId]
-WHERE [t].[Nickname] <> N'Foo'
-ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u0].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u1] ON [u].[Nickname] = [u1].[LeaderNickname] AND [u].[SquadId] = [u1].[LeaderSquadId]
+WHERE [u].[Nickname] <> N'Foo'
+ORDER BY [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -5591,21 +5591,21 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Name], [w0].[Id]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Name], [w0].[Id]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Name], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5615,21 +5615,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[c], [w0].[Id]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[c], [w0].[Id]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT N'BFG' AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5639,21 +5639,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[c], [w0].[Id]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[c], [w0].[Id]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT CAST(1 AS bit) AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -5663,22 +5663,22 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId], [s1].[MissionId]
+SELECT [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId], [s1].[MissionId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 LEFT JOIN (
     SELECT [s0].[SquadId], [s0].[MissionId]
     FROM [SquadMissions] AS [s0]
     WHERE [s0].[MissionId] <> 17
 ) AS [s1] ON [s].[Id] = [s1].[SquadId]
-WHERE [t].[Nickname] <> N'Marcus'
-ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId]
+WHERE [u].[Nickname] <> N'Marcus'
+ORDER BY [u].[FullName], [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
 
@@ -5688,7 +5688,7 @@ ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId]
 
         AssertSql(
             """
-SELECT [s].[Name], [s].[Id], [t].[FullName], [t].[Rank], [t].[Nickname], [t].[SquadId]
+SELECT [s].[Name], [s].[Id], [u].[FullName], [u].[Rank], [u].[Nickname], [u].[SquadId]
 FROM [Squads] AS [s]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[Rank]
@@ -5696,9 +5696,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t] ON [s].[Id] = [t].[SquadId]
+) AS [u] ON [s].[Id] = [u].[SquadId]
 WHERE [s].[Id] < 20
-ORDER BY [s].[Id], [t].[Nickname]
+ORDER BY [s].[Id], [u].[Nickname]
 """);
     }
 
@@ -5777,28 +5777,28 @@ ORDER BY [s].[Id], [s3].[SquadId], [s3].[MissionId], [s3].[Id], [s3].[SquadId0]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [t0].[Rank], [t0].[LeaderNickname], [t0].[LeaderSquadId]
+    SELECT [u0].[FullName], [u0].[Nickname], [u0].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [u0].[Rank], [u0].[LeaderNickname], [u0].[LeaderSquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
         WHERE [w].[Name] <> N'Bar' OR [w].[Name] IS NULL
-    ) AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-    WHERE [t0].[FullName] <> N'Foo'
-) AS [s] ON [t].[Nickname] = [s].[LeaderNickname] AND [t].[SquadId] = [s].[LeaderSquadId]
-ORDER BY [t].[HasSoulPatch] DESC, [t].[Nickname], [t].[SquadId], [s].[Rank], [s].[Nickname], [s].[SquadId], [s].[IsAutomatic]
+    ) AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+    WHERE [u0].[FullName] <> N'Foo'
+) AS [s] ON [u].[Nickname] = [s].[LeaderNickname] AND [u].[SquadId] = [s].[LeaderSquadId]
+ORDER BY [u].[HasSoulPatch] DESC, [u].[Nickname], [u].[SquadId], [s].[Rank], [s].[Nickname], [s].[SquadId], [s].[IsAutomatic]
 """);
     }
 
@@ -5808,25 +5808,25 @@ ORDER BY [t].[HasSoulPatch] DESC, [t].[Nickname], [t].[SquadId], [s].[Rank], [s]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit)
-) AS [w1] ON [t].[FullName] = [w1].[OwnerFullName]
+) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(1 AS bit)
-) AS [w2] ON [t].[FullName] = [w2].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [w1].[Id]
+) AS [w2] ON [u].[FullName] = [w2].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [w1].[Id]
 """);
     }
 
@@ -5836,25 +5836,25 @@ ORDER BY [t].[Nickname], [t].[SquadId], [w1].[Id]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit)
-) AS [w1] ON [t].[FullName] = [w1].[OwnerFullName]
+) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(0 AS bit)
-) AS [w2] ON [t].[FullName] = [w2].[OwnerFullName]
-ORDER BY [t].[Rank], [t].[Nickname], [t].[SquadId], [w1].[OwnerFullName], [w1].[Id], [w2].[IsAutomatic]
+) AS [w2] ON [u].[FullName] = [w2].[OwnerFullName]
+ORDER BY [u].[Rank], [u].[Nickname], [u].[SquadId], [w1].[OwnerFullName], [w1].[Id], [w2].[IsAutomatic]
 """);
     }
 
@@ -5864,24 +5864,24 @@ ORDER BY [t].[Rank], [t].[Nickname], [t].[SquadId], [w1].[OwnerFullName], [w1].[
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Name], [w0].[IsAutomatic], [w0].[Id], [t0].[Nickname], [t0].[Rank], [t0].[SquadId]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Name], [w0].[IsAutomatic], [w0].[Id], [u0].[Nickname], [u0].[Rank], [u0].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Name], [w].[IsAutomatic], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit)
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [w0].[Id], [t0].[FullName], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[FullName], [u].[Nickname], [u].[SquadId], [w0].[Id], [u0].[FullName], [u0].[Nickname]
 """);
     }
 
@@ -5891,12 +5891,12 @@ ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [w0].[Id], [t0].[FullNam
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -5905,9 +5905,9 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId])
+ORDER BY [u].[HasSoulPatch] DESC, [t].[Note]
 """);
     }
 
@@ -5917,21 +5917,21 @@ ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
     FROM [Officers] AS [o1]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
+) AS [u1] ON [t].[GearNickName] = [u1].[Nickname] AND [t].[GearSquadId] = [u1].[SquadId]
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t3].[Nickname], [t3].[SquadId]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u2].[Nickname], [u2].[SquadId]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[FullName]
@@ -5939,8 +5939,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [o2].[Nickname], [o2].[SquadId], [o2].[FullName]
         FROM [Officers] AS [o2]
-    ) AS [t3] ON [w].[OwnerFullName] = [t3].[FullName]
-) AS [s] ON [t2].[FullName] = [s].[OwnerFullName]
+    ) AS [u2] ON [w].[OwnerFullName] = [u2].[FullName]
+) AS [s] ON [u1].[FullName] = [s].[OwnerFullName]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -5949,9 +5949,9 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[IsAutomatic], [s].[Nickname] DESC, [s].[Id]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId])
+ORDER BY [u].[HasSoulPatch] DESC, [t].[Note], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[IsAutomatic], [s].[Nickname] DESC, [s].[Id]
 """);
     }
 
@@ -5962,21 +5962,21 @@ ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
     FROM [Officers] AS [o1]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
+) AS [u1] ON [t].[GearNickName] = [u1].[Nickname] AND [t].[GearSquadId] = [u1].[SquadId]
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t3].[Nickname], [t3].[SquadId]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u2].[Nickname], [u2].[SquadId]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[FullName]
@@ -5984,8 +5984,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [o2].[Nickname], [o2].[SquadId], [o2].[FullName]
         FROM [Officers] AS [o2]
-    ) AS [t3] ON [w].[OwnerFullName] = [t3].[FullName]
-) AS [s] ON [t2].[FullName] = [s].[OwnerFullName]
+    ) AS [u2] ON [w].[OwnerFullName] = [u2].[FullName]
+) AS [s] ON [u1].[FullName] = [s].[OwnerFullName]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -5994,9 +5994,9 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[IsAutomatic], [s].[Nickname] DESC, [s].[Id]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId])
+ORDER BY [u].[HasSoulPatch] DESC, [t].[Note], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[IsAutomatic], [s].[Nickname] DESC, [s].[Id]
 """);
     }
 
@@ -6007,24 +6007,24 @@ ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
     FROM [Officers] AS [o1]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
+) AS [u1] ON [t].[GearNickName] = [u1].[Nickname] AND [t].[GearSquadId] = [u1].[SquadId]
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t3].[Nickname], [t3].[SquadId], (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u2].[Nickname], [u2].[SquadId], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
-        WHERE [t3].[FullName] IS NOT NULL AND [t3].[FullName] = [w0].[OwnerFullName]) AS [c]
+        WHERE [u2].[FullName] IS NOT NULL AND [u2].[FullName] = [w0].[OwnerFullName]) AS [c]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[FullName]
@@ -6032,8 +6032,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [o2].[Nickname], [o2].[SquadId], [o2].[FullName]
         FROM [Officers] AS [o2]
-    ) AS [t3] ON [w].[OwnerFullName] = [t3].[FullName]
-) AS [s] ON [t2].[FullName] = [s].[OwnerFullName]
+    ) AS [u2] ON [w].[OwnerFullName] = [u2].[FullName]
+) AS [s] ON [u1].[FullName] = [s].[OwnerFullName]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -6042,9 +6042,9 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s].[Id] DESC, [s].[c], [s].[Nickname]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId])
+ORDER BY [u].[HasSoulPatch] DESC, [t].[Note], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id] DESC, [s].[c], [s].[Nickname]
 """);
     }
 
@@ -6054,30 +6054,30 @@ ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Name], [s1].[IsAutomatic], [s1].[Id1], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00], [s2].[Id], [s2].[AmmunitionType], [s2].[IsAutomatic], [s2].[Name], [s2].[OwnerFullName], [s2].[SynergyWithId], [s2].[Nickname], [s2].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Name], [s1].[IsAutomatic], [s1].[Id1], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00], [s2].[Id], [s2].[AmmunitionType], [s2].[IsAutomatic], [s2].[Name], [s2].[OwnerFullName], [s2].[SynergyWithId], [s2].[Nickname], [s2].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
     FROM [Officers] AS [o1]
-) AS [t2] ON [t0].[GearNickName] = [t2].[Nickname] AND [t0].[GearSquadId] = [t2].[SquadId]
+) AS [u1] ON [t].[GearNickName] = [u1].[Nickname] AND [t].[GearSquadId] = [u1].[SquadId]
 LEFT JOIN (
-    SELECT [t3].[FullName], [t3].[Nickname], [t3].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Name], [s0].[IsAutomatic], [s0].[Id1], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [t3].[Rank], [s0].[IsAutomatic0], [t3].[LeaderNickname], [t3].[LeaderSquadId]
+    SELECT [u2].[FullName], [u2].[Nickname], [u2].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Name], [s0].[IsAutomatic], [s0].[Id1], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [u2].[Rank], [s0].[IsAutomatic0], [u2].[LeaderNickname], [u2].[LeaderSquadId]
     FROM (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
         FROM [Gears] AS [g1]
         UNION ALL
         SELECT [o2].[Nickname], [o2].[SquadId], [o2].[FullName], [o2].[LeaderNickname], [o2].[LeaderSquadId], [o2].[Rank]
         FROM [Officers] AS [o2]
-    ) AS [t3]
+    ) AS [u2]
     LEFT JOIN (
-        SELECT [w].[Id], [t4].[Nickname], [t4].[SquadId], [s].[Id] AS [Id0], [w0].[Name], [w0].[IsAutomatic], [w0].[Id] AS [Id1], [t5].[Nickname] AS [Nickname0], [t5].[HasSoulPatch], [t5].[SquadId] AS [SquadId0], [w].[IsAutomatic] AS [IsAutomatic0], [w].[OwnerFullName]
+        SELECT [w].[Id], [u3].[Nickname], [u3].[SquadId], [s].[Id] AS [Id0], [w0].[Name], [w0].[IsAutomatic], [w0].[Id] AS [Id1], [u4].[Nickname] AS [Nickname0], [u4].[HasSoulPatch], [u4].[SquadId] AS [SquadId0], [w].[IsAutomatic] AS [IsAutomatic0], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
             SELECT [g2].[Nickname], [g2].[SquadId], [g2].[FullName]
@@ -6085,22 +6085,22 @@ LEFT JOIN (
             UNION ALL
             SELECT [o3].[Nickname], [o3].[SquadId], [o3].[FullName]
             FROM [Officers] AS [o3]
-        ) AS [t4] ON [w].[OwnerFullName] = [t4].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t4].[SquadId] = [s].[Id]
-        LEFT JOIN [Weapons] AS [w0] ON [t4].[FullName] = [w0].[OwnerFullName]
+        ) AS [u3] ON [w].[OwnerFullName] = [u3].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [u3].[SquadId] = [s].[Id]
+        LEFT JOIN [Weapons] AS [w0] ON [u3].[FullName] = [w0].[OwnerFullName]
         LEFT JOIN (
             SELECT [g3].[Nickname], [g3].[SquadId], [g3].[HasSoulPatch]
             FROM [Gears] AS [g3]
             UNION ALL
             SELECT [o4].[Nickname], [o4].[SquadId], [o4].[HasSoulPatch]
             FROM [Officers] AS [o4]
-        ) AS [t5] ON [s].[Id] = [t5].[SquadId]
+        ) AS [u4] ON [s].[Id] = [u4].[SquadId]
         WHERE [w].[Name] <> N'Bar' OR [w].[Name] IS NULL
-    ) AS [s0] ON [t3].[FullName] = [s0].[OwnerFullName]
-    WHERE [t3].[FullName] <> N'Foo'
-) AS [s1] ON [t].[Nickname] = [s1].[LeaderNickname] AND [t].[SquadId] = [s1].[LeaderSquadId]
+    ) AS [s0] ON [u2].[FullName] = [s0].[OwnerFullName]
+    WHERE [u2].[FullName] <> N'Foo'
+) AS [s1] ON [u].[Nickname] = [s1].[LeaderNickname] AND [u].[SquadId] = [s1].[LeaderSquadId]
 LEFT JOIN (
-    SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [t6].[Nickname], [t6].[SquadId]
+    SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [u5].[Nickname], [u5].[SquadId]
     FROM [Weapons] AS [w1]
     LEFT JOIN (
         SELECT [g4].[Nickname], [g4].[SquadId], [g4].[FullName]
@@ -6108,8 +6108,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [o5].[Nickname], [o5].[SquadId], [o5].[FullName]
         FROM [Officers] AS [o5]
-    ) AS [t6] ON [w1].[OwnerFullName] = [t6].[FullName]
-) AS [s2] ON [t2].[FullName] = [s2].[OwnerFullName]
+    ) AS [u5] ON [w1].[OwnerFullName] = [u5].[FullName]
+) AS [s2] ON [u1].[FullName] = [s2].[OwnerFullName]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -6118,9 +6118,9 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1]
-    WHERE [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t0].[Id], [t2].[Nickname], [t2].[SquadId], [s1].[Rank], [s1].[Nickname], [s1].[SquadId], [s1].[IsAutomatic0], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Id1], [s1].[Nickname00], [s1].[SquadId00], [s2].[IsAutomatic], [s2].[Nickname] DESC, [s2].[Id]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId])
+ORDER BY [u].[HasSoulPatch] DESC, [t].[Note], [u].[Nickname], [u].[SquadId], [t].[Id], [u1].[Nickname], [u1].[SquadId], [s1].[Rank], [s1].[Nickname], [s1].[SquadId], [s1].[IsAutomatic0], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Id1], [s1].[Nickname00], [s1].[SquadId00], [s2].[IsAutomatic], [s2].[Nickname] DESC, [s2].[Id]
 """);
     }
 
@@ -6130,23 +6130,23 @@ ORDER BY [t].[HasSoulPatch] DESC, [t0].[Note], [t].[Nickname], [t].[SquadId], [t
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t1].[ReportName], [t1].[OfficerName], [t1].[Nickname], [t1].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [u1].[ReportName], [u1].[OfficerName], [u1].[Nickname], [u1].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[FullName] AS [ReportName], [t].[FullName] AS [OfficerName], [t0].[Nickname], [t0].[SquadId]
+    SELECT [u0].[FullName] AS [ReportName], [u].[FullName] AS [OfficerName], [u0].[Nickname], [u0].[SquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-) AS [t1]
-ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+) AS [u1]
+ORDER BY [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -6156,23 +6156,23 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t1].[ReportName], [t1].[Nickname], [t1].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [u1].[ReportName], [u1].[Nickname], [u1].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[FullName] AS [ReportName], [t0].[Nickname], [t0].[SquadId]
+    SELECT [u0].[FullName] AS [ReportName], [u0].[Nickname], [u0].[SquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId] AND [t].[FullName] <> N'Foo'
-) AS [t1]
-ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId] AND [u].[FullName] <> N'Foo'
+) AS [u1]
+ORDER BY [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -6182,28 +6182,28 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Name], [s].[Nickname0], [s].[Id]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Name], [s].[Nickname0], [s].[Id]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[Id], [t0].[LeaderNickname], [t0].[LeaderSquadId]
+    SELECT [u0].[FullName], [u0].[Nickname], [u0].[SquadId], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[Id], [u0].[LeaderNickname], [u0].[LeaderSquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     OUTER APPLY (
-        SELECT [w].[Name], [t0].[Nickname], [w].[Id]
+        SELECT [w].[Name], [u0].[Nickname], [w].[Id]
         FROM [Weapons] AS [w]
-        WHERE [t0].[FullName] = [w].[OwnerFullName] AND ([w].[Name] <> N'Bar' OR [w].[Name] IS NULL)
+        WHERE [u0].[FullName] = [w].[OwnerFullName] AND ([w].[Name] <> N'Bar' OR [w].[Name] IS NULL)
     ) AS [w0]
-    WHERE [t0].[FullName] <> N'Foo'
-) AS [s] ON [t].[Nickname] = [s].[LeaderNickname] AND [t].[SquadId] = [s].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId]
+    WHERE [u0].[FullName] <> N'Foo'
+) AS [s] ON [u].[Nickname] = [s].[LeaderNickname] AND [u].[SquadId] = [s].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Nickname], [s].[SquadId]
 """);
     }
 
@@ -6213,28 +6213,28 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Name], [s].[Nickname0], [s].[Id]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s].[FullName], [s].[Nickname], [s].[SquadId], [s].[Name], [s].[Nickname0], [s].[Id]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[Id]
+    SELECT [u0].[FullName], [u0].[Nickname], [u0].[SquadId], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[Id]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
-        SELECT [w].[Name], [t].[Nickname], [w].[Id], [w].[OwnerFullName]
+        SELECT [w].[Name], [u].[Nickname], [w].[Id], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         WHERE [w].[Name] <> N'Bar' OR [w].[Name] IS NULL
-    ) AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-    WHERE [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId] AND [t0].[FullName] <> N'Foo'
+    ) AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId] AND [u0].[FullName] <> N'Foo'
 ) AS [s]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Nickname], [s].[SquadId]
 """);
     }
 
@@ -6244,33 +6244,33 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Nickname], [s].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [s].[Name], [t].[SquadId], [s].[Id], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [s].[Name], [u].[SquadId], [s].[Id], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN [Squads] AS [s]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit) OR [w].[Name] <> N'foo' OR [w].[Name] IS NULL
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [t].[Nickname], [s].[Id] DESC, [t].[SquadId], [w0].[Id], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u0].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+ORDER BY [u].[Nickname], [s].[Id] DESC, [u].[SquadId], [w0].[Id], [u1].[Nickname]
 """);
     }
 
@@ -6280,23 +6280,23 @@ ORDER BY [t].[Nickname], [s].[Id] DESC, [t].[SquadId], [w0].[Id], [t1].[Nickname
 
         AssertSql(
             """
-SELECT [s].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [s].[Id], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
-        SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname]) AS [row]
+        SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o]
-        ) AS [t]
-    ) AS [t0]
-    WHERE 1 < [t0].[row]
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
-ORDER BY [s].[Name], [s].[Id], [t1].[SquadId], [t1].[Nickname]
+        ) AS [u]
+    ) AS [u0]
+    WHERE 1 < [u0].[row]
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
+ORDER BY [s].[Name], [s].[Id], [u1].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -6306,23 +6306,23 @@ ORDER BY [s].[Name], [s].[Id], [t1].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [s].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [s].[Id], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
-        SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname]) AS [row]
+        SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o]
-        ) AS [t]
-    ) AS [t0]
-    WHERE [t0].[row] <= 2
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
-ORDER BY [s].[Name], [s].[Id], [t1].[SquadId], [t1].[Nickname]
+        ) AS [u]
+    ) AS [u0]
+    WHERE [u0].[row] <= 2
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
+ORDER BY [s].[Name], [s].[Id], [u1].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -6332,25 +6332,25 @@ ORDER BY [s].[Name], [s].[Id], [t1].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [s].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [s].[Id], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM [Squads] AS [s]
 OUTER APPLY (
-    SELECT DISTINCT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT DISTINCT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
-        SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+        SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [s].[Id] = [t].[SquadId]
-        ORDER BY [t].[Nickname]
+        ) AS [u]
+        WHERE [s].[Id] = [u].[SquadId]
+        ORDER BY [u].[Nickname]
         OFFSET 0 ROWS
-    ) AS [t0]
-) AS [t1]
-ORDER BY [s].[Name], [s].[Id], [t1].[Nickname]
+    ) AS [u0]
+) AS [u1]
+ORDER BY [s].[Name], [s].[Id], [u1].[Nickname]
 """);
     }
 
@@ -6361,16 +6361,16 @@ ORDER BY [s].[Name], [s].[Id], [t1].[Nickname]
         AssertSql(
             """
 SELECT (
-    SELECT TOP(1) [t].[FullName]
+    SELECT TOP(1) [u].[FullName]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId]
-    ORDER BY [t].[Nickname])
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId]
+    ORDER BY [u].[Nickname])
 FROM [Squads] AS [s]
 ORDER BY [s].[Name]
 """);
@@ -6382,7 +6382,7 @@ ORDER BY [s].[Name]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t].[Id], [t0].[SquadId], [w].[Name], [w].[Id]
+SELECT [u].[Nickname], [t].[Id], [u].[SquadId], [w].[Name], [w].[Id]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[HasSoulPatch]
@@ -6390,10 +6390,10 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -6403,7 +6403,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Name], [w].[Id]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [w].[Name], [w].[Id]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
@@ -6411,9 +6411,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [t].[Note], [t].[Id], [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -6423,20 +6423,20 @@ ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[FullName], [t1].[Nickname], [t1].[SquadId]
+SELECT [t].[Note], [t].[Id], [u].[Nickname], [u].[SquadId], [u0].[FullName], [u0].[Nickname], [u0].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
     FROM [Officers] AS [o0]
-) AS [t1] ON ([t0].[Nickname] = [t1].[LeaderNickname] OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND [t0].[SquadId] = [t1].[LeaderSquadId]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -6446,7 +6446,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id], [s0].[AmmunitionType], [s0].[IsAutomatic], [s0].[Name], [s0].[OwnerFullName], [s0].[SynergyWithId]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id], [s0].[AmmunitionType], [s0].[IsAutomatic], [s0].[Name], [s0].[OwnerFullName], [s0].[SynergyWithId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -6454,25 +6454,25 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 LEFT JOIN (
-    SELECT [t1].[Nickname], [t1].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+    SELECT [u0].[Nickname], [u0].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName], [g0].[HasSoulPatch]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[HasSoulPatch]
         FROM [Officers] AS [o0]
-    ) AS [t1]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
         WHERE [w].[IsAutomatic] = CAST(1 AS bit)
-    ) AS [w0] ON [t1].[FullName] = [w0].[OwnerFullName]
-    WHERE [t1].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+    WHERE [u0].[HasSoulPatch] = CAST(1 AS bit)
 ) AS [s0] ON [s].[Id] = [s0].[SquadId]
-ORDER BY [t].[Note], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId]
+ORDER BY [t].[Note], [u].[Nickname] DESC, [t].[Id], [u].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId]
 """);
     }
 
@@ -6482,7 +6482,7 @@ ORDER BY [t].[Note], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [s].[Id], [
 
         AssertSql(
             """
-SELECT [w].[Id], [t].[Nickname], [t].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id], [s0].[AmmunitionType], [s0].[IsAutomatic], [s0].[Name], [s0].[OwnerFullName], [s0].[SynergyWithId], [s0].[Rank]
+SELECT [w].[Id], [u].[Nickname], [u].[SquadId], [s].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id], [s0].[AmmunitionType], [s0].[IsAutomatic], [s0].[Name], [s0].[OwnerFullName], [s0].[SynergyWithId], [s0].[Rank]
 FROM [Weapons] AS [w]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
@@ -6490,24 +6490,24 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [t0].[Rank], [t0].[FullName]
+    SELECT [u0].[Nickname], [u0].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [u0].[Rank], [u0].[FullName]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName], [g0].[Rank]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[Rank]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
         FROM [Weapons] AS [w0]
         WHERE [w0].[IsAutomatic] = CAST(0 AS bit)
-    ) AS [w1] ON [t0].[FullName] = [w1].[OwnerFullName]
+    ) AS [w1] ON [u0].[FullName] = [w1].[OwnerFullName]
 ) AS [s0] ON [s].[Id] = [s0].[SquadId]
-ORDER BY [w].[Name], [w].[Id], [t].[Nickname], [t].[SquadId], [s].[Id], [s0].[FullName] DESC, [s0].[Nickname], [s0].[SquadId], [s0].[Id]
+ORDER BY [w].[Name], [w].[Id], [u].[Nickname], [u].[SquadId], [s].[Id], [s0].[FullName] DESC, [s0].[Nickname], [s0].[SquadId], [s0].[Id]
 """);
     }
 
@@ -6517,16 +6517,16 @@ ORDER BY [w].[Name], [w].[Id], [t].[Nickname], [t].[SquadId], [s].[Id], [s0].[Fu
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0], [s0].[HasSoulPatch], [s0].[SquadId0]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0], [s0].[HasSoulPatch], [s0].[SquadId0]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [w].[Id], [t0].[Nickname], [t0].[SquadId], [s].[Id] AS [Id0], [t1].[Nickname] AS [Nickname0], [t1].[HasSoulPatch], [t1].[SquadId] AS [SquadId0], [w].[OwnerFullName]
+    SELECT [w].[Id], [u0].[Nickname], [u0].[SquadId], [s].[Id] AS [Id0], [u1].[Nickname] AS [Nickname0], [u1].[HasSoulPatch], [u1].[SquadId] AS [SquadId0], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -6534,17 +6534,17 @@ LEFT JOIN (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-    LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+    ) AS [u0] ON [w].[OwnerFullName] = [u0].[FullName]
+    LEFT JOIN [Squads] AS [s] ON [u0].[SquadId] = [s].[Id]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[HasSoulPatch]
         FROM [Gears] AS [g1]
         UNION ALL
         SELECT [o1].[Nickname], [o1].[SquadId], [o1].[HasSoulPatch]
         FROM [Officers] AS [o1]
-    ) AS [t1] ON [s].[Id] = [t1].[SquadId]
-) AS [s0] ON [t].[FullName] = [s0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0]
+    ) AS [u1] ON [s].[Id] = [u1].[SquadId]
+) AS [s0] ON [u].[FullName] = [s0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0]
 """);
     }
 
@@ -6554,22 +6554,22 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadI
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [t0].[LeaderNickname], [t0].[LeaderSquadId]
+    SELECT [u0].[FullName], [u0].[Nickname], [u0].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [u0].[LeaderNickname], [u0].[LeaderSquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
-        SELECT [w].[Id], [t1].[Nickname], [t1].[SquadId], [s].[Id] AS [Id0], [t2].[Nickname] AS [Nickname0], [t2].[HasSoulPatch], [t2].[SquadId] AS [SquadId0], [w].[OwnerFullName]
+        SELECT [w].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id] AS [Id0], [u2].[Nickname] AS [Nickname0], [u2].[HasSoulPatch], [u2].[SquadId] AS [SquadId0], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -6577,18 +6577,18 @@ LEFT JOIN (
             UNION ALL
             SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
             FROM [Officers] AS [o1]
-        ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t1].[SquadId] = [s].[Id]
+        ) AS [u1] ON [w].[OwnerFullName] = [u1].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [u1].[SquadId] = [s].[Id]
         LEFT JOIN (
             SELECT [g1].[Nickname], [g1].[SquadId], [g1].[HasSoulPatch]
             FROM [Gears] AS [g1]
             UNION ALL
             SELECT [o2].[Nickname], [o2].[SquadId], [o2].[HasSoulPatch]
             FROM [Officers] AS [o2]
-        ) AS [t2] ON [s].[Id] = [t2].[SquadId]
-    ) AS [s0] ON [t0].[FullName] = [s0].[OwnerFullName]
-) AS [s1] ON [t].[Nickname] = [s1].[LeaderNickname] AND [t].[SquadId] = [s1].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00]
+        ) AS [u2] ON [s].[Id] = [u2].[SquadId]
+    ) AS [s0] ON [u0].[FullName] = [s0].[OwnerFullName]
+) AS [s1] ON [u].[Nickname] = [s1].[LeaderNickname] AND [u].[SquadId] = [s1].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00]
 """);
     }
 
@@ -6598,16 +6598,16 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s1].[Nickname], [s1].[SquadId], [s1].[I
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0], [s0].[HasSoulPatch], [s0].[SquadId0]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0], [s0].[HasSoulPatch], [s0].[SquadId0]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [w].[Id], [t0].[Nickname], [t0].[SquadId], [s].[Id] AS [Id0], [t1].[Nickname] AS [Nickname0], [t1].[HasSoulPatch], [t1].[SquadId] AS [SquadId0], [w].[OwnerFullName]
+    SELECT [w].[Id], [u0].[Nickname], [u0].[SquadId], [s].[Id] AS [Id0], [u1].[Nickname] AS [Nickname0], [u1].[HasSoulPatch], [u1].[SquadId] AS [SquadId0], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -6615,17 +6615,17 @@ LEFT JOIN (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-    LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+    ) AS [u0] ON [w].[OwnerFullName] = [u0].[FullName]
+    LEFT JOIN [Squads] AS [s] ON [u0].[SquadId] = [s].[Id]
     LEFT JOIN (
         SELECT [g1].[Nickname], [g1].[SquadId], [g1].[HasSoulPatch]
         FROM [Gears] AS [g1]
         UNION ALL
         SELECT [o1].[Nickname], [o1].[SquadId], [o1].[HasSoulPatch]
         FROM [Officers] AS [o1]
-    ) AS [t1] ON [s].[Id] = [t1].[SquadId]
-) AS [s0] ON [t].[FullName] = [s0].[OwnerFullName]
-ORDER BY [t].[FullName], [t].[Nickname] DESC, [t].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0]
+    ) AS [u1] ON [s].[Id] = [u1].[SquadId]
+) AS [s0] ON [u].[FullName] = [s0].[OwnerFullName]
+ORDER BY [u].[FullName], [u].[Nickname] DESC, [u].[SquadId], [s0].[Id], [s0].[Nickname], [s0].[SquadId], [s0].[Id0], [s0].[Nickname0]
 """);
     }
 
@@ -6635,22 +6635,22 @@ ORDER BY [t].[FullName], [t].[Nickname] DESC, [t].[SquadId], [s0].[Id], [s0].[Ni
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [s1].[FullName], [s1].[Nickname], [s1].[SquadId], [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00], [s1].[HasSoulPatch], [s1].[SquadId00]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [t0].[HasSoulPatch] AS [HasSoulPatch0], [s0].[IsAutomatic], [s0].[Name], [t0].[LeaderNickname], [t0].[LeaderSquadId]
+    SELECT [u0].[FullName], [u0].[Nickname], [u0].[SquadId], [s0].[Id], [s0].[Nickname] AS [Nickname0], [s0].[SquadId] AS [SquadId0], [s0].[Id0], [s0].[Nickname0] AS [Nickname00], [s0].[HasSoulPatch], [s0].[SquadId0] AS [SquadId00], [u0].[HasSoulPatch] AS [HasSoulPatch0], [s0].[IsAutomatic], [s0].[Name], [u0].[LeaderNickname], [u0].[LeaderSquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
-        SELECT [w].[Id], [t1].[Nickname], [t1].[SquadId], [s].[Id] AS [Id0], [t2].[Nickname] AS [Nickname0], [t2].[HasSoulPatch], [t2].[SquadId] AS [SquadId0], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName]
+        SELECT [w].[Id], [u1].[Nickname], [u1].[SquadId], [s].[Id] AS [Id0], [u2].[Nickname] AS [Nickname0], [u2].[HasSoulPatch], [u2].[SquadId] AS [SquadId0], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -6658,18 +6658,18 @@ LEFT JOIN (
             UNION ALL
             SELECT [o1].[Nickname], [o1].[SquadId], [o1].[FullName]
             FROM [Officers] AS [o1]
-        ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t1].[SquadId] = [s].[Id]
+        ) AS [u1] ON [w].[OwnerFullName] = [u1].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [u1].[SquadId] = [s].[Id]
         LEFT JOIN (
             SELECT [g1].[Nickname], [g1].[SquadId], [g1].[HasSoulPatch]
             FROM [Gears] AS [g1]
             UNION ALL
             SELECT [o2].[Nickname], [o2].[SquadId], [o2].[HasSoulPatch]
             FROM [Officers] AS [o2]
-        ) AS [t2] ON [s].[Id] = [t2].[SquadId]
-    ) AS [s0] ON [t0].[FullName] = [s0].[OwnerFullName]
-) AS [s1] ON [t].[Nickname] = [s1].[LeaderNickname] AND [t].[SquadId] = [s1].[LeaderSquadId]
-ORDER BY [t].[HasSoulPatch], [t].[LeaderNickname], [t].[FullName], [t].[Nickname], [t].[SquadId], [s1].[FullName], [s1].[HasSoulPatch0] DESC, [s1].[Nickname], [s1].[SquadId], [s1].[IsAutomatic], [s1].[Name] DESC, [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00]
+        ) AS [u2] ON [s].[Id] = [u2].[SquadId]
+    ) AS [s0] ON [u0].[FullName] = [s0].[OwnerFullName]
+) AS [s1] ON [u].[Nickname] = [s1].[LeaderNickname] AND [u].[SquadId] = [s1].[LeaderSquadId]
+ORDER BY [u].[HasSoulPatch], [u].[LeaderNickname], [u].[FullName], [u].[Nickname], [u].[SquadId], [s1].[FullName], [s1].[HasSoulPatch0] DESC, [s1].[Nickname], [s1].[SquadId], [s1].[IsAutomatic], [s1].[Name] DESC, [s1].[Id], [s1].[Nickname0], [s1].[SquadId0], [s1].[Id0], [s1].[Nickname00]
 """);
     }
 
@@ -6679,20 +6679,20 @@ ORDER BY [t].[HasSoulPatch], [t].[LeaderNickname], [t].[FullName], [t].[Nickname
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(1) [t].[Nickname], [t].[SquadId], [t].[FullName]
+    SELECT TOP(1) [u].[Nickname], [u].[SquadId], [u].[FullName]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    ORDER BY [t].[Nickname]
-) AS [t0]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t0].[Nickname], [t0].[SquadId]
+    ) AS [u]
+    ORDER BY [u].[Nickname]
+) AS [u0]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+ORDER BY [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -6709,7 +6709,7 @@ FROM (
     UNION ALL
     SELECT 1 AS empty
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -6719,20 +6719,20 @@ FROM (
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(1) [t].[Nickname], [t].[SquadId], [t].[FullName]
+    SELECT TOP(1) [u].[Nickname], [u].[SquadId], [u].[FullName]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    ORDER BY [t].[FullName]
-) AS [t0]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t0].[FullName], [t0].[Nickname], [t0].[SquadId]
+    ) AS [u]
+    ORDER BY [u].[FullName]
+) AS [u0]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+ORDER BY [u0].[FullName], [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -6742,20 +6742,20 @@ ORDER BY [t0].[FullName], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(1) [t].[Nickname], [t].[SquadId], [t].[FullName]
+    SELECT TOP(1) [u].[Nickname], [u].[SquadId], [u].[FullName]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    ORDER BY [t].[FullName] DESC
-) AS [t0]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t0].[FullName] DESC, [t0].[Nickname], [t0].[SquadId], [w].[Name]
+    ) AS [u]
+    ORDER BY [u].[FullName] DESC
+) AS [u0]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+ORDER BY [u0].[FullName] DESC, [u0].[Nickname], [u0].[SquadId], [w].[Name]
 """);
     }
 
@@ -6772,12 +6772,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Name]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [l1].[Id], [l1].[CapitalName], [l1].[Name], [l1].[ServerAddress], [l1].[CommanderName], [l1].[Eradicated]
     FROM [LocustHordes] AS [l1]
     WHERE [l1].[Name] = N'Swarm'
-) AS [l2] ON [t].[Name] = [l2].[CommanderName]
+) AS [l2] ON [u].[Name] = [l2].[CommanderName]
 WHERE [l2].[Eradicated] <> CAST(1 AS bit) OR [l2].[Eradicated] IS NULL
 """);
     }
@@ -6795,12 +6795,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Name]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [l1].[Id], [l1].[CapitalName], [l1].[Name], [l1].[ServerAddress], [l1].[CommanderName], [l1].[Eradicated]
     FROM [LocustHordes] AS [l1]
     WHERE [l1].[Name] = N'Swarm'
-) AS [l2] ON [t].[Name] = [l2].[CommanderName]
+) AS [l2] ON [u].[Name] = [l2].[CommanderName]
 WHERE [l2].[Eradicated] <> CAST(1 AS bit) OR [l2].[Eradicated] IS NULL
 """);
     }
@@ -6815,23 +6815,23 @@ WHERE [l2].[Eradicated] <> CAST(1 AS bit) OR [l2].[Eradicated] IS NULL
 
 SELECT [s].[Name], [s].[LocustHordeId], [s].[ThreatLevel], [s].[ThreatLevelByte], [s].[ThreatLevelNullableByte], [s].[DefeatedByNickname], [s].[DefeatedBySquadId], [s].[HighCommandId], [s].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator0] AS [Discriminator], [s].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator] AS [Discriminator0], [t1].[Id], [t1].[Note]
+    SELECT TOP(@__p_0) [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator] AS [Discriminator0], [t].[Id], [t].[Note]
     FROM (
         SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
         FROM [LocustLeaders] AS [l]
         UNION ALL
         SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
         FROM [LocustCommanders] AS [l0]
-    ) AS [t]
+    ) AS [u]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-    LEFT JOIN [Tags] AS [t1] ON ([t0].[Nickname] = [t1].[GearNickName] OR ([t0].[Nickname] IS NULL AND [t1].[GearNickName] IS NULL)) AND ([t0].[SquadId] = [t1].[GearSquadId] OR ([t0].[SquadId] IS NULL AND [t1].[GearSquadId] IS NULL))
-    ORDER BY [t1].[Note]
+    ) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+    LEFT JOIN [Tags] AS [t] ON ([u0].[Nickname] = [t].[GearNickName] OR ([u0].[Nickname] IS NULL AND [t].[GearNickName] IS NULL)) AND ([u0].[SquadId] = [t].[GearSquadId] OR ([u0].[SquadId] IS NULL AND [t].[GearSquadId] IS NULL))
+    ORDER BY [t].[Note]
 ) AS [s]
 LEFT JOIN [Weapons] AS [w] ON [s].[FullName] = [w].[OwnerFullName]
 ORDER BY [s].[Note], [s].[Name], [s].[Nickname], [s].[SquadId], [s].[Id]
@@ -6851,8 +6851,8 @@ FROM (
     UNION ALL
     SELECT [l0].[HighCommandId]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-LEFT JOIN [LocustHighCommands] AS [l1] ON [t].[HighCommandId] = [l1].[Id]
+) AS [u]
+LEFT JOIN [LocustHighCommands] AS [l1] ON [u].[HighCommandId] = [l1].[Id]
 """);
     }
 
@@ -6869,8 +6869,8 @@ FROM (
     UNION ALL
     SELECT [o].[CityOfBirthName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 """);
     }
 
@@ -6880,15 +6880,15 @@ INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-LEFT JOIN [LocustHighCommands] AS [l1] ON [t].[HighCommandId] = [l1].[Id]
+) AS [u]
+LEFT JOIN [LocustHighCommands] AS [l1] ON [u].[HighCommandId] = [l1].[Id]
 WHERE [l1].[IsOperational] = CAST(1 AS bit)
 """);
     }
@@ -6899,23 +6899,23 @@ WHERE [l1].[IsOperational] = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
+SELECT [u].[Nickname], [u].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[Note], [t0].[Id], [t1].[Nickname], [t1].[SquadId]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [t].[Id], [u0].[Nickname], [u0].[SquadId]
+    FROM [Tags] AS [t]
     INNER JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t].[FullName] = [t1].[FullName]
+    ) AS [u0] ON [u].[FullName] = [u0].[FullName]
 ) AS [s]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s].[Nickname]
 """);
     }
 
@@ -6925,23 +6925,23 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
+SELECT [u].[Nickname], [u].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[Note], [t0].[Id], [t1].[Nickname], [t1].[SquadId]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [t].[Id], [u0].[Nickname], [u0].[SquadId]
+    FROM [Tags] AS [t]
     INNER JOIN (
         SELECT [g].[Nickname], [g].[SquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t].[FullName] = [t].[Nickname]
+    ) AS [u0] ON [u].[FullName] = [u].[Nickname]
 ) AS [s]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s].[Nickname]
 """);
     }
 
@@ -6951,23 +6951,23 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
+SELECT [u].[Nickname], [u].[SquadId], [s].[Note], [s].[Id], [s].[Nickname], [s].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[Note], [t0].[Id], [t1].[Nickname], [t1].[SquadId]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [t].[Id], [u0].[Nickname], [u0].[SquadId]
+    FROM [Tags] AS [t]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t].[FullName] = [t1].[FullName]
+    ) AS [u0] ON [u].[FullName] = [u0].[FullName]
 ) AS [s]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s].[Nickname]
 """);
     }
 
@@ -6979,8 +6979,8 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s].[Nickname]
             """
 SELECT CASE
     WHEN CASE
-        WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-        ELSE COALESCE([t0].[HasSoulPatch], CAST(1 AS bit))
+        WHEN [u].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
+        ELSE COALESCE([u].[HasSoulPatch], CAST(1 AS bit))
     END = CAST(0 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [c]
@@ -6991,7 +6991,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -7001,16 +7001,16 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[Nickname], [g].[AssignedCityName], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[AssignedCityName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
-ORDER BY [c].[Name], [t].[Nickname] DESC
+) AS [u]
+LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
+ORDER BY [c].[Name], [u].[Nickname] DESC
 """);
     }
 
@@ -7020,13 +7020,13 @@ ORDER BY [c].[Name], [t].[Nickname] DESC
 
         AssertSql(
             """
-SELECT [t].[Name]
+SELECT [u].[Name]
 FROM (
     SELECT [l].[Name], [l].[HighCommandId]
     FROM [LocustCommanders] AS [l]
-) AS [t]
-INNER JOIN [LocustHighCommands] AS [l0] ON [t].[HighCommandId] = [l0].[Id]
-ORDER BY [l0].[Id], [t].[Name]
+) AS [u]
+INNER JOIN [LocustHighCommands] AS [l0] ON [u].[HighCommandId] = [l0].[Id]
+ORDER BY [l0].[Id], [u].[Name]
 """);
     }
 
@@ -7044,8 +7044,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [w].[Id]
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [w].[Id]
 """);
     }
 
@@ -7063,9 +7063,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-ORDER BY [w].[IsAutomatic], [t].[Nickname] DESC, [t].[SquadId] DESC, [w0].[Id], [w].[Name]
+ORDER BY [w].[IsAutomatic], [u].[Nickname] DESC, [u].[SquadId] DESC, [w0].[Id], [w].[Name]
 """);
     }
 
@@ -7087,21 +7087,21 @@ INNER JOIN [Weapons] AS [w0] ON [w].[Id] = [w0].[Id]
 
         AssertSql(
             """
-SELECT [t].[FullName] AS [GearName1], [t0].[FullName] AS [GearName2]
+SELECT [u].[FullName] AS [GearName1], [u0].[FullName] AS [GearName2]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[Nickname] = [u0].[Nickname] AND [u].[SquadId] = [u0].[SquadId]
 """);
     }
 
@@ -7111,18 +7111,18 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [t].[FullName] AS [GearName], [t0].[FullName] AS [OfficerName]
+SELECT [u].[FullName] AS [GearName], [u0].[FullName] AS [OfficerName]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[Nickname] = [u0].[Nickname] AND [u].[SquadId] = [u0].[SquadId]
 """);
     }
 
@@ -7148,15 +7148,15 @@ INNER JOIN [Weapons] AS [w1] ON [w0].[Id] = [w1].[Id]
 SELECT [c].[Name] AS [CityName], [s].[Nickname] AS [GearNickname]
 FROM [Cities] AS [c]
 INNER JOIN (
-    SELECT [t].[Nickname], [c0].[Name]
+    SELECT [u].[Nickname], [c0].[Name]
     FROM (
         SELECT [g].[Nickname], [g].[AssignedCityName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[AssignedCityName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    LEFT JOIN [Cities] AS [c0] ON [t].[AssignedCityName] = [c0].[Name]
+    ) AS [u]
+    LEFT JOIN [Cities] AS [c0] ON [u].[AssignedCityName] = [c0].[Name]
 ) AS [s] ON [c].[Name] = [s].[Name]
 """);
     }
@@ -7167,26 +7167,26 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [s].[Note]
+SELECT [u].[Nickname], [s].[Note]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
-    SELECT [t0].[Note], [t1].[Nickname], [t1].[SquadId]
-    FROM [Tags] AS [t0]
+    SELECT [t].[Note], [u0].[Nickname], [u0].[SquadId]
+    FROM [Tags] AS [t]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [t0].[GearNickName] = [t1].[Nickname] AND [t0].[GearSquadId] = [t1].[SquadId]
-    WHERE [t0].[Note] IN (N'Cole''s Tag', N'Dom''s Tag')
-) AS [s] ON [t].[Nickname] = [s].[Nickname] AND [t].[SquadId] = [s].[SquadId]
+    ) AS [u0] ON [t].[GearNickName] = [u0].[Nickname] AND [t].[GearSquadId] = [u0].[SquadId]
+    WHERE [t].[Note] IN (N'Cole''s Tag', N'Dom''s Tag')
+) AS [s] ON [u].[Nickname] = [s].[Nickname] AND [u].[SquadId] = [s].[SquadId]
 """);
     }
 
@@ -7207,8 +7207,8 @@ INNER JOIN (
         UNION ALL
         SELECT [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-    LEFT JOIN [Squads] AS [s0] ON [t].[SquadId] = [s0].[Id]
+    ) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+    LEFT JOIN [Squads] AS [s0] ON [u].[SquadId] = [s0].[Id]
     WHERE [w].[IsAutomatic] = CAST(1 AS bit)
 ) AS [s1] ON [s].[Id] = [s1].[Id0]
 """);
@@ -7231,8 +7231,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-    LEFT JOIN [Squads] AS [s0] ON [t].[SquadId] = [s0].[Id]
+    ) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+    LEFT JOIN [Squads] AS [s0] ON [u].[SquadId] = [s0].[Id]
 ) AS [s1] ON [s].[Id] = [s1].[Id0]
 """);
     }
@@ -7243,24 +7243,24 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u0].[Nickname], [u0].[SquadId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
-    SELECT TOP(1) [t].[Nickname], [t].[SquadId], [t].[FullName]
+    SELECT TOP(1) [u].[Nickname], [u].[SquadId], [u].[FullName]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    ORDER BY [t].[Nickname]
-) AS [t0]
+    ) AS [u]
+    ORDER BY [u].[Nickname]
+) AS [u0]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = CAST(0 AS bit)
-) AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t0].[Nickname], [t0].[SquadId], [w0].[Id]
+) AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u0].[Nickname], [u0].[SquadId], [w0].[Id]
 """);
     }
 
@@ -7271,15 +7271,15 @@ ORDER BY [t0].[Nickname], [t0].[SquadId], [w0].[Id]
         AssertSql(
             """
 SELECT [s].[Name], COALESCE((
-    SELECT TOP(1) [t].[SquadId]
+    SELECT TOP(1) [u].[SquadId]
     FROM (
         SELECT [g].[SquadId], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)), 0) AS [SquadId]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)), 0) AS [SquadId]
 FROM [Squads] AS [s]
 WHERE [s].[Name] = N'Kilo'
 """);
@@ -7292,15 +7292,15 @@ WHERE [s].[Name] = N'Kilo'
         AssertSql(
             """
 SELECT [s].[Name], (
-    SELECT TOP(1) [t].[SquadId]
+    SELECT TOP(1) [u].[SquadId]
     FROM (
         SELECT [g].[SquadId], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)) AS [SquadId]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)) AS [SquadId]
 FROM [Squads] AS [s]
 WHERE [s].[Name] = N'Kilo'
 """);
@@ -7312,23 +7312,23 @@ WHERE [s].[Name] = N'Kilo'
 
         AssertSql(
             """
-SELECT [s].[Name], [t1].[SquadId], [t1].[LeaderSquadId], [t1].[c]
+SELECT [s].[Name], [u1].[SquadId], [u1].[LeaderSquadId], [u1].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[SquadId], [t0].[LeaderSquadId], [t0].[c]
+    SELECT [u0].[SquadId], [u0].[LeaderSquadId], [u0].[c]
     FROM (
-        SELECT [t].[SquadId], [t].[LeaderSquadId], 1 AS [c], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname], [t].[SquadId]) AS [row]
+        SELECT [u].[SquadId], [u].[LeaderSquadId], 1 AS [c], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname], [u].[SquadId]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch], [g].[LeaderSquadId]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch], [o].[LeaderSquadId]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-    ) AS [t0]
-    WHERE [t0].[row] <= 1
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
+        ) AS [u]
+        WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [u0]
+    WHERE [u0].[row] <= 1
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
 WHERE [s].[Name] = N'Kilo'
 """);
     }
@@ -7342,15 +7342,15 @@ WHERE [s].[Name] = N'Kilo'
 SELECT [s].[Name]
 FROM [Squads] AS [s]
 WHERE [s].[Name] = N'Kilo' AND COALESCE((
-    SELECT TOP(1) [t].[SquadId]
+    SELECT TOP(1) [u].[SquadId]
     FROM (
         SELECT [g].[SquadId], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)), 0) <> 0
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)), 0) <> 0
 """);
     }
 
@@ -7368,8 +7368,8 @@ SELECT [s].[Name], COALESCE((
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)), 0) AS [Gear]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)), 0) AS [Gear]
 FROM [Squads] AS [s]
 """);
     }
@@ -7388,8 +7388,8 @@ SELECT [s].[Name], (
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)) AS [Gear]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)) AS [Gear]
 FROM [Squads] AS [s]
 """);
     }
@@ -7408,8 +7408,8 @@ SELECT [s].[Name], COALESCE((
         UNION ALL
         SELECT [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)), CAST(0 AS bit)) AS [Gear]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)), CAST(0 AS bit)) AS [Gear]
 FROM [Squads] AS [s]
 """);
     }
@@ -7420,23 +7420,23 @@ FROM [Squads] AS [s]
 
         AssertSql(
             """
-SELECT [s].[Name], [t1].[One]
+SELECT [s].[Name], [u1].[One]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[One], [t0].[SquadId]
+    SELECT [u0].[One], [u0].[SquadId]
     FROM (
-        SELECT 1 AS [One], [t].[SquadId], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname], [t].[SquadId]) AS [row]
+        SELECT 1 AS [One], [u].[SquadId], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname], [u].[SquadId]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-    ) AS [t0]
-    WHERE [t0].[row] <= 1
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
+        ) AS [u]
+        WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [u0]
+    WHERE [u0].[row] <= 1
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
 """);
     }
 
@@ -7446,23 +7446,23 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [s].[Name], [t1].[True1], [t1].[False1], [t1].[c]
+SELECT [s].[Name], [u1].[True1], [u1].[False1], [u1].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[True1], [t0].[False1], [t0].[c], [t0].[SquadId]
+    SELECT [u0].[True1], [u0].[False1], [u0].[c], [u0].[SquadId]
     FROM (
-        SELECT CAST(1 AS bit) AS [True1], CAST(0 AS bit) AS [False1], 1 AS [c], [t].[SquadId], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname], [t].[SquadId]) AS [row]
+        SELECT CAST(1 AS bit) AS [True1], CAST(0 AS bit) AS [False1], 1 AS [c], [u].[SquadId], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname], [u].[SquadId]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-    ) AS [t0]
-    WHERE [t0].[row] <= 1
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
+        ) AS [u]
+        WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [u0]
+    WHERE [u0].[row] <= 1
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
 """);
     }
 
@@ -7472,7 +7472,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Squads] AS [s]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -7480,8 +7480,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t] ON [s].[Id] = [t].[SquadId]
-ORDER BY [s].[Id], [t].[Nickname]
+) AS [u] ON [s].[Id] = [u].[SquadId]
+ORDER BY [s].[Id], [u].[Nickname]
 """);
     }
 
@@ -7491,16 +7491,16 @@ ORDER BY [s].[Id], [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Name], [w].[Id]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Name], [w].[Id]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -7510,23 +7510,23 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [s].[Name], [t1].[c]
+SELECT [s].[Name], [u1].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[c], [t0].[SquadId]
+    SELECT [u0].[c], [u0].[SquadId]
     FROM (
-        SELECT 1 AS [c], [t].[SquadId], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname], [t].[SquadId]) AS [row]
+        SELECT 1 AS [c], [u].[SquadId], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname], [u].[SquadId]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-    ) AS [t0]
-    WHERE [t0].[row] <= 1
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
+        ) AS [u]
+        WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [u0]
+    WHERE [u0].[row] <= 1
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
 """);
     }
 
@@ -7536,23 +7536,23 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [s].[Name], [t1].[c]
+SELECT [s].[Name], [u1].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t0].[c], [t0].[SquadId]
+    SELECT [u0].[c], [u0].[SquadId]
     FROM (
-        SELECT 1 AS [c], [t].[SquadId], ROW_NUMBER() OVER(PARTITION BY [t].[SquadId] ORDER BY [t].[Nickname], [t].[SquadId]) AS [row]
+        SELECT 1 AS [c], [u].[SquadId], ROW_NUMBER() OVER(PARTITION BY [u].[SquadId] ORDER BY [u].[Nickname], [u].[SquadId]) AS [row]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
-    ) AS [t0]
-    WHERE [t0].[row] <= 1
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
+        ) AS [u]
+        WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
+    ) AS [u0]
+    WHERE [u0].[row] <= 1
+) AS [u1] ON [s].[Id] = [u1].[SquadId]
 """);
     }
 
@@ -7562,22 +7562,22 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]), [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName]), [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -7587,23 +7587,23 @@ ORDER BY (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
 ORDER BY (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]), [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -7613,23 +7613,23 @@ ORDER BY (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
 ORDER BY COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), CAST(0 AS bit)), [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]), CAST(0 AS bit)), [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -7639,26 +7639,26 @@ ORDER BY COALESCE((
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t1] ON [t].[Nickname] = [t1].[LeaderNickname] AND [t].[SquadId] = [t1].[LeaderSquadId]
+    ) AS [u0]
+    WHERE [u0].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u1] ON [u].[Nickname] = [u1].[LeaderNickname] AND [u].[SquadId] = [u1].[LeaderSquadId]
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]), [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    WHERE [u].[FullName] = [w].[OwnerFullName]), [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -7668,35 +7668,35 @@ ORDER BY (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t2].[Nickname], [t2].[SquadId], [t2].[AssignedCityName], [t2].[CityOfBirthName], [t2].[FullName], [t2].[HasSoulPatch], [t2].[LeaderNickname], [t2].[LeaderSquadId], [t2].[Rank], [t2].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
-    SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+    SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o1].[Nickname], [o1].[SquadId], [o1].[AssignedCityName], [o1].[CityOfBirthName], [o1].[FullName], [o1].[HasSoulPatch], [o1].[LeaderNickname], [o1].[LeaderSquadId], [o1].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o1]
-    ) AS [t1]
-    WHERE [t1].[HasSoulPatch] = CAST(0 AS bit)
-) AS [t2] ON [t].[Nickname] = [t2].[LeaderNickname] AND [t].[SquadId] = [t2].[LeaderSquadId]
+    ) AS [u1]
+    WHERE [u1].[HasSoulPatch] = CAST(0 AS bit)
+) AS [u2] ON [u].[Nickname] = [u2].[LeaderNickname] AND [u].[SquadId] = [u2].[LeaderSquadId]
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = COALESCE((
-        SELECT TOP(1) [t0].[HasSoulPatch]
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = COALESCE((
+        SELECT TOP(1) [u0].[HasSoulPatch]
         FROM (
             SELECT [g].[Nickname], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[HasSoulPatch]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        WHERE [t0].[Nickname] = N'Marcus'), CAST(0 AS bit))), [t].[Nickname], [t].[SquadId], [t2].[Nickname]
+        ) AS [u0]
+        WHERE [u0].[Nickname] = N'Marcus'), CAST(0 AS bit))), [u].[Nickname], [u].[SquadId], [u2].[Nickname]
 """);
     }
 
@@ -7720,7 +7720,7 @@ FROM [Officers] AS [o]
 SELECT COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName]
@@ -7728,7 +7728,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7741,7 +7741,7 @@ FROM (
 SELECT (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id])
 FROM (
     SELECT [g].[FullName]
@@ -7749,7 +7749,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7762,7 +7762,7 @@ FROM (
 SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), 42)
 FROM (
     SELECT [g].[FullName]
@@ -7770,7 +7770,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7783,7 +7783,7 @@ FROM (
 SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), 0, 42)
 FROM (
     SELECT [g].[FullName]
@@ -7791,7 +7791,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7804,7 +7804,7 @@ FROM (
 SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), 42)
 FROM (
     SELECT [g].[FullName]
@@ -7812,7 +7812,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7825,11 +7825,11 @@ FROM (
 SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     ORDER BY [w].[Id]), (
     SELECT TOP(1) [w0].[Id]
     FROM [Weapons] AS [w0]
-    WHERE [t].[FullName] = [w0].[OwnerFullName]
+    WHERE [u].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]))
 FROM (
     SELECT [g].[FullName]
@@ -7837,7 +7837,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7850,7 +7850,7 @@ FROM (
 SELECT COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
     ORDER BY [w].[Id]), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName]
@@ -7858,7 +7858,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7871,7 +7871,7 @@ FROM (
 SELECT (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
     ORDER BY [w].[Id])
 FROM (
     SELECT [g].[FullName]
@@ -7879,7 +7879,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -7894,7 +7894,7 @@ SELECT COALESCE((
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
     ) AS [w0]), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
@@ -7902,8 +7902,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -7916,15 +7916,15 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
 SELECT COALESCE((
     SELECT DISTINCT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'), CAST(0 AS bit))
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -7939,7 +7939,7 @@ SELECT (
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Lancer%'
     ) AS [w0])
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
@@ -7947,8 +7947,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -7963,7 +7963,7 @@ SELECT COALESCE((
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
     ) AS [w0]), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
@@ -7971,8 +7971,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -7985,15 +7985,15 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
 SELECT COALESCE((
     SELECT DISTINCT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'), CAST(0 AS bit))
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'), CAST(0 AS bit))
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -8008,7 +8008,7 @@ SELECT (
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
+        WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'BFG'
     ) AS [w0])
 FROM (
     SELECT [g].[FullName], [g].[HasSoulPatch]
@@ -8016,8 +8016,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit)
 """);
     }
 
@@ -8027,7 +8027,7 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [c].[Name], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Nickname], [t].[Rank], [t].[SquadId]
+SELECT [c].[Name], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Nickname], [u].[Rank], [u].[SquadId]
 FROM [Cities] AS [c]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -8035,9 +8035,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t] ON [c].[Name] = [t].[AssignedCityName]
+) AS [u] ON [c].[Name] = [u].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [t].[Nickname]
+ORDER BY [c].[Name], [u].[Nickname]
 """);
     }
 
@@ -8047,7 +8047,7 @@ ORDER BY [c].[Name], [t].[Nickname]
 
         AssertSql(
             """
-SELECT [c].[Name], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Nickname], [t].[Rank], [t].[SquadId]
+SELECT [c].[Name], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Nickname], [u].[Rank], [u].[SquadId]
 FROM [Cities] AS [c]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -8055,9 +8055,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t] ON [c].[Name] = [t].[AssignedCityName]
+) AS [u] ON [c].[Name] = [u].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [t].[Nickname] DESC
+ORDER BY [c].[Name], [u].[Nickname] DESC
 """);
     }
 
@@ -8069,22 +8069,22 @@ ORDER BY [c].[Name], [t].[Nickname] DESC
             """
 @__nicknames_0='[]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [w].[Name], [w].[Id]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Name], [w].[Id]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
-    WHEN [t].[Nickname] IN (
+    WHEN [u].[Nickname] IN (
         SELECT [n].[value]
         FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END DESC, [t].[Nickname], [t].[SquadId]
+END DESC, [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -8224,16 +8224,16 @@ ORDER BY COALESCE([w0].[Name], N'') + N'Marcus'' Lancer'
 
         AssertSql(
             """
-SELECT N'HasSoulPatch ' + CAST([t].[HasSoulPatch] AS nvarchar(max)) + N' HasSoulPatch' AS [HasSoulPatch], N'Rank ' + CAST([t].[Rank] AS nvarchar(max)) + N' Rank' AS [Rank], N'SquadId ' + CAST([t].[SquadId] AS nvarchar(max)) + N' SquadId' AS [SquadId], N'Rating ' + COALESCE(CAST([m].[Rating] AS nvarchar(max)), N'') + N' Rating' AS [Rating], N'Timeline ' + CAST([m].[Timeline] AS nvarchar(max)) + N' Timeline' AS [Timeline]
+SELECT N'HasSoulPatch ' + CAST([u].[HasSoulPatch] AS nvarchar(max)) + N' HasSoulPatch' AS [HasSoulPatch], N'Rank ' + CAST([u].[Rank] AS nvarchar(max)) + N' Rank' AS [Rank], N'SquadId ' + CAST([u].[SquadId] AS nvarchar(max)) + N' SquadId' AS [SquadId], N'Rating ' + COALESCE(CAST([m].[Rating] AS nvarchar(max)), N'') + N' Rating' AS [Rating], N'Timeline ' + CAST([m].[Timeline] AS nvarchar(max)) + N' Timeline' AS [Timeline]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN [Missions] AS [m]
-ORDER BY [t].[Nickname], [m].[Id]
+ORDER BY [u].[Nickname], [m].[Id]
 """);
     }
 
@@ -8254,15 +8254,15 @@ FROM [Missions] AS [m]
 
         AssertSql(
             """
-SELECT AVG(CAST([t].[SquadId] AS float))
+SELECT AVG(CAST([u].[SquadId] AS float))
 FROM (
     SELECT [g].[SquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[SquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8272,15 +8272,15 @@ GROUP BY [t].[Rank]
 
         AssertSql(
             """
-SELECT COALESCE(SUM([t].[SquadId]), 0)
+SELECT COALESCE(SUM([u].[SquadId]), 0)
 FROM (
     SELECT [g].[SquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[SquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8297,8 +8297,8 @@ FROM (
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8315,8 +8315,8 @@ FROM (
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8326,15 +8326,15 @@ GROUP BY [t].[Rank]
 
         AssertSql(
             """
-SELECT MIN([t].[SquadId])
+SELECT MIN([u].[SquadId])
 FROM (
     SELECT [g].[SquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[SquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8344,16 +8344,16 @@ GROUP BY [t].[Rank]
 
         AssertSql(
             """
-SELECT [t].[Nickname] AS [Key], COUNT(*) AS [c]
+SELECT [u].[Nickname] AS [Key], COUNT(*) AS [c]
 FROM (
     SELECT [g].[Nickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Nickname]
-ORDER BY [t].[Nickname]
+) AS [u]
+GROUP BY [u].[Nickname]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -8363,34 +8363,34 @@ ORDER BY [t].[Nickname]
 
         AssertSql(
             """
-SELECT [t1].[Rank], [t1].[c], [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator], [s0].[Name], [s0].[Location], [s0].[Nation]
+SELECT [u1].[Rank], [u1].[c], [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator], [s0].[Name], [s0].[Location], [s0].[Nation]
 FROM (
-    SELECT [t].[Rank], COUNT(*) AS [c]
+    SELECT [u].[Rank], COUNT(*) AS [c]
     FROM (
         SELECT [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    GROUP BY [t].[Rank]
-) AS [t1]
+    ) AS [u]
+    GROUP BY [u].[Rank]
+) AS [u1]
 LEFT JOIN (
     SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Name], [s].[Location], [s].[Nation]
     FROM (
-        SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], ROW_NUMBER() OVER(PARTITION BY [t0].[Rank] ORDER BY [t0].[Nickname]) AS [row]
+        SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], ROW_NUMBER() OVER(PARTITION BY [u0].[Rank] ORDER BY [u0].[Nickname]) AS [row]
         FROM (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g0]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
+        ) AS [u0]
+        INNER JOIN [Cities] AS [c] ON [u0].[CityOfBirthName] = [c].[Name]
     ) AS [s]
     WHERE [s].[row] <= 1
-) AS [s0] ON [t1].[Rank] = [s0].[Rank]
-ORDER BY [t1].[Rank]
+) AS [s0] ON [u1].[Rank] = [s0].[Rank]
+ORDER BY [u1].[Rank]
 """);
     }
 
@@ -8400,15 +8400,15 @@ ORDER BY [t1].[Rank]
 
         AssertSql(
             """
-SELECT MAX([t].[SquadId])
+SELECT MAX([u].[SquadId])
 FROM (
     SELECT [g].[SquadId], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[SquadId], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[Rank]
+) AS [u]
+GROUP BY [u].[Rank]
 """);
     }
 
@@ -8420,32 +8420,32 @@ GROUP BY [t].[Rank]
             """
 SELECT [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator], [s0].[Name], [s0].[Location], [s0].[Nation]
 FROM (
-    SELECT [t].[Rank]
+    SELECT [u].[Rank]
     FROM (
         SELECT [g].[Rank]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Rank]
         FROM [Officers] AS [o]
-    ) AS [t]
-    GROUP BY [t].[Rank]
-) AS [t1]
+    ) AS [u]
+    GROUP BY [u].[Rank]
+) AS [u1]
 LEFT JOIN (
     SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[Name], [s].[Location], [s].[Nation]
     FROM (
-        SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], ROW_NUMBER() OVER(PARTITION BY [t0].[Rank] ORDER BY [t0].[Nickname], [t0].[SquadId], [c].[Name]) AS [row]
+        SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [c].[Name], [c].[Location], [c].[Nation], ROW_NUMBER() OVER(PARTITION BY [u0].[Rank] ORDER BY [u0].[Nickname], [u0].[SquadId], [c].[Name]) AS [row]
         FROM (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g0]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
-        WHERE [t0].[HasSoulPatch] = CAST(1 AS bit)
+        ) AS [u0]
+        INNER JOIN [Cities] AS [c] ON [u0].[CityOfBirthName] = [c].[Name]
+        WHERE [u0].[HasSoulPatch] = CAST(1 AS bit)
     ) AS [s]
     WHERE [s].[row] <= 1
-) AS [s0] ON [t1].[Rank] = [s0].[Rank]
+) AS [s0] ON [u1].[Rank] = [s0].[Rank]
 """);
     }
 
@@ -8455,13 +8455,13 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -8471,15 +8471,15 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 """);
     }
 
@@ -8489,16 +8489,16 @@ LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadI
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -8511,15 +8511,15 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 SELECT [s].[Name], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator], [s0].[Id], [s0].[AmmunitionType], [s0].[IsAutomatic], [s0].[Name], [s0].[OwnerFullName], [s0].[SynergyWithId]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
-    LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
+    ) AS [u]
+    LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 ) AS [s0] ON [s].[Id] = [s0].[SquadId]
 WHERE [s].[Name] = N'Delta'
 ORDER BY [s].[Id], [s0].[Nickname], [s0].[SquadId]
@@ -8533,8 +8533,8 @@ ORDER BY [s].[Id], [s0].[Nickname], [s0].[SquadId]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN CAST(LEN([t].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN CAST(LEN([u].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -8545,11 +8545,11 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 ORDER BY CASE
     WHEN CASE
-        WHEN [t].[LeaderNickname] IS NOT NULL THEN CASE
-            WHEN CAST(LEN([t].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
+        WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
+            WHEN CAST(LEN([u].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
             ELSE CAST(0 AS bit)
         END
         ELSE NULL
@@ -8636,18 +8636,18 @@ WHERE COALESCE([w].[SynergyWithId], CAST(LEN([w].[Name]) AS int) + 42) > 10
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[FullName] <> N'Dom' AND EXISTS (
+) AS [u]
+WHERE [u].[FullName] <> N'Dom' AND EXISTS (
     SELECT 1
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = CAST(1 AS bit))
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = CAST(1 AS bit))
 """);
     }
 
@@ -8658,10 +8658,10 @@ WHERE [t].[FullName] <> N'Dom' AND EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Nickname], (
+SELECT [u].[Nickname], (
     SELECT TOP(1) [w].[Name]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = CAST(1 AS bit)
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[IsAutomatic] = CAST(1 AS bit)
     ORDER BY [w].[AmmunitionType] DESC) AS [WeaponName]
 FROM (
     SELECT [g].[Nickname], [g].[FullName]
@@ -8669,8 +8669,8 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Nickname] <> N'Dom'
+) AS [u]
+WHERE [u].[Nickname] <> N'Dom'
 """);
     }
 
@@ -8689,8 +8689,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-WHERE SUBSTRING([t].[Note], 0 + 1, [t0].[SquadId]) = [t].[GearNickName] OR (([t].[Note] IS NULL OR [t0].[SquadId] IS NULL) AND [t].[GearNickName] IS NULL)
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+WHERE SUBSTRING([t].[Note], 0 + 1, [u].[SquadId]) = [t].[GearNickName] OR (([t].[Note] IS NULL OR [u].[SquadId] IS NULL) AND [t].[GearNickName] IS NULL)
 """);
     }
 
@@ -8710,8 +8710,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 WHERE SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName] OR (([t].[Note] IS NULL OR [s].[Name] IS NULL) AND [t].[GearNickName] IS NULL)
 """);
     }
@@ -8741,14 +8741,14 @@ WHERE [t].[Id] = 'df36f493-463f-4123-83f9-6b135deeb7ba'
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-LEFT JOIN [Tags] AS [t1] ON [t].[Nickname] = [t1].[GearNickName] AND [t].[SquadId] = [t1].[GearSquadId]
-WHERE ([t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL) AND ([t1].[Note] <> N'Bar' OR [t1].[Note] IS NULL)
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+LEFT JOIN [Tags] AS [t0] ON [u].[Nickname] = [t0].[GearNickName] AND [u].[SquadId] = [t0].[GearSquadId]
+WHERE ([t].[Note] <> N'Foo' OR [t].[Note] IS NULL) AND ([t0].[Note] <> N'Bar' OR [t0].[Note] IS NULL)
 """);
     }
 
@@ -8758,14 +8758,14 @@ WHERE ([t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL) AND ([t1].[Note] <> N'Bar' 
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
-WHERE ([t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL) AND ([c].[Location] <> 'Bar' OR [c].[Location] IS NULL)
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
+WHERE ([t].[Note] <> N'Foo' OR [t].[Note] IS NULL) AND ([c].[Location] <> 'Bar' OR [c].[Location] IS NULL)
 """);
     }
 
@@ -8775,15 +8775,15 @@ WHERE ([t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL) AND ([c].[Location] <> 'Bar
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-INNER JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Tags] AS [t1] ON [t].[Nickname] = [t1].[GearNickName] AND [t].[SquadId] = [t1].[GearSquadId]
-WHERE ([t0].[Note] <> N'Foo' OR [t0].[Note] IS NULL) AND ([t1].[Note] <> N'Bar' OR [t1].[Note] IS NULL)
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+INNER JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Tags] AS [t0] ON [u].[Nickname] = [t0].[GearNickName] AND [u].[SquadId] = [t0].[GearSquadId]
+WHERE ([t].[Note] <> N'Foo' OR [t].[Note] IS NULL) AND ([t0].[Note] <> N'Bar' OR [t0].[Note] IS NULL)
 """);
     }
 
@@ -8849,14 +8849,14 @@ WHERE ([c].[Name] <> N'Foo' OR [c].[Name] IS NULL) AND ([l0].[Name] <> N'Bar' OR
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM [Cities] AS [c]
@@ -8868,8 +8868,8 @@ WHERE EXISTS (
             UNION ALL
             SELECT [o0].[Nickname], [o0].[SquadId], [o0].[CityOfBirthName]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        WHERE [c].[Name] = [t0].[CityOfBirthName] AND [t0].[Nickname] = [t].[Nickname] AND [t0].[SquadId] = [t].[SquadId]))
+        ) AS [u0]
+        WHERE [c].[Name] = [u0].[CityOfBirthName] AND [u0].[Nickname] = [u].[Nickname] AND [u0].[SquadId] = [u].[SquadId]))
 """);
     }
 
@@ -8879,19 +8879,19 @@ WHERE EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [u]
+LEFT JOIN [Weapons] AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 ORDER BY (
     SELECT TOP(1) [w].[Name]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Gnasher%'), [t].[Nickname], [t].[SquadId]
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] LIKE N'%Gnasher%'), [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -8905,15 +8905,15 @@ ORDER BY (
 
 SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [t].[FullName]
+    SELECT TOP(@__p_0) [u].[FullName]
     FROM (
         SELECT [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-) AS [t0]
+    ) AS [u]
+) AS [u0]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM (
@@ -8921,7 +8921,7 @@ LEFT JOIN (
         FROM [Weapons] AS [w]
     ) AS [w0]
     WHERE [w0].[row] <= 1
-) AS [w1] ON [t0].[FullName] = [w1].[OwnerFullName]
+) AS [w1] ON [u0].[FullName] = [w1].[OwnerFullName]
 """);
     }
 
@@ -8934,15 +8934,15 @@ LEFT JOIN (
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE (
-    SELECT TOP(1) [t].[HasSoulPatch]
+    SELECT TOP(1) [u].[HasSoulPatch]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    ORDER BY [t].[Nickname], [t].[SquadId]) = CAST(1 AS bit)
+    ) AS [u]
+    ORDER BY [u].[Nickname], [u].[SquadId]) = CAST(1 AS bit)
 """);
     }
 
@@ -8989,21 +8989,21 @@ LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 
         AssertSql(
             """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
 """);
     }
 
@@ -9014,23 +9014,23 @@ LEFT JOIN (
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL THEN CAST(1 AS bit)
+    WHEN [u0].[Nickname] IS NULL OR [u0].[SquadId] IS NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+END, [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
 """);
     }
 
@@ -9040,7 +9040,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [t3].[Nickname], [t3].[SquadId], [t3].[AssignedCityName], [t3].[CityOfBirthName], [t3].[FullName], [t3].[HasSoulPatch], [t3].[LeaderNickname], [t3].[LeaderSquadId], [t3].[Rank], [t3].[Discriminator]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], N'Gear' AS [Discriminator]
@@ -9048,23 +9048,23 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
-    SELECT [t2].[Nickname], [t2].[SquadId], [t2].[AssignedCityName], [t2].[CityOfBirthName], [t2].[FullName], [t2].[HasSoulPatch], [t2].[LeaderNickname], [t2].[LeaderSquadId], [t2].[Rank], [t2].[Discriminator]
+    SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
     FROM (
-        SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [t1].[LeaderNickname], [t1].[LeaderSquadId] ORDER BY [t1].[Nickname], [t1].[SquadId]) AS [row]
+        SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], ROW_NUMBER() OVER(PARTITION BY [u0].[LeaderNickname], [u0].[LeaderSquadId] ORDER BY [u0].[Nickname], [u0].[SquadId]) AS [row]
         FROM (
             SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
             FROM [Gears] AS [g0]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
             FROM [Officers] AS [o0]
-        ) AS [t1]
-    ) AS [t2]
-    WHERE [t2].[row] <= 50
-) AS [t3] ON ([t0].[Nickname] = [t3].[LeaderNickname] OR ([t0].[Nickname] IS NULL AND [t3].[LeaderNickname] IS NULL)) AND [t0].[SquadId] = [t3].[LeaderSquadId]
-WHERE [t0].[Discriminator] = N'Officer'
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t3].[Nickname]
+        ) AS [u0]
+    ) AS [u1]
+    WHERE [u1].[row] <= 50
+) AS [u2] ON ([u].[Nickname] = [u2].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u2].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u2].[LeaderSquadId]
+WHERE [u].[Discriminator] = N'Officer'
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId], [u2].[Nickname]
 """);
     }
 
@@ -9074,7 +9074,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t3].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], N'Gear' AS [Discriminator]
@@ -9082,16 +9082,16 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t1] ON ([t0].[Nickname] = [t1].[LeaderNickname] OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND [t0].[SquadId] = [t1].[LeaderSquadId]
-WHERE [t0].[Discriminator] = N'Officer'
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
+) AS [u0] ON ([u].[Nickname] = [u0].[LeaderNickname] OR ([u].[Nickname] IS NULL AND [u0].[LeaderNickname] IS NULL)) AND [u].[SquadId] = [u0].[LeaderSquadId]
+WHERE [u].[Discriminator] = N'Officer'
+ORDER BY [t].[Id], [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -9101,7 +9101,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [t].[Id], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -9109,8 +9109,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId] AND [t].[Note] IS NOT NULL
-ORDER BY [t].[Id], [t0].[Nickname]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId] AND [t].[Note] IS NOT NULL
+ORDER BY [t].[Id], [u].[Nickname]
 """);
     }
 
@@ -9122,7 +9122,7 @@ ORDER BY [t].[Id], [t0].[Nickname]
             """
 @__isAutomatic_0='True'
 
-SELECT [t].[Nickname], [t].[FullName], CASE
+SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Collection]
@@ -9132,12 +9132,12 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] = @__isAutomatic_0
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
 
@@ -9147,21 +9147,21 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [g0].[Nickname]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[Nickname]
 """);
     }
 
@@ -9171,21 +9171,21 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [g0].[Nickname]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[Nickname]
 """);
     }
 
@@ -9233,12 +9233,12 @@ LEFT JOIN [LocustCommanders] AS [l0] ON [l].[CommanderName] = [l0].[Name]
 
         AssertSql(
             """
-SELECT CAST(1 AS bit), [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT CAST(1 AS bit), [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [LocustHordes] AS [l]
 CROSS JOIN (
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN [LocustCommanders] AS [l1] ON [l].[CommanderName] = [l1].[Name]
 """);
     }
@@ -9249,12 +9249,12 @@ LEFT JOIN [LocustCommanders] AS [l1] ON [l].[CommanderName] = [l1].[Name]
 
         AssertSql(
             """
-SELECT [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [LocustHordes] AS [l]
 CROSS JOIN (
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN [LocustCommanders] AS [l1] ON [l].[CommanderName] = [l1].[Name]
 """);
     }
@@ -9268,12 +9268,12 @@ LEFT JOIN [LocustCommanders] AS [l1] ON [l].[CommanderName] = [l1].[Name]
 SELECT CASE
     WHEN [l1].[Name] = N'Queen Myrrah' AND [l1].[Name] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+END, [l1].[Name], [l1].[LocustHordeId], [l1].[ThreatLevel], [l1].[ThreatLevelByte], [l1].[ThreatLevelNullableByte], [l1].[DefeatedByNickname], [l1].[DefeatedBySquadId], [l1].[HighCommandId], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [LocustHordes] AS [l]
 CROSS JOIN (
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN [LocustCommanders] AS [l1] ON [l].[CommanderName] = [l1].[Name]
 """);
     }
@@ -9315,12 +9315,12 @@ FROM [Missions] AS [m]
 SELECT [s].[Name], [s].[Location], [s].[Nation]
 FROM [Officers] AS [o]
 INNER JOIN (
-    SELECT [c].[Name], [c].[Location], [c].[Nation], [t].[LeaderNickname], [t].[LeaderSquadId]
+    SELECT [c].[Name], [c].[Location], [c].[Nation], [u].[LeaderNickname], [u].[LeaderSquadId]
     FROM (
         SELECT [o0].[AssignedCityName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t]
-    LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
+    ) AS [u]
+    LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
 ) AS [s] ON [o].[Nickname] = [s].[LeaderNickname] AND [o].[SquadId] = [s].[LeaderSquadId]
 """);
     }
@@ -9345,20 +9345,20 @@ FROM [LocustHordes] AS [l]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[Id], [s].[IsAutomatic], [s].[Name], [s].[Id0]
+SELECT [u].[Nickname], [u].[SquadId], [s].[Id], [s].[IsAutomatic], [s].[Name], [s].[Id0]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[IsAutomatic], [w0].[Name], [w0].[Id] AS [Id0], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-) AS [s] ON [t].[FullName] = [s].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id]
+) AS [s] ON [u].[FullName] = [s].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id]
 """);
     }
 
@@ -9368,7 +9368,7 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
@@ -9376,8 +9376,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 ORDER BY [t].[Note]
 """);
     }
@@ -9389,9 +9389,9 @@ ORDER BY [t].[Note]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u].[Nickname] IS NOT NULL AND [u].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t].[Id], [t0].[Nickname], [t0].[SquadId], [s].[Nickname], [s].[Id], [s].[SquadId]
+END, [t].[Id], [u].[Nickname], [u].[SquadId], [s].[Nickname], [s].[Id], [s].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
@@ -9399,9 +9399,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 LEFT JOIN (
-    SELECT [t1].[Nickname], [w].[Id], [t1].[SquadId], [w].[OwnerFullName]
+    SELECT [u0].[Nickname], [w].[Id], [u0].[SquadId], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -9409,9 +9409,9 @@ LEFT JOIN (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
-) AS [s] ON [t0].[FullName] = [s].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId], [s].[Id], [s].[Nickname]
+    ) AS [u0] ON [w].[OwnerFullName] = [u0].[FullName]
+) AS [s] ON [u].[FullName] = [s].[OwnerFullName]
+ORDER BY [t].[Note], [t].[Id], [u].[Nickname], [u].[SquadId], [s].[Id], [s].[Nickname]
 """);
     }
 
@@ -9428,8 +9428,8 @@ WHERE EXISTS (
     FROM (
         SELECT [o].[Nickname], [o].[CityOfBirthName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [c].[Name] = [t].[CityOfBirthName] AND [t].[Nickname] = N'Marcus')
+    ) AS [u]
+    WHERE [c].[Name] = [u].[CityOfBirthName] AND [u].[Nickname] = N'Marcus')
 """);
     }
 
@@ -9441,19 +9441,19 @@ WHERE EXISTS (
             """
 @__prm_Inner_Nickname_0='Marcus' (Size = 450)
 
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
-    SELECT DISTINCT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+    SELECT DISTINCT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [t].[Nickname] <> @__prm_Inner_Nickname_0 AND [t].[Nickname] <> @__prm_Inner_Nickname_0
-) AS [t0]
-ORDER BY [t0].[FullName]
+    ) AS [u]
+    WHERE [u].[Nickname] <> @__prm_Inner_Nickname_0 AND [u].[Nickname] <> @__prm_Inner_Nickname_0
+) AS [u0]
+ORDER BY [u0].[FullName]
 """);
     }
 
@@ -9465,39 +9465,39 @@ ORDER BY [t0].[FullName]
             """
 @__squadId_0='1'
 
-SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
+SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM (
-    SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+    SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
-    INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+    ) AS [u]
+    INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
     WHERE [s].[Id] IN (
         SELECT [s0].[Id]
         FROM [Squads] AS [s0]
         WHERE [s0].[Id] = @__squadId_0
     )
     UNION ALL
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Squads] AS [s1] ON [t0].[SquadId] = [s1].[Id]
+    ) AS [u0]
+    INNER JOIN [Squads] AS [s1] ON [u0].[SquadId] = [s1].[Id]
     WHERE [s1].[Id] IN (
         SELECT [s2].[Id]
         FROM [Squads] AS [s2]
         WHERE [s2].[Id] = @__squadId_0
     )
-) AS [u]
-ORDER BY [u].[FullName]
+) AS [u1]
+ORDER BY [u1].[FullName]
 """);
     }
 
@@ -9519,8 +9519,8 @@ WHERE EXISTS (
         UNION ALL
         SELECT [o].[SquadId]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[SquadId] = @__gearId_0 AND [t].[SquadId] = @__gearId_0)
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[SquadId] = @__gearId_0 AND [u].[SquadId] = @__gearId_0)
 """);
     }
 
@@ -9534,15 +9534,15 @@ WHERE EXISTS (
 
 SELECT [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank], [s1].[Discriminator]
 FROM (
-    SELECT DISTINCT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+    SELECT DISTINCT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
-    INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+    ) AS [u]
+    INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
     WHERE [s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
 ) AS [s1]
 INNER JOIN [Squads] AS [s0] ON [s1].[SquadId] = [s0].[Id]
@@ -9557,35 +9557,35 @@ ORDER BY [s1].[FullName]
 
         AssertSql(
             """
-SELECT [u].[Name], [u].[Count], COALESCE(SUM([u].[Count]), 0) AS [Sum]
+SELECT [u1].[Name], [u1].[Count], COALESCE(SUM([u1].[Count]), 0) AS [Sum]
 FROM (
     SELECT [c].[Name], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]) AS [Count]
+        WHERE [u].[FullName] = [w].[OwnerFullName]) AS [Count]
     FROM (
         SELECT [g].[AssignedCityName], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[AssignedCityName], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
+    ) AS [u]
+    LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
     UNION ALL
     SELECT [c0].[Name], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
-        WHERE [t0].[FullName] = [w0].[OwnerFullName]) AS [Count]
+        WHERE [u0].[FullName] = [w0].[OwnerFullName]) AS [Count]
     FROM (
         SELECT [g0].[CityOfBirthName], [g0].[FullName]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[CityOfBirthName], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Cities] AS [c0] ON [t0].[CityOfBirthName] = [c0].[Name]
-) AS [u]
-GROUP BY [u].[Name], [u].[Count]
+    ) AS [u0]
+    INNER JOIN [Cities] AS [c0] ON [u0].[CityOfBirthName] = [c0].[Name]
+) AS [u1]
+GROUP BY [u1].[Name], [u1].[Count]
 """);
     }
 
@@ -9595,35 +9595,35 @@ GROUP BY [u].[Name], [u].[Count]
 
         AssertSql(
             """
-SELECT [u].[Name], [u].[Count], COALESCE(SUM([u].[Count]), 0) AS [Sum]
+SELECT [u1].[Name], [u1].[Count], COALESCE(SUM([u1].[Count]), 0) AS [Sum]
 FROM (
     SELECT [c].[Name], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]) AS [Count]
+        WHERE [u].[FullName] = [w].[OwnerFullName]) AS [Count]
     FROM (
         SELECT [g].[AssignedCityName], [g].[FullName]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[AssignedCityName], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
+    ) AS [u]
+    LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
     UNION ALL
     SELECT [c0].[Name], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
-        WHERE [t0].[FullName] = [w0].[OwnerFullName]) AS [Count]
+        WHERE [u0].[FullName] = [w0].[OwnerFullName]) AS [Count]
     FROM (
         SELECT [g0].[CityOfBirthName], [g0].[FullName]
         FROM [Gears] AS [g0]
         UNION ALL
         SELECT [o0].[CityOfBirthName], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Cities] AS [c0] ON [t0].[CityOfBirthName] = [c0].[Name]
-) AS [u]
-GROUP BY [u].[Name], [u].[Count]
+    ) AS [u0]
+    INNER JOIN [Cities] AS [c0] ON [u0].[CityOfBirthName] = [c0].[Name]
+) AS [u1]
+GROUP BY [u1].[Name], [u1].[Count]
 """);
     }
 
@@ -9633,17 +9633,17 @@ GROUP BY [u].[Name], [u].[Count]
 
         AssertSql(
             """
-SELECT [t].[CityOfBirthName], [t].[HasSoulPatch]
+SELECT [u].[CityOfBirthName], [u].[HasSoulPatch]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[CityOfBirthName], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName]
-GROUP BY [t].[CityOfBirthName], [t].[HasSoulPatch]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName]
+GROUP BY [u].[CityOfBirthName], [u].[HasSoulPatch]
 """);
     }
 
@@ -9653,10 +9653,10 @@ GROUP BY [t].[CityOfBirthName], [t].[HasSoulPatch]
 
         AssertSql(
             """
-SELECT [t0].[CityOfBirthName], [t0].[HasSoulPatch], [t0].[IsMarcus], COUNT(*) AS [Count]
+SELECT [u0].[CityOfBirthName], [u0].[HasSoulPatch], [u0].[IsMarcus], COUNT(*) AS [Count]
 FROM (
-    SELECT [t].[CityOfBirthName], [t].[HasSoulPatch], CASE
-        WHEN [t].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
+    SELECT [u].[CityOfBirthName], [u].[HasSoulPatch], CASE
+        WHEN [u].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [IsMarcus]
     FROM (
@@ -9665,9 +9665,9 @@ FROM (
         UNION ALL
         SELECT [o].[Nickname], [o].[CityOfBirthName], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-) AS [t0]
-GROUP BY [t0].[CityOfBirthName], [t0].[HasSoulPatch], [t0].[IsMarcus]
+    ) AS [u]
+) AS [u0]
+GROUP BY [u0].[CityOfBirthName], [u0].[HasSoulPatch], [u0].[IsMarcus]
 """);
     }
 
@@ -9677,7 +9677,7 @@ GROUP BY [t0].[CityOfBirthName], [t0].[HasSoulPatch], [t0].[IsMarcus]
 
         AssertSql(
             """
-SELECT [t0].[HasSoulPatch], LOWER([s].[Name]) AS [Name]
+SELECT [u].[HasSoulPatch], LOWER([s].[Name]) AS [Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
@@ -9685,9 +9685,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
-LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-GROUP BY [t0].[HasSoulPatch], [s].[Name]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
+GROUP BY [u].[HasSoulPatch], [s].[Name]
 """);
     }
 
@@ -9704,8 +9704,8 @@ FROM (
     UNION ALL
     SELECT [o].[CityOfBirthName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 GROUP BY [c].[Name]
 """);
     }
@@ -9716,7 +9716,7 @@ GROUP BY [c].[Name]
 
         AssertSql(
             """
-SELECT [t0].[Key]
+SELECT [u0].[Key]
 FROM (
     SELECT CAST(0 AS bit) AS [Key]
     FROM (
@@ -9725,9 +9725,9 @@ FROM (
         UNION ALL
         SELECT [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-) AS [t0]
-GROUP BY [t0].[Key]
+    ) AS [u]
+) AS [u0]
+GROUP BY [u0].[Key]
 """);
     }
 
@@ -9737,15 +9737,15 @@ GROUP BY [t0].[Key]
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-GROUP BY [t].[FullName]
+) AS [u]
+GROUP BY [u].[FullName]
 HAVING 0 = 1
 """);
     }
@@ -9763,7 +9763,7 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -9782,7 +9782,7 @@ FROM (
     UNION ALL
     SELECT 1 AS empty
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -9794,14 +9794,14 @@ FROM (
             """
 @__p_0='False'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE @__p_0 = CAST(1 AS bit)
 """);
     }
@@ -9812,15 +9812,15 @@ WHERE @__p_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -9832,16 +9832,16 @@ ORDER BY [t].[Nickname]
             """
 @__ids_0='[]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 ORDER BY CASE
-    WHEN [t].[SquadId] IN (
+    WHEN [u].[SquadId] IN (
         SELECT [i].[value]
         FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
@@ -9858,51 +9858,51 @@ END
             """
 @__rank_0='1' (Nullable = true)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & @__rank_0 = @__rank_0
+) AS [u]
+WHERE [u].[Rank] & @__rank_0 = @__rank_0
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """,
             //
             """
 @__rank_0='2' (Nullable = true)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] | @__rank_0 <> @__rank_0
+) AS [u]
+WHERE [u].[Rank] | @__rank_0 <> @__rank_0
 """,
             //
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -9913,15 +9913,15 @@ WHERE 0 = 1
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
+) AS [u]
+LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
 WHERE [c].[Name] = (
     SELECT TOP(1) [c0].[Name]
     FROM (
@@ -9930,9 +9930,9 @@ WHERE [c].[Name] = (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[CityOfBirthName]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Cities] AS [c0] ON [t0].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [t0].[Nickname]) OR ([c].[Name] IS NULL AND (
+    ) AS [u0]
+    INNER JOIN [Cities] AS [c0] ON [u0].[CityOfBirthName] = [c0].[Name]
+    ORDER BY [u0].[Nickname]) OR ([c].[Name] IS NULL AND (
     SELECT TOP(1) [c0].[Name]
     FROM (
         SELECT [g0].[Nickname], [g0].[CityOfBirthName]
@@ -9940,9 +9940,9 @@ WHERE [c].[Name] = (
         UNION ALL
         SELECT [o0].[Nickname], [o0].[CityOfBirthName]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    INNER JOIN [Cities] AS [c0] ON [t0].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [t0].[Nickname]) IS NULL)
+    ) AS [u0]
+    INNER JOIN [Cities] AS [c0] ON [u0].[CityOfBirthName] = [c0].[Name]
+    ORDER BY [u0].[Nickname]) IS NULL)
 """);
     }
 
@@ -9954,22 +9954,22 @@ WHERE [c].[Name] = (
             """
 @__ranks_0='134'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[Rank] & @__ranks_0 <> 0
+) AS [u]
+WHERE [u].[Rank] & @__ranks_0 <> 0
 """,
             //
             """
 @__ranks_0='134'
 
 SELECT CASE
-    WHEN [t].[Rank] | @__ranks_0 = @__ranks_0 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] | @__ranks_0 = @__ranks_0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -9978,14 +9978,14 @@ FROM (
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """,
             //
             """
 @__ranks_0='134'
 
 SELECT CASE
-    WHEN [t].[Rank] | [t].[Rank] | @__ranks_0 | [t].[Rank] | @__ranks_0 = @__ranks_0 THEN CAST(1 AS bit)
+    WHEN [u].[Rank] | [u].[Rank] | @__ranks_0 | [u].[Rank] | @__ranks_0 = @__ranks_0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -9994,7 +9994,7 @@ FROM (
     UNION ALL
     SELECT [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -10051,29 +10051,29 @@ WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
             """
 @__prm_0='True'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] <> @__prm_0
+) AS [u]
+WHERE [u].[HasSoulPatch] <> @__prm_0
 """,
             //
             """
 @__prm_0='False'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] <> @__prm_0
+) AS [u]
+WHERE [u].[HasSoulPatch] <> @__prm_0
 """);
     }
 
@@ -10104,8 +10104,8 @@ FROM (
     UNION ALL
     SELECT [l0].[Name]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-INNER JOIN [LocustHordes] AS [l1] ON [t].[Name] = [l1].[CommanderName]
+) AS [u]
+INNER JOIN [LocustHordes] AS [l1] ON [u].[Name] = [l1].[CommanderName]
 WHERE CASE
     WHEN [l1].[Name] = N'Locust' THEN CAST(1 AS bit)
     ELSE NULL
@@ -10202,16 +10202,16 @@ WHERE DATALENGTH([s].[Banner5]) = 5
             """
 @__prm_0='True'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    WHEN [u].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -10226,23 +10226,23 @@ END = CAST(1 AS bit)
 @__prm_0='True'
 @__prm2_1='Marcus' Lancer' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[HasSoulPatch] = @__prm_0 THEN CASE
+    WHEN [u].[HasSoulPatch] = @__prm_0 THEN CASE
         WHEN (
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [t].[SquadId]) = @__prm2_1 AND (
+            WHERE [w].[Id] = [u].[SquadId]) = @__prm2_1 AND (
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [t].[SquadId]) IS NOT NULL THEN CAST(1 AS bit)
+            WHERE [w].[Id] = [u].[SquadId]) IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CAST(0 AS bit)
@@ -10283,14 +10283,14 @@ WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0
 
         AssertSql(
             """
-SELECT [t].[FullName]
+SELECT [u].[FullName]
 FROM (
     SELECT [g].[Nickname], [g].[CityOfBirthName], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[CityOfBirthName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -10300,14 +10300,14 @@ FROM (
 
         AssertSql(
             """
-SELECT [t].[CityOfBirthName]
+SELECT [u].[CityOfBirthName]
 FROM (
     SELECT [g].[Nickname], [g].[CityOfBirthName], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[CityOfBirthName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -10324,7 +10324,7 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -10381,15 +10381,15 @@ GROUP BY [w].[SynergyWithId]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE CAST([t].[ThreatLevel] AS tinyint) >= CAST(5 AS tinyint)
+) AS [u]
+WHERE CAST([u].[ThreatLevel] AS tinyint) >= CAST(5 AS tinyint)
 """);
     }
 
@@ -10399,15 +10399,15 @@ WHERE CAST([t].[ThreatLevel] AS tinyint) >= CAST(5 AS tinyint)
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE CAST([t].[ThreatLevel] AS bigint) <= CAST(5 AS bigint) + CAST([t].[ThreatLevel] AS bigint)
+) AS [u]
+WHERE CAST([u].[ThreatLevel] AS bigint) <= CAST(5 AS bigint) + CAST([u].[ThreatLevel] AS bigint)
 """);
     }
 
@@ -10509,15 +10509,15 @@ WHERE DATEPART(millisecond, [m].[Duration]) = 456
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE [t].[ThreatLevelByte] IN (
+) AS [u]
+WHERE [u].[ThreatLevelByte] IN (
     SELECT [l1].[ThreatLevelByte]
     FROM [LocustLeaders] AS [l1]
     UNION ALL
@@ -10533,14 +10533,14 @@ WHERE [t].[ThreatLevelByte] IN (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -10550,7 +10550,7 @@ WHERE EXISTS (
         SELECT [l2].[ThreatLevelNullableByte]
         FROM [LocustCommanders] AS [l2]
     ) AS [u0]
-    WHERE [u0].[ThreatLevelNullableByte] = [t].[ThreatLevelNullableByte] OR ([u0].[ThreatLevelNullableByte] IS NULL AND [t].[ThreatLevelNullableByte] IS NULL))
+    WHERE [u0].[ThreatLevelNullableByte] = [u].[ThreatLevelNullableByte] OR ([u0].[ThreatLevelNullableByte] IS NULL AND [u].[ThreatLevelNullableByte] IS NULL))
 """);
     }
 
@@ -10560,14 +10560,14 @@ WHERE EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -10587,14 +10587,14 @@ WHERE EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM (
@@ -10614,7 +10614,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM [Squads] AS [s]
 CROSS JOIN (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
@@ -10622,8 +10622,8 @@ CROSS JOIN (
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE CHARINDEX(CAST([t].[ThreatLevelByte] AS varbinary(max)), [s].[Banner]) > 0
+) AS [u]
+WHERE CHARINDEX(CAST([u].[ThreatLevelByte] AS varbinary(max)), [s].[Banner]) > 0
 """);
     }
 
@@ -10634,31 +10634,31 @@ WHERE CHARINDEX(CAST([t].[ThreatLevelByte] AS varbinary(max)), [s].[Banner]) > 0
 
         AssertSql(
             """
-SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM (
     SELECT [l].[ThreatLevelByte]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[ThreatLevelByte]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 CROSS APPLY (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0]
-    WHERE [t].[ThreatLevelByte] IN (
+    ) AS [u0]
+    WHERE [u].[ThreatLevelByte] IN (
         SELECT [l1].[ThreatLevelByte]
         FROM [LocustLeaders] AS [l1]
         UNION ALL
         SELECT [l2].[ThreatLevelByte]
         FROM [LocustCommanders] AS [l2]
     )
-) AS [t1]
+) AS [u2]
 """);
     }
 
@@ -10669,31 +10669,31 @@ CROSS APPLY (
 
         AssertSql(
             """
-SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM (
     SELECT [l].[ThreatLevelByte]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[ThreatLevelByte]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 CROSS APPLY (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0]
-    WHERE [t].[ThreatLevelByte] NOT IN (
+    ) AS [u0]
+    WHERE [u].[ThreatLevelByte] NOT IN (
         SELECT [l1].[ThreatLevelByte]
         FROM [LocustLeaders] AS [l1]
         UNION ALL
         SELECT [l2].[ThreatLevelByte]
         FROM [LocustCommanders] AS [l2]
     )
-) AS [t1]
+) AS [u2]
 """);
     }
 
@@ -10703,23 +10703,23 @@ CROSS APPLY (
 
         AssertSql(
             """
-SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM (
     SELECT [l].[ThreatLevelNullableByte]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[ThreatLevelNullableByte]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 CROSS APPLY (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0]
+    ) AS [u0]
     WHERE EXISTS (
         SELECT 1
         FROM (
@@ -10729,8 +10729,8 @@ CROSS APPLY (
             SELECT [l2].[ThreatLevelNullableByte]
             FROM [LocustCommanders] AS [l2]
         ) AS [u1]
-        WHERE [u1].[ThreatLevelNullableByte] = [t].[ThreatLevelNullableByte] OR ([u1].[ThreatLevelNullableByte] IS NULL AND [t].[ThreatLevelNullableByte] IS NULL))
-) AS [t1]
+        WHERE [u1].[ThreatLevelNullableByte] = [u].[ThreatLevelNullableByte] OR ([u1].[ThreatLevelNullableByte] IS NULL AND [u].[ThreatLevelNullableByte] IS NULL))
+) AS [u2]
 """);
     }
 
@@ -10740,23 +10740,23 @@ CROSS APPLY (
 
         AssertSql(
             """
-SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
+SELECT [u2].[Nickname], [u2].[SquadId], [u2].[AssignedCityName], [u2].[CityOfBirthName], [u2].[FullName], [u2].[HasSoulPatch], [u2].[LeaderNickname], [u2].[LeaderSquadId], [u2].[Rank], [u2].[Discriminator]
 FROM (
     SELECT [l].[ThreatLevelNullableByte]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[ThreatLevelNullableByte]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 CROSS APPLY (
-    SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+    SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t0]
+    ) AS [u0]
     WHERE NOT EXISTS (
         SELECT 1
         FROM (
@@ -10766,8 +10766,8 @@ CROSS APPLY (
             SELECT [l2].[ThreatLevelNullableByte]
             FROM [LocustCommanders] AS [l2]
         ) AS [u1]
-        WHERE [u1].[ThreatLevelNullableByte] = [t].[ThreatLevelNullableByte] OR ([u1].[ThreatLevelNullableByte] IS NULL AND [t].[ThreatLevelNullableByte] IS NULL))
-) AS [t1]
+        WHERE [u1].[ThreatLevelNullableByte] = [u].[ThreatLevelNullableByte] OR ([u1].[ThreatLevelNullableByte] IS NULL AND [u].[ThreatLevelNullableByte] IS NULL))
+) AS [u2]
 """);
     }
 
@@ -10793,15 +10793,15 @@ WHERE @__prm_0 = [w].[AmmunitionType]
             """
 @__prm_0='133'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE @__prm_0 & [t].[Rank] = [t].[Rank]
+) AS [u]
+WHERE @__prm_0 & [u].[Rank] = [u].[Rank]
 """);
     }
 
@@ -10813,15 +10813,15 @@ WHERE @__prm_0 & [t].[Rank] = [t].[Rank]
             """
 @__prm_0='5'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE @__prm_0 & CAST([t].[Rank] AS int) = CAST([t].[Rank] AS int)
+) AS [u]
+WHERE @__prm_0 & CAST([u].[Rank] AS int) = CAST([u].[Rank] AS int)
 """);
     }
 
@@ -10833,15 +10833,15 @@ WHERE @__prm_0 & CAST([t].[Rank] AS int) = CAST([t].[Rank] AS int)
             """
 @__p_0='1'
 
-SELECT TOP(@__p_0) [t].[Rank] & 1
+SELECT TOP(@__p_0) [u].[Rank] & 1
 FROM (
     SELECT [g].[Nickname], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -10916,8 +10916,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[CityOfBirthName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-LEFT JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u] ON [w].[OwnerFullName] = [u].[FullName]
+LEFT JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 GROUP BY [c].[Name], [c].[Location]
 ORDER BY [c].[Location]
 """);
@@ -10929,16 +10929,16 @@ ORDER BY [c].[Location]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Weapons] AS [w] ON [t].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
-ORDER BY [t].[Nickname], [w].[Id]
+) AS [u]
+INNER JOIN [Weapons] AS [w] ON [u].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
+ORDER BY [u].[Nickname], [w].[Id]
 """);
     }
 
@@ -10948,16 +10948,16 @@ ORDER BY [t].[Nickname], [w].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
-ORDER BY [t].[Nickname], [w].[Id]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
+ORDER BY [u].[Nickname], [w].[Id]
 """);
     }
 
@@ -10968,20 +10968,20 @@ ORDER BY [t].[Nickname], [w].[Id]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[AmmunitionType], [s].[IsAutomatic], [s].[Name], [s].[OwnerFullName], [s].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-) AS [s] ON [t].[FullName] <> [s].[OwnerFullName] OR [s].[OwnerFullName] IS NULL
-ORDER BY [t].[Nickname], [s].[Id]
+) AS [s] ON [u].[FullName] <> [s].[OwnerFullName] OR [s].[OwnerFullName] IS NULL
+ORDER BY [u].[Nickname], [s].[Id]
 """);
     }
 
@@ -10998,8 +10998,8 @@ FROM (
     UNION ALL
     SELECT [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] <> [w].[OwnerFullName] OR [w].[OwnerFullName] IS NULL
 """);
     }
 
@@ -11009,16 +11009,16 @@ LEFT JOIN [Weapons] AS [w] ON [t].[FullName] <> [w].[OwnerFullName] OR [w].[Owne
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName] AND [t].[SquadId] < [w].[Id]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName] AND [u].[SquadId] < [w].[Id]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -11028,16 +11028,16 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName] AND [t].[SquadId] <= [w].[Id]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName] AND [u].[SquadId] <= [w].[Id]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -11047,16 +11047,16 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName] AND [t].[SquadId] >= [w].[Id]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName] AND [u].[SquadId] >= [w].[Id]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -11066,21 +11066,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS APPLY (
     SELECT TOP(3) [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE [w].[OwnerFullName] <> [t].[FullName] OR [w].[OwnerFullName] IS NULL
+    WHERE [w].[OwnerFullName] <> [u].[FullName] OR [w].[OwnerFullName] IS NULL
     ORDER BY [w].[Id]
 ) AS [w0]
-ORDER BY [t].[Nickname], [w0].[Id]
+ORDER BY [u].[Nickname], [w0].[Id]
 """);
     }
 
@@ -11093,16 +11093,16 @@ ORDER BY [t].[Nickname], [w0].[Id]
 SELECT [s].[Name]
 FROM [Squads] AS [s]
 WHERE [s].[Name] = N'Delta' AND COALESCE((
-    SELECT TOP(1) [t].[SquadId]
+    SELECT TOP(1) [u].[SquadId]
     FROM (
         SELECT [g].[SquadId], [g].[FullName], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[HasSoulPatch] = CAST(1 AS bit)
-    ORDER BY [t].[FullName]), 0) <> 0
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[HasSoulPatch] = CAST(1 AS bit)
+    ORDER BY [u].[FullName]), 0) <> 0
 """);
     }
 
@@ -11112,23 +11112,23 @@ WHERE [s].[Name] = N'Delta' AND COALESCE((
 
         AssertSql(
             """
-SELECT [t].[FullName], [t].[Nickname], [t].[SquadId], [t1].[ReportName], [t1].[OfficerName], [t1].[Nickname], [t1].[SquadId]
+SELECT [u].[FullName], [u].[Nickname], [u].[SquadId], [u1].[ReportName], [u1].[OfficerName], [u1].[Nickname], [u1].[SquadId]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT [t0].[FullName] AS [ReportName], [t].[FullName] AS [OfficerName], [t0].[Nickname], [t0].[SquadId]
+    SELECT [u0].[FullName] AS [ReportName], [u].[FullName] AS [OfficerName], [u0].[Nickname], [u0].[SquadId]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o0].[Nickname], [o0].[SquadId], [o0].[FullName], [o0].[LeaderNickname], [o0].[LeaderSquadId]
         FROM [Officers] AS [o0]
-    ) AS [t0]
-    WHERE [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-) AS [t1]
-ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
+    ) AS [u0]
+    WHERE [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+) AS [u1]
+ORDER BY [u].[Nickname], [u].[SquadId], [u1].[Nickname]
 """);
     }
 
@@ -11138,27 +11138,27 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t1].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE [t].[Discriminator] = N'LocustCommander' AND ([t].[HighCommandId] <> 0 OR [t].[HighCommandId] IS NULL)
+) AS [u]
+WHERE [u].[Discriminator] = N'LocustCommander' AND ([u].[HighCommandId] <> 0 OR [u].[HighCommandId] IS NULL)
 """,
             //
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-WHERE [t].[Discriminator] = N'LocustCommander' AND ([t].[HighCommandId] <> 0 OR [t].[HighCommandId] IS NULL)
+) AS [u]
+WHERE [u].[Discriminator] = N'LocustCommander' AND ([u].[HighCommandId] <> 0 OR [u].[HighCommandId] IS NULL)
 """);
     }
 
@@ -11168,22 +11168,22 @@ WHERE [t].[Discriminator] = N'LocustCommander' AND ([t].[HighCommandId] <> 0 OR 
 
         AssertSql(
             """
-SELECT TOP(1) [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT TOP(1) [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-WHERE [t].[Name] LIKE N'%Queen%'
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+WHERE [u].[Name] LIKE N'%Queen%'
 """);
     }
 
@@ -11193,15 +11193,15 @@ WHERE [t].[Name] LIKE N'%Queen%'
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [c].[Name], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [c].[Location], [c].[Nation]
+SELECT [u].[Nickname], [u].[SquadId], [c].[Name], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [c].[Location], [c].[Nation]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[CityOfBirthName], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
+) AS [u]
+INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM (
@@ -11209,8 +11209,8 @@ LEFT JOIN (
         FROM [Weapons] AS [w]
     ) AS [w0]
     WHERE [w0].[row] <= 10
-) AS [w1] ON [t].[FullName] = [w1].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [c].[Name]
+) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [c].[Name]
 """);
     }
 
@@ -11258,22 +11258,22 @@ FROM [Officers] AS [o]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
+) AS [u0]
+WHERE [u].[Nickname] = [u0].[Nickname] AND [u].[SquadId] = [u0].[SquadId]
 """);
     }
 
@@ -11283,22 +11283,22 @@ WHERE [t].[Nickname] = [t0].[Nickname] AND [t].[SquadId] = [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 CROSS JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0]
-WHERE [t].[Nickname] <> [t0].[Nickname] OR [t].[SquadId] <> [t0].[SquadId]
+) AS [u0]
+WHERE [u].[Nickname] <> [u0].[Nickname] OR [u].[SquadId] <> [u0].[SquadId]
 """);
     }
 
@@ -11308,19 +11308,19 @@ WHERE [t].[Nickname] <> [t0].[Nickname] OR [t].[SquadId] <> [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+WHERE [u0].[Nickname] IS NULL OR [u0].[SquadId] IS NULL
 """);
     }
 
@@ -11330,19 +11330,19 @@ WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-WHERE [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+WHERE [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL
 """);
     }
 
@@ -11355,7 +11355,7 @@ WHERE [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL
 SELECT [t].[Note], CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch]
+END, [u].[Nickname], [u].[SquadId], [u].[HasSoulPatch]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
@@ -11363,9 +11363,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END = 1
 """);
@@ -11380,7 +11380,7 @@ END = 1
 SELECT [t].[Note], CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch]
+END, [u].[Nickname], [u].[SquadId], [u].[HasSoulPatch]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
@@ -11388,9 +11388,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END + 1 = 2
 """);
@@ -11403,7 +11403,7 @@ END + 1 = 2
         AssertSql(
             """
 SELECT [t].[Note], CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END + 1 AS [Value]
 FROM [Tags] AS [t]
@@ -11413,9 +11413,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 """);
@@ -11429,7 +11429,7 @@ END IS NOT NULL
             """
 SELECT CASE
     WHEN [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL THEN CASE
-        WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+        WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
         ELSE NULL
     END
     ELSE -1
@@ -11441,7 +11441,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -11452,7 +11452,7 @@ LEFT JOIN (
         AssertSql(
             """
 SELECT SUBSTRING(CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END, 0 + 1, 3)
 FROM [Tags] AS [t]
@@ -11462,7 +11462,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 """);
     }
 
@@ -11473,7 +11473,7 @@ LEFT JOIN (
         AssertSql(
             """
 SELECT [t].[Note], SUBSTRING([t].[Note], 0 + 1, CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END) AS [Function]
 FROM [Tags] AS [t]
@@ -11483,9 +11483,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 """);
@@ -11498,13 +11498,13 @@ END IS NOT NULL
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN CAST(LEN([t0].[Nickname]) AS int)
+    WHEN [t].[GearNickName] IS NOT NULL THEN CAST(LEN([u].[Nickname]) AS int)
     ELSE NULL
 END, CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END, CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END + 1
 FROM [Tags] AS [t]
@@ -11514,9 +11514,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 ORDER BY [t].[Note]
@@ -11530,7 +11530,7 @@ ORDER BY [t].[Note]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END AS [Id]
 FROM [Tags] AS [t]
@@ -11540,9 +11540,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 ORDER BY [t].[Note]
@@ -11556,13 +11556,13 @@ ORDER BY [t].[Note]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN CAST(LEN([t0].[Nickname]) AS int)
+    WHEN [t].[GearNickName] IS NOT NULL THEN CAST(LEN([u].[Nickname]) AS int)
     ELSE NULL
 END, CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END, CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END + 1
 FROM [Tags] AS [t]
@@ -11572,9 +11572,9 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 ORDER BY [t].[Note]
@@ -11595,12 +11595,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL AND CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[HasSoulPatch]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[HasSoulPatch]
     ELSE NULL
 END = CAST(0 AS bit)
 ORDER BY [t].[Note]
@@ -11613,17 +11613,17 @@ ORDER BY [t].[Note]
 
         AssertSql(
             """
-SELECT [t].[Nickname]
+SELECT [u].[Nickname]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[CityOfBirthName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE DATEPART(month, [t0].[IssueDate]) <> 5 OR [t0].[IssueDate] IS NULL
-ORDER BY [t].[Nickname]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE DATEPART(month, [t].[IssueDate]) <> 5 OR [t].[IssueDate] IS NULL
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -11636,7 +11636,7 @@ ORDER BY [t].[Nickname]
 SELECT [t].[Note], CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch]
+END, [u].[Nickname], [u].[SquadId], [u].[HasSoulPatch]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
@@ -11644,13 +11644,13 @@ LEFT JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[GearNickName] = [t0].[Nickname] AND [t].[GearSquadId] = [t0].[SquadId]
+) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
 WHERE CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[Nickname]
     ELSE NULL
 END IS NOT NULL
 ORDER BY CASE
-    WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
+    WHEN [t].[GearNickName] IS NOT NULL THEN [u].[SquadId]
     ELSE NULL
 END, [t].[Note]
 """);
@@ -11857,8 +11857,8 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[IssueDate], [t0].[Note], CASE
-    WHEN [t0].[Id] IS NULL THEN CAST(1 AS bit)
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], CASE
+    WHEN [t].[Id] IS NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsNull], [c].[Name], [c].[Location], [c].[Nation], CASE
     WHEN [c].[Name] IS NULL THEN CAST(1 AS bit)
@@ -11873,10 +11873,10 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-LEFT JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
-LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+LEFT JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
+LEFT JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 """);
     }
 
@@ -11886,8 +11886,8 @@ LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], CASE
-    WHEN [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL THEN CAST(1 AS bit)
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], CASE
+    WHEN [u0].[Nickname] IS NULL OR [u0].[SquadId] IS NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsNull], [l1].[Id], [l1].[CapitalName], [l1].[Name], [l1].[ServerAddress], [l1].[CommanderName], [l1].[Eradicated], CASE
     WHEN [l1].[Id] IS NULL THEN CAST(1 AS bit)
@@ -11902,16 +11902,16 @@ FROM (
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-LEFT JOIN [LocustHordes] AS [l1] ON [t].[Name] = [l1].[CommanderName]
-LEFT JOIN [LocustHighCommands] AS [l2] ON [t].[HighCommandId] = [l2].[Id]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+LEFT JOIN [LocustHordes] AS [l1] ON [u].[Name] = [l1].[CommanderName]
+LEFT JOIN [LocustHighCommands] AS [l2] ON [u].[HighCommandId] = [l2].[Id]
 """);
     }
 
@@ -11926,27 +11926,27 @@ LEFT JOIN [LocustHighCommands] AS [l2] ON [t].[HighCommandId] = [l2].[Id]
 
 SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[HasSoulPatch0], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t1].[HasSoulPatch] AS [HasSoulPatch0]
+    SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u1].[HasSoulPatch] AS [HasSoulPatch0]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
-    ) AS [t]
+    ) AS [u]
     INNER JOIN (
-        SELECT MIN(CAST(LEN([t0].[Nickname]) AS int)) AS [c], [t0].[HasSoulPatch]
+        SELECT MIN(CAST(LEN([u0].[Nickname]) AS int)) AS [c], [u0].[HasSoulPatch]
         FROM (
             SELECT [g0].[Nickname], [g0].[HasSoulPatch]
             FROM [Gears] AS [g0]
             UNION ALL
             SELECT [o0].[Nickname], [o0].[HasSoulPatch]
             FROM [Officers] AS [o0]
-        ) AS [t0]
-        WHERE [t0].[Nickname] <> N'Dom'
-        GROUP BY [t0].[HasSoulPatch]
-    ) AS [t1] ON CAST(LEN([t].[Nickname]) AS int) = [t1].[c]
-    ORDER BY [t].[Nickname]
+        ) AS [u0]
+        WHERE [u0].[Nickname] <> N'Dom'
+        GROUP BY [u0].[HasSoulPatch]
+    ) AS [u1] ON CAST(LEN([u].[Nickname]) AS int) = [u1].[c]
+    ORDER BY [u].[Nickname]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [s]
 LEFT JOIN [Weapons] AS [w] ON [s].[FullName] = [w].[OwnerFullName]
@@ -11962,15 +11962,15 @@ ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
             """
 @__values_0='[false,true]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
     SELECT [v].[value]
     FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
@@ -11985,15 +11985,15 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (
             """
 @__values_0='[false,true]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (
+) AS [u]
+WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
     SELECT [v].[value]
     FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
@@ -12023,15 +12023,15 @@ WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Locatio
 @__p_0='1'
 @__value_1='1'
 
-SELECT TOP(@__p_0) [t].[Rank] & @__value_1
+SELECT TOP(@__p_0) [u].[Rank] & @__value_1
 FROM (
     SELECT [g].[Nickname], [g].[Rank]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[Rank]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[Nickname]
+) AS [u]
+ORDER BY [u].[Nickname]
 """);
     }
 
@@ -12043,7 +12043,7 @@ ORDER BY [t].[Nickname]
             """
 @__prm_0='1'
 
-SELECT [t].[Nickname], [t].[FullName], CASE
+SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Collection]
@@ -12053,12 +12053,12 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[Id] > @__prm_0
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
 
@@ -12068,16 +12068,16 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w2].[Id], [w2].[AmmunitionType], [w2].[IsAutomatic], [w2].[Name], [w2].[OwnerFullName], [w2].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 LEFT JOIN (
     SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
     FROM (
@@ -12085,8 +12085,8 @@ LEFT JOIN (
         FROM [Weapons] AS [w0]
     ) AS [w1]
     WHERE [w1].[row] <= 1
-) AS [w2] ON [t].[FullName] = [w2].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id]
+) AS [w2] ON [u].[FullName] = [w2].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id]
 """);
     }
 
@@ -12107,16 +12107,16 @@ FROM [Missions] AS [m]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [s].[HasSoulPatch]
+SELECT [u].[Nickname], [u].[SquadId], [s].[HasSoulPatch]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
-    SELECT DISTINCT [t1].[HasSoulPatch]
+    SELECT DISTINCT [u1].[HasSoulPatch]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g0].[AssignedCityName], [g0].[FullName]
@@ -12124,18 +12124,18 @@ OUTER APPLY (
         UNION ALL
         SELECT [o0].[AssignedCityName], [o0].[FullName]
         FROM [Officers] AS [o0]
-    ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-    LEFT JOIN [Cities] AS [c] ON [t0].[AssignedCityName] = [c].[Name]
+    ) AS [u0] ON [w].[OwnerFullName] = [u0].[FullName]
+    LEFT JOIN [Cities] AS [c] ON [u0].[AssignedCityName] = [c].[Name]
     INNER JOIN (
         SELECT [g1].[CityOfBirthName], [g1].[HasSoulPatch]
         FROM [Gears] AS [g1]
         UNION ALL
         SELECT [o1].[CityOfBirthName], [o1].[HasSoulPatch]
         FROM [Officers] AS [o1]
-    ) AS [t1] ON [c].[Name] = [t1].[CityOfBirthName]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    ) AS [u1] ON [c].[Name] = [u1].[CityOfBirthName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
 ) AS [s]
-ORDER BY [t].[Nickname], [t].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12173,7 +12173,7 @@ WHERE [w].[AmmunitionType] = 1
             """
 @__isAutomatic_0='True'
 
-SELECT [t].[Nickname], [t].[FullName], CASE
+SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Collection]
@@ -12183,12 +12183,12 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     WHERE [w].[IsAutomatic] <> @__isAutomatic_0
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
 
@@ -12238,24 +12238,24 @@ WHERE [l].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 
         AssertSql(
             """
-SELECT [t].[Nickname], COALESCE((
-    SELECT TOP(1) [t2].[IssueDate]
-    FROM [Tags] AS [t2]
-    WHERE [t2].[GearNickName] = [t].[FullName]
-    ORDER BY [t2].[Id]), '0001-01-01T00:00:00.0000000') AS [invalidTagIssueDate]
+SELECT [u].[Nickname], COALESCE((
+    SELECT TOP(1) [t1].[IssueDate]
+    FROM [Tags] AS [t1]
+    WHERE [t1].[GearNickName] = [u].[FullName]
+    ORDER BY [t1].[Id]), '0001-01-01T00:00:00.0000000') AS [invalidTagIssueDate]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
-WHERE [t0].[IssueDate] > COALESCE((
-    SELECT TOP(1) [t1].[IssueDate]
-    FROM [Tags] AS [t1]
-    WHERE [t1].[GearNickName] = [t].[FullName]
-    ORDER BY [t1].[Id]), '0001-01-01T00:00:00.0000000')
+) AS [u]
+LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
+WHERE [t].[IssueDate] > COALESCE((
+    SELECT TOP(1) [t0].[IssueDate]
+    FROM [Tags] AS [t0]
+    WHERE [t0].[GearNickName] = [u].[FullName]
+    ORDER BY [t0].[Id]), '0001-01-01T00:00:00.0000000')
 """);
     }
 
@@ -12269,21 +12269,21 @@ WHERE [t0].[IssueDate] > COALESCE((
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[IsAutomatic], [w0].[Name], [w0].[Count]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[IsAutomatic], [w0].[Name], [w0].[Count]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT [w].[IsAutomatic], [w].[Name], COUNT(*) AS [Count]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic], [w].[Name]
 ) AS [w0]
-ORDER BY [t].[Nickname], [t].[SquadId], [w0].[IsAutomatic]
+ORDER BY [u].[Nickname], [u].[SquadId], [w0].[IsAutomatic]
 """);
     }
 
@@ -12316,20 +12316,20 @@ FROM [Tags] AS [t]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Name], [w0].[IsAutomatic]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Name], [w0].[IsAutomatic]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT DISTINCT [w].[Name], [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
 ) AS [w0]
-ORDER BY [t].[Nickname], [t].[SquadId], [w0].[Name]
+ORDER BY [u].[Nickname], [u].[SquadId], [w0].[Name]
 """);
     }
 
@@ -12351,24 +12351,24 @@ LEFT JOIN [Cities] AS [c] ON [l].[CapitalName] = [c].[Name]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-WHERE [t].[Name] LIKE N'%Queen%'
-ORDER BY [t].[Name], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+WHERE [u].[Name] LIKE N'%Queen%'
+ORDER BY [u].[Name], [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -12378,20 +12378,20 @@ ORDER BY [t].[Name], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[Name]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[Name]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT DISTINCT [w].[Id], [w].[Name]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
 ) AS [w0]
-ORDER BY [t].[Nickname], [t].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12414,21 +12414,21 @@ WHERE [m].[Rating] IS NULL
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Key]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Key]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT [w].[IsAutomatic] AS [Key]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic]
 ) AS [w0]
-ORDER BY [t].[Nickname], [t].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12449,7 +12449,7 @@ FROM [LocustHordes] AS [l]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [LocustHordes] AS [l]
 LEFT JOIN [Cities] AS [c] ON [l].[CapitalName] = [c].[Name]
 INNER JOIN (
@@ -12458,8 +12458,8 @@ INNER JOIN (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t] ON [c].[Name] = [t].[CityOfBirthName]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u] ON [c].[Name] = [u].[CityOfBirthName]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 """);
     }
 
@@ -12469,19 +12469,19 @@ INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
 
         AssertSql(
             """
-SELECT [s].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch]
+SELECT [s].[Id], [u0].[Nickname], [u0].[SquadId], [u0].[HasSoulPatch]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT DISTINCT [t].[Nickname], [t].[SquadId], [t].[HasSoulPatch]
+    SELECT DISTINCT [u].[Nickname], [u].[SquadId], [u].[HasSoulPatch]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
         FROM [Officers] AS [o]
-    ) AS [t]
-) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[Nickname]
+    ) AS [u]
+) AS [u0] ON [s].[Id] = [u0].[SquadId]
+ORDER BY [s].[Id], [u0].[Nickname]
 """);
     }
 
@@ -12491,8 +12491,8 @@ ORDER BY [s].[Id], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], CASE
-    WHEN [t].[Discriminator] = N'Officer' THEN CAST(1 AS bit)
+SELECT [u].[Nickname], CASE
+    WHEN [u].[Discriminator] = N'Officer' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsOfficer]
 FROM (
@@ -12501,7 +12501,7 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -12544,22 +12544,22 @@ FROM (
     FROM [Squads] AS [s]
 ) AS [s0]
 OUTER APPLY (
-    SELECT [t0].[Nickname], [t0].[FullName], [t0].[HasSoulPatch], [w0].[Id], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[FullName] AS [FullName0], [w0].[HasSoulPatch] AS [HasSoulPatch0], [w0].[Id0]
+    SELECT [u0].[Nickname], [u0].[FullName], [u0].[HasSoulPatch], [w0].[Id], [w0].[Name], [w0].[Nickname] AS [Nickname0], [w0].[FullName] AS [FullName0], [w0].[HasSoulPatch] AS [HasSoulPatch0], [w0].[Id0]
     FROM (
-        SELECT DISTINCT [t].[Nickname], [t].[FullName], [t].[HasSoulPatch]
+        SELECT DISTINCT [u].[Nickname], [u].[FullName], [u].[HasSoulPatch]
         FROM (
             SELECT [g].[Nickname], [g].[SquadId], [g].[FullName], [g].[HasSoulPatch]
             FROM [Gears] AS [g]
             UNION ALL
             SELECT [o].[Nickname], [o].[SquadId], [o].[FullName], [o].[HasSoulPatch]
             FROM [Officers] AS [o]
-        ) AS [t]
-        WHERE [t].[SquadId] = [s0].[Id]
-    ) AS [t0]
+        ) AS [u]
+        WHERE [u].[SquadId] = [s0].[Id]
+    ) AS [u0]
     OUTER APPLY (
-        SELECT [s0].[Id], [s0].[Name], [t0].[Nickname], [t0].[FullName], [t0].[HasSoulPatch], [w].[Id] AS [Id0]
+        SELECT [s0].[Id], [s0].[Name], [u0].[Nickname], [u0].[FullName], [u0].[HasSoulPatch], [w].[Id] AS [Id0]
         FROM [Weapons] AS [w]
-        WHERE [w].[OwnerFullName] = [t0].[FullName]
+        WHERE [w].[OwnerFullName] = [u0].[FullName]
     ) AS [w0]
 ) AS [s1]
 ORDER BY [s0].[Id], [s1].[Nickname], [s1].[FullName], [s1].[HasSoulPatch]
@@ -12610,14 +12610,14 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-SELECT [t].[FullName] + N'' + COALESCE([t].[LeaderNickname], N'') + N''
+SELECT [u].[FullName] + N'' + COALESCE([u].[LeaderNickname], N'') + N''
 FROM (
     SELECT [g].[FullName], [g].[LeaderNickname]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[FullName], [o].[LeaderNickname]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -12627,19 +12627,19 @@ FROM (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Id], [w0].[Name], [w0].[OwnerFullName]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Id], [w0].[Name], [w0].[OwnerFullName]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT DISTINCT [w].[Id], [w].[Name], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-) AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId]
+) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12650,21 +12650,21 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w0].[Key], [w0].[Count]
+SELECT [u].[Nickname], [u].[SquadId], [w0].[Key], [w0].[Count]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT [w].[IsAutomatic] AS [Key], COUNT(*) AS [Count]
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName]
+    WHERE [u].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic]
 ) AS [w0]
-ORDER BY [t].[Nickname], [t].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12685,24 +12685,24 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [w1].[Key], [w1].[Count]
+SELECT [u].[Nickname], [u].[SquadId], [w1].[Key], [w1].[Count]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 OUTER APPLY (
     SELECT [w0].[Key], COUNT(*) AS [Count]
     FROM (
         SELECT CAST(LEN([w].[Name]) AS int) AS [Key]
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]
+        WHERE [u].[FullName] = [w].[OwnerFullName]
     ) AS [w0]
     GROUP BY [w0].[Key]
 ) AS [w1]
-ORDER BY [t].[Nickname], [t].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId]
 """);
     }
 
@@ -12991,8 +12991,8 @@ WHERE NOT EXISTS (
         UNION ALL
         SELECT [o].[SquadId]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId])
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId])
 """);
     }
 
@@ -13012,8 +13012,8 @@ WHERE NOT EXISTS (
         UNION ALL
         SELECT [o].[SquadId], [o].[FullName]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId] AND [t].[FullName] = N'Anthony Carmine')
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[FullName] = N'Anthony Carmine')
 """);
     }
 
@@ -13023,18 +13023,18 @@ WHERE NOT EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName])
+    WHERE [u].[FullName] = [w].[OwnerFullName])
 """);
     }
 
@@ -13044,18 +13044,18 @@ WHERE NOT EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Weapons] AS [w]
-    WHERE [t].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'Hammer of Dawn')
+    WHERE [u].[FullName] = [w].[OwnerFullName] AND [w].[Name] = N'Hammer of Dawn')
 """);
     }
 
@@ -13065,21 +13065,21 @@ WHERE NOT EXISTS (
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t0] ON [t].[DefeatedByNickname] = [t0].[Nickname] AND [t].[DefeatedBySquadId] = [t0].[SquadId]
+) AS [u0] ON [u].[DefeatedByNickname] = [u0].[Nickname] AND [u].[DefeatedBySquadId] = [u0].[SquadId]
 """);
     }
 
@@ -13089,22 +13089,22 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -13114,19 +13114,19 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
 
         AssertSql(
             """
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[Nickname] = [t0].[LeaderNickname] AND [t].[SquadId] = [t0].[LeaderSquadId]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
+) AS [u0] ON [u].[Nickname] = [u0].[LeaderNickname] AND [u].[SquadId] = [u0].[LeaderSquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 """);
     }
 
@@ -13138,15 +13138,15 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname]
             """
 @__p_0='0'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[FullName]
+) AS [u]
+ORDER BY [u].[FullName]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
@@ -13159,15 +13159,15 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='1'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[FullName]
+) AS [u]
+ORDER BY [u].[FullName]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
@@ -13180,15 +13180,15 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='2'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-ORDER BY [t].[FullName]
+) AS [u]
+ORDER BY [u].[FullName]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
@@ -13209,9 +13209,9 @@ WHERE NOT EXISTS (
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId]
-    ORDER BY [t].[Nickname]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId]
+    ORDER BY [u].[Nickname]
     OFFSET 2 ROWS)
 """);
     }
@@ -13225,16 +13225,16 @@ WHERE NOT EXISTS (
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE (
-    SELECT [t].[Nickname]
+    SELECT [u].[Nickname]
     FROM (
         SELECT [g].[Nickname], [g].[SquadId]
         FROM [Gears] AS [g]
         UNION ALL
         SELECT [o].[Nickname], [o].[SquadId]
         FROM [Officers] AS [o]
-    ) AS [t]
-    WHERE [s].[Id] = [t].[SquadId]
-    ORDER BY [t].[Nickname]
+    ) AS [u]
+    WHERE [s].[Id] = [u].[SquadId]
+    ORDER BY [u].[Nickname]
     OFFSET [s].[Id] ROWS FETCH NEXT 1 ROWS ONLY) = N'Cole Train'
 """);
     }
@@ -13258,22 +13258,22 @@ FROM [Squads] AS [s]
             """
 @__unixEpochMilliseconds_0='0'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 LEFT JOIN [SquadMissions] AS [s1] ON [s].[Id] = [s1].[SquadId]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
     WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochMilliseconds_0 = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
 
@@ -13285,22 +13285,22 @@ ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId]
             """
 @__unixEpochSeconds_0='0'
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 LEFT JOIN [SquadMissions] AS [s1] ON [s].[Id] = [s1].[SquadId]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
     WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochSeconds_0 = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
-ORDER BY [t].[Nickname], [t].[SquadId], [s].[Id], [s1].[SquadId]
+ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
 
@@ -13318,9 +13318,9 @@ SELECT [s].[Name], (
         UNION ALL
         SELECT [o2].[SquadId], [o2].[CityOfBirthName]
         FROM [Officers] AS [o2]
-    ) AS [t0]
-    INNER JOIN [Squads] AS [s0] ON [t0].[SquadId] = [s0].[Id]
-    INNER JOIN [Cities] AS [c] ON [t0].[CityOfBirthName] = [c].[Name]
+    ) AS [u3]
+    INNER JOIN [Squads] AS [s0] ON [u3].[SquadId] = [s0].[Id]
+    INNER JOIN [Cities] AS [c] ON [u3].[CityOfBirthName] = [c].[Name]
     WHERE N'Marcus' IN (
         SELECT [g3].[Nickname]
         FROM [Gears] AS [g3]
@@ -13340,8 +13340,8 @@ FROM (
     UNION ALL
     SELECT [o].[SquadId]
     FROM [Officers] AS [o]
-) AS [t]
-INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+) AS [u]
+INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
 WHERE N'Marcus' IN (
     SELECT [g0].[Nickname]
     FROM [Gears] AS [g0]
@@ -13367,19 +13367,19 @@ GROUP BY [s].[Name]
             """
 @__numbers_0='[1,-1]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Weapons] AS [w]
-        WHERE [t].[FullName] = [w].[OwnerFullName]) THEN 1
+        WHERE [u].[FullName] = [w].[OwnerFullName]) THEN 1
     ELSE 0
 END IN (
     SELECT [n].[value]
@@ -13396,18 +13396,18 @@ END IN (
             """
 @__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE (
     SELECT TOP(1) [w0].[Name]
     FROM [Weapons] AS [w0]
-    WHERE [t].[FullName] = [w0].[OwnerFullName]
+    WHERE [u].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]) IN (
     SELECT [w].[value]
     FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w]
@@ -13423,14 +13423,14 @@ WHERE (
             """
 @__numbers_0='[0,1,2]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
+SELECT [u].[Nickname], [u].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM (
@@ -13442,8 +13442,8 @@ LEFT JOIN (
         FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
         ORDER BY [n].[value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
-) AS [w1] ON [t].[FullName] = [w1].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [w1].[OwnerFullName], [w1].[Id]
+) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [w1].[OwnerFullName], [w1].[Id]
 """);
     }
 
@@ -13480,17 +13480,17 @@ ORDER BY [t].[Nickname], [t].[SquadId], [w1].[OwnerFullName], [w1].[Id]
         await base.Include_one_to_many_on_composite_key_then_orderby_key_properties(async);
 
         AssertSql(
-"""
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+            """
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[SquadId], [t].[Nickname]
+) AS [u]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[SquadId], [u].[Nickname]
 """);
     }
 
@@ -13499,19 +13499,19 @@ ORDER BY [t].[SquadId], [t].[Nickname]
         await base.Find_underlying_property_after_GroupJoin_DefaultIfEmpty(async);
 
         AssertSql(
-"""
-SELECT [t].[FullName], CAST([t0].[ThreatLevel] AS int) AS [ThreatLevel]
+            """
+SELECT [u].[FullName], CAST([u0].[ThreatLevel] AS int) AS [ThreatLevel]
 FROM (
     SELECT [g].[Nickname], [g].[FullName]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[FullName]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [l].[ThreatLevel], [l].[DefeatedByNickname]
     FROM [LocustCommanders] AS [l]
-) AS [t0] ON [t].[Nickname] = [t0].[DefeatedByNickname]
+) AS [u0] ON [u].[Nickname] = [u0].[DefeatedByNickname]
 """);
     }
 
@@ -13520,9 +13520,9 @@ LEFT JOIN (
         await base.Join_include_coalesce_simple(async);
 
         AssertSql(
-"""
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
-    WHEN [t].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
+            """
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
+    WHEN [u].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -13531,57 +13531,57 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """,
-                //
-                """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+            //
+            """
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """,
-                //
-                """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+            //
+            """
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t].[FullName] = [w0].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id]
 """);
     }
 
@@ -13590,9 +13590,9 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
         await base.Join_include_coalesce_nested(async);
 
         AssertSql(
-"""
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
-    WHEN [t].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
+            """
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
+    WHEN [u].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -13601,38 +13601,38 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """,
-                //
-                """
-SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
+            //
+            """
+SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w1] ON [t0].[FullName] = [w1].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id], [w0].[Id]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u0].[FullName] = [w].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w0] ON [u0].[FullName] = [w0].[OwnerFullName]
+LEFT JOIN [Weapons] AS [w1] ON [u0].[FullName] = [w1].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId], [w].[Id], [w0].[Id]
 """);
     }
 
@@ -13641,12 +13641,12 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [w].[Id
         await base.Join_include_conditional(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [u0].[Nickname] IS NOT NULL AND [u0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t0].[Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
-    WHEN [t].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
+END, [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator], [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], CASE
+    WHEN [u].[Nickname] = N'Marcus' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -13655,16 +13655,16 @@ FROM (
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
     SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
-) AS [t0] ON [t].[LeaderNickname] = [t0].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
+) AS [u0] ON [u].[LeaderNickname] = [u0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
+ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname], [u0].[SquadId]
 """);
     }
 
@@ -13674,15 +13674,15 @@ ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]
 
         AssertSql(
             """
-SELECT [t].[Name], [t].[LocustHordeId], [t].[ThreatLevel], [t].[ThreatLevelByte], [t].[ThreatLevelNullableByte], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t].[Discriminator], [l1].[Id], [l1].[IsOperational], [l1].[Name]
+SELECT [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [l1].[Id], [l1].[IsOperational], [l1].[Name]
 FROM (
     SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
     FROM [LocustLeaders] AS [l]
     UNION ALL
     SELECT [l0].[Name], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[ThreatLevelByte], [l0].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], N'LocustCommander' AS [Discriminator]
     FROM [LocustCommanders] AS [l0]
-) AS [t]
-LEFT JOIN [LocustHighCommands] AS [l1] ON [t].[HighCommandId] = [l1].[Id]
+) AS [u]
+LEFT JOIN [LocustHighCommands] AS [l1] ON [u].[HighCommandId] = [l1].[Id]
 """);
     }
 
@@ -13696,16 +13696,16 @@ LEFT JOIN [LocustHighCommands] AS [l1] ON [t].[HighCommandId] = [l1].[Id]
 @__key_2='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
 @__keys_0='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
-SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator]
+SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g]
     UNION ALL
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
-) AS [t]
+) AS [u]
 WHERE CASE
-    WHEN [t].[Rank] IN (
+    WHEN [u].[Rank] IN (
         SELECT [r].[value]
         FROM OPENJSON(@__ranks_1) WITH ([value] int '$') AS [r]
     ) THEN @__key_2

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
@@ -35,16 +35,16 @@ FROM [Kiwi] AS [k]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[Name] = N'Great spotted kiwi'
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[Name] = N'Great spotted kiwi'
+ORDER BY [u].[Species]
 """);
     }
 
@@ -54,7 +54,7 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [c].[Id], [c].[Name], [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [c].[Id], [c].[Name], [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM [Countries] AS [c]
 LEFT JOIN (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
@@ -62,7 +62,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t] ON [c].[Id] = [t].[CountryId]
+) AS [u] ON [c].[Id] = [u].[CountryId]
 ORDER BY [c].[Name], [c].[Id]
 """);
     }
@@ -73,7 +73,7 @@ ORDER BY [c].[Name], [c].[Id]
 
         AssertSql(
             """
-SELECT [e1].[Id], [e1].[CountryId], [e1].[Name], [e1].[Species], [e1].[EagleId], [e1].[IsFlightless], [e1].[Group], [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [e1].[Id], [e1].[CountryId], [e1].[Name], [e1].[Species], [e1].[EagleId], [e1].[IsFlightless], [e1].[Group], [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT TOP(2) [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group]
     FROM [Eagle] AS [e]
@@ -84,7 +84,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t] ON [e1].[Id] = [t].[EagleId]
+) AS [u] ON [e1].[Id] = [u].[EagleId]
 ORDER BY [e1].[Id]
 """);
     }
@@ -98,15 +98,15 @@ ORDER BY [e1].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -116,15 +116,15 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -134,15 +134,15 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Species], [t].[CountryId], [t].[Genus], [t].[Name], [t].[HasThorns], [t].[AdditionalInfo_Nickname], [t].[AdditionalInfo_LeafStructure_AreLeavesBig], [t].[AdditionalInfo_LeafStructure_NumLeaves], [t].[Discriminator]
+SELECT [u].[Species], [u].[CountryId], [u].[Genus], [u].[Name], [u].[HasThorns], [u].[AdditionalInfo_Nickname], [u].[AdditionalInfo_LeafStructure_AreLeavesBig], [u].[AdditionalInfo_LeafStructure_NumLeaves], [u].[Discriminator]
 FROM (
     SELECT [d].[Species], [d].[CountryId], [d].[Genus], [d].[Name], [d].[AdditionalInfo_Nickname], [d].[AdditionalInfo_LeafStructure_AreLeavesBig], [d].[AdditionalInfo_LeafStructure_NumLeaves], NULL AS [HasThorns], N'Daisy' AS [Discriminator]
     FROM [Daisies] AS [d]
     UNION ALL
     SELECT [r].[Species], [r].[CountryId], [r].[Genus], [r].[Name], NULL AS [AdditionalInfo_Nickname], NULL AS [AdditionalInfo_LeafStructure_AreLeavesBig], NULL AS [AdditionalInfo_LeafStructure_NumLeaves], [r].[HasThorns], N'Rose' AS [Discriminator]
     FROM [Roses] AS [r]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -261,7 +261,7 @@ FROM [Kiwi] AS [k]
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[Discriminator] = N'Kiwi' THEN [t].[FoundOn]
+    WHEN [u].[Discriminator] = N'Kiwi' THEN [u].[FoundOn]
     ELSE CAST(0 AS tinyint)
 END AS [Value]
 FROM (
@@ -270,7 +270,7 @@ FROM (
     UNION ALL
     SELECT [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -281,7 +281,7 @@ FROM (
         AssertSql(
             """
 SELECT CASE
-    WHEN [t].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
+    WHEN [u].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM (
@@ -290,7 +290,7 @@ FROM (
     UNION ALL
     SELECT N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
+) AS [u]
 """);
     }
 
@@ -300,15 +300,15 @@ FROM (
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[Discriminator] = N'Kiwi' AND [t].[CountryId] = 1
+) AS [u]
+WHERE [u].[Discriminator] = N'Kiwi' AND [u].[CountryId] = 1
 """);
     }
 
@@ -318,15 +318,15 @@ WHERE [t].[Discriminator] = N'Kiwi' AND [t].[CountryId] = 1
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -336,15 +336,15 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -354,15 +354,15 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT TOP(1) [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT TOP(1) [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-ORDER BY [t].[Species]
+) AS [u]
+ORDER BY [u].[Species]
 """);
     }
 
@@ -372,16 +372,16 @@ ORDER BY [t].[Species]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[CountryId] = 1
-ORDER BY [t].[Species]
+) AS [u]
+WHERE [u].[CountryId] = 1
+ORDER BY [u].[Species]
 """);
     }
 
@@ -416,12 +416,12 @@ FROM [Kiwi] AS [k]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[FoundOn] = CAST(0 AS tinyint)
+) AS [u]
+WHERE [u].[FoundOn] = CAST(0 AS tinyint)
 """);
     }
 
@@ -431,12 +431,12 @@ WHERE [t].[FoundOn] = CAST(0 AS tinyint)
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[FoundOn] = CAST(1 AS tinyint)
+) AS [u]
+WHERE [u].[FoundOn] = CAST(1 AS tinyint)
 """);
     }
 
@@ -488,19 +488,19 @@ ORDER BY [k].[Name]
             """
 @__p_0='5'
 
-SELECT DISTINCT [t0].[Id], [t0].[CountryId], [t0].[Name], [t0].[Species], [t0].[EagleId], [t0].[IsFlightless], [t0].[FoundOn], [t0].[Discriminator]
+SELECT DISTINCT [u0].[Id], [u0].[CountryId], [u0].[Name], [u0].[Species], [u0].[EagleId], [u0].[IsFlightless], [u0].[FoundOn], [u0].[Discriminator]
 FROM (
-    SELECT TOP(@__p_0) [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn], [t].[Discriminator]
+    SELECT TOP(@__p_0) [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
     FROM (
         SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
         FROM [Eagle] AS [e]
         UNION ALL
         SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn], N'Kiwi' AS [Discriminator]
         FROM [Kiwi] AS [k]
-    ) AS [t]
-    ORDER BY [t].[Species]
-) AS [t0]
-WHERE [t0].[Discriminator] = N'Kiwi'
+    ) AS [u]
+    ORDER BY [u].[Species]
+) AS [u0]
+WHERE [u0].[Discriminator] = N'Kiwi'
 """);
     }
 
@@ -524,29 +524,29 @@ WHERE [t0].[Discriminator] = N'Kiwi'
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
+) AS [u]
 WHERE EXISTS (
     SELECT 1
     FROM (
-        SELECT TOP(1) [t0].[Discriminator]
+        SELECT TOP(1) [u0].[Discriminator]
         FROM (
             SELECT [e0].[Name], N'Eagle' AS [Discriminator]
             FROM [Eagle] AS [e0]
             UNION ALL
             SELECT [k0].[Name], N'Kiwi' AS [Discriminator]
             FROM [Kiwi] AS [k0]
-        ) AS [t0]
-        WHERE [t0].[Name] = N'Great spotted kiwi'
-    ) AS [t1]
-    WHERE [t1].[Discriminator] = N'Kiwi')
-ORDER BY [t].[Species]
+        ) AS [u0]
+        WHERE [u0].[Name] = N'Great spotted kiwi'
+    ) AS [u1]
+    WHERE [u1].[Discriminator] = N'Kiwi')
+ORDER BY [u].[Species]
 """);
     }
 
@@ -626,12 +626,12 @@ FROM [Kiwi] AS [k]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[Discriminator] = N'Eagle'
+) AS [u]
+WHERE [u].[Discriminator] = N'Eagle'
 """);
     }
 
@@ -641,12 +641,12 @@ WHERE [t].[Discriminator] = N'Eagle'
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[Discriminator]
 FROM (
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[Discriminator] = N'Eagle'
+) AS [u]
+WHERE [u].[Discriminator] = N'Eagle'
 """);
     }
 
@@ -663,14 +663,14 @@ WHERE [t].[Discriminator] = N'Eagle'
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -681,14 +681,14 @@ WHERE 0 = 1
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -732,15 +732,15 @@ FROM [Kiwi] AS [k]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[CountryId], [t].[Name], [t].[Species], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn], [t].[Discriminator]
+SELECT [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[Group], [u].[FoundOn], [u].[Discriminator]
 FROM (
     SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
     FROM [Eagle] AS [e]
     UNION ALL
     SELECT [k].[Id], [k].[CountryId], [k].[Name], [k].[Species], [k].[EagleId], [k].[IsFlightless], NULL AS [Group], [k].[FoundOn], N'Kiwi' AS [Discriminator]
     FROM [Kiwi] AS [k]
-) AS [t]
-WHERE [t].[Discriminator] <> N'Kiwi'
+) AS [u]
+WHERE [u].[Discriminator] <> N'Kiwi'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
@@ -116,8 +116,8 @@ ORDER BY (
         UNION ALL
         SELECT [l].[Id], [l].[Name]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
+    ) AS [u] ON [j].[EntityBranchId] = [u].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [u].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -194,7 +194,7 @@ INNER JOIN (
 SELECT MIN([s].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [e0].[ThreeSkipSharedId]
+    SELECT [u].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id]
@@ -208,7 +208,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Id] = [s].[ThreeSkipSharedId]
 """);
     }
@@ -232,12 +232,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Key1], [e].[RootSkipSharedId]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 """);
     }
 
@@ -356,7 +356,7 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [s].[Id], [s].[Name], [s].[EntityBranchId]
     FROM (
@@ -365,7 +365,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e] ON [j].[EntityOneId] = [e].[Id]
     ) AS [s]
     WHERE [s].[row] <= 1
-) AS [s0] ON [t].[Id] = [s0].[EntityBranchId]
+) AS [s0] ON [u].[Id] = [s0].[EntityBranchId]
 """);
     }
 
@@ -415,7 +415,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[LeafId], [s].[CompositeId1], [
 SELECT [e].[Key1], [e].[Key2], [e].[Key3], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
@@ -429,8 +429,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] = N'EntityLeaf'
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
+    WHERE [u].[Discriminator] = N'EntityLeaf'
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 """);
@@ -495,12 +495,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 """);
     }
 
@@ -589,7 +589,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[ThreeSkipSharedId]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
@@ -603,8 +603,8 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
+    WHERE [u].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [s] ON [e].[Id] = [s].[ThreeSkipSharedId]
 """);
     }
@@ -618,7 +618,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [EntityOnes] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[EntityOneId]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [j].[EntityOneId]
     FROM [JoinOneToBranch] AS [j]
     INNER JOIN (
         SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -626,7 +626,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
+    ) AS [u] ON [j].[EntityBranchId] = [u].[Id]
 ) AS [s] ON [e].[Id] = [s].[EntityOneId]
 """);
     }
@@ -705,7 +705,7 @@ ORDER BY [e].[Id]
 SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [s].[Id], [s].[Name], [s].[Number], [s].[Slumber], [s].[IsGreen], [s].[IsBrown], [s].[Discriminator], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
@@ -719,7 +719,7 @@ LEFT JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 """);
@@ -910,7 +910,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s0].[CompositeId1], [s0].[Composit
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [s0].[Id], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id0], [s0].[Name0], [s0].[OneId], [s0].[ThreeId]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [s0].[Id], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id0], [s0].[Name0], [s0].[OneId], [s0].[ThreeId]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -923,7 +923,7 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [s].[Id] AS [Id0], [s].[Name] AS [Name0], [s].[OneId], [s].[ThreeId]
     FROM [EntityRootEntityThree] AS [e]
@@ -934,8 +934,8 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
         WHERE [e1].[Id] < 10
     ) AS [s] ON [e0].[Id] = [s].[ThreeId]
-) AS [s0] ON [t].[Id] = [s0].[RootSkipSharedId]
-ORDER BY [t].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[OneId], [s0].[ThreeId]
+) AS [s0] ON [u].[Id] = [s0].[RootSkipSharedId]
+ORDER BY [u].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[OneId], [s0].[ThreeId]
 """);
     }
 
@@ -945,7 +945,7 @@ ORDER BY [t].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id],
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[Name], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId], [s1].[Id0]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[Name], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId], [s1].[Id0]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -958,7 +958,7 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [s0].[Id], [s0].[CollectionInverseId], [s0].[Name] AS [Name0], [s0].[ReferenceInverseId], [s0].[Id0], [s0].[CompositeId1], [s0].[CompositeId2], [s0].[CompositeId3]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
@@ -972,8 +972,8 @@ LEFT JOIN (
         ) AS [s]
         WHERE 1 < [s].[row] AND [s].[row] <= 3
     ) AS [s0] ON [e0].[Key1] = [s0].[CompositeId1] AND [e0].[Key2] = [s0].[CompositeId2] AND [e0].[Key3] = [s0].[CompositeId3]
-) AS [s1] ON [t].[Id] = [s1].[RootSkipSharedId]
-ORDER BY [t].[Id], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id]
+) AS [s1] ON [u].[Id] = [s1].[RootSkipSharedId]
+ORDER BY [u].[Id], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id]
 """);
     }
 
@@ -1098,7 +1098,7 @@ LEFT JOIN (
         WHERE 1 < [s].[row] AND [s].[row] <= 3
     ) AS [s0] ON [e0].[Id] = [s0].[OneId]
     LEFT JOIN (
-        SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j1].[EntityBranchId], [j1].[EntityOneId]
+        SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [j1].[EntityBranchId], [j1].[EntityOneId]
         FROM [JoinOneToBranch] AS [j1]
         INNER JOIN (
             SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -1106,8 +1106,8 @@ LEFT JOIN (
             UNION ALL
             SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
             FROM [Leaves] AS [l]
-        ) AS [t] ON [j1].[EntityBranchId] = [t].[Id]
-        WHERE [t].[Id] < 20
+        ) AS [u] ON [j1].[EntityBranchId] = [u].[Id]
+        WHERE [u].[Id] < 20
     ) AS [s1] ON [e0].[Id] = [s1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [s2] ON [e].[Id] = [s2].[ThreeId]
@@ -1190,7 +1190,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[Slumber], [s].[IsGreen], [s].[IsBrown], [s].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
@@ -1204,7 +1204,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]
 """);
@@ -1473,7 +1473,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s0].[CompositeId1], [s0].[Composit
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -1486,12 +1486,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
-ORDER BY [t].[Id]
+) AS [u]
+ORDER BY [u].[Id]
 """,
             //
             """
-SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId]
+SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1504,17 +1504,17 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 """,
             //
             """
-SELECT [s0].[Id], [s0].[Name], [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+SELECT [s0].[Id], [s0].[Name], [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1527,19 +1527,19 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Id], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 INNER JOIN (
     SELECT [e1].[Id], [e1].[Name], [j].[ThreeId]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
     WHERE [e1].[Id] < 10
 ) AS [s0] ON [s].[Id] = [s0].[ThreeId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 """);
     }
 
@@ -1549,7 +1549,7 @@ ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -1562,12 +1562,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
-ORDER BY [t].[Id]
+) AS [u]
+ORDER BY [u].[Id]
 """,
             //
             """
-SELECT [s].[Key1], [s].[Key2], [s].[Key3], [s].[Name], [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
+SELECT [s].[Key1], [s].[Key2], [s].[Key3], [s].[Name], [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1580,17 +1580,17 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
 """,
             //
             """
-SELECT [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId], [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
+SELECT [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId], [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1603,12 +1603,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 INNER JOIN (
     SELECT [s0].[Id], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId], [s0].[CompositeId1], [s0].[CompositeId2], [s0].[CompositeId3]
     FROM (
@@ -1618,7 +1618,7 @@ INNER JOIN (
     ) AS [s0]
     WHERE 1 < [s0].[row] AND [s0].[row] <= 3
 ) AS [s1] ON [s].[Key1] = [s1].[CompositeId1] AND [s].[Key2] = [s1].[CompositeId2] AND [s].[Key3] = [s1].[CompositeId3]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id]
 """);
     }
 
@@ -1849,7 +1849,7 @@ INNER JOIN (
     WHERE [e0].[Id] < 10
 ) AS [s] ON [e].[Id] = [s].[ThreeId]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j1].[EntityOneId]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [j1].[EntityOneId]
     FROM [JoinOneToBranch] AS [j1]
     INNER JOIN (
         SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -1857,8 +1857,8 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j1].[EntityBranchId] = [t].[Id]
-    WHERE [t].[Id] < 20
+    ) AS [u] ON [j1].[EntityBranchId] = [u].[Id]
+    WHERE [u].[Id] < 20
 ) AS [s2] ON [s].[Id] = [s2].[EntityOneId]
 ORDER BY [e].[Id], [s].[OneId], [s].[ThreeId], [s].[Id]
 """);
@@ -2053,14 +2053,14 @@ FROM [Leaves] AS [l]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
     SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -2204,8 +2204,8 @@ ORDER BY (
         UNION ALL
         SELECT [u2].[Id], [u2].[Name]
         FROM [UnidirectionalLeaves] AS [u2]
-    ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
+    ) AS [u3] ON [u0].[UnidirectionalEntityBranchId] = [u3].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [u3].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 
@@ -2253,7 +2253,7 @@ LEFT JOIN (
 SELECT [u].[Key1], [u].[Key2], [u].[Key3], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 FROM [UnidirectionalEntityCompositeKeys] AS [u]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
+    SELECT [u4].[Id], [u4].[Name], [u4].[Number], [u4].[IsGreen], [u4].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
     FROM [UnidirectionalEntityCompositeKeyUnidirectionalEntityRoot] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], NULL AS [Number], NULL AS [IsGreen], N'UnidirectionalEntityRoot' AS [Discriminator]
@@ -2264,8 +2264,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u3]
-    ) AS [t] ON [u0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] = N'UnidirectionalEntityLeaf'
+    ) AS [u4] ON [u0].[RootSkipSharedId] = [u4].[Id]
+    WHERE [u4].[Discriminator] = N'UnidirectionalEntityLeaf'
 ) AS [s] ON [u].[Key1] = [s].[UnidirectionalEntityCompositeKeyKey1] AND [u].[Key2] = [s].[UnidirectionalEntityCompositeKeyKey2] AND [u].[Key3] = [s].[UnidirectionalEntityCompositeKeyKey3]
 ORDER BY [u].[Key1], [u].[Key2], [u].[Key3], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 """);
@@ -2327,12 +2327,12 @@ FROM (
     UNION ALL
     SELECT [u1].[Id]
     FROM [UnidirectionalLeaves] AS [u1]
-) AS [t]
+) AS [u2]
 INNER JOIN (
-    SELECT [u3].[Id], [u3].[CollectionInverseId], [u3].[Name], [u3].[ReferenceInverseId], [u2].[UnidirectionalEntityRootId]
-    FROM [UnidirectionalEntityRootUnidirectionalEntityThree] AS [u2]
-    INNER JOIN [UnidirectionalEntityThrees] AS [u3] ON [u2].[ThreeSkipSharedId] = [u3].[Id]
-) AS [s] ON [t].[Id] = [s].[UnidirectionalEntityRootId]
+    SELECT [u4].[Id], [u4].[CollectionInverseId], [u4].[Name], [u4].[ReferenceInverseId], [u3].[UnidirectionalEntityRootId]
+    FROM [UnidirectionalEntityRootUnidirectionalEntityThree] AS [u3]
+    INNER JOIN [UnidirectionalEntityThrees] AS [u4] ON [u3].[ThreeSkipSharedId] = [u4].[Id]
+) AS [s] ON [u2].[Id] = [s].[UnidirectionalEntityRootId]
 """);
     }
 
@@ -2401,7 +2401,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [UnidirectionalEntityOnes] AS [u]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [u0].[UnidirectionalEntityOneId]
+    SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], [u3].[Discriminator], [u0].[UnidirectionalEntityOneId]
     FROM [UnidirectionalJoinOneToBranch] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], [u1].[Number], NULL AS [IsGreen], N'UnidirectionalEntityBranch' AS [Discriminator]
@@ -2409,7 +2409,7 @@ INNER JOIN (
         UNION ALL
         SELECT [u2].[Id], [u2].[Name], [u2].[Number], [u2].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u2]
-    ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
+    ) AS [u3] ON [u0].[UnidirectionalEntityBranchId] = [u3].[Id]
 ) AS [s] ON [u].[Id] = [s].[UnidirectionalEntityOneId]
 """);
     }
@@ -2440,7 +2440,7 @@ ORDER BY [u].[Id], [s].[LeftId], [s].[RightId]
 SELECT [u].[Key1], [u].[Key2], [u].[Key3], [u].[Name], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 FROM [UnidirectionalEntityCompositeKeys] AS [u]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
+    SELECT [u4].[Id], [u4].[Name], [u4].[Number], [u4].[IsGreen], [u4].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
     FROM [UnidirectionalEntityCompositeKeyUnidirectionalEntityRoot] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], NULL AS [Number], NULL AS [IsGreen], N'UnidirectionalEntityRoot' AS [Discriminator]
@@ -2451,7 +2451,7 @@ LEFT JOIN (
         UNION ALL
         SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u3]
-    ) AS [t] ON [u0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u4] ON [u0].[RootSkipSharedId] = [u4].[Id]
 ) AS [s] ON [u].[Key1] = [s].[UnidirectionalEntityCompositeKeyKey1] AND [u].[Key2] = [s].[UnidirectionalEntityCompositeKeyKey2] AND [u].[Key3] = [s].[UnidirectionalEntityCompositeKeyKey3]
 ORDER BY [u].[Key1], [u].[Key2], [u].[Key3], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 """);
@@ -2778,14 +2778,14 @@ FROM [UnidirectionalLeaves] AS [u]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+SELECT [u1].[Id], [u1].[Name], [u1].[Number], [u1].[IsGreen], [u1].[Discriminator]
 FROM (
     SELECT [u].[Id], [u].[Name], [u].[Number], NULL AS [IsGreen], N'UnidirectionalEntityBranch' AS [Discriminator]
     FROM [UnidirectionalBranches] AS [u]
     UNION ALL
     SELECT [u0].[Id], [u0].[Name], [u0].[Number], [u0].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
     FROM [UnidirectionalLeaves] AS [u0]
-) AS [t]
+) AS [u1]
 WHERE 0 = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
@@ -116,8 +116,8 @@ ORDER BY (
         UNION ALL
         SELECT [l].[Id], [l].[Name]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
+    ) AS [u] ON [j].[EntityBranchId] = [u].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [u].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -194,7 +194,7 @@ INNER JOIN (
 SELECT MIN([s].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [e0].[ThreeSkipSharedId]
+    SELECT [u].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id]
@@ -208,7 +208,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Id] = [s].[ThreeSkipSharedId]
 """);
     }
@@ -232,12 +232,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Key1], [e].[RootSkipSharedId]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 """);
     }
 
@@ -356,7 +356,7 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [s].[Id], [s].[Name], [s].[EntityBranchId]
     FROM (
@@ -365,7 +365,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e] ON [j].[EntityOneId] = [e].[Id]
     ) AS [s]
     WHERE [s].[row] <= 1
-) AS [s0] ON [t].[Id] = [s0].[EntityBranchId]
+) AS [s0] ON [u].[Id] = [s0].[EntityBranchId]
 """);
     }
 
@@ -415,7 +415,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[LeafId], [s].[CompositeId1], [
 SELECT [e].[Key1], [e].[Key2], [e].[Key3], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
@@ -429,8 +429,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] = N'EntityLeaf'
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
+    WHERE [u].[Discriminator] = N'EntityLeaf'
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 """);
@@ -495,12 +495,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 """);
     }
 
@@ -589,7 +589,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[ThreeSkipSharedId]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
@@ -603,8 +603,8 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
+    WHERE [u].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [s] ON [e].[Id] = [s].[ThreeSkipSharedId]
 """);
     }
@@ -618,7 +618,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [EntityOnes] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[EntityOneId]
+    SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator], [j].[EntityOneId]
     FROM [JoinOneToBranch] AS [j]
     INNER JOIN (
         SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -626,7 +626,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
+    ) AS [u] ON [j].[EntityBranchId] = [u].[Id]
 ) AS [s] ON [e].[Id] = [s].[EntityOneId]
 """);
     }
@@ -705,7 +705,7 @@ ORDER BY [e].[Id]
 SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Id], [s].[Name], [s].[Number], [s].[Slumber], [s].[IsGreen], [s].[IsBrown], [s].[Discriminator]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
@@ -719,7 +719,7 @@ LEFT JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3]
 """);
@@ -910,7 +910,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s0].[CompositeId1], [s0].[Composit
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId], [s0].[OneId], [s0].[ThreeId], [s0].[Payload], [s0].[Id0], [s0].[Name0]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId], [s0].[OneId], [s0].[ThreeId], [s0].[Payload], [s0].[Id0], [s0].[Name0]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -923,7 +923,7 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [s].[OneId], [s].[ThreeId], [s].[Payload], [s].[Id] AS [Id0], [s].[Name] AS [Name0]
     FROM [EntityRootEntityThree] AS [e]
@@ -934,8 +934,8 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
         WHERE [e1].[Id] < 10
     ) AS [s] ON [e0].[Id] = [s].[ThreeId]
-) AS [s0] ON [t].[Id] = [s0].[RootSkipSharedId]
-ORDER BY [t].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[OneId], [s0].[ThreeId]
+) AS [s0] ON [u].[Id] = [s0].[RootSkipSharedId]
+ORDER BY [u].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id], [s0].[OneId], [s0].[ThreeId]
 """);
     }
 
@@ -945,7 +945,7 @@ ORDER BY [t].[Id], [s0].[RootSkipSharedId], [s0].[ThreeSkipSharedId], [s0].[Id],
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[Name], [s1].[Id], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[ThreeId], [s1].[Id0], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[Name], [s1].[Id], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[ThreeId], [s1].[Id0], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -958,7 +958,7 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [s0].[Id], [s0].[CompositeId1], [s0].[CompositeId2], [s0].[CompositeId3], [s0].[ThreeId], [s0].[Id0], [s0].[CollectionInverseId], [s0].[Name] AS [Name0], [s0].[ReferenceInverseId]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
@@ -972,8 +972,8 @@ LEFT JOIN (
         ) AS [s]
         WHERE 1 < [s].[row] AND [s].[row] <= 3
     ) AS [s0] ON [e0].[Key1] = [s0].[CompositeId1] AND [e0].[Key2] = [s0].[CompositeId2] AND [e0].[Key3] = [s0].[CompositeId3]
-) AS [s1] ON [t].[Id] = [s1].[RootSkipSharedId]
-ORDER BY [t].[Id], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id0]
+) AS [s1] ON [u].[Id] = [s1].[RootSkipSharedId]
+ORDER BY [u].[Id], [s1].[RootSkipSharedId], [s1].[CompositeKeySkipSharedKey1], [s1].[CompositeKeySkipSharedKey2], [s1].[CompositeKeySkipSharedKey3], [s1].[Key1], [s1].[Key2], [s1].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id0]
 """);
     }
 
@@ -1098,7 +1098,7 @@ LEFT JOIN (
         WHERE 1 < [s].[row] AND [s].[row] <= 3
     ) AS [s0] ON [e0].[Id] = [s0].[OneId]
     LEFT JOIN (
-        SELECT [j1].[EntityBranchId], [j1].[EntityOneId], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+        SELECT [j1].[EntityBranchId], [j1].[EntityOneId], [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator]
         FROM [JoinOneToBranch] AS [j1]
         INNER JOIN (
             SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -1106,8 +1106,8 @@ LEFT JOIN (
             UNION ALL
             SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
             FROM [Leaves] AS [l]
-        ) AS [t] ON [j1].[EntityBranchId] = [t].[Id]
-        WHERE [t].[Id] < 20
+        ) AS [u] ON [j1].[EntityBranchId] = [u].[Id]
+        WHERE [u].[Id] < 20
     ) AS [s1] ON [e0].[Id] = [s1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [s2] ON [e].[Id] = [s2].[ThreeId]
@@ -1190,7 +1190,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]
 SELECT [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Id], [s].[Name], [s].[Number], [s].[Slumber], [s].[IsGreen], [s].[IsBrown], [s].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
@@ -1204,7 +1204,7 @@ INNER JOIN (
         UNION ALL
         SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
         FROM [Leaf2s] AS [l0]
-    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u] ON [e0].[RootSkipSharedId] = [u].[Id]
 ) AS [s] ON [e].[Key1] = [s].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [s].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [s].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]
 """);
@@ -1473,7 +1473,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [s0].[CompositeId1], [s0].[Composit
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -1486,12 +1486,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
-ORDER BY [t].[Id]
+) AS [u]
+ORDER BY [u].[Id]
 """,
             //
             """
-SELECT [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [t].[Id]
+SELECT [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [u].[Id]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1504,17 +1504,17 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 """,
             //
             """
-SELECT [s0].[OneId], [s0].[ThreeId], [s0].[Payload], [s0].[Id], [s0].[Name], [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+SELECT [s0].[OneId], [s0].[ThreeId], [s0].[Payload], [s0].[Id], [s0].[Name], [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1527,19 +1527,19 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id]
     FROM [EntityRootEntityThree] AS [e]
     INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 INNER JOIN (
     SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e1].[Id], [e1].[Name]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
     WHERE [e1].[Id] < 10
 ) AS [s0] ON [s].[Id] = [s0].[ThreeId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 """);
     }
 
@@ -1549,7 +1549,7 @@ ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[ThreeSkipSharedId], [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[Slumber], [u].[IsGreen], [u].[IsBrown], [u].[Discriminator]
 FROM (
     SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
@@ -1562,12 +1562,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
     FROM [Leaf2s] AS [l0]
-) AS [t]
-ORDER BY [t].[Id]
+) AS [u]
+ORDER BY [u].[Id]
 """,
             //
             """
-SELECT [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s].[Name], [t].[Id]
+SELECT [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s].[Name], [u].[Id]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1580,17 +1580,17 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
 """,
             //
             """
-SELECT [s1].[Id], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[ThreeId], [s1].[Id0], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId], [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
+SELECT [s1].[Id], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[ThreeId], [s1].[Id0], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId], [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3]
 FROM (
     SELECT [r].[Id]
     FROM [Roots] AS [r]
@@ -1603,12 +1603,12 @@ FROM (
     UNION ALL
     SELECT [l0].[Id]
     FROM [Leaf2s] AS [l0]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON [e].[CompositeKeySkipSharedKey1] = [e0].[Key1] AND [e].[CompositeKeySkipSharedKey2] = [e0].[Key2] AND [e].[CompositeKeySkipSharedKey3] = [e0].[Key3]
-) AS [s] ON [t].[Id] = [s].[RootSkipSharedId]
+) AS [s] ON [u].[Id] = [s].[RootSkipSharedId]
 INNER JOIN (
     SELECT [s0].[Id], [s0].[CompositeId1], [s0].[CompositeId2], [s0].[CompositeId3], [s0].[ThreeId], [s0].[Id0], [s0].[CollectionInverseId], [s0].[Name], [s0].[ReferenceInverseId]
     FROM (
@@ -1618,7 +1618,7 @@ INNER JOIN (
     ) AS [s0]
     WHERE 1 < [s0].[row] AND [s0].[row] <= 3
 ) AS [s1] ON [s].[Key1] = [s1].[CompositeId1] AND [s].[Key2] = [s1].[CompositeId2] AND [s].[Key3] = [s1].[CompositeId3]
-ORDER BY [t].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id0]
+ORDER BY [u].[Id], [s].[RootSkipSharedId], [s].[CompositeKeySkipSharedKey1], [s].[CompositeKeySkipSharedKey2], [s].[CompositeKeySkipSharedKey3], [s].[Key1], [s].[Key2], [s].[Key3], [s1].[CompositeId1], [s1].[CompositeId2], [s1].[CompositeId3], [s1].[Id0]
 """);
     }
 
@@ -1849,7 +1849,7 @@ INNER JOIN (
     WHERE [e0].[Id] < 10
 ) AS [s] ON [e].[Id] = [s].[ThreeId]
 INNER JOIN (
-    SELECT [j1].[EntityBranchId], [j1].[EntityOneId], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [j1].[EntityBranchId], [j1].[EntityOneId], [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator]
     FROM [JoinOneToBranch] AS [j1]
     INNER JOIN (
         SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
@@ -1857,8 +1857,8 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
-    ) AS [t] ON [j1].[EntityBranchId] = [t].[Id]
-    WHERE [t].[Id] < 20
+    ) AS [u] ON [j1].[EntityBranchId] = [u].[Id]
+    WHERE [u].[Id] < 20
 ) AS [s2] ON [s].[Id] = [s2].[EntityOneId]
 ORDER BY [e].[Id], [s].[OneId], [s].[ThreeId], [s].[Id]
 """);
@@ -2061,14 +2061,14 @@ FROM [Leaves] AS [l]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[Number], [u].[IsGreen], [u].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
     SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
-) AS [t]
+) AS [u]
 WHERE 0 = 1
 """);
     }
@@ -2205,8 +2205,8 @@ ORDER BY (
         UNION ALL
         SELECT [u2].[Id], [u2].[Name]
         FROM [UnidirectionalLeaves] AS [u2]
-    ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
+    ) AS [u3] ON [u0].[UnidirectionalEntityBranchId] = [u3].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [u3].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 
@@ -2254,7 +2254,7 @@ LEFT JOIN (
 SELECT [u].[Key1], [u].[Key2], [u].[Key3], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 FROM [UnidirectionalEntityCompositeKeys] AS [u]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
+    SELECT [u4].[Id], [u4].[Name], [u4].[Number], [u4].[IsGreen], [u4].[Discriminator], [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3]
     FROM [UnidirectionalEntityCompositeKeyUnidirectionalEntityRoot] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], NULL AS [Number], NULL AS [IsGreen], N'UnidirectionalEntityRoot' AS [Discriminator]
@@ -2265,8 +2265,8 @@ LEFT JOIN (
         UNION ALL
         SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u3]
-    ) AS [t] ON [u0].[RootSkipSharedId] = [t].[Id]
-    WHERE [t].[Discriminator] = N'UnidirectionalEntityLeaf'
+    ) AS [u4] ON [u0].[RootSkipSharedId] = [u4].[Id]
+    WHERE [u4].[Discriminator] = N'UnidirectionalEntityLeaf'
 ) AS [s] ON [u].[Key1] = [s].[UnidirectionalEntityCompositeKeyKey1] AND [u].[Key2] = [s].[UnidirectionalEntityCompositeKeyKey2] AND [u].[Key3] = [s].[UnidirectionalEntityCompositeKeyKey3]
 ORDER BY [u].[Key1], [u].[Key2], [u].[Key3], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 """);
@@ -2328,12 +2328,12 @@ FROM (
     UNION ALL
     SELECT [u1].[Id]
     FROM [UnidirectionalLeaves] AS [u1]
-) AS [t]
+) AS [u2]
 INNER JOIN (
-    SELECT [u3].[Id], [u3].[CollectionInverseId], [u3].[Name], [u3].[ReferenceInverseId], [u2].[UnidirectionalEntityRootId]
-    FROM [UnidirectionalEntityRootUnidirectionalEntityThree] AS [u2]
-    INNER JOIN [UnidirectionalEntityThrees] AS [u3] ON [u2].[ThreeSkipSharedId] = [u3].[Id]
-) AS [s] ON [t].[Id] = [s].[UnidirectionalEntityRootId]
+    SELECT [u4].[Id], [u4].[CollectionInverseId], [u4].[Name], [u4].[ReferenceInverseId], [u3].[UnidirectionalEntityRootId]
+    FROM [UnidirectionalEntityRootUnidirectionalEntityThree] AS [u3]
+    INNER JOIN [UnidirectionalEntityThrees] AS [u4] ON [u3].[ThreeSkipSharedId] = [u4].[Id]
+) AS [s] ON [u2].[Id] = [s].[UnidirectionalEntityRootId]
 """);
     }
 
@@ -2402,7 +2402,7 @@ INNER JOIN (
 SELECT [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [UnidirectionalEntityOnes] AS [u]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [u0].[UnidirectionalEntityOneId]
+    SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], [u3].[Discriminator], [u0].[UnidirectionalEntityOneId]
     FROM [UnidirectionalJoinOneToBranch] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], [u1].[Number], NULL AS [IsGreen], N'UnidirectionalEntityBranch' AS [Discriminator]
@@ -2410,7 +2410,7 @@ INNER JOIN (
         UNION ALL
         SELECT [u2].[Id], [u2].[Name], [u2].[Number], [u2].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u2]
-    ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
+    ) AS [u3] ON [u0].[UnidirectionalEntityBranchId] = [u3].[Id]
 ) AS [s] ON [u].[Id] = [s].[UnidirectionalEntityOneId]
 """);
     }
@@ -2440,7 +2440,7 @@ ORDER BY [u].[Id], [s].[LeftId], [s].[RightId]
 SELECT [u].[Key1], [u].[Key2], [u].[Key3], [u].[Name], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3], [s].[Id], [s].[Name], [s].[Number], [s].[IsGreen], [s].[Discriminator]
 FROM [UnidirectionalEntityCompositeKeys] AS [u]
 LEFT JOIN (
-    SELECT [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [u0].[RootSkipSharedId], [u0].[UnidirectionalEntityCompositeKeyKey1], [u0].[UnidirectionalEntityCompositeKeyKey2], [u0].[UnidirectionalEntityCompositeKeyKey3], [u4].[Id], [u4].[Name], [u4].[Number], [u4].[IsGreen], [u4].[Discriminator]
     FROM [UnidirectionalEntityCompositeKeyUnidirectionalEntityRoot] AS [u0]
     INNER JOIN (
         SELECT [u1].[Id], [u1].[Name], NULL AS [Number], NULL AS [IsGreen], N'UnidirectionalEntityRoot' AS [Discriminator]
@@ -2451,7 +2451,7 @@ LEFT JOIN (
         UNION ALL
         SELECT [u3].[Id], [u3].[Name], [u3].[Number], [u3].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u3]
-    ) AS [t] ON [u0].[RootSkipSharedId] = [t].[Id]
+    ) AS [u4] ON [u0].[RootSkipSharedId] = [u4].[Id]
 ) AS [s] ON [u].[Key1] = [s].[UnidirectionalEntityCompositeKeyKey1] AND [u].[Key2] = [s].[UnidirectionalEntityCompositeKeyKey2] AND [u].[Key3] = [s].[UnidirectionalEntityCompositeKeyKey3]
 ORDER BY [u].[Key1], [u].[Key2], [u].[Key3], [s].[RootSkipSharedId], [s].[UnidirectionalEntityCompositeKeyKey1], [s].[UnidirectionalEntityCompositeKeyKey2], [s].[UnidirectionalEntityCompositeKeyKey3]
 """);
@@ -2802,14 +2802,14 @@ FROM [UnidirectionalLeaves] AS [u]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+SELECT [u1].[Id], [u1].[Name], [u1].[Number], [u1].[IsGreen], [u1].[Discriminator]
 FROM (
     SELECT [u].[Id], [u].[Name], [u].[Number], NULL AS [IsGreen], N'UnidirectionalEntityBranch' AS [Discriminator]
     FROM [UnidirectionalBranches] AS [u]
     UNION ALL
     SELECT [u0].[Id], [u0].[Name], [u0].[Number], [u0].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
     FROM [UnidirectionalLeaves] AS [u0]
-) AS [t]
+) AS [u1]
 WHERE 0 = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCRelationshipsQuerySqlServerTest.cs
@@ -25,19 +25,19 @@ public class TPCRelationshipsQuerySqlServerTest
 
         AssertSql(
             """
-SELECT [s].[Id], [s].[Name], [s].[BaseId], [s].[Discriminator], [s].[BaseInheritanceRelationshipEntityId], [s].[Id1], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [s].[Id0], [s].[Name0], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [s].[OwnedReferenceOnDerived_Id], [s].[OwnedReferenceOnDerived_Name], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator]
+SELECT [s].[Id], [s].[Name], [s].[BaseId], [s].[Discriminator], [s].[BaseInheritanceRelationshipEntityId], [s].[Id1], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [s].[Id0], [s].[Name0], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [s].[OwnedReferenceOnDerived_Id], [s].[OwnedReferenceOnDerived_Name], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator]
 FROM (
-    SELECT TOP(2) [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [o].[Id] AS [Id0], [o].[Name] AS [Name0], [d0].[Id] AS [Id1], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+    SELECT TOP(2) [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [o].[Id] AS [Id0], [o].[Name] AS [Name0], [d0].[Id] AS [Id1], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
     FROM (
         SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
         FROM [BaseEntities] AS [b]
         UNION ALL
         SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
         FROM [DerivedEntities] AS [d]
-    ) AS [t]
-    LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-    LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-    WHERE [t].[Name] = N'Derived1(4)'
+    ) AS [u]
+    LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+    LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+    WHERE [u].[Name] = N'Derived1(4)'
 ) AS [s]
 LEFT JOIN [OwnedCollections] AS [o0] ON [s].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [s].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
@@ -47,7 +47,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d2]
-) AS [t0] ON [s].[Id] = [t0].[BaseParentId]
+) AS [u0] ON [s].[Id] = [u0].[BaseParentId]
 ORDER BY [s].[Id], [s].[BaseInheritanceRelationshipEntityId], [s].[Id1], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
@@ -58,20 +58,20 @@ ORDER BY [s].[Id], [s].[BaseInheritanceRelationshipEntityId], [s].[Id1], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-LEFT JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [u].[Id] = [c].[ParentId]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -81,7 +81,7 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -89,12 +89,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -104,21 +104,21 @@ ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-LEFT JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [u].[Id] = [c].[ParentId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -128,7 +128,7 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -136,13 +136,13 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -152,26 +152,26 @@ ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d2]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -181,7 +181,7 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
@@ -192,7 +192,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [d1].[Id], [d1].[BaseParentId], [d1].[Name], [d1].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d1]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]
 """);
     }
@@ -203,7 +203,7 @@ ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInherita
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[Id], [u].[Name], [u].[ParentId], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
@@ -214,7 +214,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [d1].[Id], [d1].[Name], [d1].[ParentId], [d1].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
     FROM [DerivedCollectionsOnDerived] AS [d1]
-) AS [t] ON [d].[Id] = [t].[ParentId]
+) AS [u] ON [d].[Id] = [u].[ParentId]
 ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]
 """);
     }
@@ -241,19 +241,19 @@ ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInherita
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentId], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
     FROM [BaseCollectionsOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
     FROM [DerivedCollectionsOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[ParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -263,26 +263,26 @@ ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -292,27 +292,27 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d2]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -322,27 +322,27 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -352,20 +352,20 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [ReferencesOnBase] AS [r] ON [t].[Id] = [r].[ParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [ReferencesOnBase] AS [r] ON [u].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -423,7 +423,7 @@ ORDER BY [r].[Id], [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[Ba
 
         AssertSql(
             """
-SELECT [r].[Id], [r].[Name], [r].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [r].[Id], [r].[Name], [r].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [ReferencesOnBase] AS [r]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -431,12 +431,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [r].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u] ON [r].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [r].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -446,21 +446,21 @@ ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [ReferencesOnBase] AS [r] ON [t].[Id] = [r].[ParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [ReferencesOnBase] AS [r] ON [u].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -470,7 +470,7 @@ ORDER BY [t].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id
 
         AssertSql(
             """
-SELECT [r].[Id], [r].[Name], [r].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [r].[Id], [r].[Name], [r].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [ReferencesOnBase] AS [r]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -478,13 +478,13 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [r].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u] ON [r].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE [r].[Name] <> N'Bar' OR [r].[Name] IS NULL
-ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [r].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -494,26 +494,26 @@ ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -523,7 +523,7 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
@@ -531,11 +531,11 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -545,7 +545,7 @@ ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[Ba
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
@@ -553,11 +553,11 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
     FROM [DerivedReferencesOnDerived] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -583,19 +583,19 @@ ORDER BY [d].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
     FROM [BaseReferencesOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
     FROM [DerivedReferencesOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[BaseParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[BaseParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -605,7 +605,7 @@ ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[B
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
@@ -613,12 +613,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE [d].[Name] <> N'Bar' OR [d].[Name] IS NULL
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -628,7 +628,7 @@ ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[Ba
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
@@ -636,12 +636,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
     FROM [DerivedReferencesOnDerived] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE [d].[Name] <> N'Bar' OR [d].[Name] IS NULL
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -668,20 +668,20 @@ ORDER BY [d].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
     FROM [BaseReferencesOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
     FROM [DerivedReferencesOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[BaseParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[BaseParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -691,26 +691,26 @@ ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -720,27 +720,27 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -750,27 +750,27 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -780,23 +780,23 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d0].[Name], [d0].[BaseId], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d0].[Name], [d0].[BaseId], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[BaseId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[BaseId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o2] ON [d0].[Id] = [o2].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [d0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d3].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -806,7 +806,7 @@ ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Name], [t].[BaseId], [t].[Discriminator], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[Name], [u].[BaseId], [u].[Discriminator], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -814,15 +814,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t] ON [d].[BaseId] = [t].[Id]
+) AS [u] ON [d].[BaseId] = [u].[Id]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 LEFT JOIN [OwnedCollections] AS [o1] ON [d].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [d].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-LEFT JOIN [OwnedCollections] AS [o2] ON [t].[Id] = [o2].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d3].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o2] ON [u].[Id] = [o2].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d3].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -849,36 +849,36 @@ ORDER BY [r].[Id], [s].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN (
-    SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id] AS [Id0], [t1].[Name] AS [Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator] AS [Discriminator0]
+    SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id] AS [Id0], [u1].[Name] AS [Name0], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator] AS [Discriminator0]
     FROM (
         SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
         FROM [BaseCollectionsOnBase] AS [b0]
         UNION ALL
         SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
         FROM [DerivedCollectionsOnBase] AS [d2]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
         FROM [NestedCollections] AS [n]
         UNION ALL
         SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
         FROM [NestedCollectionsDerived] AS [n0]
-    ) AS [t1] ON [t0].[Id] = [t1].[ParentCollectionId]
-) AS [s] ON [t].[Id] = [s].[BaseParentId]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [s].[Id]
+    ) AS [u1] ON [u0].[Id] = [u1].[ParentCollectionId]
+) AS [s] ON [u].[Id] = [s].[BaseParentId]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [s].[Id]
 """);
     }
 
@@ -888,33 +888,33 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -924,36 +924,36 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityI
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN (
-    SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id] AS [Id0], [t1].[Name] AS [Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator] AS [Discriminator0]
+    SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id] AS [Id0], [u1].[Name] AS [Name0], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator] AS [Discriminator0]
     FROM (
         SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
         FROM [BaseCollectionsOnBase] AS [b0]
         UNION ALL
         SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
         FROM [DerivedCollectionsOnBase] AS [d2]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
         FROM [NestedReferences] AS [n]
         UNION ALL
         SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
         FROM [NestedReferencesDerived] AS [n0]
-    ) AS [t1] ON [t0].[Id] = [t1].[ParentCollectionId]
-) AS [s] ON [t].[Id] = [s].[BaseParentId]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [s].[Id]
+    ) AS [u1] ON [u0].[Id] = [u1].[ParentCollectionId]
+) AS [s] ON [u].[Id] = [s].[BaseParentId]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [s].[Id]
 """);
     }
 
@@ -963,33 +963,33 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -999,33 +999,33 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityI
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t1] ON [t0].[Id] = [t1].[ParentReferenceId]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[Id] = [u1].[ParentReferenceId]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -1035,7 +1035,7 @@ ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[ParentCollectionId], [u0].[ParentReferenceId], [u0].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
@@ -1043,7 +1043,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
@@ -1053,8 +1053,8 @@ LEFT JOIN (
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[ParentReferenceId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1064,33 +1064,33 @@ ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[Ba
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+) AS [u0] ON [u].[ParentReferenceId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -1100,33 +1100,33 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityI
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Name], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator], [u1].[Name], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
 LEFT JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t1] ON [t0].[Id] = [t1].[ParentReferenceId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u1] ON [u0].[Id] = [u1].[ParentReferenceId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -1136,7 +1136,7 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityI
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[Discriminator], [u0].[Name], [u0].[ParentCollectionId], [u0].[ParentReferenceId], [u0].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
@@ -1144,18 +1144,18 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+) AS [u0] ON [u].[Id] = [u0].[ParentReferenceId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -1165,33 +1165,33 @@ ORDER BY [d].[Id], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+) AS [u0] ON [u].[ParentReferenceId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]
 """);
     }
 
@@ -1201,22 +1201,22 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityI
 
         AssertSql(
             """
-SELECT [t].[Id], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator]
+SELECT [u].[Id], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+ORDER BY [u].[Id]
 """);
     }
 
@@ -1226,21 +1226,21 @@ ORDER BY [t].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d2].[Id], [d2].[Name], [d2].[ParentId], [d2].[DerivedInheritanceRelationshipEntityId]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d2].[Id], [d2].[Name], [d2].[ParentId], [d2].[DerivedInheritanceRelationshipEntityId]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedCollectionsOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Id] >= 4
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+LEFT JOIN [OwnedCollections] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [u].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedCollectionsOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Id] >= 4
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1250,68 +1250,68 @@ ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o0].[B
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 INNER JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d3]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1321,68 +1321,68 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t0].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t0].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u0].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u0].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t0].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u0].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -1392,72 +1392,72 @@ ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 INNER JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d3]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1467,71 +1467,71 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator], [u0].[Id], [u0].[Name], [u0].[BaseId], [u0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t0].[Id] = [d1].[Id]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u0].[Id] = [d1].[Id]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t0].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t0].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u0].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u0].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t0].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[BaseParentId] = [u0].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u0].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -1541,62 +1541,62 @@ ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [CollectionsOnBase] AS [c] ON [u].[Id] = [c].[ParentId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1606,7 +1606,7 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 
         AssertSql(
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -1614,14 +1614,14 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+ORDER BY [c].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id]
@@ -1629,15 +1629,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id]
@@ -1645,11 +1645,11 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1659,66 +1659,66 @@ ORDER BY [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[I
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id], [b].[Name]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
-WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [CollectionsOnBase] AS [c] ON [u].[Id] = [c].[ParentId]
+WHERE [u].[Name] <> N'Bar' OR [u].[Name] IS NULL
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1728,7 +1728,7 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 
         AssertSql(
             """
-SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [c].[Id], [c].[Name], [c].[ParentId], [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
@@ -1736,15 +1736,15 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
 WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+ORDER BY [c].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id]
@@ -1752,16 +1752,16 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
 WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+ORDER BY [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN (
     SELECT [b].[Id]
@@ -1769,12 +1769,12 @@ LEFT JOIN (
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t] ON [c].[ParentId] = [t].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+) AS [u] ON [c].[ParentId] = [u].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
 WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+ORDER BY [c].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -1807,7 +1807,7 @@ ORDER BY [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [u].[Id], [u].[BaseParentId], [u].[Name], [u].[DerivedProperty], [u].[Discriminator], [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN (
@@ -1816,7 +1816,7 @@ INNER JOIN (
     UNION ALL
     SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d2]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 ORDER BY [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """);
     }
@@ -1849,7 +1849,7 @@ ORDER BY [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [u].[Id], [u].[Name], [u].[ParentId], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator], [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN (
@@ -1858,7 +1858,7 @@ INNER JOIN (
     UNION ALL
     SELECT [d2].[Id], [d2].[Name], [d2].[ParentId], [d2].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
     FROM [DerivedCollectionsOnDerived] AS [d2]
-) AS [t] ON [d].[Id] = [t].[ParentId]
+) AS [u] ON [d].[Id] = [u].[ParentId]
 ORDER BY [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """);
     }
@@ -1906,47 +1906,47 @@ ORDER BY [d].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentId], [u].[DerivedInheritanceRelationshipEntityId], [u].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
     FROM [BaseCollectionsOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
     FROM [DerivedCollectionsOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[ParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM (
     SELECT [b].[Id], [b].[ParentId]
     FROM [BaseCollectionsOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[ParentId]
     FROM [DerivedCollectionsOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[ParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN [OwnedCollections] AS [o1] ON [d0].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM (
     SELECT [b].[Id], [b].[ParentId]
     FROM [BaseCollectionsOnDerived] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[ParentId]
     FROM [DerivedCollectionsOnDerived] AS [d]
-) AS [t]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+) AS [u]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[ParentId] = [d0].[Id]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [d0].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """);
     }
 
@@ -1956,96 +1956,96 @@ ORDER BY [t].[Id], [d0].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+ORDER BY [u].[Id], [u0].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [t1].[Id], [t1].[Name], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator], [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [u1].[Id], [u1].[Name], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator], [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId]
     FROM [BaseReferencesOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t].[Id] = [d2].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u].[Id] = [d2].[Id]
 INNER JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t1] ON [t0].[Id] = [t1].[ParentReferenceId]
-ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[Id] = [u1].[ParentReferenceId]
+ORDER BY [u].[Id], [u0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -2055,7 +2055,7 @@ ORDER BY [t].[Id], [t0].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[
 
         AssertSql(
             """
-SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+SELECT [d].[Id], [d].[Name], [d].[BaseId], [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [u].[BaseParentId], [u].[Name], [u].[Discriminator]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
@@ -2063,13 +2063,13 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
@@ -2077,14 +2077,14 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN [OwnedCollections] AS [o1] ON [d].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
@@ -2092,14 +2092,14 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [d].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """,
             //
             """
-SELECT [t0].[Id], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator], [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+SELECT [u0].[Id], [u0].[Name], [u0].[ParentCollectionId], [u0].[ParentReferenceId], [u0].[Discriminator], [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 FROM [DerivedEntities] AS [d]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
@@ -2107,7 +2107,7 @@ LEFT JOIN (
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d0]
-) AS [t] ON [d].[Id] = [t].[BaseParentId]
+) AS [u] ON [d].[Id] = [u].[BaseParentId]
 LEFT JOIN [OwnedReferences] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
 INNER JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
@@ -2115,8 +2115,8 @@ INNER JOIN (
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
-ORDER BY [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
+) AS [u0] ON [u].[Id] = [u0].[ParentReferenceId]
+ORDER BY [d].[Id], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 """);
     }
 
@@ -2126,89 +2126,89 @@ ORDER BY [d].[Id], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+) AS [u0] ON [u].[ParentReferenceId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentReferenceId]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentReferenceId]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+) AS [u0] ON [u].[ParentReferenceId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentReferenceId]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentReferenceId]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseReferencesOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedReferencesOnBase] AS [d]
-) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+) AS [u0] ON [u].[ParentReferenceId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -2218,78 +2218,78 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntity
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0] AS [Discriminator], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [s].[Id], [s].[BaseParentId], [s].[Name], [s].[DerivedProperty], [s].[Discriminator], [s].[Id0], [s].[Name0], [s].[ParentCollectionId], [s].[ParentReferenceId], [s].[Discriminator0] AS [Discriminator], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 INNER JOIN (
-    SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id] AS [Id0], [t1].[Name] AS [Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator] AS [Discriminator0]
+    SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id] AS [Id0], [u1].[Name] AS [Name0], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator] AS [Discriminator0]
     FROM (
         SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
         FROM [BaseCollectionsOnBase] AS [b0]
         UNION ALL
         SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
         FROM [DerivedCollectionsOnBase] AS [d3]
-    ) AS [t0]
+    ) AS [u0]
     LEFT JOIN (
         SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
         FROM [NestedReferences] AS [n]
         UNION ALL
         SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
         FROM [NestedReferencesDerived] AS [n0]
-    ) AS [t1] ON [t0].[Id] = [t1].[ParentCollectionId]
-) AS [s] ON [t].[Id] = [s].[BaseParentId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+    ) AS [u1] ON [u0].[Id] = [u1].[ParentCollectionId]
+) AS [s] ON [u].[Id] = [s].[BaseParentId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 
@@ -2299,89 +2299,89 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentCollectionId]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentCollectionId]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentCollectionId]
     FROM [NestedReferences] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentCollectionId]
     FROM [NestedReferencesDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -2391,96 +2391,96 @@ ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntity
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 INNER JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d3]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [t0].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [u0].[Id]
 """,
             //
             """
-SELECT [t1].[Id], [t1].[Name], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [t0].[Id]
+SELECT [u1].[Id], [u1].[Name], [u1].[ParentCollectionId], [u1].[ParentReferenceId], [u1].[Discriminator], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [u0].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
 INNER JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d3].[Id], [d3].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d3]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
 INNER JOIN (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t1] ON [t0].[Id] = [t1].[ParentCollectionId]
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [t0].[Id]
+) AS [u1] ON [u0].[Id] = [u1].[ParentCollectionId]
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [u0].[Id]
 """);
     }
 
@@ -2490,89 +2490,89 @@ ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id], [t0].[
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[ParentCollectionId], [u].[ParentReferenceId], [u].[Discriminator], [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u1].[Id], [u1].[Name], [u1].[BaseId], [u1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id], [o].[Id], [o].[Name], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t1].[Id] = [d1].[Id]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [u1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u1].[Id] = [d1].[Id]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentCollectionId]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentCollectionId]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u1].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """,
             //
             """
-SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 FROM (
     SELECT [n].[Id], [n].[ParentCollectionId]
     FROM [NestedCollections] AS [n]
     UNION ALL
     SELECT [n0].[Id], [n0].[ParentCollectionId]
     FROM [NestedCollectionsDerived] AS [n0]
-) AS [t]
+) AS [u]
 LEFT JOIN (
     SELECT [b].[Id], [b].[BaseParentId]
     FROM [BaseCollectionsOnBase] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[BaseParentId]
     FROM [DerivedCollectionsOnBase] AS [d]
-) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+) AS [u0] ON [u].[ParentCollectionId] = [u0].[Id]
 LEFT JOIN (
     SELECT [b0].[Id]
     FROM [BaseEntities] AS [b0]
     UNION ALL
     SELECT [d0].[Id]
     FROM [DerivedEntities] AS [d0]
-) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d2] ON [t1].[Id] = [d2].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
+) AS [u1] ON [u0].[BaseParentId] = [u1].[Id]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d2] ON [u1].[Id] = [d2].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [u1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [u].[Id], [u0].[Id], [u1].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d2].[Id]
 """);
     }
 
@@ -2605,34 +2605,34 @@ ORDER BY [r].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id]
+SELECT [u].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-ORDER BY [t].[Id]
+) AS [u]
+ORDER BY [u].[Id]
 """,
             //
             """
-SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t].[Id]
+SELECT [u0].[Id], [u0].[BaseParentId], [u0].[Name], [u0].[DerivedProperty], [u0].[Discriminator], [u].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
+) AS [u]
 INNER JOIN (
     SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
     FROM [BaseCollectionsOnBase] AS [b0]
     UNION ALL
     SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
     FROM [DerivedCollectionsOnBase] AS [d0]
-) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id]
+) AS [u0] ON [u].[Id] = [u0].[BaseParentId]
+ORDER BY [u].[Id]
 """);
     }
 
@@ -2642,66 +2642,66 @@ ORDER BY [t].[Id]
 
         AssertSql(
             """
-SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+SELECT [u].[Id], [u].[Name], [u].[BaseId], [u].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
 FROM (
     SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[Id]
-WHERE [t].[Id] >= 4
-ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o] ON [u].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d0] ON [u].[Id] = [d0].[Id]
+WHERE [u].[Id] >= 4
+ORDER BY [u].[Id], [o].[BaseInheritanceRelationshipEntityId], [d0].[Id]
 """,
             //
             """
-SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
-WHERE [t].[Id] >= 4
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [OwnedCollections] AS [o1] ON [u].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+WHERE [u].[Id] >= 4
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Id] >= 4
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [u].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Id] >= 4
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """,
             //
             """
-SELECT [d3].[Id], [d3].[Name], [d3].[ParentId], [d3].[DerivedInheritanceRelationshipEntityId], [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+SELECT [d3].[Id], [d3].[Name], [d3].[ParentId], [d3].[DerivedInheritanceRelationshipEntityId], [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 FROM (
     SELECT [b].[Id]
     FROM [BaseEntities] AS [b]
     UNION ALL
     SELECT [d].[Id]
     FROM [DerivedEntities] AS [d]
-) AS [t]
-LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
-LEFT JOIN [DerivedEntities] AS [d1] ON [t].[Id] = [d1].[Id]
-INNER JOIN [DerivedCollectionsOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
-WHERE [t].[Id] >= 4
-ORDER BY [t].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
+) AS [u]
+LEFT JOIN [OwnedReferences] AS [o0] ON [u].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities] AS [d1] ON [u].[Id] = [d1].[Id]
+INNER JOIN [DerivedCollectionsOnDerived] AS [d3] ON [u].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [u].[Id] >= 4
+ORDER BY [u].[Id], [o0].[BaseInheritanceRelationshipEntityId], [d1].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
@@ -39,14 +39,14 @@ VALUES (@p0, @p1);");
 
         AssertSql(
             """
-SELECT TOP(2) [t].[Id], [t].[Name], [t].[PrincipalId], [t].[Discriminator]
+SELECT TOP(2) [u].[Id], [u].[Name], [u].[PrincipalId], [u].[Discriminator]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[PrincipalId], N'Category' AS [Discriminator]
     FROM [Categories] AS [c]
     UNION ALL
     SELECT [s].[Id], [s].[Name], [s].[PrincipalId], N'SpecialCategory' AS [Discriminator]
     FROM [SpecialCategory] AS [s]
-) AS [t]
+) AS [u]
 """,
             //
             """
@@ -69,14 +69,14 @@ WHERE [Id] = @p1;
 """,
             //
             """
-SELECT TOP(2) [t].[Id], [t].[Name], [t].[PrincipalId], [t].[Discriminator]
+SELECT TOP(2) [u].[Id], [u].[Name], [u].[PrincipalId], [u].[Discriminator]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[PrincipalId], N'Category' AS [Discriminator]
     FROM [Categories] AS [c]
     UNION ALL
     SELECT [s].[Id], [s].[Name], [s].[PrincipalId], N'SpecialCategory' AS [Discriminator]
     FROM [SpecialCategory] AS [s]
-) AS [t]
+) AS [u]
 """,
             //
             """

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -45,8 +45,8 @@ WHERE (
         UNION ALL
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "t"."CountryId" = 1 AND "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "u"."CountryId" = 1 AND "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -62,8 +62,8 @@ WHERE (
     FROM (
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "t"."CountryId" = 1 AND "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "u"."CountryId" = 1 AND "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -163,8 +163,8 @@ WHERE (
         UNION ALL
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "t"."CountryId" = 1 AND "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "u"."CountryId" = 1 AND "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -194,8 +194,8 @@ WHERE (
     FROM (
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "t"."CountryId" = 1 AND "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "u"."CountryId" = 1 AND "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
@@ -45,8 +45,8 @@ WHERE (
         UNION ALL
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -62,8 +62,8 @@ WHERE (
     FROM (
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -161,8 +161,8 @@ WHERE (
         UNION ALL
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 
@@ -191,8 +191,8 @@ WHERE (
     FROM (
         SELECT "k"."CountryId"
         FROM "Kiwi" AS "k"
-    ) AS "t"
-    WHERE "c"."Id" = "t"."CountryId" AND "t"."CountryId" > 0) > 0
+    ) AS "u"
+    WHERE "c"."Id" = "u"."CountryId" AND "u"."CountryId" > 0) > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
@@ -215,7 +215,7 @@ LEFT JOIN "OwnedReferencePart3" AS "o1" ON "o"."LeafEntityId" = "o1"."LeafEntity
 
         AssertSql(
             """
-SELECT "t"."Id", "t"."BaseValue", "t"."MiddleValue", "t"."SiblingValue", "t"."LeafValue", "t"."Discriminator", "o"."LeafEntityId", "o"."Id", "o"."OwnedIntValue1", "o"."OwnedIntValue2", "o1"."OwnedIntValue3", "o0"."OwnedIntValue4", "o"."OwnedStringValue1", "o"."OwnedStringValue2", "o1"."OwnedStringValue3", "o0"."OwnedStringValue4"
+SELECT "u"."Id", "u"."BaseValue", "u"."MiddleValue", "u"."SiblingValue", "u"."LeafValue", "u"."Discriminator", "o"."LeafEntityId", "o"."Id", "o"."OwnedIntValue1", "o"."OwnedIntValue2", "o1"."OwnedIntValue3", "o0"."OwnedIntValue4", "o"."OwnedStringValue1", "o"."OwnedStringValue2", "o1"."OwnedStringValue3", "o0"."OwnedStringValue4"
 FROM (
     SELECT "b"."Id", "b"."BaseValue", NULL AS "MiddleValue", NULL AS "SiblingValue", NULL AS "LeafValue", 'BaseEntity' AS "Discriminator"
     FROM "BaseEntity" AS "b"
@@ -228,8 +228,8 @@ FROM (
     UNION ALL
     SELECT "l"."Id", "l"."BaseValue", "l"."MiddleValue", NULL AS "SiblingValue", "l"."LeafValue", 'LeafEntity' AS "Discriminator"
     FROM "LeafEntity" AS "l"
-) AS "t"
-LEFT JOIN "OwnedReferencePart1" AS "o" ON "t"."Id" = "o"."LeafEntityId"
+) AS "u"
+LEFT JOIN "OwnedReferencePart1" AS "o" ON "u"."Id" = "o"."LeafEntityId"
 LEFT JOIN "OwnedReferencePart4" AS "o0" ON "o"."LeafEntityId" = "o0"."LeafEntityId"
 LEFT JOIN "OwnedReferencePart3" AS "o1" ON "o"."LeafEntityId" = "o1"."LeafEntityId"
 """);
@@ -370,7 +370,7 @@ ORDER BY "b"."Id", "s0"."LeafEntityId"
 
         AssertSql(
             """
-SELECT "t"."Id", "t"."BaseValue", "t"."MiddleValue", "t"."SiblingValue", "t"."LeafValue", "t"."Discriminator", "s0"."LeafEntityId", "s0"."Id", "s0"."OwnedIntValue1", "s0"."OwnedIntValue2", "s0"."OwnedIntValue3", "s0"."OwnedIntValue4", "s0"."OwnedStringValue1", "s0"."OwnedStringValue2", "s0"."OwnedStringValue3", "s0"."OwnedStringValue4"
+SELECT "u"."Id", "u"."BaseValue", "u"."MiddleValue", "u"."SiblingValue", "u"."LeafValue", "u"."Discriminator", "s0"."LeafEntityId", "s0"."Id", "s0"."OwnedIntValue1", "s0"."OwnedIntValue2", "s0"."OwnedIntValue3", "s0"."OwnedIntValue4", "s0"."OwnedStringValue1", "s0"."OwnedStringValue2", "s0"."OwnedStringValue3", "s0"."OwnedStringValue4"
 FROM (
     SELECT "b"."Id", "b"."BaseValue", NULL AS "MiddleValue", NULL AS "SiblingValue", NULL AS "LeafValue", 'BaseEntity' AS "Discriminator"
     FROM "BaseEntity" AS "b"
@@ -383,14 +383,14 @@ FROM (
     UNION ALL
     SELECT "l"."Id", "l"."BaseValue", "l"."MiddleValue", NULL AS "SiblingValue", "l"."LeafValue", 'LeafEntity' AS "Discriminator"
     FROM "LeafEntity" AS "l"
-) AS "t"
+) AS "u"
 LEFT JOIN (
     SELECT "o"."LeafEntityId", "o"."Id", "o"."OwnedIntValue1", "o"."OwnedIntValue2", "o1"."OwnedIntValue3", "o0"."OwnedIntValue4", "o"."OwnedStringValue1", "o"."OwnedStringValue2", "o1"."OwnedStringValue3", "o0"."OwnedStringValue4"
     FROM "OwnedReferencePart1" AS "o"
     INNER JOIN "OwnedReferencePart4" AS "o0" ON "o"."LeafEntityId" = "o0"."LeafEntityId" AND "o"."Id" = "o0"."Id"
     INNER JOIN "OwnedReferencePart3" AS "o1" ON "o"."LeafEntityId" = "o1"."LeafEntityId" AND "o"."Id" = "o1"."Id"
-) AS "s0" ON "t"."Id" = "s0"."LeafEntityId"
-ORDER BY "t"."Id", "s0"."LeafEntityId"
+) AS "s0" ON "u"."Id" = "s0"."LeafEntityId"
+ORDER BY "u"."Id", "s0"."LeafEntityId"
 """);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPCGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPCGearsOfWarQuerySqliteTest.cs
@@ -371,16 +371,16 @@ WHERE "s"."Banner5" = @__byteArrayParam_0
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
 WHERE (
-    SELECT "t"."Nickname"
+    SELECT "u"."Nickname"
     FROM (
         SELECT "g"."Nickname", "g"."SquadId"
         FROM "Gears" AS "g"
         UNION ALL
         SELECT "o"."Nickname", "o"."SquadId"
         FROM "Officers" AS "o"
-    ) AS "t"
-    WHERE "s"."Id" = "t"."SquadId"
-    ORDER BY "t"."Nickname"
+    ) AS "u"
+    WHERE "s"."Id" = "u"."SquadId"
+    ORDER BY "u"."Nickname"
     LIMIT 1 OFFSET "s"."Id") = 'Cole Train'
 """);
     }


### PR DESCRIPTION
Our current TPC design uses a special TableExpressionBase - TpcTablesExpression - to represent the potential set of table queries that will be needed. In postprocessing, TpcTablesExpressionRemovingExpressionVisitor reduces TpcTablesExpression to actual unioned subqueries, based on the concrete entity types that are actually needed.

This refactor does two main things:
* It removes `_tpcDiscriminatorValues` from SelectExpression. This was private state which specified - for each TpcTablesExpression contained in the SelectExpression - the discriminator column and actual needed discriminator values. This information was moved onto TpcTablesExpression itself.
* Make TpcTablesExpressionRemovingExpressionVisitor a fully immutable visitor, rather than mutating the tree.