### PR TITLE
Fix to #32984 - Query/Test: change query test infra to output SQL whenever we encounter an exception during query execution

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCInheritanceBulkUpdatesFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCInheritanceBulkUpdatesFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-public abstract class TPCInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase
+public abstract class TPCInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPCInheritanceBulkUpdatesTest";

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPHInheritanceBulkUpdatesFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPHInheritanceBulkUpdatesFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-public abstract class TPHInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase
+public abstract class TPHInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPHInheritanceBulkUpdatesTest";

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-public abstract class TPTInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase
+public abstract class TPTInheritanceBulkUpdatesFixture : InheritanceBulkUpdatesFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPTInheritanceBulkUpdatesTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ComplexNavigationsQueryRelationalFixtureBase : ComplexNavigationsQueryFixtureBase
+public abstract class ComplexNavigationsQueryRelationalFixtureBase : ComplexNavigationsQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryRelationalFixtureBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ComplexNavigationsSharedTypeQueryRelationalFixtureBase : ComplexNavigationsSharedTypeQueryFixtureBase
+public abstract class ComplexNavigationsSharedTypeQueryRelationalFixtureBase : ComplexNavigationsSharedTypeQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalFixtureBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ComplexTypeQueryRelationalFixtureBase : ComplexTypeQueryFixtureBase
+public abstract class ComplexTypeQueryRelationalFixtureBase : ComplexTypeQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/CompositeKeysQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/CompositeKeysQueryRelationalFixtureBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class CompositeKeysQueryRelationalFixtureBase : CompositeKeysQueryFixtureBase
+public abstract class CompositeKeysQueryRelationalFixtureBase : CompositeKeysQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class GearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase
+public abstract class GearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase, ITestSqlLoggerFactory
 {
     public override Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationshipsQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationshipsQueryRelationalFixture.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class InheritanceRelationshipsQueryRelationalFixture : InheritanceRelationshipsQueryFixtureBase
+public abstract class InheritanceRelationshipsQueryRelationalFixture : InheritanceRelationshipsQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryContext>, IQueryFixtureBase
+public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryContext>, IQueryFixtureBase, ITestSqlLoggerFactory
 {
     private JsonQueryData _expectedData;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ManyToManyQueryRelationalFixture : ManyToManyQueryFixtureBase
+public abstract class ManyToManyQueryRelationalFixture : ManyToManyQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/MappingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/MappingQueryTestBase.cs
@@ -86,7 +86,7 @@ public abstract class MappingQueryTestBase<TFixture> : IClassFixture<TFixture>
         Three
     }
 
-    public abstract class MappingQueryFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
+    public abstract class MappingQueryFixtureBase : SharedStoreFixtureBase<PoolableDbContext>, ITestSqlLoggerFactory
     {
         protected abstract string DatabaseSchema { get; }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindQueryRelationalFixture<TModelCustomizer> : NorthwindQueryFixtureBase<TModelCustomizer>
+public abstract class NorthwindQueryRelationalFixture<TModelCustomizer> : NorthwindQueryFixtureBase<TModelCustomizer>, ITestSqlLoggerFactory
     where TModelCustomizer : ITestModelCustomizer, new()
 {
     public new RelationalTestStore TestStore

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<NullSemanticsContext>, IQueryFixtureBase
+public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<NullSemanticsContext>, IQueryFixtureBase, ITestSqlLoggerFactory
 {
     public Func<DbContext> GetContextCreator()
         => () => CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryFixtureBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.OptionalDependent;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase<OptionalDependentContext>, IQueryFixtureBase
+public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase<OptionalDependentContext>, IQueryFixtureBase, ITestSqlLoggerFactory
 {
     private OptionalDependentData _expectedData;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
@@ -118,7 +118,7 @@ public abstract class OwnedQueryRelationalTestBase<TFixture> : OwnedQueryTestBas
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression, canExecuteQueryString: CanExecuteQueryString);
 
-    public abstract class RelationalOwnedQueryFixture : OwnedQueryFixtureBase
+    public abstract class RelationalOwnedQueryFixture : OwnedQueryFixtureBase, ITestSqlLoggerFactory
     {
         public new RelationalTestStore TestStore
             => (RelationalTestStore)base.TestStore;

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class QueryFilterFuncletizationRelationalFixture : QueryFilterFuncletizationFixtureBase
+public abstract class QueryFilterFuncletizationRelationalFixture : QueryFilterFuncletizationFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/SpatialQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SpatialQueryRelationalFixture.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class SpatialQueryRelationalFixture : SpatialQueryFixtureBase
+public abstract class SpatialQueryRelationalFixture : SpatialQueryFixtureBase, ITestSqlLoggerFactory
 {
     public new RelationalTestStore TestStore
         => (RelationalTestStore)base.TestStore;

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class TPCGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase
+public abstract class TPCGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPCGearsOfWarQueryTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class TPCInheritanceQueryFixture : InheritanceQueryFixtureBase
+public abstract class TPCInheritanceQueryFixture : InheritanceQueryFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPCInheritanceTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/TPHInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPHInheritanceQueryFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class TPHInheritanceQueryFixture : InheritanceQueryFixtureBase
+public abstract class TPHInheritanceQueryFixture : InheritanceQueryFixtureBase, ITestSqlLoggerFactory
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class TPTGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase
+public abstract class TPTGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPTGearsOfWarQueryTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTInheritanceQueryFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class TPTInheritanceQueryFixture : InheritanceQueryFixtureBase
+public abstract class TPTInheritanceQueryFixture : InheritanceQueryFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TPTInheritanceTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -366,7 +366,7 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
         }
     }
 
-    public abstract class UdfFixtureBase : SharedStoreFixtureBase<DbContext>
+    public abstract class UdfFixtureBase : SharedStoreFixtureBase<DbContext>, ITestSqlLoggerFactory
     {
         protected override Type ContextType { get; } = typeof(UDFSqlContext);
 

--- a/test/EFCore.Relational.Specification.Tests/RelationalComplianceTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/RelationalComplianceTestBase.cs
@@ -8,4 +8,21 @@ public abstract class RelationalComplianceTestBase : ComplianceTestBase
     protected override IEnumerable<Type> GetBaseTestClasses()
         => base.GetBaseTestClasses().Concat(
             typeof(RelationalComplianceTestBase).Assembly.ExportedTypes.Where(t => t.Name.Contains("TestBase")));
+
+    [ConditionalFact]
+    public virtual void All_query_test_fixtures_must_implement_ITestSqlLoggerFactory()
+    {
+        var queryFixturesWithoutTestSqlLogger = TargetAssembly
+            .GetTypes()
+            .Where(x => x.BaseType != typeof(object) && (x.IsPublic || x.IsNestedPublic))
+            .Select(x => new { Type = x, Interfaces = x.GetInterfaces().ToList() })
+            .Where(x => x.Interfaces.Contains(typeof(IQueryFixtureBase)))
+            .Where(x => !x.Interfaces.Contains(typeof(ITestSqlLoggerFactory)))
+            .Select(x => x.Type)
+            .ToList();
+
+        Assert.False(
+            queryFixturesWithoutTestSqlLogger.Count > 0,
+            "\r\n-- Missing ITestSqlLoggerFactory implementation for relational QueryFixtures --\r\n" + string.Join(Environment.NewLine, queryFixturesWithoutTestSqlLogger));
+    }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/ITestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/ITestSqlLoggerFactory.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+public interface ITestSqlLoggerFactory
+{
+    TestSqlLoggerFactory TestSqlLoggerFactory { get; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalQueryAsserter.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalQueryAsserter.cs
@@ -89,4 +89,701 @@ public class RelationalQueryAsserter(
 
         return count;
     }
+
+    public override async Task AssertSingleResult<TResult>(
+        Expression<Func<ISetSource, TResult>> actualSyncQuery,
+        Expression<Func<ISetSource, Task<TResult>>> actualAsyncQuery,
+        Expression<Func<ISetSource, TResult>> expectedQuery,
+        Action<TResult, TResult> asserter,
+        bool async,
+        bool filteredQuery = false)
+    {
+        var outputSql = true;
+        try
+        {
+            await base.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, async, filteredQuery);
+            outputSql = false;
+        }
+        finally
+        {
+            if (outputSql)
+            {
+                ((ITestSqlLoggerFactory)QueryFixture).TestSqlLoggerFactory.OutputSql();
+            }
+        }
+    }
+
+    public override async Task AssertQuery<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Func<TResult, object> elementSorter,
+        Action<TResult, TResult> elementAsserter,
+        bool assertOrder,
+        bool assertEmpty,
+        bool async,
+        string testMethodName,
+        bool filteredQuery = false)
+    {
+        var outputSql = true;
+        try
+        {
+            await base.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, assertEmpty, async, testMethodName, filteredQuery);
+            outputSql = false;
+        }
+        finally
+        {
+            if (outputSql)
+            {
+                ((ITestSqlLoggerFactory)QueryFixture).TestSqlLoggerFactory.OutputSql();
+            }
+        }
+    }
+
+    public override async Task AssertQueryScalar<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter,
+        bool assertOrder,
+        bool assertEmpty,
+        bool async,
+        string testMethodName,
+        bool filteredQuery = false)
+    {
+        var outputSql = true;
+        try
+        {
+            await base.AssertQueryScalar(actualQuery, expectedQuery, asserter, assertOrder, assertEmpty, async, testMethodName, filteredQuery);
+            outputSql = false;
+        }
+        finally
+        {
+            if (outputSql)
+            {
+                ((ITestSqlLoggerFactory)QueryFixture).TestSqlLoggerFactory.OutputSql();
+            }
+        }
+    }
+
+    public override async Task AssertQueryScalar<TResult>(
+        Func<ISetSource, IQueryable<TResult?>> actualQuery,
+        Func<ISetSource, IQueryable<TResult?>> expectedQuery,
+        Action<TResult?, TResult?> asserter,
+        bool assertOrder,
+        bool assertEmpty,
+        bool async,
+        string testMethodName,
+        bool filteredQuery = false)
+    {
+        var outputSql = true;
+        try
+        {
+            await base.AssertQueryScalar(actualQuery, expectedQuery, asserter, assertOrder, assertEmpty, async, testMethodName, filteredQuery);
+            outputSql = false;
+        }
+        finally
+        {
+            if (outputSql)
+            {
+                ((ITestSqlLoggerFactory)QueryFixture).TestSqlLoggerFactory.OutputSql();
+            }
+        }
+    }
+
+    private async Task RunAndOutputSqlOnFailure(Func<Task> assertQuery)
+    {
+        var outputSql = true;
+        try
+        {
+            await assertQuery();
+            outputSql = false;
+        }
+        finally
+        {
+            if (outputSql)
+            {
+                ((ITestSqlLoggerFactory)QueryFixture).TestSqlLoggerFactory.OutputSql();
+            }
+        }
+    }
+
+    public override Task AssertAll<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAll(actualQuery, expectedQuery, actualPredicate, expectedPredicate, async, filteredQuery));
+
+    public override Task AssertAny<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAny(actualQuery, expectedQuery, async, filteredQuery));
+
+    public override Task AssertAny<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAny(actualQuery, expectedQuery, actualPredicate, expectedPredicate, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<decimal>> actualQuery,
+        Func<ISetSource, IQueryable<decimal>> expectedQuery,
+        Action<decimal, decimal> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<decimal?>> actualQuery,
+        Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+        Action<decimal?, decimal?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<double>> actualQuery,
+        Func<ISetSource, IQueryable<double>> expectedQuery,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<double?>> actualQuery,
+        Func<ISetSource, IQueryable<double?>> expectedQuery,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<float>> actualQuery,
+        Func<ISetSource, IQueryable<float>> expectedQuery,
+        Action<float, float> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<float?>> actualQuery,
+        Func<ISetSource, IQueryable<float?>> expectedQuery,
+        Action<float?, float?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<int>> actualQuery,
+        Func<ISetSource, IQueryable<int>> expectedQuery,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<int?>> actualQuery,
+        Func<ISetSource, IQueryable<int?>> expectedQuery,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<long>> actualQuery,
+        Func<ISetSource, IQueryable<long>> expectedQuery,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage(
+        Func<ISetSource, IQueryable<long?>> actualQuery,
+        Func<ISetSource, IQueryable<long?>> expectedQuery,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, decimal>> actualSelector,
+        Expression<Func<TResult, decimal>> expectedSelector,
+        Action<decimal, decimal> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, decimal?>> actualSelector,
+        Expression<Func<TResult, decimal?>> expectedSelector,
+        Action<decimal?, decimal?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, double>> actualSelector,
+        Expression<Func<TResult, double>> expectedSelector,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, double?>> actualSelector,
+        Expression<Func<TResult, double?>> expectedSelector,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, float>> actualSelector,
+        Expression<Func<TResult, float>> expectedSelector,
+        Action<float, float> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, float?>> actualSelector,
+        Expression<Func<TResult, float?>> expectedSelector,
+        Action<float?, float?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, int>> actualSelector,
+        Expression<Func<TResult, int>> expectedSelector,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, int?>> actualSelector,
+        Expression<Func<TResult, int?>> expectedSelector,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, long>> actualSelector,
+        Expression<Func<TResult, long>> expectedSelector,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertAverage<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, long?>> actualSelector,
+        Expression<Func<TResult, long?>> expectedSelector,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertCount<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertCount(actualQuery, expectedQuery, async, filteredQuery));
+
+    public override Task AssertCount<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertCount(actualQuery, expectedQuery, actualPredicate, expectedPredicate, async, filteredQuery));
+
+    public override Task AssertElementAt<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Func<int> actualIndex,
+        Func<int> expectedIndex,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertElementAt(actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, async, filteredQuery));
+
+    public override Task AssertElementAtOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Func<int> actualIndex,
+        Func<int> expectedIndex,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertElementAtOrDefault(actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, async, filteredQuery));
+
+    public override Task AssertFirst<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertFirst(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertFirst<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertFirst(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertFirstOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertFirstOrDefault(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertFirstOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertFirstOrDefault(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertLast<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLast(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertLast<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLast(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertLastOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLastOrDefault(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertLastOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLastOrDefault(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertLongCount<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLongCount(actualQuery, expectedQuery, async, filteredQuery));
+
+    public override Task AssertLongCount<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertLongCount(actualQuery, expectedQuery, actualPredicate, expectedPredicate, async, filteredQuery));
+
+    public override Task AssertMax<TResult, TSelector>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, TSelector>> actualSelector,
+        Expression<Func<TResult, TSelector>> expectedSelector,
+        Action<TSelector, TSelector> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertMax(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertMax<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertMax(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertMin<TResult, TSelector>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, TSelector>> actualSelector,
+        Expression<Func<TResult, TSelector>> expectedSelector,
+        Action<TSelector, TSelector> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertMin(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertMin<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertMin(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSingle<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSingle(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSingle<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSingle(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertSingleOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSingleOrDefault(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSingleOrDefault<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, bool>> actualPredicate,
+        Expression<Func<TResult, bool>> expectedPredicate,
+        Action<TResult, TResult> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSingleOrDefault(actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<decimal>> actualQuery,
+        Func<ISetSource, IQueryable<decimal>> expectedQuery,
+        Action<decimal, decimal> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<decimal?>> actualQuery,
+        Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+        Action<decimal?, decimal?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<double>> actualQuery,
+        Func<ISetSource, IQueryable<double>> expectedQuery,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<double?>> actualQuery,
+        Func<ISetSource, IQueryable<double?>> expectedQuery,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<float>> actualQuery,
+        Func<ISetSource, IQueryable<float>> expectedQuery,
+        Action<float, float> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<float?>> actualQuery,
+        Func<ISetSource, IQueryable<float?>> expectedQuery,
+        Action<float?, float?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<int>> actualQuery,
+        Func<ISetSource, IQueryable<int>> expectedQuery,
+        Action<int, int> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<int?>> actualQuery,
+        Func<ISetSource, IQueryable<int?>> expectedQuery,
+        Action<int?, int?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<long>> actualQuery,
+        Func<ISetSource, IQueryable<long>> expectedQuery,
+        Action<long, long> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum(
+        Func<ISetSource, IQueryable<long?>> actualQuery,
+        Func<ISetSource, IQueryable<long?>> expectedQuery,
+        Action<long?, long?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, decimal>> actualSelector,
+        Expression<Func<TResult, decimal>> expectedSelector,
+        Action<decimal, decimal> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, decimal?>> actualSelector,
+        Expression<Func<TResult, decimal?>> expectedSelector,
+        Action<decimal?, decimal?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, double>> actualSelector,
+        Expression<Func<TResult, double>> expectedSelector,
+        Action<double, double> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, double?>> actualSelector,
+        Expression<Func<TResult, double?>> expectedSelector,
+        Action<double?, double?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, float>> actualSelector,
+        Expression<Func<TResult, float>> expectedSelector,
+        Action<float, float> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, float?>> actualSelector,
+        Expression<Func<TResult, float?>> expectedSelector,
+        Action<float?, float?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, int>> actualSelector,
+        Expression<Func<TResult, int>> expectedSelector,
+        Action<int, int> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, int?>> actualSelector,
+        Expression<Func<TResult, int?>> expectedSelector,
+        Action<int?, int?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, long>> actualSelector,
+        Expression<Func<TResult, long>> expectedSelector,
+        Action<long, long> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
+
+    public override Task AssertSum<TResult>(
+        Func<ISetSource, IQueryable<TResult>> actualQuery,
+        Func<ISetSource, IQueryable<TResult>> expectedQuery,
+        Expression<Func<TResult, long?>> actualSelector,
+        Expression<Func<TResult, long?>> expectedSelector,
+        Action<long?, long?> asserter = null,
+        bool async = false,
+        bool filteredQuery = false)
+        => RunAndOutputSqlOnFailure(() => base.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async, filteredQuery));
 }

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -41,6 +41,12 @@ public class TestSqlLoggerFactory : ListLoggerFactory
     public string Sql
         => string.Join(_eol + _eol, SqlStatements);
 
+    public void OutputSql()
+    {
+        Logger.TestOutputHelper?.WriteLine("SQL sent to the database:");
+        Logger.TestOutputHelper?.WriteLine(Sql);
+    }
+
     public void AssertBaseline(string[] expected, bool assertOrder = true, bool forUpdate = false)
     {
         if (_proceduralQueryGeneration)

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -44,7 +44,7 @@ public class QueryAsserter(
     protected ISetSource GetExpectedData(DbContext context, bool filteredQuery)
         => filteredQuery ? ((IFilteredQueryFixtureBase)QueryFixture).GetFilteredExpectedData(context) : _expectedData;
 
-    public async Task AssertSingleResult<TResult>(
+    public virtual async Task AssertSingleResult<TResult>(
         Expression<Func<ISetSource, TResult>> actualSyncQuery,
         Expression<Func<ISetSource, Task<TResult>>> actualAsyncQuery,
         Expression<Func<ISetSource, TResult>> expectedQuery,
@@ -64,7 +64,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertQuery<TResult>(
+    public virtual async Task AssertQuery<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Func<TResult, object> elementSorter,
@@ -155,7 +155,7 @@ public class QueryAsserter(
         }
     }
 
-    public async Task AssertQueryScalar<TResult>(
+    public virtual async Task AssertQueryScalar<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter,
@@ -196,7 +196,7 @@ public class QueryAsserter(
         AssertResultCount(actual.Count, assertEmpty);
     }
 
-    public async Task AssertQueryScalar<TResult>(
+    public virtual async Task AssertQueryScalar<TResult>(
         Func<ISetSource, IQueryable<TResult?>> actualQuery,
         Func<ISetSource, IQueryable<TResult?>> expectedQuery,
         Action<TResult?, TResult?> asserter,
@@ -239,7 +239,7 @@ public class QueryAsserter(
 
     #region Assert termination operation methods
 
-    public async Task AssertAny<TResult>(
+    public virtual async Task AssertAny<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         bool async = false,
@@ -256,7 +256,7 @@ public class QueryAsserter(
         Assert.Equal(expected, actual);
     }
 
-    public async Task AssertAny<TResult>(
+    public virtual async Task AssertAny<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -277,7 +277,7 @@ public class QueryAsserter(
         Assert.Equal(expected, actual);
     }
 
-    public async Task AssertAll<TResult>(
+    public virtual async Task AssertAll<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -298,7 +298,7 @@ public class QueryAsserter(
         Assert.Equal(expected, actual);
     }
 
-    public async Task AssertElementAt<TResult>(
+    public virtual async Task AssertElementAt<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Func<int> actualIndex,
@@ -318,7 +318,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertElementAtOrDefault<TResult>(
+    public virtual async Task AssertElementAtOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Func<int> actualIndex,
@@ -338,7 +338,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertFirst<TResult>(
+    public virtual async Task AssertFirst<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -356,7 +356,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertFirst<TResult>(
+    public virtual async Task AssertFirst<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -378,7 +378,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertFirstOrDefault<TResult>(
+    public virtual async Task AssertFirstOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -396,7 +396,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertFirstOrDefault<TResult>(
+    public virtual async Task AssertFirstOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -418,7 +418,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertSingle<TResult>(
+    public virtual async Task AssertSingle<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -436,7 +436,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertSingle<TResult>(
+    public virtual async Task AssertSingle<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -458,7 +458,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertSingleOrDefault<TResult>(
+    public virtual async Task AssertSingleOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -476,7 +476,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertSingleOrDefault<TResult>(
+    public virtual async Task AssertSingleOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -498,7 +498,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertLast<TResult>(
+    public virtual async Task AssertLast<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -516,7 +516,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertLast<TResult>(
+    public virtual async Task AssertLast<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -538,7 +538,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertLastOrDefault<TResult>(
+    public virtual async Task AssertLastOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -556,7 +556,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertLastOrDefault<TResult>(
+    public virtual async Task AssertLastOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -578,7 +578,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertCount<TResult>(
+    public virtual async Task AssertCount<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         bool async = false,
@@ -596,7 +596,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertCount<TResult>(
+    public virtual async Task AssertCount<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -618,7 +618,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertLongCount<TResult>(
+    public virtual async Task AssertLongCount<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         bool async = false,
@@ -636,7 +636,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertLongCount<TResult>(
+    public virtual async Task AssertLongCount<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
@@ -658,7 +658,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertMin<TResult>(
+    public virtual async Task AssertMin<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -676,7 +676,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertMin<TResult, TSelector>(
+    public virtual async Task AssertMin<TResult, TSelector>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, TSelector>> actualSelector,
@@ -699,7 +699,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertMax<TResult>(
+    public virtual async Task AssertMax<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
@@ -717,7 +717,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertMax<TResult, TSelector>(
+    public virtual async Task AssertMax<TResult, TSelector>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, TSelector>> actualSelector,
@@ -740,7 +740,7 @@ public class QueryAsserter(
         AssertEqual(expected, actual, asserter);
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<int>> actualQuery,
         Func<ISetSource, IQueryable<int>> expectedQuery,
         Action<int, int> asserter = null,
@@ -759,7 +759,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<int?>> actualQuery,
         Func<ISetSource, IQueryable<int?>> expectedQuery,
         Action<int?, int?> asserter = null,
@@ -778,7 +778,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<long>> actualQuery,
         Func<ISetSource, IQueryable<long>> expectedQuery,
         Action<long, long> asserter = null,
@@ -797,7 +797,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<long?>> actualQuery,
         Func<ISetSource, IQueryable<long?>> expectedQuery,
         Action<long?, long?> asserter = null,
@@ -816,7 +816,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<decimal>> actualQuery,
         Func<ISetSource, IQueryable<decimal>> expectedQuery,
         Action<decimal, decimal> asserter = null,
@@ -835,7 +835,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<decimal?>> actualQuery,
         Func<ISetSource, IQueryable<decimal?>> expectedQuery,
         Action<decimal?, decimal?> asserter = null,
@@ -854,7 +854,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<float>> actualQuery,
         Func<ISetSource, IQueryable<float>> expectedQuery,
         Action<float, float> asserter = null,
@@ -873,7 +873,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<float?>> actualQuery,
         Func<ISetSource, IQueryable<float?>> expectedQuery,
         Action<float?, float?> asserter = null,
@@ -892,7 +892,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<double>> actualQuery,
         Func<ISetSource, IQueryable<double>> expectedQuery,
         Action<double, double> asserter = null,
@@ -911,7 +911,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum(
+    public virtual async Task AssertSum(
         Func<ISetSource, IQueryable<double?>> actualQuery,
         Func<ISetSource, IQueryable<double?>> expectedQuery,
         Action<double?, double?> asserter = null,
@@ -930,7 +930,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, int>> actualSelector,
@@ -953,7 +953,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, int?>> actualSelector,
@@ -976,7 +976,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, long>> actualSelector,
@@ -999,7 +999,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, long?>> actualSelector,
@@ -1022,7 +1022,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, decimal>> actualSelector,
@@ -1045,7 +1045,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, decimal?>> actualSelector,
@@ -1069,7 +1069,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, float>> actualSelector,
@@ -1092,7 +1092,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, float?>> actualSelector,
@@ -1115,7 +1115,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, double>> actualSelector,
@@ -1138,7 +1138,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertSum<TResult>(
+    public virtual async Task AssertSum<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, double?>> actualSelector,
@@ -1161,7 +1161,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<int>> actualQuery,
         Func<ISetSource, IQueryable<int>> expectedQuery,
         Action<double, double> asserter = null,
@@ -1180,7 +1180,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<int?>> actualQuery,
         Func<ISetSource, IQueryable<int?>> expectedQuery,
         Action<double?, double?> asserter = null,
@@ -1199,7 +1199,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<long>> actualQuery,
         Func<ISetSource, IQueryable<long>> expectedQuery,
         Action<double, double> asserter = null,
@@ -1218,7 +1218,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<long?>> actualQuery,
         Func<ISetSource, IQueryable<long?>> expectedQuery,
         Action<double?, double?> asserter = null,
@@ -1237,7 +1237,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<decimal>> actualQuery,
         Func<ISetSource, IQueryable<decimal>> expectedQuery,
         Action<decimal, decimal> asserter = null,
@@ -1256,7 +1256,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<decimal?>> actualQuery,
         Func<ISetSource, IQueryable<decimal?>> expectedQuery,
         Action<decimal?, decimal?> asserter = null,
@@ -1275,7 +1275,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<float>> actualQuery,
         Func<ISetSource, IQueryable<float>> expectedQuery,
         Action<float, float> asserter = null,
@@ -1294,7 +1294,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<float?>> actualQuery,
         Func<ISetSource, IQueryable<float?>> expectedQuery,
         Action<float?, float?> asserter = null,
@@ -1313,7 +1313,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<double>> actualQuery,
         Func<ISetSource, IQueryable<double>> expectedQuery,
         Action<double, double> asserter = null,
@@ -1332,7 +1332,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage(
+    public virtual async Task AssertAverage(
         Func<ISetSource, IQueryable<double?>> actualQuery,
         Func<ISetSource, IQueryable<double?>> expectedQuery,
         Action<double?, double?> asserter = null,
@@ -1351,7 +1351,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, int>> actualSelector,
@@ -1374,7 +1374,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, int?>> actualSelector,
@@ -1397,7 +1397,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, long>> actualSelector,
@@ -1420,7 +1420,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, long?>> actualSelector,
@@ -1443,7 +1443,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, decimal>> actualSelector,
@@ -1466,7 +1466,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, decimal?>> actualSelector,
@@ -1490,7 +1490,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, float>> actualSelector,
@@ -1513,7 +1513,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, float?>> actualSelector,
@@ -1536,7 +1536,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, double>> actualSelector,
@@ -1559,7 +1559,7 @@ public class QueryAsserter(
         Assert.Empty(context.ChangeTracker.Entries());
     }
 
-    public async Task AssertAverage<TResult>(
+    public virtual async Task AssertAverage<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, double?>> actualSelector,

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
@@ -270,7 +270,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].
 
     private string Sql { get; set; }
 
-    public class ManyToManyFieldsLoadSqlServerFixture : ManyToManyFieldsLoadFixtureBase
+    public class ManyToManyFieldsLoadSqlServerFixture : ManyToManyFieldsLoadFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -289,7 +289,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].
 
     private string Sql { get; set; }
 
-    public class ManyToManyLoadSqlServerFixture : ManyToManyLoadFixtureBase
+    public class ManyToManyLoadSqlServerFixture : ManyToManyLoadFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
@@ -26,8 +26,11 @@ public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToMany
         { "UnidirectionalEntityTwo.SelfSkipSharedRight", DeleteBehavior.ClientCascade },
     };
 
-    public class ManyToManyTrackingSqlServerFixtureBase : ManyToManyTrackingRelationalFixture
+    public class ManyToManyTrackingSqlServerFixtureBase : ManyToManyTrackingRelationalFixture, ITestSqlLoggerFactory
     {
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
         protected override ITestStoreFactory TestStoreFactory
             => SqlServerTestStoreFactory.Instance;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
@@ -917,7 +917,7 @@ ORDER BY [p2].[LastName] DESC, [p4].[Id], [p6].[LastName], [p6].[Id]
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class Ef6GroupBySqlServerFixture : Ef6GroupByFixtureBase
+    public class Ef6GroupBySqlServerFixture : Ef6GroupByFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -602,7 +602,7 @@ WHERE [f].[FirstName] LIKE @__s_0_contains ESCAPE N'\' OR [f].[LastName] LIKE @_
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class FunkyDataQuerySqlServerFixture : FunkyDataQueryFixtureBase
+    public class FunkyDataQuerySqlServerFixture : FunkyDataQueryFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeOneToOneSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeOneToOneSqlServerTest.cs
@@ -62,7 +62,7 @@ LEFT JOIN [Address2] AS [a] ON [p].[Id] = [a].[PersonId]
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class OneToOneQuerySqlServerFixture : OneToOneQueryFixtureBase
+    public class OneToOneQuerySqlServerFixture : OneToOneQueryFixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -833,7 +833,7 @@ END IN (N'one', N'two', N'three')
     private PrimitiveCollectionsContext CreateContext()
         => Fixture.CreateContext();
 
-    public class PrimitiveCollectionsQueryOldSqlServerFixture : PrimitiveCollectionsQueryFixtureBase
+    public class PrimitiveCollectionsQueryOldSqlServerFixture : PrimitiveCollectionsQueryFixtureBase, ITestSqlLoggerFactory
     {
         // Use a different store name to prevent concurrency issues with the non-old PrimitiveCollectionsQuerySqlServerTest
         protected override string StoreName

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -1530,7 +1530,7 @@ END IN (
     private PrimitiveCollectionsContext CreateContext()
         => Fixture.CreateContext();
 
-    public class PrimitiveCollectionsQuerySqlServerFixture : PrimitiveCollectionsQueryFixtureBase
+    public class PrimitiveCollectionsQuerySqlServerFixture : PrimitiveCollectionsQueryFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBase
+public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBase, ITestSqlLoggerFactory
 {
     protected override string StoreName
         => "TemporalManyToManyQueryTest";

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1835,7 +1835,7 @@ ORDER BY "b"."Id", "b0"."Id"
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class BuiltInDataTypesSqliteFixture : BuiltInDataTypesFixtureBase
+    public class BuiltInDataTypesSqliteFixture : BuiltInDataTypesFixtureBase, ITestSqlLoggerFactory
     {
         public override bool StrictEquality
             => false;

--- a/test/EFCore.Sqlite.FunctionalTests/ComplexTypesTrackingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ComplexTypesTrackingSqliteTest.cs
@@ -15,7 +15,7 @@ public class ComplexTypesTrackingSqliteTest : ComplexTypesTrackingTestBase<Compl
     protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         => facade.UseTransaction(transaction.GetDbTransaction());
 
-    public class SqliteFixture : FixtureBase
+    public class SqliteFixture : FixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/ConcurrencyDetectorDisabledSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConcurrencyDetectorDisabledSqliteTest.cs
@@ -6,7 +6,7 @@ namespace Microsoft.EntityFrameworkCore;
 public class ConcurrencyDetectorDisabledSqliteTest(ConcurrencyDetectorDisabledSqliteTest.ConcurrencyDetectorSqlServerFixture fixture) : ConcurrencyDetectorDisabledRelationalTestBase<
     ConcurrencyDetectorDisabledSqliteTest.ConcurrencyDetectorSqlServerFixture>(fixture)
 {
-    public class ConcurrencyDetectorSqlServerFixture : ConcurrencyDetectorFixtureBase
+    public class ConcurrencyDetectorSqlServerFixture : ConcurrencyDetectorFixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/ConcurrencyDetectorEnabledSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConcurrencyDetectorEnabledSqliteTest.cs
@@ -6,7 +6,7 @@ namespace Microsoft.EntityFrameworkCore;
 public class ConcurrencyDetectorEnabledSqliteTest(ConcurrencyDetectorEnabledSqliteTest.ConcurrencyDetectorSqlServerFixture fixture) : ConcurrencyDetectorEnabledRelationalTestBase<
     ConcurrencyDetectorEnabledSqliteTest.ConcurrencyDetectorSqlServerFixture>(fixture)
 {
-    public class ConcurrencyDetectorSqlServerFixture : ConcurrencyDetectorFixtureBase
+    public class ConcurrencyDetectorSqlServerFixture : ConcurrencyDetectorFixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
@@ -13,7 +13,7 @@ public class ConvertToProviderTypesSqliteTest : ConvertToProviderTypesTestBase<
         fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    public class ConvertToProviderTypesSqliteFixture : ConvertToProviderTypesFixtureBase
+    public class ConvertToProviderTypesSqliteFixture : ConvertToProviderTypesFixtureBase, ITestSqlLoggerFactory
     {
         public override bool StrictEquality
             => false;

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -137,7 +137,7 @@ WHERE "b"."IndexerVisible" = 'Nay'
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class CustomConvertersSqliteFixture : CustomConvertersFixtureBase
+    public class CustomConvertersSqliteFixture : CustomConvertersFixtureBase, ITestSqlLoggerFactory
     {
         public override bool StrictEquality
             => false;

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -173,7 +173,7 @@ RETURNING "Unique_No";
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class DataAnnotationSqliteFixture : DataAnnotationRelationalFixtureBase
+    public class DataAnnotationSqliteFixture : DataAnnotationRelationalFixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/ManyToManyFieldsLoadSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ManyToManyFieldsLoadSqliteTestBase.cs
@@ -8,8 +8,11 @@ namespace Microsoft.EntityFrameworkCore;
 public class ManyToManyFieldsLoadSqliteTest(ManyToManyFieldsLoadSqliteTest.ManyToManyFieldsLoadSqliteFixture fixture)
     : ManyToManyFieldsLoadTestBase<ManyToManyFieldsLoadSqliteTest.ManyToManyFieldsLoadSqliteFixture>(fixture)
 {
-    public class ManyToManyFieldsLoadSqliteFixture : ManyToManyFieldsLoadFixtureBase
+    public class ManyToManyFieldsLoadSqliteFixture : ManyToManyFieldsLoadFixtureBase, ITestSqlLoggerFactory
     {
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;
 

--- a/test/EFCore.Sqlite.FunctionalTests/ManyToManyLoadSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ManyToManyLoadSqliteTestBase.cs
@@ -13,8 +13,11 @@ public abstract class ManyToManyLoadSqliteTestBase<TFixture> : ManyToManyLoadTes
     {
     }
 
-    public class ManyToManyLoadSqliteFixtureBase : ManyToManyLoadFixtureBase
+    public class ManyToManyLoadSqliteFixtureBase : ManyToManyLoadFixtureBase, ITestSqlLoggerFactory
     {
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;
 

--- a/test/EFCore.Sqlite.FunctionalTests/ManyToManyTrackingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ManyToManyTrackingSqliteTest.cs
@@ -8,8 +8,11 @@ namespace Microsoft.EntityFrameworkCore;
 public class ManyToManyTrackingSqliteTest(ManyToManyTrackingSqliteTest.ManyToManyTrackingSqliteFixture fixture)
     : ManyToManyTrackingRelationalTestBase<ManyToManyTrackingSqliteTest.ManyToManyTrackingSqliteFixture>(fixture)
 {
-    public class ManyToManyTrackingSqliteFixture : ManyToManyTrackingRelationalFixture
+    public class ManyToManyTrackingSqliteFixture : ManyToManyTrackingRelationalFixture, ITestSqlLoggerFactory
     {
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;
 

--- a/test/EFCore.Sqlite.FunctionalTests/NonLoadingNavigationsManyToManyLoadSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/NonLoadingNavigationsManyToManyLoadSqliteTest.cs
@@ -8,10 +8,13 @@ namespace Microsoft.EntityFrameworkCore;
 public class NonLoadingNavigationsManyToManyLoadSqliteTest(NonLoadingNavigationsManyToManyLoadSqliteTest.NonLoadingNavigationsManyToManyLoadSqliteFixture fixture)
     : ManyToManyLoadTestBase<NonLoadingNavigationsManyToManyLoadSqliteTest.NonLoadingNavigationsManyToManyLoadSqliteFixture>(fixture)
 {
-    public class NonLoadingNavigationsManyToManyLoadSqliteFixture : ManyToManyLoadFixtureBase
+    public class NonLoadingNavigationsManyToManyLoadSqliteFixture : ManyToManyLoadFixtureBase, ITestSqlLoggerFactory
     {
         protected override string StoreName
             => "NonLoadingNavigationsManyToMany";
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
 
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -47,7 +47,7 @@ public class Ef6GroupBySqliteTest : Ef6GroupByTestBase<Ef6GroupBySqliteTest.Ef6G
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Group_Join_from_LINQ_101(async))).Message);
 
-    public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase
+    public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
@@ -37,7 +37,7 @@ WHERE ("f"."FirstName" IS NOT NULL AND instr("f"."FirstName", @__s_0) > 0) OR "f
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-    public class FunkyDataQuerySqliteFixture : FunkyDataQueryFixtureBase
+    public class FunkyDataQuerySqliteFixture : FunkyDataQueryFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/IncludeOneToOneSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/IncludeOneToOneSqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public class IncludeOneToOneSqliteTest(IncludeOneToOneSqliteTest.OneToOneQuerySqliteFixture fixture) : IncludeOneToOneTestBase<IncludeOneToOneSqliteTest.OneToOneQuerySqliteFixture>(fixture)
 {
-    public class OneToOneQuerySqliteFixture : OneToOneQueryFixtureBase
+    public class OneToOneQuerySqliteFixture : OneToOneQueryFixtureBase, ITestSqlLoggerFactory
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -1437,7 +1437,7 @@ END IN (
     private PrimitiveCollectionsContext CreateContext()
         => Fixture.CreateContext();
 
-    public class PrimitiveCollectionsQuerySqlServerFixture : PrimitiveCollectionsQueryFixtureBase
+    public class PrimitiveCollectionsQuerySqlServerFixture : PrimitiveCollectionsQueryFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;


### PR DESCRIPTION
Added overrides to all relational Assert* methods to log the generated sql in case the test fails. Before we only outputted sql if the test succeeded, results were correct, but sql was different than expected.

Fixes #32984