### PR TITLE
Stop using case-insensitive comparisons for indexed properties

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -151,7 +151,7 @@ public readonly record struct RelationalTypeMappingInfo
         int? scale)
     {
         // Note: Empty string is allowed for store type name because SQLite
-        _coreTypeMappingInfo = new TypeMappingInfo(null, null, false, unicode, size, null, precision, scale);
+        _coreTypeMappingInfo = new TypeMappingInfo(null, null, false, unicode, size, null, precision, scale, false);
         StoreTypeName = storeTypeName;
         StoreTypeNameBase = storeTypeNameBase;
         IsFixedLength = null;
@@ -225,6 +225,7 @@ public readonly record struct RelationalTypeMappingInfo
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="dbType">The suggested <see cref="DbType" />, or <see langword="null" /> for default.</param>
+    /// <param name="key">If <see langword="true" />, then a special mapping for a key may be returned.</param>
     public RelationalTypeMappingInfo(
         Type? type = null,
         RelationalTypeMapping? elementTypeMapping = null,
@@ -237,9 +238,10 @@ public readonly record struct RelationalTypeMappingInfo
         bool? fixedLength = null,
         int? precision = null,
         int? scale = null,
-        DbType? dbType = null)
+        DbType? dbType = null,
+        bool key = false)
     {
-        _coreTypeMappingInfo = new TypeMappingInfo(type, elementTypeMapping, keyOrIndex, unicode, size, rowVersion, precision, scale);
+        _coreTypeMappingInfo = new TypeMappingInfo(type, elementTypeMapping, keyOrIndex, unicode, size, rowVersion, precision, scale, key);
 
         IsFixedLength = fixedLength;
         StoreTypeName = storeTypeName;
@@ -278,7 +280,8 @@ public readonly record struct RelationalTypeMappingInfo
             size ?? typeMappingConfiguration.GetMaxLength(),
             rowVersion: false,
             precision ?? typeMappingConfiguration.GetPrecision(),
-            scale ?? typeMappingConfiguration.GetScale());
+            scale ?? typeMappingConfiguration.GetScale(),
+            key: false);
 
         IsFixedLength = (bool?)typeMappingConfiguration[RelationalAnnotationNames.IsFixedLength];
         StoreTypeName = storeTypeName;
@@ -339,7 +342,16 @@ public readonly record struct RelationalTypeMappingInfo
     public DbType? DbType { get; init; }
 
     /// <summary>
-    ///     Indicates whether or not the mapping is part of a key or index.
+    ///     Indicates whether or not the mapping is part of a key or foreign key.
+    /// </summary>
+    public bool IsKey
+    {
+        get => _coreTypeMappingInfo.IsKey;
+        init => _coreTypeMappingInfo = _coreTypeMappingInfo with { IsKey = value };
+    }
+
+    /// <summary>
+    ///     Indicates whether or not the mapping is part of a key, foreign key, or index.
     /// </summary>
     public bool IsKeyOrIndex
     {

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -338,7 +338,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                     size: size,
                     fixedLength: isFixedLength,
                     storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None,
-                    useKeyComparison: mappingInfo.IsKeyOrIndex);
+                    useKeyComparison: mappingInfo.IsKey);
             }
 
             if (clrType == typeof(byte[]))

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -182,7 +182,8 @@ public readonly record struct TypeMappingInfo
         var property = principals[0];
 
         ElementTypeMapping = property.GetElementType()?.FindTypeMapping();
-        IsKeyOrIndex = property.IsKey() || property.IsForeignKey() || property.IsIndex();
+        IsKey = property.IsKey() || property.IsForeignKey();
+        IsKeyOrIndex = IsKey || property.IsIndex();
         Size = fallbackSize ?? mappingHints?.Size;
         IsUnicode = fallbackUnicode ?? mappingHints?.IsUnicode;
         IsRowVersion = property is { IsConcurrencyToken: true, ValueGenerated: ValueGenerated.OnAddOrUpdate };
@@ -246,6 +247,7 @@ public readonly record struct TypeMappingInfo
     /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="key">If <see langword="true" />, then a special mapping for a key may be returned.</param>
     public TypeMappingInfo(
         Type? type = null,
         CoreTypeMapping? elementTypeMapping = null,
@@ -254,11 +256,13 @@ public readonly record struct TypeMappingInfo
         int? size = null,
         bool? rowVersion = null,
         int? precision = null,
-        int? scale = null)
+        int? scale = null,
+        bool key = false)
     {
         ClrType = type?.UnwrapNullableType();
         ElementTypeMapping = elementTypeMapping;
 
+        IsKey = key;
         IsKeyOrIndex = keyOrIndex;
         Size = size;
         IsUnicode = unicode;
@@ -285,6 +289,7 @@ public readonly record struct TypeMappingInfo
         int? scale = null)
     {
         IsRowVersion = source.IsRowVersion;
+        IsKey = source.IsKey;
         IsKeyOrIndex = source.IsKeyOrIndex;
 
         var mappingHints = converter.MappingHints;
@@ -314,7 +319,12 @@ public readonly record struct TypeMappingInfo
         => new(this, converterInfo);
 
     /// <summary>
-    ///     Indicates whether or not the mapping is part of a key or index.
+    ///     Indicates whether or not the mapping is part of a key or foreign key.
+    /// </summary>
+    public bool IsKey { get; init; }
+
+    /// <summary>
+    ///     Indicates whether or not the mapping is part of a key, foreign key, or index.
     /// </summary>
     public bool IsKeyOrIndex { get; init; }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -588,6 +588,17 @@ public class GraphUpdatesSqlServerOwnedTest(GraphUpdatesSqlServerOwnedTest.SqlSe
                     b.Property(e => e.IdUserState).HasDefaultValue(1).HasSentinel(667);
                     b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
                 });
