### PR TITLE
Retarget tools to .NET Framework 4.7.2

### DIFF
--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -10,6 +10,7 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
     <ImplicitUsings>true</ImplicitUsings>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.nuspec
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.nuspec
@@ -11,7 +11,6 @@
   <files>
     $CommonFileElements$
     <file src="PACKAGE.md" target="docs\" />
-    <file src="_._" target="lib\$targetFramework$\" />
     <file src="$OutputBinary$" target="analyzers\dotnet\cs\" />
     <file src="$OutputSymbol$" target="analyzers\dotnet\cs\" />
   </files>

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -117,7 +117,7 @@ public class DbContextOperations
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Optimize(string? outputDir, string? modelNamespace, string? contextTypeName)
+    public virtual IReadOnlyList<string> Optimize(string? outputDir, string? modelNamespace, string? contextTypeName)
     {
         using var context = CreateContext(contextTypeName);
         var contextType = context.GetType();
@@ -141,7 +141,7 @@ public class DbContextOperations
 
         var finalModelNamespace = modelNamespace ?? GetNamespaceFromOutputPath(outputDir) ?? "";
 
-        scaffolder.ScaffoldModel(
+        var scaffoldedFiles = scaffolder.ScaffoldModel(
             context.GetService<IDesignTimeModel>().Model,
             outputDir,
             new CompiledModelCodeGenerationOptions
@@ -165,6 +165,8 @@ public class DbContextOperations
         {
             _reporter.WriteWarning(DesignStrings.CompiledModelCustomCacheKeyFactory(cacheKeyFactory.GetType().ShortDisplayName()));
         }
+
+        return scaffoldedFiles;
     }
 
     private string? GetNamespaceFromOutputPath(string directoryPath)

--- a/src/EFCore.Design/Design/Internal/IOperationReporter.cs
+++ b/src/EFCore.Design/Design/Internal/IOperationReporter.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CodeDom.Compiler;
-using System.Text;
-
 namespace Microsoft.EntityFrameworkCore.Design.Internal;
 
 /// <summary>
@@ -45,54 +42,4 @@ public interface IOperationReporter
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     void WriteVerbose(string message);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    void Write(CompilerError error)
-    {
-        var builder = new StringBuilder();
-
-        if (!string.IsNullOrEmpty(error.FileName))
-        {
-            builder.Append(error.FileName);
-
-            if (error.Line > 0)
-            {
-                builder
-                    .Append("(")
-                    .Append(error.Line);
-
-                if (error.Column > 0)
-                {
-                    builder
-                        .Append(",")
-                        .Append(error.Column);
-                }
-
-                builder.Append(")");
-            }
-
-            builder.Append(" : ");
-        }
-
-        builder
-            .Append(error.IsWarning ? "warning" : "error")
-            .Append(" ")
-            .Append(error.ErrorNumber)
-            .Append(": ")
-            .AppendLine(error.ErrorText);
-
-        if (error.IsWarning)
-        {
-            WriteWarning(builder.ToString());
-        }
-        else
-        {
-            WriteError(builder.ToString());
-        }
-    }
 }

--- a/src/EFCore.Design/Design/Internal/OperationReporterExtensions.cs
+++ b/src/EFCore.Design/Design/Internal/OperationReporterExtensions.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CodeDom.Compiler;
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public static class OperationReporterExtensions
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static void Write(this IOperationReporter reporter, CompilerError error)
+    {
+        var builder = new StringBuilder();
+
+        if (!string.IsNullOrEmpty(error.FileName))
+        {
+            builder.Append(error.FileName);
+
+            if (error.Line > 0)
+            {
+                builder
+                    .Append("(")
+                    .Append(error.Line);
+
+                if (error.Column > 0)
+                {
+                    builder
+                        .Append(",")
+                        .Append(error.Column);
+                }
+
+                builder.Append(")");
+            }
+
+            builder.Append(" : ");
+        }
+
+        builder
+            .Append(error.IsWarning ? "warning" : "error")
+            .Append(" ")
+            .Append(error.ErrorNumber)
+            .Append(": ")
+            .AppendLine(error.ErrorText);
+
+        if (error.IsWarning)
+        {
+            reporter.WriteWarning(builder.ToString());
+        }
+        else
+        {
+            reporter.WriteError(builder.ToString());
+        }
+    }
+}

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -526,7 +526,7 @@ public class OperationExecutor : MarshalByRefObject
         }
     }
 
