### PR TITLE
Fix to #33073 - JSON columns throws Invalid token type: 'StartObject' exception with AsNoTrackingWithIdentityResolution()

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1178,6 +1178,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("JsonNodeMustBeHandledByProviderSpecificVisitor");
 
         /// <summary>
+        ///     Using parameter to access the element of a JSON collection '{entityTypeName}' is not supported when using '{asNoTrackingWithIdentityResolution}'. Use constant, or project the entire JSON entity collection instead.
+        /// </summary>
+        public static string JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(object? entityTypeName, object? asNoTrackingWithIdentityResolution)
+            => string.Format(
+                GetString("JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution", nameof(entityTypeName), nameof(asNoTrackingWithIdentityResolution)),
+                entityTypeName, asNoTrackingWithIdentityResolution);
+
+        /// <summary>
+        ///     When using '{asNoTrackingWithIdentityResolution}' entities mapped to JSON must be projected in a particular order. Project entire collection of entities '{entityTypeName}' before its individual elements.
+        /// </summary>
+        public static string JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(object? entityTypeName, object? asNoTrackingWithIdentityResolution)
+            => string.Format(
+                GetString("JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution", nameof(entityTypeName), nameof(asNoTrackingWithIdentityResolution)),
+                entityTypeName, asNoTrackingWithIdentityResolution);
+
+        /// <summary>
+        ///     Projecting queryable operations on JSON collection is not supported for '{asNoTrackingWithIdentityResolution}'.
+        /// </summary>
+        public static string JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(object? asNoTrackingWithIdentityResolution)
+            => string.Format(
+                GetString("JsonProjectingQueryableOperationNoTrackingWithIdentityResolution", nameof(asNoTrackingWithIdentityResolution)),
+                asNoTrackingWithIdentityResolution);
+
+        /// <summary>
         ///     The JSON property name should only be configured on nested owned navigations.
         /// </summary>
         public static string JsonPropertyNameShouldBeConfiguredOnNestedNavigation

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -562,6 +562,15 @@
   <data name="JsonNodeMustBeHandledByProviderSpecificVisitor" xml:space="preserve">
     <value>This node should be handled by provider-specific sql generator.</value>
   </data>
+  <data name="JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution" xml:space="preserve">
+    <value>Using parameter to access the element of a JSON collection '{entityTypeName}' is not supported for '{asNoTrackingWithIdentityResolution}'. Use constant, or project the entire JSON entity collection instead.</value>
+  </data>
+  <data name="JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution" xml:space="preserve">
+    <value>When using '{asNoTrackingWithIdentityResolution}' entities mapped to JSON must be projected in a particular order. Project entire collection of entities '{entityTypeName}' before its individual elements.</value>
+  </data>
+  <data name="JsonProjectingQueryableOperationNoTrackingWithIdentityResolution" xml:space="preserve">
+    <value>Projecting queryable operations on JSON collection is not supported for '{asNoTrackingWithIdentityResolution}'.</value>
+  </data>
   <data name="JsonPropertyNameShouldBeConfiguredOnNestedNavigation" xml:space="preserve">
     <value>The JSON property name should only be configured on nested owned navigations.</value>
   </data>

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -115,6 +115,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private readonly RelationalShapedQueryCompilingExpressionVisitor _parentVisitor;
         private readonly ISet<string>? _tags;
         private readonly bool _isTracking;
+        private readonly bool _queryStateManager;
         private readonly bool _isAsync;
         private readonly bool _splitQuery;
         private readonly bool _detailedErrorsEnabled;
@@ -226,6 +227,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             _generateCommandResolver = true;
             _detailedErrorsEnabled = parentVisitor._detailedErrorsEnabled;
             _isTracking = parentVisitor.QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+            _queryStateManager = parentVisitor.QueryCompilationContext.QueryTrackingBehavior is QueryTrackingBehavior.TrackAll
+                or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
             _isAsync = parentVisitor.QueryCompilationContext.IsAsync;
             _splitQuery = splitQuery;
 
@@ -252,6 +255,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             _generateCommandResolver = false;
             _detailedErrorsEnabled = parentVisitor._detailedErrorsEnabled;
             _isTracking = parentVisitor.QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+            _queryStateManager = parentVisitor.QueryCompilationContext.QueryTrackingBehavior is QueryTrackingBehavior.TrackAll
+                or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
             _isAsync = parentVisitor.QueryCompilationContext.IsAsync;
             _splitQuery = false;
         }
@@ -281,6 +286,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             _generateCommandResolver = true;
             _detailedErrorsEnabled = parentVisitor._detailedErrorsEnabled;
             _isTracking = parentVisitor.QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+            _queryStateManager = parentVisitor.QueryCompilationContext.QueryTrackingBehavior is QueryTrackingBehavior.TrackAll
+                or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
             _isAsync = parentVisitor.QueryCompilationContext.IsAsync;
             _splitQuery = true;
 
@@ -357,6 +364,17 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             _containsCollectionMaterialization = new CollectionShaperFindingExpressionVisitor()
                 .ContainsCollectionMaterialization(shaperExpression);
