### PR TITLE
[release/8.0] Stop using case-insensitive comparisons for indexed properties (#32899)

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -225,6 +225,41 @@ public readonly record struct RelationalTypeMappingInfo
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="dbType">The suggested <see cref="DbType" />, or <see langword="null" /> for default.</param>
+    [Obsolete("Use overload that takes 'key' parameter.")]
+    public RelationalTypeMappingInfo(
+        Type? type,
+        RelationalTypeMapping? elementTypeMapping,
+        string? storeTypeName,
+        string? storeTypeNameBase,
+        bool keyOrIndex,
+        bool? unicode,
+        int? size,
+        bool? rowVersion,
+        bool? fixedLength,
+        int? precision,
+        int? scale,
+        DbType? dbType)
+        : this(
+            type, elementTypeMapping, storeTypeName, storeTypeNameBase, keyOrIndex, unicode, size, rowVersion, fixedLength,
+            precision, scale, dbType, keyOrIndex)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of <see cref="TypeMappingInfo" />.
+    /// </summary>
+    /// <param name="type">The CLR type in the model for which mapping is needed.</param>
+    /// <param name="elementTypeMapping">The type mapping for elements, if known.</param>
+    /// <param name="storeTypeName">The database type name.</param>
+    /// <param name="storeTypeNameBase">The provider-specific relational type name, with any facets removed.</param>
+    /// <param name="keyOrIndex">If <see langword="true" />, then a special mapping for a key or index may be returned.</param>
+    /// <param name="unicode">Specifies Unicode or ANSI mapping, or <see langword="null" /> for default.</param>
+    /// <param name="size">Specifies a size for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
+    /// <param name="fixedLength">Specifies a fixed length mapping, or <see langword="null" /> for default.</param>
+    /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="dbType">The suggested <see cref="DbType" />, or <see langword="null" /> for default.</param>
     /// <param name="key">If <see langword="true" />, then a special mapping for a key may be returned.</param>
     public RelationalTypeMappingInfo(
         Type? type = null,
@@ -247,45 +282,6 @@ public readonly record struct RelationalTypeMappingInfo
         StoreTypeName = storeTypeName;
         StoreTypeNameBase = storeTypeNameBase;
         DbType = dbType;
-    }
-
-    /// <summary>
-    ///     Creates a new instance of <see cref="TypeMappingInfo" />.
-    /// </summary>
-    /// <param name="type">The CLR type in the model for which mapping is needed.</param>
-    /// <param name="typeMappingConfiguration">The type mapping configuration.</param>
-    /// <param name="elementTypeMapping">The type mapping for elements, if known.</param>
-    /// <param name="storeTypeName">The database type name.</param>
-    /// <param name="storeTypeNameBase">The provider-specific relational type name, with any facets removed.</param>
-    /// <param name="unicode">Specifies Unicode or ANSI mapping, or <see langword="null" /> for default.</param>
-    /// <param name="size">Specifies a size for the mapping, or <see langword="null" /> for default.</param>
-    /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
-    /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
-    public RelationalTypeMappingInfo(
-        Type type,
-        ITypeMappingConfiguration typeMappingConfiguration,
-        RelationalTypeMapping? elementTypeMapping = null,
-        string? storeTypeName = null,
-        string? storeTypeNameBase = null,
-        bool? unicode = null,
-        int? size = null,
-        int? precision = null,
-        int? scale = null)
-    {
-        _coreTypeMappingInfo = new TypeMappingInfo(
-            typeMappingConfiguration.GetValueConverter()?.ProviderClrType ?? type,
-            elementTypeMapping,
-            keyOrIndex: false,
-            unicode ?? typeMappingConfiguration.IsUnicode(),
-            size ?? typeMappingConfiguration.GetMaxLength(),
-            rowVersion: false,
-            precision ?? typeMappingConfiguration.GetPrecision(),
-            scale ?? typeMappingConfiguration.GetScale(),
-            key: false);
-
-        IsFixedLength = (bool?)typeMappingConfiguration[RelationalAnnotationNames.IsFixedLength];
-        StoreTypeName = storeTypeName;
-        StoreTypeNameBase = storeTypeNameBase;
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -338,7 +338,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                     size: size,
                     fixedLength: isFixedLength,
                     storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None,
-                    useKeyComparison: mappingInfo.IsKeyOrIndex);
+                    useKeyComparison: mappingInfo.IsKey);
             }
 
             if (clrType == typeof(byte[]))

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -15,6 +15,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 /// </summary>
 public class SqlServerTypeMappingSource : RelationalTypeMappingSource
 {
+    private static readonly bool UseOldBehavior32898 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32898", out var enabled32898) && enabled32898;
+
     private static readonly SqlServerFloatTypeMapping RealAlias
         = new("placeholder", storeTypePostfix: StoreTypePostfix.None);
 
@@ -338,7 +341,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                     size: size,
                     fixedLength: isFixedLength,
                     storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None,
-                    useKeyComparison: mappingInfo.IsKey);
+                    useKeyComparison: UseOldBehavior32898 ? mappingInfo.IsKeyOrIndex : mappingInfo.IsKey);
             }
 
             if (clrType == typeof(byte[]))

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -182,7 +182,8 @@ public readonly record struct TypeMappingInfo
         var property = principals[0];
 
         ElementTypeMapping = property.GetElementType()?.FindTypeMapping();
