### PR TITLE
[release/8.0] Throw for empty strings in primitive collection columns

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -994,6 +994,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 complexType);
 
         /// <summary>
+        ///     The empty string is not valid JSON.
+        /// </summary>
+        public static string EmptyJsonString
+            => GetString("EmptyJsonString");
+
+        /// <summary>
         ///     Cannot translate '{comparisonOperator}' on a subquery expression of entity type '{entityType}' because it has a composite primary key. See https://go.microsoft.com/fwlink/?linkid=2141942 for information on how to rewrite your query.
         /// </summary>
         public static string EntityEqualityOnCompositeKeyEntitySubqueryNotSupported(object? comparisonOperator, object? entityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -486,6 +486,9 @@
   <data name="EmptyComplexType" xml:space="preserve">
     <value>Complex type '{complexType}' has no properties defines. Configure at least one property or don't include this type in the model.</value>
   </data>
+  <data name="EmptyJsonString" xml:space="preserve">
+    <value>The empty string is not valid JSON.</value>
+  </data>
   <data name="EntityEqualityOnCompositeKeyEntitySubqueryNotSupported" xml:space="preserve">
     <value>Cannot translate '{comparisonOperator}' on a subquery expression of entity type '{entityType}' because it has a composite primary key. See https://go.microsoft.com/fwlink/?linkid=2141942 for information on how to rewrite your query.</value>
   </data>

--- a/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 /// </remarks>
 public abstract class JsonValueReaderWriter
 {
+    private static readonly bool UseOldBehavior32896 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32896", out var enabled32896) && enabled32896;
+
     /// <summary>
     ///     Ensures the external types extend from the generic <see cref="JsonValueReaderWriter{TValue}" />
     /// </summary>
@@ -63,7 +66,8 @@ public abstract class JsonValueReaderWriter
     /// <returns>The read value.</returns>
     public object FromJsonString(string json, object? existingObject = null)
     {
-        if (string.IsNullOrWhiteSpace(json))
+        if (!UseOldBehavior32896
+            && string.IsNullOrWhiteSpace(json))
         {
             throw new InvalidOperationException(CoreStrings.EmptyJsonString);
         }

--- a/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
@@ -63,6 +63,11 @@ public abstract class JsonValueReaderWriter
     /// <returns>The read value.</returns>
     public object FromJsonString(string json, object? existingObject = null)
     {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new InvalidOperationException(CoreStrings.EmptyJsonString);
+        }
+
         var readerManager = new Utf8JsonReaderManager(new JsonReaderData(Encoding.UTF8.GetBytes(json)), null);
         return FromJson(ref readerManager, existingObject);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -1317,6 +1317,48 @@ END IN (
 """);
     }
 
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)] // Issue #32896
+    public async Task Empty_string_used_for_primitive_collection_throws(bool async)
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        await using var context = new SimpleContext(connection);
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        await context.Database.ExecuteSqlRawAsync("INSERT INTO SimpleEntities (List) VALUES ('');");
+
+        var set = context.SimpleEntities;
+
+        var message = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+            {
+                if (async)
+                {
+                    await set.FirstAsync();
+                }
+                else
+                {
+                    set.First();
+                }
+            });
+
+        Assert.Equal(CoreStrings.EmptyJsonString, message.Message);
+    }
+
+    public class SimpleContext(SqliteConnection connection) : DbContext
+    {
+        public DbSet<SimpleEntity> SimpleEntities => Set<SimpleEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlite(connection);
+    }
+
+    public record SimpleEntity(int Id, IEnumerable<string> List);
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Port of #32924
Fixes #32896

### Description

The empty string is not valid JSON. EF will never write this, but if a database column contains the empty string, then EF should throw.

### Customer impact

Hang when using a column containing an empty string as a primitive collection.

### How found

Customer reported on 8.

### Regression

No, primitive collections are a new feature in 8.

### Testing

Tests added.

### Risk

Low. Quirked.
