### PR TITLE
Fix to #33046 - ArgumentException thrown when building queries involving owned entities mapped with .ToJson()

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -1312,7 +1312,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 if (ownedNavigation.IsCollection)
                 {
                     var shaperEntityParameter = Parameter(ownedNavigation.DeclaringEntityType.ClrType);
-                    var shaperCollectionParameter = Parameter(ownedNavigation.ClrType);
+                    var ownedNavigationType = ownedNavigation.GetMemberInfo(forMaterialization: true, forSet: true).GetMemberType();
+                    var shaperCollectionParameter = Parameter(ownedNavigationType);
                     var expressions = new List<Expression>();
                     var expressionsForTracking = new List<Expression>();
 
@@ -1484,11 +1485,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             if (navigation is { IsCollection: true })
             {
+                var collectionClrType = navigation.GetMemberInfo(forMaterialization: true, forSet: true).GetMemberType();
                 var materializeJsonEntityCollectionMethodCall =
                     Call(
                         MaterializeJsonEntityCollectionMethodInfo.MakeGenericMethod(
                             navigation.TargetEntityType.ClrType,
-                            navigation.ClrType),
+                            collectionClrType),
                         QueryCompilationContext.QueryContextParameter,
                         keyValuesParameter,
                         jsonReaderDataParameter,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTest.cs
@@ -72,6 +72,11 @@ VALUES(
 N'{{""RootName"":""e4"",""Collection"":[{{""BranchName"":""e4 c1"",""Nested"":{{""LeafName"":""e4 c1 l""}}}},{{""BranchName"":""e4 c2"",""Nested"":{{""LeafName"":""e4 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e4 or"",""Nested"":{{""LeafName"":""e4 or l""}}}}}}')");
     }
 
+    protected override void Seed33046(Context33046 ctx)
+        => ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO [Reviews] ([Rounds], [Id])
+VALUES(N'[{{""RoundNumber"":11,""SubRounds"":[{{""SubRoundNumber"":111}},{{""SubRoundNumber"":112}}]}}]', 1)");
+
     protected override void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx)
     {
         var entity1 = new MyEntityArrayOfPrimitives

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
@@ -68,6 +68,11 @@ VALUES(
 '{{""RootName"":""e4"",""Collection"":[{{""BranchName"":""e4 c1"",""Nested"":{{""LeafName"":""e4 c1 l""}}}},{{""BranchName"":""e4 c2"",""Nested"":{{""LeafName"":""e4 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e4 or"",""Nested"":{{""LeafName"":""e4 or l""}}}}}}')");
     }
 
+    protected override void Seed33046(Context33046 ctx)
+        => ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO ""Reviews"" (""Rounds"", ""Id"")
+VALUES('[{{""RoundNumber"":11,""SubRounds"":[{{""SubRoundNumber"":111}},{{""SubRoundNumber"":112}}]}}]', 1)");
+
     protected override void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx)
     {
         var entity1 = new MyEntityArrayOfPrimitives


### PR DESCRIPTION
when building MaterializeJsonEntityCollection method call, we were using navigation.ClrType as target collection type. However in case of navigation mapped to a private field, where the public property type doesn't match the backing field, we need more sophisticated approach. Fix is to use navigation.GetMemberInfo(...).GetMemberType() which correctly returns the type of a backing field in that case, so we don't have a type mismatch when trying to assign MaterializeJsonEntityCollection to the field.

Fixes #33046