+
+            // for NoTrackingWithIdentityResolution we need to make sure we see JSON entities in the correct order
+            // specifically, if we project JSON collection, it needs to be projected before any individual element from that collection
+            // otherwise we store JSON entities in incorrect order in the Change Tracker, leading to possible data corruption
+            // we only need to do this once, on top level
+            // see issue #33073 for more context
+            if (_queryStateManager && !_isTracking && collectionId == 0)
+            {
+                var jsonCorrectOrderOfEntitiesForChangeTrackerValidator = new JsonCorrectOrderOfEntitiesForChangeTrackerValidator(_selectExpression);
+                jsonCorrectOrderOfEntitiesForChangeTrackerValidator.Validate(shaperExpression);
+            }
 
             if (!_containsCollectionMaterialization)
             {
@@ -1546,7 +1564,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             var rewrittenEntityShaperMaterializer = new JsonEntityMaterializerRewriter(
                 entityType,
-                _isTracking,
+                _queryStateManager,
                 jsonReaderDataShaperLambdaParameter,
                 innerShapersMap,
                 innerFixupMap,
@@ -1674,7 +1692,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private sealed class JsonEntityMaterializerRewriter : ExpressionVisitor
         {
             private readonly IEntityType _entityType;
-            private readonly bool _isTracking;
+            private readonly bool _queryStateManager;
             private readonly ParameterExpression _jsonReaderDataParameter;
             private readonly IDictionary<string, Expression> _innerShapersMap;
             private readonly IDictionary<string, LambdaExpression> _innerFixupMap;
@@ -1694,7 +1712,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             public JsonEntityMaterializerRewriter(
                 IEntityType entityType,
-                bool isTracking,
+                bool queryStateManager,
                 ParameterExpression jsonReaderDataParameter,
                 IDictionary<string, Expression> innerShapersMap,
                 IDictionary<string, LambdaExpression> innerFixupMap,
@@ -1703,7 +1721,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 ILiftableConstantFactory liftableConstantFactory)
             {
                 _entityType = entityType;
-                _isTracking = isTracking;
+                _queryStateManager = queryStateManager;
                 _jsonReaderDataParameter = jsonReaderDataParameter;
                 _innerShapersMap = innerShapersMap;
                 _innerFixupMap = innerFixupMap;
@@ -1877,9 +1895,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         finalBlockExpressions.Add(propertyAssignmentReplacer.Visit(jsonEntityTypeInitializerBlockExpression));
                     }
 
-                    // Fixup is only needed for non-tracking queries, in case of tracking - ChangeTracker does the job
+                    // Fixup is only needed for non-tracking queries, in case of tracking (or NoTrackingWithIdentityResolution) - ChangeTracker does the job
                     // or for empty/null collections of a tracking queries.
-                    if (_isTracking)
+                    if (_queryStateManager)
                     {
                         ProcessFixup(_trackingInnerFixupMap);
                     }
@@ -2075,7 +2093,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 // the code here re-arranges the existing materializer so that even if we find parent in the change tracker
                 // we still process all the child navigations, it's just that we use the parent instance from change tracker, rather than create new one
 #pragma warning disable EF1001 // Internal EF Core API usage.
-                if (_isTracking
+                if (_queryStateManager
                     && visited is ConditionalExpression
                     {
                         Test: BinaryExpression
@@ -3056,6 +3074,234 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
 
                 return base.Visit(expression);
+            }
+        }
+
+        private sealed class JsonCorrectOrderOfEntitiesForChangeTrackerValidator(SelectExpression selectExpression) : ExpressionVisitor
+        {
+            private bool _insideCollection;
+            private bool _insideInclude;
+            private readonly List<(IEntityType JsonEntityType, List<(IProperty? KeyProperty, int? ConstantKeyValue, int? KeyProjectionIndex)> KeyAccessInfo)> _projectedKeyAccessInfos = [];
+            private readonly List<IEntityType> _includedJsonEntityTypes = [];
+
+            public void Validate(Expression expression)
+            {
+                // this visitor makes sure that we don't end up with data corruption in NoTrackingWithIdentityResolution mode
+                // In order to avoid it, we need to make sure entities land in Change Tracker in a correct order
+                // This is because until we have ordered collections, when we populate collection from Change Tracker, we do it in the same
+                // order that the entities landed there. So if, say, 3rd element of the collection is read first, if subsequently the entire
+                // collection is projected, that third element will appear at the start, and only after elements 1 and 2 will show up
+                _insideCollection = false;
+                _insideInclude = false;
+                Visit(expression);
+
+                // all projections that are contained in any of the included are safe - we process all the includes first
+                // so the entries are guaranteed to land in Change Tracker in the right order
+                // for all the remaining - entities deeper in the structure must appear after entities/collections that are "shallower"
+                // i.e. entity.MyJsonCollection must appear before entity.MyJsonCollection[2]
+                // we can verify that by comparing key access infos
+                // we process from the end to the beginning, so we can safely remove elements as we iterate over the list
+                if (_projectedKeyAccessInfos.Count > 0 && _includedJsonEntityTypes.Count > 0)
+                {
+                    for (var i = _projectedKeyAccessInfos.Count - 1; i >= 0; i--)
+                    {
+                        if (_includedJsonEntityTypes.Any(t => t == _projectedKeyAccessInfos[i].JsonEntityType
+                            || _projectedKeyAccessInfos[i].JsonEntityType.IsInOwnershipPath(t)))
+                        {
+                            _projectedKeyAccessInfos.RemoveAt(i);
+                        }
+                    }
+                }
+
+                // if there is only one thing projected, we are good no matter what
+                // if we project one thing only, the result will always land in correct order in ChangeTracker
+                if (_projectedKeyAccessInfos.Count > 1)
+                {
+                    var i = 0;
+
+                    do
+                    {
+                        var outerKeyAccessInfo = _projectedKeyAccessInfos[i].KeyAccessInfo;
+                        var outerJsonEntityType = _projectedKeyAccessInfos[i].JsonEntityType;
+
+                        // accessing collection element using parameter is not supported for NoTrackingWithIdentityResolution
+                        // we can't always tell if the path is the same or not - e.g. when we use two different parameters with the same value
+                        // or a constant and a parameter with the same value as the constant we would think it's different, but they are the same
+                        // so we can't correctly flag this scenario as invalid and it could cause data corruption
+                        // so we just disable it altogether
+                        // consider this query:
+                        // var prm1 = 0;
+                        // var prm2 = 0
+                        // entities.Select(x => new
+                        // {
+                        //     One = x.JsonCollection[prm1].NestedCollection[1],
+                        //     Two = x.JsonCollection[prm2].NestedCollection
+                        // })
+                        if (outerKeyAccessInfo.Any(x => x.KeyProperty == null && x.KeyProjectionIndex != null))
+                        {
+                            throw new InvalidOperationException(RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                                outerJsonEntityType.DisplayName(), nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));
+                        }
+
+                        for (var j = _projectedKeyAccessInfos.Count -1; j > i; j--)
+                        {
+                            var innerKeyAccessInfo = _projectedKeyAccessInfos[j].KeyAccessInfo;
+                            var innerJsonEntityType = _projectedKeyAccessInfos[j].JsonEntityType;
+
+                            var different = false;
+                            for (var k = 0; k < Math.Min(outerKeyAccessInfo.Count, innerKeyAccessInfo.Count); k++)
+                            {
+                                if (!KeyAccessInfoElementEqual(outerKeyAccessInfo[k], innerKeyAccessInfo[k]))
+                                {
+                                    different = true;
+                                    break;
+                                }
+                            }
+
+                            // if shared path is the same, we are ok if full paths are the same or if the outer path is shorter than inner
+                            // in that case the inner entry can be removed from the list - it will land in ChangeTracker in the correct order
+                            // if outer path is longer however, there is risk of data corruption so we throw
+                            // if common paths are different, we don't do anything - outer and inner are different they won't clash in ChangeTracker
+                            // just continue processing, inner will eventually become outer and we will validate if all is correct with it
+                            if (!different)
+                            {
+                                if (outerJsonEntityType != innerJsonEntityType
+                                    && !innerJsonEntityType.IsInOwnershipPath(outerJsonEntityType)
+                                    && !outerJsonEntityType.IsInOwnershipPath(innerJsonEntityType))
+                                {
+                                    // inner and outer are on different ownership paths - they are not related so they won't clash
+                                    continue;
+                                }
+
+                                if ((outerJsonEntityType == innerJsonEntityType || innerJsonEntityType.IsInOwnershipPath(outerJsonEntityType))
+                                    && outerKeyAccessInfo.Count <= innerKeyAccessInfo.Count)
+                                {
+                                    // outer and inner are on same ownership paths and outer is the owner of inner
+                                    // this is good - we can remove inner from the list now, because it will be materialized correctly
+                                    _projectedKeyAccessInfos.RemoveAt(j);
+                                    continue;
+                                }
+
+                                throw new InvalidOperationException(RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                                    outerJsonEntityType.DisplayName(),
+                                    nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));
+                            }
+                        }
+
+                        i++;
+                    }
+                    while (i < _projectedKeyAccessInfos.Count);
+                }
+
+                static bool KeyAccessInfoElementEqual(
+                    (IProperty? KeyProperty, int? ConstantKeyValue, int? KeyProjectionIndex) first,
+                    (IProperty? KeyProperty, int? ConstantKeyValue, int? KeyProjectionIndex) second)
+                {
+                    if (first.KeyProperty != null != (second.KeyProperty != null))
+                    {
+                        return false;
+                    }
+
+                    if (first.ConstantKeyValue != second.ConstantKeyValue)
+                    {
+                        return false;
+                    }
+
+                    // key property itself could be different, as long as they map to the same index in data reader, it's the same key
+                    // this could be a problem when index is a parameter (two different parameters but same value),
+                    // but we disabled that scenario already
+                    return first.KeyProjectionIndex == second.KeyProjectionIndex;
+                }
+            }
+
+            protected override Expression VisitExtension(Expression extensionExpression)
+            {
+                if (extensionExpression is RelationalCollectionShaperExpression collectionShaperExpression)
+                {
+                    var insideCollection = _insideCollection;
+                    _insideCollection = true;
+                    Visit(collectionShaperExpression.InnerShaper);
+                    _insideCollection = insideCollection;
+
+                    return collectionShaperExpression;
+                }
+
+                if (extensionExpression is RelationalSplitCollectionShaperExpression splitCollectionShaperExpression)
+                {
+                    var insideCollection = _insideCollection;
+                    _insideCollection = true;
+                    Visit(splitCollectionShaperExpression.InnerShaper);
+                    _insideCollection = insideCollection;
+
+                    return splitCollectionShaperExpression;
+                }
+
+                if (extensionExpression is IncludeExpression includeExpression)
+                {
+                    var insideInclude = _insideInclude;
+                    _insideInclude = true;
+                    Visit(includeExpression.NavigationExpression);
+                    _insideInclude = insideInclude;
+                }
+
+                if (extensionExpression is StructuralTypeShaperExpression { ValueBufferExpression: ProjectionBindingExpression entityProjectionBindingExpression } entityShaperExpression)
+                {
+                    var entityProjection = selectExpression.GetProjection(entityProjectionBindingExpression).GetConstantValue<object>();
+
+                    if (entityProjection is QueryableJsonProjectionInfo || (_insideCollection && entityProjection is JsonProjectionInfo))
+                    {
+                        throw new InvalidOperationException(
+                            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));
+                    }
+
+                    if (entityProjection is JsonProjectionInfo jsonEntityProjectionInfo)
+                    {
+                        var jsonEntityType = (IEntityType)entityShaperExpression.StructuralType;
+                        if (_insideInclude)
+                        {
+                            if (!_includedJsonEntityTypes.Contains(jsonEntityType))
+                            {
+                                _includedJsonEntityTypes.Add(jsonEntityType);
+                            }
+                        }
+                        else
+                        {
+                            _projectedKeyAccessInfos.Add((jsonEntityType, jsonEntityProjectionInfo.KeyAccessInfo));
+                        }
+                    }
+
+                    return extensionExpression;
+                }
+
+                if (extensionExpression is CollectionResultExpression { ProjectionBindingExpression: ProjectionBindingExpression collectionProjectionBindingExpression } collectionResultExpression)
+                {
+                    var collectionProjection = selectExpression.GetProjection(collectionProjectionBindingExpression).GetConstantValue<object>();
+                    if (collectionProjection is QueryableJsonProjectionInfo || (_insideCollection && collectionProjection is JsonProjectionInfo))
+                    {
+                        throw new InvalidOperationException(
+                            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));
+                    }
+
+                    if (collectionProjection is JsonProjectionInfo jsonCollectionProjectionInfo)
+                    {
+                        var jsonEntityType = collectionResultExpression.Navigation!.TargetEntityType;
+                        if (_insideInclude)
+                        {
+                            if (!_includedJsonEntityTypes.Contains(jsonEntityType))
+                            {
+                                _includedJsonEntityTypes.Add(jsonEntityType);
+                            }
+                        }
+                        else
+                        {
+                            _projectedKeyAccessInfos.Add((jsonEntityType, jsonCollectionProjectionInfo.KeyAccessInfo));
+                        }
+                    }
+
+                    return extensionExpression;
+                }
+
+                return base.VisitExtension(extensionExpression);
             }
         }
     }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -132,10 +132,10 @@ public abstract class QueryContext : IParameterValues
     /// </summary>
     [EntityFrameworkInternal]
     public virtual InternalEntityEntry? TryGetEntry(
-            IKey key,
-            object[] keyValues,
-            bool throwOnNullKey,
-            out bool hasNullKey)
+        IKey key,
+        object[] keyValues,
+        bool throwOnNullKey,
+        out bool hasNullKey)
         // InitializeStateManager will populate the field before calling here
         => _stateManager!.TryGetEntry(key, keyValues, throwOnNullKey, out hasNullKey);
 

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -31,6 +31,13 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().AsNoTrackingWithIdentityResolution());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owner_entity_duplicated(bool async)
         => AssertQuery(
             async,
@@ -57,6 +64,19 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntitySingleOwned>().Select(x => new { First = x, Second = x }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.First.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.First, a.First);
+                AssertEqual(e.Second, a.Second);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owner_entity_twice(bool async)
         => AssertQuery(
             async,
@@ -74,6 +94,19 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => new { First = x, Second = x }).AsNoTracking(),
+            elementSorter: e => e.First.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.First, a.First);
+                AssertEqual(e.Second, a.Second);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owner_entity_twice_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new { First = x, Second = x }).AsNoTrackingWithIdentityResolution(),
             elementSorter: e => e.First.Id,
             elementAsserter: (e, a) =>
             {
@@ -141,27 +174,10 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_reference_duplicated2(bool async)
+    public virtual Task Basic_json_projection_owned_reference_root_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => new
-                    {
-                        Root1 = x.OwnedReferenceRoot,
-                        Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                        Root2 = x.OwnedReferenceRoot,
-                        Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                    }).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.Root1, a.Root1);
-                AssertEqual(e.Root2, a.Root2);
-                AssertEqual(e.Leaf1, a.Leaf1);
-                AssertEqual(e.Leaf2, a.Leaf2);
-            });
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot).AsNoTrackingWithIdentityResolution());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -189,10 +205,90 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_reference_duplicated_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => new
+                    {
+                        Root1 = x.OwnedReferenceRoot,
+                        Branch1 = x.OwnedReferenceRoot.OwnedReferenceBranch,
+                        Root2 = x.OwnedReferenceRoot,
+                        Branch2 = x.OwnedReferenceRoot.OwnedReferenceBranch,
+                    }).AsNoTrackingWithIdentityResolution(),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Root1, a.Root1);
+                AssertEqual(e.Root2, a.Root2);
+                AssertEqual(e.Branch1, a.Branch1);
+                AssertEqual(e.Branch2, a.Branch2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_reference_duplicated2(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => new
+                    {
+                        Root1 = x.OwnedReferenceRoot,
+                        Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                        Root2 = x.OwnedReferenceRoot,
+                        Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                    }).AsNoTracking(),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Root1, a.Root1);
+                AssertEqual(e.Root2, a.Root2);
+                AssertEqual(e.Leaf1, a.Leaf1);
+                AssertEqual(e.Leaf2, a.Leaf2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_reference_duplicated2_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => new
+                    {
+                        Root1 = x.OwnedReferenceRoot,
+                        Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                        Root2 = x.OwnedReferenceRoot,
+                        Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Root1, a.Root1);
+                AssertEqual(e.Root2, a.Root2);
+                AssertEqual(e.Leaf1, a.Leaf1);
+                AssertEqual(e.Leaf2, a.Leaf2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_collection_root(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot).AsNoTracking(),
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot).AsNoTrackingWithIdentityResolution(),
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [ConditionalTheory]
@@ -204,10 +300,25 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch).AsNoTrackingWithIdentityResolution());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_collection_branch(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedCollectionBranch).AsNoTracking(),
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Basic_json_projection_owned_collection_branch_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedCollectionBranch).AsNoTrackingWithIdentityResolution(),
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [ConditionalTheory]
@@ -1386,7 +1497,8 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Select(
                     x => new
                     {
-                        First = x.OwnedReferenceRoot.OwnedCollectionBranch.Distinct().ToList(), Second = x.EntityCollection.ToList()
+                        First = x.OwnedReferenceRoot.OwnedCollectionBranch.Distinct().ToList(),
+                        Second = x.EntityCollection.ToList()
                     })
                 .AsNoTracking(),
             assertOrder: true,
