### PR TITLE
[release/8.0] Fix to #33004 - Unfulfillable nullable contraints are set for complextypes with TPH entities

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -20,6 +20,9 @@ public static class RelationalPropertyExtensions
     private static readonly bool UseOldBehavior32763 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32763", out var enabled32763) && enabled32763;
 
+    private static readonly bool UseOldBehavior33004 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue33004", out var enabled33004) && enabled33004;
+
     private static readonly MethodInfo GetFieldValueMethod =
         typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), new[] { typeof(int) })!;
 
@@ -1191,8 +1194,12 @@ public static class RelationalPropertyExtensions
             return sharedTableRootProperty.IsColumnNullable(storeObject);
         }
 
+        var declaringEntityType = UseOldBehavior33004
+            ? property.DeclaringType
+            : property.DeclaringType.ContainingEntityType;
+
         return property.IsNullable
-            || (property.DeclaringType is IReadOnlyEntityType entityType
+            || (declaringEntityType is IReadOnlyEntityType entityType
                 && ((entityType.BaseType != null
                         && entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy)
                     || IsOptionalSharingDependent(entityType, storeObject, 0)));

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -9328,6 +9328,25 @@ CREATE TABLE [Customers] (
 """);
     }
 
+    public override async Task Create_table_with_complex_type_with_required_properties_on_derived_entity_in_TPH()
+    {
+        await base.Create_table_with_complex_type_with_required_properties_on_derived_entity_in_TPH();
+
+        AssertSql(
+"""
+CREATE TABLE [Contacts] (
+    [Id] int NOT NULL IDENTITY,
+    [Discriminator] nvarchar(8) NOT NULL,
+    [Name] nvarchar(max) NULL,
+    [Number] int NULL,
+    [MyComplex_Prop] nvarchar(max) NULL,
+    [MyComplex_MyNestedComplex_Bar] datetime2 NULL,
+    [MyComplex_MyNestedComplex_Foo] int NULL,
+    CONSTRAINT [PK_Contacts] PRIMARY KEY ([Id])
+);
+""");
+    }
+
     protected override string NonDefaultCollation
         => _nonDefaultCollation ??= GetDatabaseCollation() == "German_PhoneBook_CI_AS"
             ? "French_CI_AS"

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsSqliteTest.cs
@@ -1702,6 +1702,24 @@ CREATE TABLE "Person" (
 """);
     }
 
+    public override async Task Create_table_with_complex_type_with_required_properties_on_derived_entity_in_TPH()
+    {
+        await base.Create_table_with_complex_type_with_required_properties_on_derived_entity_in_TPH();
+
+        AssertSql(
+"""
+CREATE TABLE "Contacts" (
+    "Id" INTEGER NOT NULL CONSTRAINT "PK_Contacts" PRIMARY KEY AUTOINCREMENT,
+    "Discriminator" TEXT NOT NULL,
+    "Name" TEXT NULL,
+    "Number" INTEGER NULL,
+    "MyComplex_Prop" TEXT NULL,
+    "MyComplex_MyNestedComplex_Bar" TEXT NULL,
+    "MyComplex_MyNestedComplex_Foo" INTEGER NULL
+);
+""");
+    }
+
     public override Task Create_sequence()
         => AssertNotSupportedAsync(base.Create_sequence, SqliteStrings.SequencesNotSupported);
 


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/33052
Fixes https://github.com/dotnet/efcore/issues/33004

**Description**
When figuring out nullability of columns representing a given property, if property is declared on derived entity in TPH, we make that column nullable. For complex type properties we should be doing the same (and we did), but declaring type of that property is the complex type itself. Instead we should look at the ContainingEntityType rather than just DeclaringType.

**Customer impact**
For scenario where customer defines a complex type on a derived entity in TPH hierarchy and that complex type has a required property we generate incorrect model. The result it is impossible to create an entity in that hierarchy that doesn't contain the complex type (this should be allowed for base types, if the complex type is defined on derived). Workaround is to manually modify the migration and set all the necessary columns to nullable. 

**How found**
Customer reported on 8.

**Regression**
No, complex type support is a new feature in EF8.

**Testing**
Test added.

**Risk**
Very Low. Fix is a one line and a very straightforward change. We add call to the API that properly takes complex types into account when figuring out declaring entity type. We use that API in numerous places already and it's a no-op for non-complex type cases. Added quirk just to be safe.



