### PR TITLE
Added ToHashSetAsync<T> Extension methods on IQueryable<T>

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2337,6 +2337,84 @@ public static class EntityFrameworkQueryableExtensions
 
     #endregion
 
+    #region ToHashSet
+
+    /// <summary>
+    ///     Asynchronously creates a <see cref="HashSet{T}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+    ///     asynchronously.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
+    ///         that any asynchronous operations have completed before calling another method on this context.
+    ///         See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more information and examples.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-async-linq">Querying data with EF Core</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> to create a set from.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains a <see cref="HashSet{T}" /> that contains elements from the input sequence.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<HashSet<TSource>> ToHashSetAsync<TSource>(
+        this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        var set = new HashSet<TSource>();
+        await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            set.Add(element);
+        }
+
+        return set;
+    }
+
+    /// <summary>
+    ///     Asynchronously creates a <see cref="HashSet{T}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+    ///     asynchronously.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
+    ///         that any asynchronous operations have completed before calling another method on this context.
+    ///         See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more information and examples.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-async-linq">Querying data with EF Core</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> to create a set from.</param>
+    /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing values in the set, or null to use the default <see cref="EqualityComparer{T}"/> implementation for the set type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains a <see cref="HashSet{T}" /> that contains elements from the input sequence.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<HashSet<TSource>> ToHashSetAsync<TSource>(
+        this IQueryable<TSource> source,
+        IEqualityComparer<TSource>? comparer,
+        CancellationToken cancellationToken = default)
+    {
+        var set = new HashSet<TSource>(comparer);
+        await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            set.Add(element);
+        }
+
+        return set;
+    }
+
+    #endregion
+
     #region Include
 
     internal static readonly MethodInfo IncludeMethodInfo
@@ -2834,8 +2912,8 @@ public static class EntityFrameworkQueryableExtensions
     /// </exception>
     public static IQueryable<T> TagWithCallSite<T>(
         this IQueryable<T> source,
-        [NotParameterized] [CallerFilePath] string? filePath = null,
-        [NotParameterized] [CallerLineNumber] int lineNumber = 0)
+        [NotParameterized][CallerFilePath] string? filePath = null,
+        [NotParameterized][CallerLineNumber] int lineNumber = 0)
         => source.Provider is EntityQueryProvider
             ? source.Provider.CreateQuery<T>(
                 Expression.Call(

--- a/test/EFCore.Tests/Extensions/QueryableExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/QueryableExtensionsTest.cs
@@ -298,6 +298,10 @@ public class QueryableExtensionsTest
             () => Source().ToDictionaryAsync(e => e, e => e, ReferenceEqualityComparer.Instance));
         await SourceNonAsyncEnumerableTest<int>(
             () => Source().ToDictionaryAsync(e => e, e => e, ReferenceEqualityComparer.Instance, new CancellationToken()));
+        await SourceNonAsyncEnumerableTest<int>(() => Source().ToHashSetAsync());
+        await SourceNonAsyncEnumerableTest<int>(() => Source().ToHashSetAsync(EqualityComparer<int>.Default));
+        await SourceNonAsyncEnumerableTest<int>(
+            () => Source().ToHashSetAsync(EqualityComparer<int>.Default, new CancellationToken()));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToListAsync());
 
         Assert.Equal(


### PR DESCRIPTION
Added ToHashSetAsync<T> Extension methods on IQueryable<T>
- Added ToHashSetAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default)
- Added ToHashSetAsync<TSource>(this IQueryable<TSource> source, IEqualityComparer<TSource>? comparer, CancellationToken cancellationToken = default)

Fixes #30033
