### PR TITLE
Updating Microsoft.CodeAnalysis version to 4.8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
     <!-- NB: This version affects Visual Studio compatibility. See https://learn.microsoft.com/visualstudio/extensibility/roslyn-version-support -->
-    <MicrosoftCodeAnalysisVersion>4.5.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.8.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23371.1</MicrosoftCodeAnalysisTestingVersion>
     <XUnitVersion>2.6.1</XUnitVersion>
     <XUnitRunnerVisualstudioVersion>2.5.3</XUnitRunnerVisualstudioVersion>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -9,6 +9,7 @@
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
     <ImplicitUsings>true</ImplicitUsings>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See #32070

Whether or not this is a good idea depends on this table: https://learn.microsoft.com/visualstudio/extensibility/roslyn-version-support
And whether or not we are okay with requiring VS 17.8 or later.

