### PR TITLE
[release/7.0] Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,5 +5,6 @@
       <!-- This repo does its own symbol package generation.  Arcade's symbols.nupkg generation conflicts with the symbol package generation in 
            this repo and causes confusion (due to empty symblos.nupkg's) in downstream processes -->
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/efcore/pull/33132 to release/7.0