@@ -2599,4 +2711,789 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<JsonEntityInheritanceDerived>().OrderBy(x => x.Id).Select(x => x.CollectionOnDerived),
             elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => (ee.Date, ee.Enum, ee.Fraction)),
             assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_using_queryable_methods_on_top_of_JSON_collection_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Skip = x.OwnedCollectionRoot.Skip(1).ToList(),
+                    Take = x.OwnedCollectionRoot.Take(2).ToList(),
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertCollection(e.Skip, a.Skip);
+                AssertCollection(e.Take, a.Take);
+            }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_nested_collection_anonymous_projection_in_projection_NoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>()
+                    .OrderBy(x => x.Id)
+                    .Select(
+                        x => x.OwnedCollectionRoot
+                            .Select(
+                                xx => xx.OwnedCollectionBranch.Select(
+                                    xxx => new
+                                    {
+                                        xxx.Date,
+                                        xxx.Enum,
+                                        xxx.Enums,
+                                        xxx.Fraction,
+                                        xxx.OwnedReferenceLeaf,
+                                        xxx.OwnedCollectionLeaf
+                                    }).ToList()))
+                    .AsNoTrackingWithIdentityResolution(),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(
+                    e, a, ordered: true, elementAsserter: (ee, aa) => AssertCollection(
+                        ee, aa, ordered: true, elementAsserter: (eee, aaa) =>
+                        {
+                            AssertEqual(eee.Date, aaa.Date);
+                            AssertEqual(eee.Enum, aaa.Enum);
+                            AssertCollection(eee.Enums, aaa.Enums, ordered: true);
+                            AssertEqual(eee.Fraction, aaa.Fraction);
+                            AssertEqual(eee.OwnedReferenceLeaf, aaa.OwnedReferenceLeaf);
+                            AssertCollection(eee.OwnedCollectionLeaf, aaa.OwnedCollectionLeaf, ordered: true);
+                        }))))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_nested_collection_and_element_using_parameter_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 0;
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf[1],
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_nested_collection_and_element_using_parameter_AsNoTrackingWithIdentityResolution2(bool async)
+    {
+        var prm1 = 0;
+        var prm2 = 0;
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm1].OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm2].OwnedCollectionLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_through_collection_element_parameter_different_values_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm1 = 0;
+        var prm2 = 1;
+
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm1].OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm2].OwnedCollectionLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_through_collection_element_parameter_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 0;
+
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_through_collection_element_parameter_projected_before_owner_nested_AsNoTrackingWithIdentityResolution2(bool async)
+    {
+        var prm1 = 0;
+        var prm2 = 0;
+
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm1].OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm2].OwnedCollectionLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Original, a.Original);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_through_collection_element_parameter_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 0;
+
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf[1],
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_through_collection_element_constant_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                    Original = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Original, a.Original);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_branch_collection_distinct_and_other_collection_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>()
+                    .OrderBy(x => x.Id)
+                    .Select(
+                        x => new
+                        {
+                            First = x.EntityCollection.ToList(),
+                            Second = x.OwnedReferenceRoot.OwnedCollectionBranch.Distinct().ToList()
+                        })
+                    .AsNoTrackingWithIdentityResolution(),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e.First, a.First, ordered: true);
+                    AssertCollection(e.Second, a.Second, elementSorter: ee => ee.Fraction);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_SelectMany_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                    async,
+                    ss => ss.Set<JsonEntityBasic>()
+                        .SelectMany(x => x.OwnedCollectionRoot)
+                        .AsNoTrackingWithIdentityResolution(),
+                    elementSorter: e => (e.Number, e.Name)))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_deduplication_with_collection_indexer_in_target_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 1;
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate1 = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                        Original = x.OwnedReferenceRoot,
+                        Duplicate2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[prm]
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Original, a.Original);
+                    AssertEqual(e.Duplicate1, a.Duplicate1);
+                    AssertEqual(e.Duplicate2, a.Duplicate2);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_nested_collection_and_element_wrong_order_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                    AssertCollection(e.Original, a.Original, ordered: true);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_projected_before_entire_collection_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                        Original = x.OwnedReferenceRoot.OwnedCollectionBranch,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Original, a.Original);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_projected_before_owner_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                        Original = x.OwnedReferenceRoot,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Original, a.Original);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedCollectionBranch#JsonOwnedBranch",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_projection_second_element_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(
+                    x => new
+                    {
+                        x.Id,
+                        Duplicate = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[1],
+                        Original = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
+                        Parent = x.OwnedReferenceRoot.OwnedReferenceBranch,
+                    }).AsNoTrackingWithIdentityResolution(),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.Id, a.Id);
+                    AssertEqual(e.Original, a.Original);
+                    AssertEqual(e.Duplicate, a.Duplicate);
+                }))).Message;
+
+        Assert.Equal(
+            RelationalStrings.JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(
+                "JsonEntityBasic.OwnedReferenceRoot#JsonOwnedRoot.OwnedReferenceBranch#JsonOwnedBranch.OwnedCollectionLeaf#JsonOwnedLeaf",
+                nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_collection_element_and_reference_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                    Reference = x.OwnedReferenceRoot.OwnedReferenceBranch,
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.CollectionElement, a.CollectionElement);
+                AssertEqual(e.Reference, a.Reference);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_nothing_interesting_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    x.Name
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_owner_entity_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    x
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.x, a.x);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_nested_collection_anonymous_projection_of_primitives_in_projection_NoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => x.OwnedCollectionRoot
+                        .Select(
+                            xx => xx.OwnedCollectionBranch.Select(
+                                xxx => new
+                                {
+                                    xxx.Date,
+                                    xxx.Enum,
+                                    xxx.Enums,
+                                    xxx.Fraction,
+                                }).ToList()))
+                .AsNoTrackingWithIdentityResolution(),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(
+                e, a, ordered: true, elementAsserter: (ee, aa) => AssertCollection(
+                    ee, aa, ordered: true, elementAsserter: (eee, aaa) =>
+                    {
+                        AssertEqual(eee.Date, aaa.Date);
+                        AssertEqual(eee.Enum, aaa.Enum);
+                        AssertCollection(eee.Enums, aaa.Enums, ordered: true);
+                        AssertEqual(eee.Fraction, aaa.Fraction);
+                    })));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_second_element_through_collection_element_constant_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Original = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertCollection(e.Original, a.Original, ordered: true);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_reference_collection_and_collection_element_nested_AsNoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Reference = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedReferenceLeaf,
+                    Collection = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                    CollectionElement = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Reference, a.Reference);
+                AssertCollection(e.Collection, a.Collection, ordered: true);
+                AssertEqual(e.CollectionElement, a.CollectionElement);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_second_element_through_collection_element_parameter_correctly_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Original = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[prm],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertCollection(e.Original, a.Original, ordered: true);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_only_second_element_through_collection_element_constant_projected_nested_AsNoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Element = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Element, a.Element);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_only_second_element_through_collection_element_parameter_projected_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm1 = 0;
+        var prm2 = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Element = x.OwnedReferenceRoot.OwnedCollectionBranch[prm1].OwnedCollectionLeaf[prm2],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Element, a.Element);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_second_element_through_collection_element_constant_different_values_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                    Original = x.OwnedReferenceRoot.OwnedCollectionBranch[1].OwnedCollectionLeaf,
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Duplicate, a.Duplicate);
+                AssertCollection(e.Original, a.Original, ordered: true);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_nested_collection_and_element_correct_order_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Original = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[0].OwnedCollectionLeaf[1],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertCollection(e.Original, a.Original, ordered: true);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_nested_collection_element_using_parameter_and_the_owner_in_correct_order_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var prm = 0;
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Original = x.OwnedReferenceRoot,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[prm].OwnedCollectionLeaf[1],
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Original, a.Original);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_second_element_projected_before_owner_as_well_as_root_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                    Original = x.OwnedReferenceRoot,
+                    Owned = x
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Original, a.Original);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_second_element_projected_before_owner_nested_as_well_as_root_AsNoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(
+                x => new
+                {
+                    x.Id,
+                    Duplicate = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[1],
+                    Original = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
+                    Parent = x.OwnedReferenceRoot.OwnedReferenceBranch,
+                    Owner = x
+                }).AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Duplicate, a.Duplicate);
+                AssertCollection(e.Original, a.Original, ordered: true);
+                AssertEqual(e.Owner, a.Owner);
+            });
 }

