### PR TITLE
Cleanup asserts

### DIFF
--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -968,7 +968,7 @@ public partial class TestDbContext : DbContext
                 new ModelCodeGenerationOptions { UseDataAnnotations = false },
                 code => Assert.Contains(".IsFixedLength()", code.ContextFile.Code),
                 model =>
-                    Assert.Equal(true, model.FindEntityType("TestNamespace.Employee").GetProperty("Name").IsFixedLength()));
+                    Assert.True(model.FindEntityType("TestNamespace.Employee").GetProperty("Name").IsFixedLength()));
 
         [ConditionalFact]
         public Task Global_namespace_works()

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
@@ -85,8 +85,8 @@ public abstract class AdHocJsonQueryTestBase : NonSharedModelTestBase
                 : query.Single();
 
             Assert.Equal(3, result.Id);
-            Assert.Equal(null, result.Reference.NullableScalar);
-            Assert.Equal(null, result.Collection[0].NullableScalar);
+            Assert.Null(result.Reference.NullableScalar);
+            Assert.Null(result.Collection[0].NullableScalar);
         }
     }
 
@@ -107,8 +107,8 @@ public abstract class AdHocJsonQueryTestBase : NonSharedModelTestBase
 
             Assert.Equal(3, result.Count);
             Assert.Equal(11, result[0]);
-            Assert.Equal(null, result[1]);
-            Assert.Equal(null, result[2]);
+            Assert.Null(result[1]);
+            Assert.Null(result[2]);
         }
     }
 

--- a/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
@@ -75,7 +75,6 @@ public abstract class TwoDatabasesTestBase
 
     [ConditionalTheory]
     [InlineData(true, false)]
-    [InlineData(true, false)]
     [InlineData(true, true)]
     public virtual void Can_set_connection_string_in_interceptor(bool withConnectionString, bool withNullConnectionString)
     {

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
@@ -772,8 +772,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(false, result.Reference.TestBoolean);
-                Assert.Equal(true, result.Collection[0].TestBoolean);
+                Assert.False(result.Reference.TestBoolean);
+                Assert.True(result.Collection[0].TestBoolean);
             });
 
     [ConditionalFact]
@@ -1217,8 +1217,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableInt32);
-                Assert.Equal(null, result.Collection[0].TestNullableInt32);
+                Assert.Null(result.Reference.TestNullableInt32);
+                Assert.Null(result.Collection[0].TestNullableInt32);
             });
 
     [ConditionalFact]
@@ -1305,8 +1305,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnum);
-                Assert.Equal(null, result.Collection[0].TestNullableEnum);
+                Assert.Null(result.Reference.TestNullableEnum);
+                Assert.Null(result.Collection[0].TestNullableEnum);
             });
 
     [ConditionalFact]
@@ -1349,8 +1349,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnumWithIntConverter);
-                Assert.Equal(null, result.Collection[0].TestNullableEnumWithIntConverter);
+                Assert.Null(result.Reference.TestNullableEnumWithIntConverter);
+                Assert.Null(result.Collection[0].TestNullableEnumWithIntConverter);
             });
 
     [ConditionalFact]
@@ -1393,8 +1393,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnumWithConverterThatHandlesNulls);
-                Assert.Equal(null, result.Collection[0].TestNullableEnumWithConverterThatHandlesNulls);
+                Assert.Null(result.Reference.TestNullableEnumWithConverterThatHandlesNulls);
+                Assert.Null(result.Collection[0].TestNullableEnumWithConverterThatHandlesNulls);
             });
 
     [ConditionalFact]
@@ -1522,7 +1522,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(false, result.Reference.BoolConvertedToIntZeroOne);
+                Assert.False(result.Reference.BoolConvertedToIntZeroOne);
             });
 
     [ConditionalFact]
@@ -1542,7 +1542,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(true, result.Reference.BoolConvertedToStringTrueFalse);
+                Assert.True(result.Reference.BoolConvertedToStringTrueFalse);
             });
 
     [ConditionalFact]
@@ -1562,7 +1562,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(false, result.Reference.BoolConvertedToStringYN);
+                Assert.False(result.Reference.BoolConvertedToStringYN);
             });
 
     [ConditionalFact]
