### PR TITLE
Also catch type initialization errors when attempting to load types that might not exist

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Data.Sqlite
                     storageFolderType = Type.GetType("Windows.Storage.StorageFolder, Windows, ContentType=WindowsRuntime")
                         ?? Type.GetType("Windows.Storage.StorageFolder, Microsoft.Windows.SDK.NET");
                 }
-                catch (FileLoadException)
+                catch (Exception)
                 {
-                    // Ignore "Could not load assembly."
+                    // Ignore "Could not load assembly." or any type initialization error.
                 }
 
                 object? currentAppData = null;


### PR DESCRIPTION
Since it appears that they can exist but be the wrong version for us to use.

Fixes #32614
