### PR TITLE
Add fill factor to keys and unique constraints

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -238,7 +238,10 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
             .Append("ALTER TABLE ")
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
             .Append(" ADD ");
+
         PrimaryKeyConstraint(operation, model, builder);
+
+        KeyOptions(operation, builder);
 
         if (terminate)
         {
@@ -263,7 +266,11 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
             .Append("ALTER TABLE ")
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
             .Append(" ADD ");
+
         UniqueConstraint(operation, model, builder);
+
+        KeyOptions(operation, builder);
+
         builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
         EndStatement(builder);
     }
@@ -1669,6 +1676,15 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
         builder.Append("(")
             .Append(operation.Sql)
             .Append(")");
+    }
+
+    /// <summary>
+    ///     Generates a SQL fragment for extras where options of an key from a <see cref="AddPrimaryKeyOperation" /> or <see cref="AddUniqueConstraintOperation" />.
+    /// </summary>
+    /// <param name="operation">The operation.</param>
+    /// <param name="builder">The command builder to use to add the SQL fragment.</param>
+    protected virtual void KeyOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
+    {
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -241,7 +241,7 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
 
         PrimaryKeyConstraint(operation, model, builder);
 
-        KeyOptions(operation, builder);
+        KeyWithOptions(operation, builder);
 
         if (terminate)
         {
@@ -269,7 +269,7 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
 
         UniqueConstraint(operation, model, builder);
 
-        KeyOptions(operation, builder);
+        KeyWithOptions(operation, builder);
 
         builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
         EndStatement(builder);
@@ -1679,11 +1679,12 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
     }
 
     /// <summary>
-    ///     Generates a SQL fragment for extras where options of an key from a <see cref="AddPrimaryKeyOperation" /> or <see cref="AddUniqueConstraintOperation" />.
+    ///     Generates a SQL fragment for extra with options of a key from a
+    ///     <see cref="AddPrimaryKeyOperation" /> or <see cref="AddUniqueConstraintOperation" />.
     /// </summary>
     /// <param name="operation">The operation.</param>
     /// <param name="builder">The command builder to use to add the SQL fragment.</param>
-    protected virtual void KeyOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
+    protected virtual void KeyWithOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
     {
     }
 

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -132,6 +132,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
         {
             var annotations = parameters.Annotations;
             annotations.Remove(SqlServerAnnotationNames.Clustered);
+            annotations.Remove(SqlServerAnnotationNames.FillFactor);
         }
 
         base.Generate(key, parameters);
@@ -144,6 +145,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
         {
             var annotations = parameters.Annotations;
             annotations.Remove(SqlServerAnnotationNames.Clustered);
+            annotations.Remove(SqlServerAnnotationNames.FillFactor);
         }
 
         base.Generate(uniqueConstraint, parameters);

--- a/src/EFCore.SqlServer/Extensions/SqlServerKeyBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerKeyBuilderExtensions.cs
@@ -96,4 +96,86 @@ public static class SqlServerKeyBuilderExtensions
         bool? clustered,
         bool fromDataAnnotation = false)
         => keyBuilder.CanSetAnnotation(SqlServerAnnotationNames.Clustered, clustered, fromDataAnnotation);