-    private void OptimizeContextImpl(string? outputDir, string? modelNamespace, string? contextType)
+    private IReadOnlyList<string> OptimizeContextImpl(string? outputDir, string? modelNamespace, string? contextType)
         => ContextOperations.Optimize(outputDir, modelNamespace, contextType);
 
     /// <summary>

--- a/src/EFCore.Design/Design/OperationReportHandler.cs
+++ b/src/EFCore.Design/Design/OperationReportHandler.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.EntityFrameworkCore.Design;
 
 /// <summary>

--- a/src/EFCore.Design/Design/OperationResultHandler.cs
+++ b/src/EFCore.Design/Design/OperationResultHandler.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.EntityFrameworkCore.Design;
 
 /// <summary>

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.Design</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DevelopmentDependency>True</DevelopmentDependency>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -17,12 +17,12 @@
     <file src="lib\**\*" target="lib/" />
     <file src="tools\**\*" target="tools/" />
     <file src="$intermediateOutputPath$*.psd1" target="tools/" />
-    <file src="../../artifacts/bin/ef/$configuration$/net461/ef.exe" target="tools/net461/any/" />
-    <file src="../../artifacts/bin/ef/$configuration$/net461/ef.pdb" target="tools/net461/any/" />
-    <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.exe" target="tools/net461/win-x86/" />
-    <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.pdb" target="tools/net461/win-x86/" />
-    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net461/ef.exe" target="tools/net461/win-arm64/" />
-    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net461/ef.pdb" target="tools/net461/win-arm64/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net472/ef.exe" target="tools/net472/any/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net472/ef.pdb" target="tools/net472/any/" />
+    <file src="../../artifacts/bin/ef/x86/$configuration$/net472/ef.exe" target="tools/net472/win-x86/" />
+    <file src="../../artifacts/bin/ef/x86/$configuration$/net472/ef.pdb" target="tools/net472/win-x86/" />
+    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net472/ef.exe" target="tools/net472/win-arm64/" />
+    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net472/ef.pdb" target="tools/net472/win-arm64/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.dll" target="tools/netcoreapp2.0/any/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.pdb" target="tools/netcoreapp2.0/any/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.runtimeconfig.json" target="tools/netcoreapp2.0/any/" />

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1220,15 +1220,15 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
         $platformTarget = GetPlatformTarget $startupProject
         if ($platformTarget -eq 'x86')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\win-x86\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net472\win-x86\ef.exe'
         }
         elseif ($platformTarget -eq 'ARM64')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\win-arm64\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net472\win-arm64\ef.exe'
         }
         elseif ($platformTarget -in 'AnyCPU', 'x64')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\any\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net472\any\ef.exe'
         }
         else
         {

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -106,7 +106,7 @@ internal class RootCommand : CommandBase
         {
             executable = Path.Combine(
                 toolsPath,
-                "net461",
+                "net472",
                 startupProject.PlatformTarget == "x86"
                     ? "win-x86"
                     : "any",
@@ -126,7 +126,7 @@ internal class RootCommand : CommandBase
             {
                 executable = Path.Combine(
                     toolsPath,
-                    "net461",
+                    "net472",
                     startupProject.PlatformTarget switch
                     {
                         "x86" => "win-x86",

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -88,12 +88,12 @@ dotnet ef database update
       <NuspecProperty Include="OutputBinary=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.dll" />
       <NuspecProperty Include="OutputRuntimeConfig=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.runtimeconfig.json" />
       <NuspecProperty Include="OutputSymbol=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.pdb" />
-      <NuspecProperty Include="OutputExe=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputExeSymbol=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.pdb" />
-      <NuspecProperty Include="OutputX86Exe=..\..\artifacts\bin\ef\x86\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputX86ExeSymbol=..\..\artifacts\bin\ef\x86\$(Configuration)\net461\ef.pdb" />
-      <NuspecProperty Include="OutputARM64Exe=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputARM64ExeSymbol=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net461\ef.pdb" />
+      <NuspecProperty Include="OutputExe=..\..\artifacts\bin\ef\$(Configuration)\net472\ef.exe" />
+      <NuspecProperty Include="OutputExeSymbol=..\..\artifacts\bin\ef\$(Configuration)\net472\ef.pdb" />
+      <NuspecProperty Include="OutputX86Exe=..\..\artifacts\bin\ef\x86\$(Configuration)\net472\ef.exe" />
+      <NuspecProperty Include="OutputX86ExeSymbol=..\..\artifacts\bin\ef\x86\$(Configuration)\net472\ef.pdb" />
+      <NuspecProperty Include="OutputARM64Exe=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net472\ef.exe" />
+      <NuspecProperty Include="OutputARM64ExeSymbol=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net472\ef.pdb" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/dotnet-ef/dotnet-ef.nuspec
+++ b/src/dotnet-ef/dotnet-ef.nuspec
@@ -16,11 +16,11 @@
     <file src="$OutputBinary$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputRuntimeConfig$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputSymbol$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
-    <file src="$OutputExe$" target="tools\$targetFramework$\any\tools\net461\any" />
-    <file src="$OutputExeSymbol$" target="tools\$targetFramework$\any\tools\net461\any" />
-    <file src="$OutputX86Exe$" target="tools\$targetFramework$\any\tools\net461\win-x86" />
-    <file src="$OutputX86ExeSymbol$" target="tools\$targetFramework$\any\tools\net461\win-x86" />
-    <file src="$OutputARM64Exe$" target="tools\$targetFramework$\any\tools\net461\win-arm64" />
-    <file src="$OutputARM64ExeSymbol$" target="tools\$targetFramework$\any\tools\net461\win-arm64" />
+    <file src="$OutputExe$" target="tools\$targetFramework$\any\tools\net472\any" />
+    <file src="$OutputExeSymbol$" target="tools\$targetFramework$\any\tools\net472\any" />
+    <file src="$OutputX86Exe$" target="tools\$targetFramework$\any\tools\net472\win-x86" />
+    <file src="$OutputX86ExeSymbol$" target="tools\$targetFramework$\any\tools\net472\win-x86" />
+    <file src="$OutputARM64Exe$" target="tools\$targetFramework$\any\tools\net472\win-arm64" />
+    <file src="$OutputARM64ExeSymbol$" target="tools\$targetFramework$\any\tools\net472\win-arm64" />
   </files>
 </package>

--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -32,7 +32,7 @@ internal partial class MigrationsBundleCommand
         }
     }
 
-#if NET461
+#if NET472
     protected override int Execute(string[] args)
         => throw new CommandException(Resources.VersionRequired("6.0.0"));
 #else

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using System.Reflection;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
-#if NET461
+#if NET472
 using System;
 using System.Configuration;
 #endif
@@ -68,7 +68,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         {
             try
             {
-#if NET461
+                var reportHandler = new OperationReportHandler(
+                        Reporter.WriteError,
+                        Reporter.WriteWarning,
+                        Reporter.WriteInformation,
+                        Reporter.WriteVerbose);
+#if NET472
                 try
                 {
                     return new AppDomainOperationExecutor(
@@ -79,7 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                         _rootNamespace!.Value(),
                         _language!.Value(),
                         _nullable!.HasValue(),
-                        remainingArguments);
+                        remainingArguments,
+                        reportHandler);
                 }
                 catch (MissingMethodException) // NB: Thrown with EF Core 3.1
                 {
@@ -116,7 +122,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                     _rootNamespace!.Value(),
                     _language!.Value(),
                     _nullable!.HasValue(),
-                    remainingArguments);
+                    remainingArguments,
+                    reportHandler);
             }
             catch (FileNotFoundException ex)
                 when (ex.FileName != null

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Microsoft.EntityFrameworkCore.Tools;
 
@@ -16,7 +14,7 @@ internal interface IOperationExecutor : IDisposable
     IDictionary GetContextInfo(string? name);
     void UpdateDatabase(string? migration, string? connectionString, string? contextType);
     IEnumerable<IDictionary> GetContextTypes();
-    void OptimizeContext(string? outputDir, string? modelNamespace, string? contextType);
+    IEnumerable<string> OptimizeContext(string? outputDir, string? modelNamespace, string? contextType);
 
     IDictionary ScaffoldContext(
         string provider,

--- a/src/ef/ReflectionOperationExecutor.cs
+++ b/src/ef/ReflectionOperationExecutor.cs
@@ -1,11 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
 
@@ -27,19 +26,21 @@ internal class ReflectionOperationExecutor : OperationExecutorBase
         string? rootNamespace,
         string? language,
         bool nullable,
-        string[] remainingArguments)
-        : base(assembly, startupAssembly, projectDir, rootNamespace, language, nullable, remainingArguments)
+        string[] remainingArguments,
+        IOperationReportHandler reportHandler)
+        : base(assembly, startupAssembly, projectDir, rootNamespace, language, nullable, remainingArguments, reportHandler)
     {
+        var reporter = new OperationReporter(reportHandler);
         var configurationFile = (startupAssembly ?? assembly) + ".config";
         if (File.Exists(configurationFile))
         {
-            Reporter.WriteVerbose(Resources.UsingConfigurationFile(configurationFile));
+            reporter.WriteVerbose(Resources.UsingConfigurationFile(configurationFile));
             AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", configurationFile);
         }
 
         if (dataDirectory != null)
         {
-            Reporter.WriteVerbose(Resources.UsingDataDir(dataDirectory));
+            reporter.WriteVerbose(Resources.UsingDataDir(dataDirectory));
             AppDomain.CurrentDomain.SetData("DataDirectory", dataDirectory);
         }
 
@@ -48,16 +49,16 @@ internal class ReflectionOperationExecutor : OperationExecutorBase
         _commandsAssembly = Assembly.Load(new AssemblyName { Name = DesignAssemblyName });
         var reportHandlerType = _commandsAssembly.GetType(ReportHandlerTypeName, throwOnError: true, ignoreCase: false)!;
 
-        var reportHandler = Activator.CreateInstance(
+        var designReportHandler = Activator.CreateInstance(
             reportHandlerType,
-            (Action<string>)Reporter.WriteError,
-            (Action<string>)Reporter.WriteWarning,
-            (Action<string>)Reporter.WriteInformation,
-            (Action<string>)Reporter.WriteVerbose)!;
+            (Action<string>)reportHandler.OnError,
+            (Action<string>)reportHandler.OnWarning,
+            (Action<string>)reportHandler.OnInformation,
+            (Action<string>)reportHandler.OnVerbose)!;
 
         _executor = Activator.CreateInstance(
             _commandsAssembly.GetType(ExecutorTypeName, throwOnError: true, ignoreCase: false)!,
-            reportHandler,
+            designReportHandler,
             new Dictionary<string, object?>
             {
                 { "targetName", AssemblyFileName },

--- a/src/ef/Reporter.cs
+++ b/src/ef/Reporter.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using static Microsoft.EntityFrameworkCore.Tools.AnsiConstants;
 
 namespace Microsoft.EntityFrameworkCore.Tools;

--- a/src/ef/Utilities/CallContext.cs
+++ b/src/ef/Utilities/CallContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET472
 namespace System.Runtime.Remoting.Messaging
 {
     internal static class CallContext

--- a/src/ef/Utilities/CompilerError.cs
+++ b/src/ef/Utilities/CompilerError.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET472
 namespace System.CodeDom.Compiler
 {
     internal class CompilerError

--- a/src/ef/Utilities/CompilerErrorCollection.cs
+++ b/src/ef/Utilities/CompilerErrorCollection.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET472
 namespace System.CodeDom.Compiler
 {
     internal class CompilerErrorCollection

--- a/src/ef/WrappedException.cs
+++ b/src/ef/WrappedException.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.EntityFrameworkCore.Tools;
 
 internal class WrappedException : Exception

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net472</TargetFrameworks>
     <Description>Entity Framework Core Command-line Tools</Description>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
-    <CheckEolTargetFramework>False</CheckEolTargetFramework>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
     <RollForward>Major</RollForward>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,10 +20,12 @@
     <Compile Include="..\EFCore.Design\Design\IOperationResultHandler.cs" />
     <Compile Include="..\EFCore.Design\Design\OperationReportHandler.cs" />
     <Compile Include="..\EFCore.Design\Design\OperationResultHandler.cs" />
+    <Compile Include="..\EFCore.Design\Design\Internal\IOperationReporter.cs" />
+    <Compile Include="..\EFCore.Design\Design\Internal\OperationReporter.cs" />
     <Compile Include="..\EFCore.Relational\Internal\SemanticVersionComparer.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
@@ -64,7 +67,7 @@
     </Compile>
   </ItemGroup>
 
-  <Target Name="BuildOtherPlatforms" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' == 'AnyCPU' ">
+  <Target Name="BuildOtherPlatforms" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net472' And '$(Platform)' == 'AnyCPU' ">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86;Configuration=$(Configuration)" Targets="Build" />
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=ARM64;Configuration=$(Configuration)" Targets="Build" />
   </Target>


### PR DESCRIPTION
Refactor `OperationExecutor` to use `IOperationReportHandler` instead of `Reporter` directly

Part of #24894