+
+            modelBuilder.Entity<StringKeyAndIndexParent>(
+                b =>
+                {
+                    b.HasAlternateKey(e => e.AlternateId);
+                    b.OwnsOne(
+                        x => x.Child, b =>
+                        {
+                            b.WithOwner(e => e.Parent).HasForeignKey(e => e.ParentId);
+                        });
+                });
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
@@ -11,6 +11,134 @@ public abstract class GraphUpdatesSqlServerTestBase<TFixture> : GraphUpdatesTest
     {
     }
 
+    [ConditionalFact] // Issue #32638
+    public virtual void Key_and_index_properties_use_appropriate_comparer()
+    {
+        var parent = new StringKeyAndIndexParent
+        {
+            Id = "Parent",
+            AlternateId = "Parent",
+            Index = "Index",
+            UniqueIndex = "UniqueIndex"
+        };
+
+        var child = new StringKeyAndIndexChild
+        {
+            Id = "Child",
+            ParentId = "parent"
+        };
+
+        using var context = CreateContext();
+        context.AttachRange(parent, child);
+
+        Assert.Same(child, parent.Child);
+        Assert.Same(parent, child.Parent);
+
+        parent.Id = "parent";
+        parent.AlternateId = "parent";
+        parent.Index = "index";
+        parent.UniqueIndex = "uniqueIndex";
+        child.Id = "child";
+        child.ParentId = "Parent";
+
+        context.ChangeTracker.DetectChanges();
+
+        var parentEntry = context.Entry(parent);
+        Assert.Equal(EntityState.Modified, parentEntry.State);
+        Assert.False(parentEntry.Property(e => e.Id).IsModified);
+        Assert.False(parentEntry.Property(e => e.AlternateId).IsModified);
+        Assert.True(parentEntry.Property(e => e.Index).IsModified);
+        Assert.True(parentEntry.Property(e => e.UniqueIndex).IsModified);
+
+        var childEntry = context.Entry(child);
+
+        if (childEntry.Metadata.IsOwned())
+        {
+            Assert.Equal(EntityState.Modified, childEntry.State);
+            Assert.True(childEntry.Property(e => e.Id).IsModified); // Not a key for the owned type
+            Assert.False(childEntry.Property(e => e.ParentId).IsModified);
+        }
+        else
+        {
+            Assert.Equal(EntityState.Unchanged, childEntry.State);
+            Assert.False(childEntry.Property(e => e.Id).IsModified);
+            Assert.False(childEntry.Property(e => e.ParentId).IsModified);
+        }
+
+    }
+
+    protected class StringKeyAndIndexParent : NotifyingEntity
+    {
+        private string _id;
+        private string _alternateId;
+        private string _uniqueIndex;
+        private string _index;
+        private StringKeyAndIndexChild _child;
+
+        public string Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public string AlternateId
+        {
+            get => _alternateId;
+            set => SetWithNotify(value, ref _alternateId);
+        }
+
+        public string Index
+        {
+            get => _index;
+            set => SetWithNotify(value, ref _index);
+        }
+
+        public string UniqueIndex
+        {
+            get => _uniqueIndex;
+            set => SetWithNotify(value, ref _uniqueIndex);
+        }
+
+        public StringKeyAndIndexChild Child
+        {
+            get => _child;
+            set => SetWithNotify(value, ref _child);
+        }
+    }
+
+    protected class StringKeyAndIndexChild : NotifyingEntity
+    {
+        private string _id;
+        private string _parentId;
+        private int _foo;
+        private StringKeyAndIndexParent _parent;
+
+        public string Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public string ParentId
+        {
+            get => _parentId;
+            set => SetWithNotify(value, ref _parentId);
+        }
+
+
+        public int Foo
+        {
+            get => _foo;
+            set => SetWithNotify(value, ref _foo);
+        }
+
+        public StringKeyAndIndexParent Parent
+        {
+            get => _parent;
+            set => SetWithNotify(value, ref _parent);
+        }
+    }
+
     protected override IQueryable<Root> ModifyQueryRoot(IQueryable<Root> query)
         => query.AsSplitQuery();
 
@@ -59,6 +187,15 @@ public abstract class GraphUpdatesSqlServerTestBase<TFixture> : GraphUpdatesTest
 
             modelBuilder.Entity<SomethingOfCategoryA>().Property<int>("CategoryId").HasDefaultValue(1);
             modelBuilder.Entity<SomethingOfCategoryB>().Property(e => e.CategoryId).HasDefaultValue(2);
+
+            modelBuilder.Entity<StringKeyAndIndexParent>(
+                b =>
+                {
+                    b.HasOne(e => e.Child)
+                        .WithOne(e => e.Parent)
+                        .HasForeignKey<StringKeyAndIndexChild>(e => e.ParentId)
+                        .HasPrincipalKey<StringKeyAndIndexParent>(e => e.AlternateId);
+                });
         }
     }
 }


### PR DESCRIPTION
Fixes #32898

Note that we didn't change what we do in the update pipeline, which appears to already be using provider values.