+
+    /// <summary>
+    ///     Configures whether the key is created with fill factor option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="fillFactor">A value indicating whether the key is created with fill factor option.</param>
+    /// <returns>A builder to further configure the key.</returns>
+    public static KeyBuilder HasFillFactor(this KeyBuilder keyBuilder, int fillFactor)
+    {
+        keyBuilder.Metadata.SetFillFactor(fillFactor);
+
+        return keyBuilder;
+    }
+
+    /// <summary>
+    ///     Configures whether the key is created with fill factor option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="fillFactor">A value indicating whether the key is created with fill factor option.</param>
+    /// <returns>A builder to further configure the key.</returns>
+    public static KeyBuilder<TEntity> HasFillFactor<TEntity>(
+        this KeyBuilder<TEntity> keyBuilder,
+        int fillFactor)
+        => (KeyBuilder<TEntity>)HasFillFactor((KeyBuilder)keyBuilder, fillFactor);
+
+    /// <summary>
+    ///     Configures whether the key is created with fill factor option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="fillFactor">A value indicating whether the key is created with fill factor option.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionKeyBuilder? HasFillFactor(
+        this IConventionKeyBuilder keyBuilder,
+        int? fillFactor,
+        bool fromDataAnnotation = false)
+    {
+        if (keyBuilder.CanSetFillFactor(fillFactor, fromDataAnnotation))
+        {
+            keyBuilder.Metadata.SetFillFactor(fillFactor, fromDataAnnotation);
+
+            return keyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the key can be configured with fill factor option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="fillFactor">A value indicating whether the key is created with fill factor option.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the key can be configured with fill factor option when targeting SQL Server.</returns>
+    public static bool CanSetFillFactor(
+        this IConventionKeyBuilder keyBuilder,
+        int? fillFactor,
+        bool fromDataAnnotation = false)
+        => keyBuilder.CanSetAnnotation(SqlServerAnnotationNames.FillFactor, fillFactor, fromDataAnnotation);
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerKeyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerKeyExtensions.cs
@@ -82,4 +82,85 @@ public static class SqlServerKeyExtensions
     /// <returns>The <see cref="ConfigurationSource" /> for whether the key is clustered.</returns>
     public static ConfigurationSource? GetIsClusteredConfigurationSource(this IConventionKey key)
         => key.FindAnnotation(SqlServerAnnotationNames.Clustered)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns the fill factor that the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The fill factor that the key uses</returns>
+    public static int? GetFillFactor(this IReadOnlyKey key)
+        => (key is RuntimeKey)
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (int?)key[SqlServerAnnotationNames.FillFactor];
+
+    /// <summary>
+    ///     Returns the fill factor that the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="storeObject">The identifier of the store object.</param>
+    /// <returns>The fill factor that the key uses</returns>
+    public static int? GetFillFactor(this IReadOnlyKey key, in StoreObjectIdentifier storeObject)
+    {
+        if (key is RuntimeKey)
+        {
+            throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
+        }
+
+        var annotation = key.FindAnnotation(SqlServerAnnotationNames.FillFactor);
+        if (annotation != null)
+        {
+            return (int?)annotation.Value;
+        }
+
+        var sharedTableRootKey = key.FindSharedObjectRootKey(storeObject);
+        return sharedTableRootKey?.GetFillFactor(storeObject);
+    }
+
+    /// <summary>
+    ///     Sets a value for fill factor the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="fillFactor">The value to set.</param>
+    public static void SetFillFactor(this IMutableKey key, int? fillFactor)
+    {
+        if (fillFactor is <= 0 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fillFactor));
+        }
+
+        key.SetAnnotation(
+            SqlServerAnnotationNames.FillFactor,
+            fillFactor);
+    }
+
+    /// <summary>
+    ///     Sets a value for fill factor the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="fillFactor">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static int? SetFillFactor(
+        this IConventionKey key,
+        int? fillFactor,
+        bool fromDataAnnotation = false)
+    {
+        if (fillFactor is <= 0 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fillFactor));
+        }
+
+        return (int?)key.SetAnnotation(
+            SqlServerAnnotationNames.FillFactor,
+            fillFactor,
+            fromDataAnnotation)?.Value;
+    }
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for whether the key uses the fill factor.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for whether the key uses the fill factor.</returns>
+    public static ConfigurationSource? GetFillFactorConfigurationSource(this IConventionKey key)
+        => key.FindAnnotation(SqlServerAnnotationNames.FillFactor)?.GetConfigurationSource();
 }

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
@@ -116,6 +116,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         if (!runtime)
         {
             annotations.Remove(SqlServerAnnotationNames.Clustered);
+            annotations.Remove(SqlServerAnnotationNames.FillFactor);
         }
     }
 

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -158,6 +158,11 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
         {
             yield return new Annotation(SqlServerAnnotationNames.Clustered, isClustered);
         }
+
+        if (key.GetFillFactor() is int fillFactor)
+        {
+            yield return new Annotation(SqlServerAnnotationNames.FillFactor, fillFactor);
+        }
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1742,6 +1742,35 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
     }
 
     /// <summary>
