### PR TITLE
Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,5 +5,6 @@
       <!-- This repo does its own symbol package generation.  Arcade's symbols.nupkg generation conflicts with the symbol package generation in 
            this repo and causes confusion (due to empty symblos.nupkg's) in downstream processes -->
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add a boolean property named `ProducesDotNetReleaseShippingAssets` in Publishing.props for repos that produce .NET shipping packages (packages that we ship with the release infra)
Based on this property we will select which packages to ship as part of .NET on release day.

This is a infrastructure only change. It will add extra metadata to the MergedManifest.xml produced during CI build.

Issue: https://github.com/dotnet/release/issues/822



<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

