### PR TITLE
[release/8.0] Stop specifying incorrect column name in snapshot for owned type of generic entity type

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -183,7 +183,9 @@ public static class RelationalPropertyExtensions
             var foreignKey = property.GetContainingForeignKeys().First();
             var principalEntityType = foreignKey.PrincipalEntityType;
             if (principalEntityType is { HasSharedClrType: false, ClrType.IsConstructedGenericType: true }
-                && foreignKey.DependentToPrincipal == null)
+                && foreignKey.DependentToPrincipal == null
+                && (principalEntityType.GetTableName() != foreignKey.DeclaringEntityType.GetTableName()
+                    || principalEntityType.GetSchema() != foreignKey.DeclaringEntityType.GetSchema()))
             {
                 var principalProperty = property.FindFirstPrincipal()!;
                 var principalName = principalEntityType.ShortName();

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -17,6 +17,9 @@ namespace Microsoft.EntityFrameworkCore;
 /// </remarks>
 public static class RelationalPropertyExtensions
 {
+    private static readonly bool UseOldBehavior32763 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32763", out var enabled32763) && enabled32763;
+
     private static readonly MethodInfo GetFieldValueMethod =
         typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), new[] { typeof(int) })!;
 
@@ -184,7 +187,8 @@ public static class RelationalPropertyExtensions
             var principalEntityType = foreignKey.PrincipalEntityType;
             if (principalEntityType is { HasSharedClrType: false, ClrType.IsConstructedGenericType: true }
                 && foreignKey.DependentToPrincipal == null
-                && (principalEntityType.GetTableName() != foreignKey.DeclaringEntityType.GetTableName()
+                && (UseOldBehavior32763
+                    || principalEntityType.GetTableName() != foreignKey.DeclaringEntityType.GetTableName()
                     || principalEntityType.GetSchema() != foreignKey.DeclaringEntityType.GetSchema()))
             {
                 var principalProperty = property.FindFirstPrincipal()!;

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -4696,7 +4696,7 @@ namespace RootNamespace
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>", b =>
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Beak>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -4712,9 +4712,9 @@ namespace RootNamespace
                     b.ToTable("Parrot<Beak>", "DefaultSchema");
                 });
 
-            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>", b =>
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Beak>", b =>
                 {
-                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak", "Child", b1 =>
+                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Beak", "Child", b1 =>
                         {
                             b1.Property<int>("ParrotId")
                                 .HasColumnType("int");
@@ -4735,7 +4735,7 @@ namespace RootNamespace
 """),
             model =>
             {
-                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>");
+                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Beak>");
                 Assert.NotNull(parentType);
                 Assert.NotNull(parentType.FindNavigation("Child")!.TargetEntityType);
 
@@ -4755,7 +4755,7 @@ namespace RootNamespace
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot", b =>
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -4771,9 +4771,9 @@ namespace RootNamespace
                     b.ToTable("Parrot", "DefaultSchema");
                 });
 
-            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot", b =>
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot", b =>
                 {
-                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak", "Child", b1 =>
+                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Beak", "Child", b1 =>
                         {
                             b1.Property<int>("ParrotId")
                                 .HasColumnType("int");
@@ -4794,7 +4794,7 @@ namespace RootNamespace
 """),
             model =>
             {
-                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot");
+                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Parrot");
                 Assert.NotNull(parentType);
                 Assert.NotNull(parentType.FindNavigation("Child")!.TargetEntityType);
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -370,6 +370,25 @@ public class ModelSnapshotSqlServerTest
         public T Bar { get; set; }
     }
 
+    public class Parrot<TChild>
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public TChild Child { get; set; }
+    }
+
+    public class Parrot
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Beak Child { get; set; }
+    }
+
+    public class Beak
+    {
+        public string Name { get; set; }
+    }
+
     #region Model
 
     [ConditionalFact]
@@ -4648,6 +4667,139 @@ namespace RootNamespace
                 var property = entityType.FindProperty("FooExtensionId");
                 Assert.NotNull(property);
                 Assert.Equal("FooExtension<BarA>Id", property.GetColumnName());
+
+                Assert.Collection(
+                    model.GetRelationalModel().Tables,
+                    t =>
+                    {
+
+                        Assert.Equal("BarBase", t.Name);
+                        Assert.Equal(["Id", "Discriminator", "FooExtension<BarA>Id"], t.Columns.Select(t => t.Name));
+                    },
+                    t =>
+                    {
+
+                        Assert.Equal("FooExtension<BarA>", t.Name);
+                        Assert.Equal(["Id"], t.Columns.Select(t => t.Name));
+                    });
+            });
+
+    [ConditionalFact]
+    public virtual void Generic_entity_type_with_owned_entities()
+        => Test(
+            modelBuilder => modelBuilder.Entity<Parrot<Beak>>().OwnsOne(e => e.Child),
+            AddBoilerPlate(
+            """
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Parrot<Beak>", "DefaultSchema");
+                });
+
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>", b =>
+                {
+                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak", "Child", b1 =>
+                        {
+                            b1.Property<int>("ParrotId")
+                                .HasColumnType("int");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.HasKey("ParrotId");
+
+                            b1.ToTable("Parrot<Beak>", "DefaultSchema");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ParrotId");
+                        });
+
+                    b.Navigation("Child");
+                });
+"""),
+            model =>
+            {
+                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot<Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak>");
+                Assert.NotNull(parentType);
+                Assert.NotNull(parentType.FindNavigation("Child")!.TargetEntityType);
+
+                var table = model.GetRelationalModel().Tables.Single();
+                Assert.Equal(["Id", "Child_Name", "Name"], table.Columns.Select(t => t.Name));
+            });
+
+    [ConditionalFact]
+    public virtual void Non_generic_entity_type_with_owned_entities()
+        => Test(
+            modelBuilder => modelBuilder.Entity<Parrot>().OwnsOne(e => e.Child),
+            AddBoilerPlate(
+            """
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Parrot", "DefaultSchema");
+                });
+
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot", b =>
+                {
+                    b.OwnsOne("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Beak", "Child", b1 =>
+                        {
+                            b1.Property<int>("ParrotId")
+                                .HasColumnType("int");
+
+                            b1.Property<string>("Name")
+                                .HasColumnType("nvarchar(max)");
+
+                            b1.HasKey("ParrotId");
+
+                            b1.ToTable("Parrot", "DefaultSchema");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ParrotId");
+                        });
+
+                    b.Navigation("Child");
+                });
+"""),
+            model =>
+            {
+                var parentType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+Parrot");
+                Assert.NotNull(parentType);
+                Assert.NotNull(parentType.FindNavigation("Child")!.TargetEntityType);
+
+                var table = model.GetRelationalModel().Tables.Single();
+                Assert.Equal(["Id", "Child_Name", "Name"], table.Columns.Select(t => t.Name));
             });
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #32763
Port of #32937

### Description

A bug fix in 8 to fix the naming of foreign key columns when the principal type is generic resulted in a regression when the dependent type shares the same table.

### Customer impact

Repeated generation of invalid migrations.

### How found

Customer reported on 8.

### Regression

Yes, from 7.

### Testing

Tests added.

### Risk

Low. Quirked.