+    ///     Generates a SQL fragment for extra where options of an key from a
+    ///     <see cref="AddPrimaryKeyOperation" />, or <see cref="AddUniqueConstraintOperation" />.
+    /// </summary>
+    /// <param name="operation">The operation.</param>
+    /// <param name="builder">The command builder to use to add the SQL fragment.</param>
+    protected override void KeyOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
+    {
+        KeyWithOptions(operation, builder);
+    }
+
+    private static void KeyWithOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
+    {
+        var options = new List<string>();
+
+        if (operation[SqlServerAnnotationNames.FillFactor] is int fillFactor)
+        {
+            options.Add("FILLFACTOR = " + fillFactor);
+        }
+
+        if (options.Count > 0)
+        {
+            builder
+                .Append(" WITH (")
+                .Append(string.Join(", ", options))
+                .Append(")");
+        }
+    }
+
+    /// <summary>
     ///     Generates a SQL fragment for traits of an index from a <see cref="CreateIndexOperation" />,
     ///     <see cref="AddPrimaryKeyOperation" />, or <see cref="AddUniqueConstraintOperation" />.
     /// </summary>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1742,17 +1742,12 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
     }
 
     /// <summary>
-    ///     Generates a SQL fragment for extra where options of an key from a
+    ///     Generates a SQL fragment for extra with options of a key from a
     ///     <see cref="AddPrimaryKeyOperation" />, or <see cref="AddUniqueConstraintOperation" />.
     /// </summary>
     /// <param name="operation">The operation.</param>
     /// <param name="builder">The command builder to use to add the SQL fragment.</param>
-    protected override void KeyOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
-    {
-        KeyWithOptions(operation, builder);
-    }
-
-    private static void KeyWithOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
+    protected override void KeyWithOptions(MigrationOperation operation, MigrationCommandListBuilder builder)
     {
         var options = new List<string>();
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -5916,6 +5916,72 @@ namespace RootNamespace
                 Assert.Equal("IndexName", key["Relational:Name"]);
             });
 
+    [ConditionalFact]
+    public virtual void Key_fill_factor_is_stored_in_snapshot()
+        => Test(
+            builder =>
+            {
+                builder.Entity<EntityWithOneProperty>().HasKey(t => t.Id).HasFillFactor(90);
+                builder.Ignore<EntityWithTwoProperties>();
+            },
+            AddBoilerPlate(
+                GetHeading()
+                + """
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithOneProperty", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.HasKey("Id");
+
+                    SqlServerKeyBuilderExtensions.HasFillFactor(b.HasKey("Id"), 90);
+
+                    b.ToTable("EntityWithOneProperty", "DefaultSchema");
+                });
+"""),
+            o => Assert.Equal(90, o.GetEntityTypes().First().GetKeys().Single(k => k.IsPrimaryKey()).GetFillFactor()));
+
+    [ConditionalFact]
+    public virtual void Unique_constraint_fill_factor_is_stored_in_snapshot()
+        => Test(
+            builder =>
+            {
+                builder.Entity<EntityWithTwoProperties>().HasAlternateKey(t => t.AlternateId).HasName("KeyName").HasFillFactor(90);
+                builder.Ignore<EntityWithOneProperty>();
+            },
+            AddBoilerPlate(
+                GetHeading()
+                + """
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithTwoProperties", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("AlternateId")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasAlternateKey("AlternateId")
+                        .HasName("KeyName");
+
+                    SqlServerKeyBuilderExtensions.HasFillFactor(b.HasAlternateKey("AlternateId"), 90);
+
+                    b.ToTable("EntityWithTwoProperties", "DefaultSchema");
+                });
+"""),
+            model =>
+            {
+                var key = model.GetEntityTypes().First().GetKeys().First();
+                Assert.Equal(90, key.GetFillFactor());
+            });
+
     #endregion
 
     #region Index

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -4749,6 +4749,33 @@ CREATE TABLE PrimaryKeyName (
             },
             "DROP TABLE PrimaryKeyName;");
 
