### PR TITLE
[release/8.0] Don't assume that FK of skip navigation is non-null

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -68,7 +68,8 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention,
                 s => s.Inverse != null
                     && IsMappedToSameTable(s.DeclaringEntityType, s.TargetEntityType));
 
-        if (skipNavigation != null)
+        if (skipNavigation != null
+            && skipNavigation.ForeignKey != null)
         {
             var isFirstSkipNavigation = IsFirstSkipNavigation(skipNavigation);
             if (!isFirstSkipNavigation)

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -18,6 +18,9 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention,
     ISkipNavigationForeignKeyChangedConvention,
     IEntityTypeAnnotationChangedConvention
 {
+    private static readonly bool UseOldBehavior32732 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32732", out var enabled32732) && enabled32732;
+
     /// <summary>
     ///     Creates a new instance of <see cref="SqlServerOnDeleteConvention" />.
     /// </summary>
@@ -69,7 +72,7 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention,
                     && IsMappedToSameTable(s.DeclaringEntityType, s.TargetEntityType));
 
         if (skipNavigation != null
-            && skipNavigation.ForeignKey != null)
+            && (UseOldBehavior32732 || skipNavigation.ForeignKey != null))
         {
             var isFirstSkipNavigation = IsFirstSkipNavigation(skipNavigation);
             if (!isFirstSkipNavigation)

--- a/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerOnDeleteConventionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerOnDeleteConventionTest.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+public class SqlServerOnDeleteConventionTest
+{
+    [ConditionalFact] // Issue #32732
+    public void Convention_does_not_assume_skip_navigations_have_non_null_FK()
+    {
+        using var context = new SkippyDbContext();
+        var model = context.Model;
+        Assert.Equal(["ArenaPropensity", "Arena", "Propensity"], model.GetEntityTypes().Select(e => e.ShortName()));
+        Assert.Equal(
+            [DeleteBehavior.Cascade, DeleteBehavior.ClientCascade],
+            model.GetEntityTypes().Single(e => e.ShortName() == "ArenaPropensity").GetForeignKeys().Select(k => k.DeleteBehavior));
+    }
+
+    public class SkippyDbContext : DbContext
+    {
+        public DbSet<Arena> Areas { get; private set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlServer();
+    }
+
+    public class Arena : Propensity
+    {
+        public virtual ICollection<Propensity> AreaProperties { get; set; }
+    }
+
+    public abstract class Propensity
+    {
+        public int Id { get; set; }
+
+        public int? PrimaryYId { get; set; }
+        public virtual Propensity PrimaryYProp { get; set; }
+
+        public virtual ICollection<Arena> PropertyAreas { get; set; }
+    }
+}


### PR DESCRIPTION
Port of #32920
Fixes #32732

### Description

With some combination of skip and normal navigations, we execute the SQL Server delete convention for skip navigations that do not yet have an associated FK.

### Customer impact

Null reference exception from model building.

### How found

Customer reported on 8.

### Regression

Yes, from 7.

### Testing

Tests added.

### Risk

Low. Quirked.