@@ -2227,8 +2227,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableInt32Collection);
-                Assert.Equal(null, result.Collection[0].TestNullableInt32Collection);
+                Assert.Null(result.Reference.TestNullableInt32Collection);
+                Assert.Null(result.Collection[0].TestNullableInt32Collection);
 
                 Assert.True(result.Reference.NewCollectionSet); // Set to null.
                 Assert.True(result.Collection[0].NewCollectionSet); // Set to null.
@@ -2327,8 +2327,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnumCollection);
-                Assert.Equal(null, result.Collection[0].TestNullableEnumCollection);
+                Assert.Null(result.Reference.TestNullableEnumCollection);
+                Assert.Null(result.Collection[0].TestNullableEnumCollection);
 
                 Assert.True(result.Reference.NewCollectionSet); // Set to null.
                 Assert.True(result.Collection[0].NewCollectionSet); // Set to null.
@@ -2383,8 +2383,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnumWithIntConverterCollection);
-                Assert.Equal(null, result.Collection[0].TestNullableEnumWithIntConverterCollection);
+                Assert.Null(result.Reference.TestNullableEnumWithIntConverterCollection);
+                Assert.Null(result.Collection[0].TestNullableEnumWithIntConverterCollection);
 
                 Assert.True(result.Reference.NewCollectionSet); // Set to null.
                 Assert.True(result.Collection[0].NewCollectionSet); // Set to null.
@@ -2434,8 +2434,8 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.Reference.TestNullableEnumWithConverterThatHandlesNullsCollection);
-                Assert.Equal(null, result.Collection[0].TestNullableEnumWithConverterThatHandlesNullsCollection);
+                Assert.Null(result.Reference.TestNullableEnumWithConverterThatHandlesNullsCollection);
+                Assert.Null(result.Collection[0].TestNullableEnumWithConverterThatHandlesNullsCollection);
 
                 Assert.False(result.Reference.NewCollectionSet);
                 Assert.False(result.Collection[0].NewCollectionSet);
@@ -2878,7 +2878,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.TestNullableInt32Collection);
+                Assert.Null(result.TestNullableInt32Collection);
 
                 Assert.True(result.NewCollectionSet); // Set to null.
             });
@@ -2966,7 +2966,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.TestNullableEnumCollection);
+                Assert.Null(result.TestNullableEnumCollection);
 
                 Assert.True(result.NewCollectionSet); // Set to null.
             });
@@ -3013,7 +3013,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.TestNullableEnumWithIntConverterCollection);
+                Assert.Null(result.TestNullableEnumWithIntConverterCollection);
 
                 Assert.True(result.NewCollectionSet); // Set to null.
             });