--- a/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
@@ -162,20 +162,20 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
 
         public DbSet<Customer> Customers { get; set; }
         public DbSet<Postcode> Postcodes { get; set; }
-    }
 
-    public class Customer
-    {
-        public int CustomerID { get; set; }
-        public string CustomerName { get; set; }
-        public int? PostcodeID { get; set; }
-    }
+        public class Customer
+        {
+            public int CustomerID { get; set; }
+            public string CustomerName { get; set; }
+            public int? PostcodeID { get; set; }
+        }
 
-    public class Postcode
-    {
-        public int PostcodeID { get; set; }
-        public string PostcodeValue { get; set; }
-        public string TownName { get; set; }
+        public class Postcode
+        {
+            public int PostcodeID { get; set; }
+            public string PostcodeValue { get; set; }
+            public string TownName { get; set; }
+        }
     }
 
     #endregion

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -39,6 +39,17 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
+    public override async Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
     public override async Task Basic_json_projection_owner_entity_duplicated(bool async)
     {
         await base.Basic_json_projection_owner_entity_duplicated(async);
@@ -53,6 +64,17 @@ FROM [JsonEntitiesBasic] AS [j]
     public override async Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
     {
         await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
+
+        AssertSql(
+            """
+SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
+FROM [JsonEntitiesSingleOwned] AS [j]
+""");
+    }
+
+    public override async Task Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(async);
 
         AssertSql(
             """
@@ -83,6 +105,17 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
+    public override async Task Basic_json_projection_owner_entity_twice_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owner_entity_twice_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
     public override async Task Basic_json_projection_owned_reference_root(bool async)
     {
         await base.Basic_json_projection_owned_reference_root(async);
@@ -94,15 +127,14 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
+    public override async Task Basic_json_projection_owned_reference_root_NoTrackingWithIdentityResolution(bool async)
     {
-        await base.Basic_json_projection_owned_reference_duplicated2(async);
+        await base.Basic_json_projection_owned_reference_root_NoTrackingWithIdentityResolution(async);
 
         AssertSql(
             """
-SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
+SELECT [j].[OwnedReferenceRoot], [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-ORDER BY [j].[Id]
 """);
     }
 
@@ -118,9 +150,56 @@ ORDER BY [j].[Id]
 """);
     }
 
+    public override async Task Basic_json_projection_owned_reference_duplicated_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owned_reference_duplicated_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
+FROM [JsonEntitiesBasic] AS [j]
+ORDER BY [j].[Id]
+""");
+    }
+
+    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
+    {
+        await base.Basic_json_projection_owned_reference_duplicated2(async);
+
+        AssertSql(
+            """
+SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
+FROM [JsonEntitiesBasic] AS [j]
+ORDER BY [j].[Id]
+""");
+    }
+
+    public override async Task Basic_json_projection_owned_reference_duplicated2_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owned_reference_duplicated2_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
+FROM [JsonEntitiesBasic] AS [j]
+ORDER BY [j].[Id]
+""");
+    }
+
     public override async Task Basic_json_projection_owned_collection_root(bool async)
     {
         await base.Basic_json_projection_owned_collection_root(async);
+
+        AssertSql(
+            """
+SELECT [j].[OwnedCollectionRoot], [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(async);
 
         AssertSql(
             """
@@ -140,9 +219,31 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
+    public override async Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
     public override async Task Basic_json_projection_owned_collection_branch(bool async)
     {
         await base.Basic_json_projection_owned_collection_branch(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Basic_json_projection_owned_collection_branch_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Basic_json_projection_owned_collection_branch_NoTrackingWithIdentityResolution(async);
 
         AssertSql(
             """
@@ -2745,8 +2846,6 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.StringYNConvertedToBool') AS bit) = CA
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_basic(bool async)
     {
         await base.FromSql_on_entity_with_json_basic(async);
@@ -2760,8 +2859,6 @@ FROM (
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual async Task FromSqlInterpolated_on_entity_with_json_with_predicate(bool async)
     {
         var parameter = new SqlParameter { ParameterName = "prm", Value = 1 };
@@ -2783,8 +2880,6 @@ FROM (
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_project_json_reference(bool async)
     {
         await base.FromSql_on_entity_with_json_project_json_reference(async);
@@ -2798,8 +2893,6 @@ FROM (
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_project_json_collection(bool async)
     {
         await base.FromSql_on_entity_with_json_project_json_collection(async);
@@ -2813,8 +2906,6 @@ FROM (
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_inheritance_on_base(bool async)
     {
         await base.FromSql_on_entity_with_json_inheritance_on_base(async);
@@ -2828,8 +2919,6 @@ FROM (
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_inheritance_on_derived(bool async)
     {
         await base.FromSql_on_entity_with_json_inheritance_on_derived(async);
@@ -2844,8 +2933,6 @@ WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_inheritance_project_reference_on_base(bool async)
     {
         await base.FromSql_on_entity_with_json_inheritance_project_reference_on_base(async);
@@ -2860,8 +2947,6 @@ ORDER BY [m].[Id]
 """);
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_inheritance_project_reference_on_derived(bool async)
     {
         await base.FromSql_on_entity_with_json_inheritance_project_reference_on_derived(async);
@@ -2874,6 +2959,166 @@ FROM (
 ) AS [m]
 WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
 ORDER BY [m].[Id]
+""");
+    }
+
+
+    public override async Task Json_projection_nothing_interesting_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_nothing_interesting_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Name]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_owner_entity_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_owner_entity_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_nested_collection_anonymous_projection_of_primitives_in_projection_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_nested_collection_anonymous_projection_of_primitives_in_projection_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [s].[key], [s].[c], [s].[c0], [s].[c1], [s].[c2], [s].[key0]
+FROM [JsonEntitiesBasic] AS [j]
+OUTER APPLY (
+    SELECT [o].[key], CAST(JSON_VALUE([o0].[value], '$.Date') AS datetime2) AS [c], CAST(JSON_VALUE([o0].[value], '$.Enum') AS int) AS [c0], JSON_QUERY([o0].[value], '$.Enums') AS [c1], CAST(JSON_VALUE([o0].[value], '$.Fraction') AS decimal(18,2)) AS [c2], [o0].[key] AS [key0], CAST([o].[key] AS int) AS [c3], CAST([o0].[key] AS int) AS [c4]
+    FROM OPENJSON([j].[OwnedCollectionRoot], '$') AS [o]
+    OUTER APPLY OPENJSON(JSON_QUERY([o].[value], '$.OwnedCollectionBranch'), '$') AS [o0]
+) AS [s]
+ORDER BY [j].[Id], [s].[c3], [s].[key], [s].[c4]
+""");
+    }
+
+    public override async Task Json_projection_second_element_through_collection_element_constant_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_second_element_through_collection_element_constant_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[1]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_reference_collection_and_collection_element_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_reference_collection_and_collection_element_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[1]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_projection_second_element_through_collection_element_parameter_correctly_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_second_element_through_collection_element_parameter_correctly_projected_after_owner_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_only_second_element_through_collection_element_constant_projected_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_only_second_element_through_collection_element_constant_projected_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[1]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_projection_only_second_element_through_collection_element_parameter_projected_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_only_second_element_through_collection_element_parameter_projected_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+@__prm1_0='0'
+@__prm2_1='1'
+
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm1_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST(@__prm2_1 AS nvarchar(max)) + ']'), @__prm1_0, @__prm2_1
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_second_element_through_collection_element_constant_different_values_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_second_element_through_collection_element_constant_different_values_projected_before_owner_nested_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[1]'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1].OwnedCollectionLeaf')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_nested_collection_and_element_correct_order_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_nested_collection_and_element_correct_order_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[1]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_projection_nested_collection_element_using_parameter_and_the_owner_in_correct_order_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_nested_collection_element_using_parameter_and_the_owner_in_correct_order_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+@__prm_0='0'
+
+SELECT [j].[Id], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[1]'), @__prm_0
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_second_element_projected_before_owner_as_well_as_root_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_second_element_projected_before_owner_as_well_as_root_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_second_element_projected_before_owner_nested_as_well_as_root_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Json_projection_second_element_projected_before_owner_nested_as_well_as_root_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[1]'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -446,6 +446,26 @@ FROM "JsonEntitiesCustomNaming" AS "j"
 """);
     }
 
+    public override async Task Json_nested_collection_anonymous_projection_of_primitives_in_projection_NoTrackingWithIdentityResolution(bool async)
+    => Assert.Equal(
+        SqliteStrings.ApplyNotSupported,
+        (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Json_nested_collection_anonymous_projection_of_primitives_in_projection_NoTrackingWithIdentityResolution(async)))
+        .Message);
+
+    // Sqlit throws APPLY error, but base expects different exception
+    public override Task Json_branch_collection_distinct_and_other_collection_AsNoTrackingWithIdentityResolution(bool async)
+        => Task.CompletedTask;
+
+    public override Task Json_collection_SelectMany_AsNoTrackingWithIdentityResolution(bool async)
+        => Task.CompletedTask;
+
+    public override Task Json_nested_collection_anonymous_projection_in_projection_NoTrackingWithIdentityResolution(bool async)
+        => Task.CompletedTask;
+
+    public override Task Json_projection_using_queryable_methods_on_top_of_JSON_collection_AsNoTrackingWithIdentityResolution(bool async)
+        => Task.CompletedTask;
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
Problem was that we were treating NoTrackingWithIdentityResolution queries as regular NoTracking in the context of JSON queries. However due to how JSON is materialized (streaming + nested includes are part of the parent materialization, rather than each entity materialized separately) we have special provisions when ChangeTracker is being used. In NoTrackingWithIdentityResolution, ChangeTracker is being used but the materializer didn't adjust to that, which lead to errors.

Fix is to generate JSON materializer code based on whether query uses Change Tracker rather than if it's a Tracking/NoTracking query.

Fixes #33073