+    [ConditionalFact]
+    public void Primary_key_fill_factor()
+        => Test(
+            @"
+CREATE TABLE PrimaryKeyFillFactor
+(
+    Id INT IDENTITY NOT NULL,
+    Name NVARCHAR(100),
+ CONSTRAINT [PK_Id] PRIMARY KEY NONCLUSTERED
+(
+        [Id] ASC
+) WITH (FILLFACTOR = 80) ON [PRIMARY]
+) ON [PRIMARY];",
+            Enumerable.Empty<string>(),
+            Enumerable.Empty<string>(),
+            (dbModel, scaffoldingFactory) =>
+            {
+                var pk = dbModel.Tables.Single().PrimaryKey;
+                Assert.NotNull(pk);
+                Assert.Equal(["Id"], pk!.Columns.Select(kc => kc.Name).ToList());
+                Assert.Equal(80, pk[SqlServerAnnotationNames.FillFactor]);
+
+                var model = scaffoldingFactory.Create(dbModel, new());
+                Assert.Equal(1, model.GetEntityTypes().Count());
+            },
+            "DROP TABLE PrimaryKeyFillFactor;");
+
     #endregion
 
     #region UniqueConstraintFacets
@@ -4830,6 +4857,34 @@ CREATE TABLE UniqueConstraintName (
                 Assert.Equal(1, model.GetEntityTypes().Count());
             },
             "DROP TABLE UniqueConstraintName;");
+
+    [ConditionalFact]
+    public void Unique_constraint_fill_factor()
+        => Test(
+            @"
+CREATE TABLE UniqueConstraintFillFactor
+(
+    Something NVARCHAR(100) NOT NULL,
+    SomethingElse NVARCHAR(100) NOT NULL,
+ CONSTRAINT [UC_Something_SomethingElse] UNIQUE NONCLUSTERED
+(
+    [Something] ASC,
+    [SomethingElse] ASC
+) WITH (FILLFACTOR = 80) ON [PRIMARY]
+) ON [PRIMARY];",
+            Enumerable.Empty<string>(),
+            Enumerable.Empty<string>(),
+            (dbModel, scaffoldingFactory) =>
+            {
+                var uniqueConstraint = Assert.Single(dbModel.Tables.Single().UniqueConstraints);
+                Assert.NotNull(uniqueConstraint);
+                Assert.Equal(["Something", "SomethingElse"], uniqueConstraint!.Columns.Select(kc => kc.Name).ToList());
+                Assert.Equal(80, uniqueConstraint[SqlServerAnnotationNames.FillFactor]);
+
+                var model = scaffoldingFactory.Create(dbModel, new());
+                Assert.Equal(1, model.GetEntityTypes().Count());
+            },
+            "DROP TABLE UniqueConstraintFillFactor;");
 
     #endregion
 

--- a/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
@@ -58,6 +58,51 @@ public class SqlServerAnnotationCodeGeneratorTest
     }
 
     [ConditionalFact]
+    public void GenerateFluentApi_IKey_works_with_fillfactor()
+    {
+        var generator = CreateGenerator();
+        var modelBuilder = SqlServerConventionSetBuilder.CreateModelBuilder();
+        modelBuilder.Entity(
+            "Post",
+            x =>
+            {
+                x.Property<int>("Id");
+                x.HasKey("Id").HasFillFactor(80);
+            });
+
+        var key = (IKey)modelBuilder.Model.FindEntityType("Post")!.GetKeys().Single();
+        var result = generator.GenerateFluentApiCalls(key, key.GetAnnotations().ToDictionary(a => a.Name, a => a))
+            .Single();
+
+        Assert.Equal("HasFillFactor", result.Method);
+        Assert.Equal(1, result.Arguments.Count);
+        Assert.Equal(80, result.Arguments[0]);
+    }
+
+    [ConditionalFact]
+    public void GenerateFluentApi_IUniqueConstraint_works_with_fillfactor()
+    {
+        var generator = CreateGenerator();
+        var modelBuilder = SqlServerConventionSetBuilder.CreateModelBuilder();
+        modelBuilder.Entity(
+            "Post",
+            x =>
+            {
+                x.Property<int>("Something");
+                x.Property<int>("SomethingElse");
+                x.HasAlternateKey(["Something", "SomethingElse"]).HasFillFactor(80);
+            });
+        
+        var uniqueConstraint = (IKey)modelBuilder.Model.FindEntityType("Post")!.GetKeys().Single();
+        var result = generator.GenerateFluentApiCalls(uniqueConstraint, uniqueConstraint.GetAnnotations().ToDictionary(a => a.Name, a => a))
+            .Single();
+
+        Assert.Equal("HasFillFactor", result.Method);
+        Assert.Equal(1, result.Arguments.Count);
+        Assert.Equal(80, result.Arguments[0]);
+    }
+
+    [ConditionalFact]
     public void GenerateFluentApi_IIndex_works_when_clustered()
     {
         var generator = CreateGenerator();

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -128,6 +128,36 @@ public class SqlServerBuilderExtensionsTest
     }
 
     [ConditionalFact]