-        IsKeyOrIndex = property.IsKey() || property.IsForeignKey() || property.IsIndex();
+        IsKey = property.IsKey() || property.IsForeignKey();
+        IsKeyOrIndex = IsKey || property.IsIndex();
         Size = fallbackSize ?? mappingHints?.Size;
         IsUnicode = fallbackUnicode ?? mappingHints?.IsUnicode;
         IsRowVersion = property is { IsConcurrencyToken: true, ValueGenerated: ValueGenerated.OnAddOrUpdate };
@@ -227,6 +228,7 @@ public readonly record struct TypeMappingInfo
     /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="key">If <see langword="true" />, then a special mapping for a key may be returned.</param>
     public TypeMappingInfo(
         Type? type = null,
         CoreTypeMapping? elementTypeMapping = null,
@@ -235,11 +237,13 @@ public readonly record struct TypeMappingInfo
         int? size = null,
         bool? rowVersion = null,
         int? precision = null,
-        int? scale = null)
+        int? scale = null,
+        bool key = false)
     {
         ClrType = type?.UnwrapNullableType();
         ElementTypeMapping = elementTypeMapping;
 
+        IsKey = key;
         IsKeyOrIndex = keyOrIndex;
         Size = size;
         IsUnicode = unicode;
@@ -266,6 +270,7 @@ public readonly record struct TypeMappingInfo
         int? scale = null)
     {
         IsRowVersion = source.IsRowVersion;
+        IsKey = source.IsKey;
         IsKeyOrIndex = source.IsKeyOrIndex;
 
         var mappingHints = converter.MappingHints;
@@ -295,7 +300,12 @@ public readonly record struct TypeMappingInfo
         => new(this, converterInfo);
 
     /// <summary>
-    ///     Indicates whether or not the mapping is part of a key or index.
+    ///     Indicates whether or not the mapping is part of a key or foreign key.
+    /// </summary>
+    public bool IsKey { get; init; }
+
+    /// <summary>
+    ///     Indicates whether or not the mapping is part of a key, foreign key, or index.
     /// </summary>
     public bool IsKeyOrIndex { get; init; }
 

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -228,6 +228,31 @@ public readonly record struct TypeMappingInfo
     /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
+    [Obsolete("Use overload that takes 'key' parameter.")]
+    public TypeMappingInfo(
+        Type? type,
+        CoreTypeMapping? elementTypeMapping,
+        bool keyOrIndex,
+        bool? unicode,
+        int? size,
+        bool? rowVersion,
+        int? precision,
+        int? scale)
+        : this(type, elementTypeMapping, keyOrIndex, unicode, size, rowVersion, precision, scale, false)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of <see cref="TypeMappingInfo" />.
+    /// </summary>
+    /// <param name="type">The CLR type in the model for which mapping is needed.</param>
+    /// <param name="elementTypeMapping">The type mapping for elements, if known.</param>
+    /// <param name="keyOrIndex">If <see langword="true" />, then a special mapping for a key or index may be returned.</param>
+    /// <param name="unicode">Specifies Unicode or ANSI mapping, or <see langword="null" /> for default.</param>
+    /// <param name="size">Specifies a size for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
+    /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="key">If <see langword="true" />, then a special mapping for a key may be returned.</param>
     public TypeMappingInfo(
         Type? type = null,
@@ -242,7 +267,6 @@ public readonly record struct TypeMappingInfo
     {
         ClrType = type?.UnwrapNullableType();
         ElementTypeMapping = elementTypeMapping;
-
         IsKey = key;
         IsKeyOrIndex = keyOrIndex;
         Size = size;

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -572,6 +572,17 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
                     b.Property(e => e.IdUserState).HasDefaultValue(1).HasSentinel(667);
                     b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
                 });
+
+            modelBuilder.Entity<StringKeyAndIndexParent>(
+                b =>
+                {
+                    b.HasAlternateKey(e => e.AlternateId);
+                    b.OwnsOne(
+                        x => x.Child, b =>
+                        {
+                            b.WithOwner(e => e.Parent).HasForeignKey(e => e.ParentId);
+                        });
+                });
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
@@ -11,6 +11,134 @@ public abstract class GraphUpdatesSqlServerTestBase<TFixture> : GraphUpdatesTest
     {
     }
 
+    [ConditionalFact] // Issue #32638
+    public virtual void Key_and_index_properties_use_appropriate_comparer()
+    {
+        var parent = new StringKeyAndIndexParent
+        {
+            Id = "Parent",
+            AlternateId = "Parent",
+            Index = "Index",
+            UniqueIndex = "UniqueIndex"
+        };
+
+        var child = new StringKeyAndIndexChild
+        {
+            Id = "Child",
+            ParentId = "parent"
+        };
+
+        using var context = CreateContext();
+        context.AttachRange(parent, child);
+
+        Assert.Same(child, parent.Child);
+        Assert.Same(parent, child.Parent);
+
+        parent.Id = "parent";
+        parent.AlternateId = "parent";
+        parent.Index = "index";
+        parent.UniqueIndex = "uniqueIndex";
+        child.Id = "child";
+        child.ParentId = "Parent";
+
+        context.ChangeTracker.DetectChanges();
+
+        var parentEntry = context.Entry(parent);
+        Assert.Equal(EntityState.Modified, parentEntry.State);
+        Assert.False(parentEntry.Property(e => e.Id).IsModified);
+        Assert.False(parentEntry.Property(e => e.AlternateId).IsModified);
+        Assert.True(parentEntry.Property(e => e.Index).IsModified);
+        Assert.True(parentEntry.Property(e => e.UniqueIndex).IsModified);
+
+        var childEntry = context.Entry(child);
+
+        if (childEntry.Metadata.IsOwned())
+        {
+            Assert.Equal(EntityState.Modified, childEntry.State);
+            Assert.True(childEntry.Property(e => e.Id).IsModified); // Not a key for the owned type
+            Assert.False(childEntry.Property(e => e.ParentId).IsModified);
+        }
+        else
+        {
+            Assert.Equal(EntityState.Unchanged, childEntry.State);
+            Assert.False(childEntry.Property(e => e.Id).IsModified);
+            Assert.False(childEntry.Property(e => e.ParentId).IsModified);
+        }
+
+    }
+
+    protected class StringKeyAndIndexParent : NotifyingEntity
+    {
+        private string _id;
+        private string _alternateId;
+        private string _uniqueIndex;
+        private string _index;
+        private StringKeyAndIndexChild _child;
+
+        public string Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public string AlternateId
+        {
+            get => _alternateId;
+            set => SetWithNotify(value, ref _alternateId);
+        }
+
+        public string Index
+        {
+            get => _index;
+            set => SetWithNotify(value, ref _index);
+        }
+
+        public string UniqueIndex
+        {
+            get => _uniqueIndex;
+            set => SetWithNotify(value, ref _uniqueIndex);
+        }
+
+        public StringKeyAndIndexChild Child
+        {
+            get => _child;
+            set => SetWithNotify(value, ref _child);
+        }
+    }
+
+    protected class StringKeyAndIndexChild : NotifyingEntity
+    {
+        private string _id;
+        private string _parentId;
+        private int _foo;
+        private StringKeyAndIndexParent _parent;
+
+        public string Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public string ParentId
+        {
+            get => _parentId;
+            set => SetWithNotify(value, ref _parentId);
+        }
+
+
+        public int Foo
+        {
+            get => _foo;
+            set => SetWithNotify(value, ref _foo);
+        }
+
+        public StringKeyAndIndexParent Parent
+        {
+            get => _parent;
+            set => SetWithNotify(value, ref _parent);
+        }
+    }
+
     protected override IQueryable<Root> ModifyQueryRoot(IQueryable<Root> query)
         => query.AsSplitQuery();
 
@@ -59,6 +187,15 @@ public abstract class GraphUpdatesSqlServerTestBase<TFixture> : GraphUpdatesTest
 
             modelBuilder.Entity<SomethingOfCategoryA>().Property<int>("CategoryId").HasDefaultValue(1);
             modelBuilder.Entity<SomethingOfCategoryB>().Property(e => e.CategoryId).HasDefaultValue(2);
+
+            modelBuilder.Entity<StringKeyAndIndexParent>(
+                b =>
+                {
+                    b.HasOne(e => e.Child)
+                        .WithOne(e => e.Parent)
+                        .HasForeignKey<StringKeyAndIndexChild>(e => e.ParentId)
+                        .HasPrincipalKey<StringKeyAndIndexParent>(e => e.AlternateId);
+                });
         }
     }
 }


### PR DESCRIPTION
Port of #32899
Fixes #32898

### Description

EF8 contained a small enhancement to match SQL Server defaults and do case-insensitive comparisons by default. This change also included properties with indexes, which was a mistake.

### Customer impact

Customers get incorrect change detection, resulting in possible corrupted data, on index properties.

### How found

Customer reported on 8.

### Regression

Yes, from 7.

### Testing

Tests added.

### Risk

Low. Quirked.
