### PR TITLE
Fix to #32939 - Accidentally using field instead of property for JSON metadata produce hard to understand exception

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
@@ -266,6 +266,59 @@ public abstract class AdHocJsonQueryTestBase : NonSharedModelTestBase
 
     #endregion
 
+    #region 32939
+
+    [ConditionalFact]
+    public virtual async Task Project_json_with_no_properties()
+    {
+        var contextFactory = await InitializeAsync<Context32939>(seed: Seed30028);
+        using var context = contextFactory.CreateContext();
+        context.Entities.ToList();
+    }
+
+    protected void Seed30028(Context32939 ctx)
+    {
+        var entity = new Context32939.Entity32939
+        {
+            Empty = new Context32939.JsonEmpty32939(),
+            FieldOnly = new Context32939.JsonFieldOnly32939()
+        };
+
+        ctx.Entities.Add(entity);
+        ctx.SaveChanges();
+    }
+
+    protected class Context32939(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Entity32939> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Entity32939>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<Entity32939>().OwnsOne(x => x.Empty, b => b.ToJson());
+            modelBuilder.Entity<Entity32939>().OwnsOne(x => x.FieldOnly, b => b.ToJson());
+        }
+
+        public class Entity32939
+        {
+            public int Id { get; set; }
+            public JsonEmpty32939 Empty { get; set; }
+            public JsonFieldOnly32939 FieldOnly { get; set; }
+
+        }
+
+        public class JsonEmpty32939
+        {
+        }
+
+        public class JsonFieldOnly32939
+        {
+            public int Field;
+        }
+    }
+
+    #endregion
+
     #region ArrayOfPrimitives
 
     [ConditionalTheory]


### PR DESCRIPTION
When processing shaper for JSON streaming we didn't protect against the case where there are no properties on JSON entity that should be populated as part of the loop. Fix check the count of properties we found before we start generating Switch-Case statement for PropertyName.

Fixes #32939