+    public void Can_set_key_with_fillfactor()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder
+            .Entity<Customer>()
+            .HasKey(e => e.Id)
+            .HasFillFactor(90);
+
+        var key = modelBuilder.Model.FindEntityType(typeof(Customer)).FindPrimaryKey();
+
+        Assert.Equal(90, key.GetFillFactor());
+    }
+
+    [ConditionalFact]
+    public void Can_set_key_with_fillfactor_non_generic()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder
+            .Entity(typeof(Customer))
+            .HasKey("Id")
+            .HasFillFactor(90);
+
+        var key = modelBuilder.Model.FindEntityType(typeof(Customer)).FindPrimaryKey();
+
+        Assert.Equal(90, key.GetFillFactor());
+    }
+
+    [ConditionalFact]
     public void Can_set_index_include()
     {
         var modelBuilder = CreateConventionModelBuilder();
@@ -1059,6 +1089,23 @@ public class SqlServerBuilderExtensionsTest
         var index = modelBuilder.Model.FindEntityType(typeof(Customer)).GetIndexes().Single();
 
         Assert.Equal(90, index.GetFillFactor());
+    }
+
+    [ConditionalTheory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void Throws_if_attempt_to_set_key_fillfactor_with_argument_out_of_range(int fillFactor)
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () =>
+            {
+                modelBuilder
+                    .Entity(typeof(Customer))
+                    .HasKey("Id")
+                    .HasFillFactor(fillFactor);
+            });
     }
 
     [ConditionalTheory]

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -1251,6 +1251,56 @@ public class SqlServerModelDifferTest : MigrationsModelDifferTestBase
         => annotatable[SqlServerAnnotationNames.MemoryOptimized] as bool?;
 
     [ConditionalFact]
+    public void Dont_rebuild_key_index_with_unchanged_fillfactor_option()
+        => Execute(
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id").HasFillFactor(90);
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id").HasFillFactor(90);
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                    }),
+            operations => Assert.Equal(0, operations.Count));
+
+    [ConditionalFact]
+    public void Dont_rebuild_composite_key_index_with_unchanged_fillfactor_option()
+        => Execute(
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.HasAlternateKey("Zip", "City").HasFillFactor(90);
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.HasAlternateKey("Zip", "City").HasFillFactor(90);
+                    }),
+            operations => Assert.Equal(0, operations.Count));
+
+    [ConditionalFact]
     public void Dont_rebuild_index_with_unchanged_fillfactor_option()
         => Execute(
             source => source
@@ -1276,6 +1326,230 @@ public class SqlServerModelDifferTest : MigrationsModelDifferTestBase
                             .HasFillFactor(90);
                     }),
             operations => Assert.Equal(0, operations.Count));
