### PR TITLE
[release/8.0] Also catch type initialization errors when attempting to load types that might not exist

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Data.Sqlite
                     storageFolderType = Type.GetType("Windows.Storage.StorageFolder, Windows, ContentType=WindowsRuntime")
                         ?? Type.GetType("Windows.Storage.StorageFolder, Microsoft.Windows.SDK.NET");
                 }
-                catch (FileLoadException)
+                catch (Exception)
                 {
-                    // Ignore "Could not load assembly."
+                    // Ignore "Could not load assembly." or any type initialization error.
                 }
 
                 object? currentAppData = null;


### PR DESCRIPTION
Port of #32938
Fixes #32614

### Description

Uncaught exception when using tools with a project where an assembly can't be loaded for some other reason that it does not exist.

### Customer impact

Exception using the tools.

### How found

Customer reported on 8.

### Regression

Yes, from 7.

### Testing

Manually tested.

### Risk

Low.