@@ -3057,7 +3057,7 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
             async context =>
             {
                 var result = await context.Set<JsonEntityAllTypes>().SingleAsync(x => x.Id == 1);
-                Assert.Equal(null, result.TestNullableEnumWithConverterThatHandlesNullsCollection);
+                Assert.Null(result.TestNullableEnumWithConverterThatHandlesNullsCollection);
 
                 Assert.False(result.NewCollectionSet);
             });

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -3479,7 +3479,7 @@ SELECT @@ROWCOUNT');
             {
                 var table = Assert.Single(model.Tables);
                 Assert.Equal("Customer", table.Name);
-                Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
+                Assert.True(true, table[SqlServerAnnotationNames.IsTemporal]);
                 Assert.Equal("CustomerHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
                 Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
                 Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -3479,7 +3479,7 @@ SELECT @@ROWCOUNT');
             {
                 var table = Assert.Single(model.Tables);
                 Assert.Equal("Customer", table.Name);
-                Assert.True(true, table[SqlServerAnnotationNames.IsTemporal]);
+                Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
                 Assert.Equal("CustomerHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
                 Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
                 Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -1491,7 +1491,7 @@ public class PropertyEntryTest
         Assert.Equal(11, cultureEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", cultureEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", cultureEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, cultureEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(cultureEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.Culture.Manufacturer, cultureManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", cultureManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, cultureManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1532,7 +1532,7 @@ public class PropertyEntryTest
         Assert.Equal(11, milkEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", milkEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", milkEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, milkEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(milkEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.Milk.Manufacturer, milkManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", milkManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, milkManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1573,7 +1573,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldCultureEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", fieldCultureEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", fieldCultureEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, fieldCultureEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(fieldCultureEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.FieldCulture.Manufacturer, fieldCultureManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", fieldCultureManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, fieldCultureManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1614,7 +1614,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldMilkEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", fieldMilkEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", fieldMilkEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, fieldMilkEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(fieldMilkEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.FieldMilk.Manufacturer, fieldMilkManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", fieldMilkManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, fieldMilkManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1636,7 +1636,7 @@ public class PropertyEntryTest
         Assert.Equal(11, cultureEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", cultureEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", cultureEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, cultureEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(cultureEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.Culture.Manufacturer, cultureManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", cultureManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, cultureManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1656,7 +1656,7 @@ public class PropertyEntryTest
         Assert.Equal(11, milkEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", milkEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", milkEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, milkEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(milkEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.Milk.Manufacturer, milkManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", milkManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, milkManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1676,7 +1676,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldCultureEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", fieldCultureEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", fieldCultureEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, fieldCultureEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(fieldCultureEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.FieldCulture.Manufacturer, fieldCultureManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", fieldCultureManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, fieldCultureManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -1696,7 +1696,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldMilkEntry.Property(e => e.Rating).CurrentValue);
         Assert.Equal("XY", fieldMilkEntry.Property(e => e.Species).CurrentValue);
         Assert.Equal("Z", fieldMilkEntry.Property(e => e.Subspecies).CurrentValue);
-        Assert.Equal(true, fieldMilkEntry.Property(e => e.Validation).CurrentValue);
+        Assert.True(fieldMilkEntry.Property(e => e.Validation).CurrentValue);
         Assert.Equal(yogurt.FieldMilk.Manufacturer, fieldMilkManufacturerEntry.CurrentValue);
         Assert.Equal("Nom", fieldMilkManufacturerEntry.Property(e => e.Name).CurrentValue);
         Assert.Equal(9, fieldMilkManufacturerEntry.Property(e => e.Rating).CurrentValue);
@@ -2681,7 +2681,7 @@ public class PropertyEntryTest
         Assert.Equal(11, cultureEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", cultureEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", cultureEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, cultureEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(cultureEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", cultureManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, cultureManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", cultureManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2741,7 +2741,7 @@ public class PropertyEntryTest
         Assert.Equal(11, milkEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", milkEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", milkEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, milkEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(milkEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", milkManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, milkManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", milkManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2801,7 +2801,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldCultureEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", fieldCultureEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", fieldCultureEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, fieldCultureEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(fieldCultureEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", fieldCultureManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, fieldCultureManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", fieldCultureManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2861,7 +2861,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldMilkEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", fieldMilkEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", fieldMilkEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, fieldMilkEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(fieldMilkEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", fieldMilkManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, fieldMilkManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", fieldMilkManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2889,7 +2889,7 @@ public class PropertyEntryTest
         Assert.Equal(11, cultureEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", cultureEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", cultureEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, cultureEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(cultureEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", cultureManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, cultureManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", cultureManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2915,7 +2915,7 @@ public class PropertyEntryTest
         Assert.Equal(11, milkEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", milkEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", milkEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, milkEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(milkEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", milkManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, milkManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", milkManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2941,7 +2941,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldCultureEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", fieldCultureEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", fieldCultureEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, fieldCultureEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(fieldCultureEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", fieldCultureManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, fieldCultureManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", fieldCultureManTogEntry.Property(e => e.Text).OriginalValue);
@@ -2967,7 +2967,7 @@ public class PropertyEntryTest
         Assert.Equal(11, fieldMilkEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("XY", fieldMilkEntry.Property(e => e.Species).OriginalValue);
         Assert.Equal("Z", fieldMilkEntry.Property(e => e.Subspecies).OriginalValue);
-        Assert.Equal(true, fieldMilkEntry.Property(e => e.Validation).OriginalValue);
+        Assert.True(fieldMilkEntry.Property(e => e.Validation).OriginalValue);
         Assert.Equal("Nom", fieldMilkManufacturerEntry.Property(e => e.Name).OriginalValue);
         Assert.Equal(9, fieldMilkManufacturerEntry.Property(e => e.Rating).OriginalValue);
         Assert.Equal("Tog1", fieldMilkManTogEntry.Property(e => e.Text).OriginalValue);


### PR DESCRIPTION
Use `Assert.Null` instead of `Assert.Equal(null, ...)`.

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Code follows the same patterns and style as existing code in this repo