+
+    [ConditionalFact]
+    public void Rebuild_key_index_when_adding_fillfactor_option()
+        => Execute(
+            _ => { },
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasIndex("Zip");
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id").HasFillFactor(90);
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasIndex("Zip");
+                    }),
+            upOps =>
+            {
+                Assert.Equal(2, upOps.Count);
+
+                var operation1 = Assert.IsType<DropPrimaryKeyOperation>(upOps[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddPrimaryKeyOperation>(upOps[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                var annotation = operation2.GetAnnotation(SqlServerAnnotationNames.FillFactor);
+                Assert.NotNull(annotation);
+
+                var annotationValue = Assert.IsType<int>(annotation.Value);
+                Assert.Equal(90, annotationValue);
+            },
+            downOps =>
+            {
+                Assert.Equal(2, downOps.Count);
+
+                var operation1 = Assert.IsType<DropPrimaryKeyOperation>(downOps[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddPrimaryKeyOperation>(downOps[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                Assert.Empty(operation2.GetAnnotations());
+            });
+
+    [ConditionalFact]
+    public void Rebuild_key_index_with_different_fillfactor_value()
+        => Execute(
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id").HasFillFactor(50);
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.HasKey("Id").HasFillFactor(90);
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                    }),
+            operations =>
+            {
+                Assert.Equal(2, operations.Count);
+
+                var operation1 = Assert.IsType<DropPrimaryKeyOperation>(operations[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddPrimaryKeyOperation>(operations[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("PK_Address", operation1.Name);
+
+                var annotation = operation2.GetAnnotation(SqlServerAnnotationNames.FillFactor);
+                Assert.NotNull(annotation);
+
+                var annotationValue = Assert.IsType<int>(annotation.Value);
+
+                Assert.Equal(90, annotationValue);
+            });
+
+    [ConditionalFact]
+    public void Rebuild_composite_key_index_when_adding_fillfactor_option()
+        => Execute(
+            _ => { },
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasAlternateKey("Zip", "City");
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasAlternateKey("Zip", "City").HasFillFactor(90);
+                    }),
+            upOps =>
+            {
+                Assert.Equal(2, upOps.Count);
+
+                var operation1 = Assert.IsType<DropUniqueConstraintOperation>(upOps[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddUniqueConstraintOperation>(upOps[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                var annotation = operation2.GetAnnotation(SqlServerAnnotationNames.FillFactor);
+                Assert.NotNull(annotation);
+
+                var annotationValue = Assert.IsType<int>(annotation.Value);
+                Assert.Equal(90, annotationValue);
+            },
+            downOps =>
+            {
+                Assert.Equal(2, downOps.Count);
+
+                var operation1 = Assert.IsType<DropUniqueConstraintOperation>(downOps[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddUniqueConstraintOperation>(downOps[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                Assert.Empty(operation2.GetAnnotations());
+            });
+
+    [ConditionalFact]
+    public void Rebuild_composite_key_index_with_different_fillfactor_value()
+        => Execute(
+            source => source
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasIndex("Zip");
+                        x.HasAlternateKey("Zip", "City").HasFillFactor(50);
+                    }),
+            target => target
+                .Entity(
+                    "Address",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Zip");
+                        x.Property<string>("City");
+                        x.Property<string>("Street");
+                        x.HasIndex("Zip");
+                        x.HasAlternateKey("Zip", "City").HasFillFactor(90);
+                    }),
+            operations =>
+            {
+                Assert.Equal(2, operations.Count);
+
+                var operation1 = Assert.IsType<DropUniqueConstraintOperation>(operations[0]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                Assert.Empty(operation1.GetAnnotations());
+
+                var operation2 = Assert.IsType<AddUniqueConstraintOperation>(operations[1]);
+                Assert.Equal("Address", operation1.Table);
+                Assert.Equal("AK_Address_Zip_City", operation1.Name);
+
+                var annotation = operation2.GetAnnotation(SqlServerAnnotationNames.FillFactor);
+                Assert.NotNull(annotation);
+
+                var annotationValue = Assert.IsType<int>(annotation.Value);
+
+                Assert.Equal(90, annotationValue);
+            });
 
     [ConditionalFact]
     public void Rebuild_index_when_adding_fillfactor_option()


### PR DESCRIPTION
Add a fill factor to keys and unique contraints for SqlServer to work with the HasFillFactor extension method.

Fixes #32803


- [X] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [X] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [X] The code builds and tests pass locally (also verified by our automated build checks)
- [X] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code follows the same patterns and style as existing code in this repo

