### PR TITLE
Fix to #33183 - Complex property causes "The multi-part identifier "xxx" could not be bound" after GroupBy + Select(x => x.First())

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -432,6 +432,26 @@ public sealed partial class SelectExpression
                 case ColumnExpression column when _tableAliasMap.TryGetValue(column.TableAlias, out var newTableAlias):
                     return new ColumnExpression(column.Name, newTableAlias, column.Type, column.TypeMapping, column.IsNullable);
 
+                case StructuralTypeProjectionExpression:
+                    var result = (StructuralTypeProjectionExpression)base.Visit(expression);
+
+                    // TableMap aliases are not stored in form of expression so we need to update them manually
+                    var tableMapChanged = false;
+                    var newTableMap = result.TableMap.ToDictionary(x => x.Key, x => x.Value);
+                    foreach (var (oldAlias, newAlias) in _tableAliasMap)
+                    {
+                        var match = newTableMap.FirstOrDefault(x => x.Value == oldAlias).Key;
+                        if (match != null)
+                        {
+                            newTableMap[match] = newAlias;
+                            tableMapChanged = true;
+                        }
+                    }
+
+                    return tableMapChanged
+                        ? result.UpdateTableMap(newTableMap)
+                        : result;
+
                 default:
                     return base.Visit(expression);
             }

--- a/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
@@ -298,11 +298,11 @@ public class StructuralTypeProjectionExpression : Expression
             case RelationalAnnotationNames.TpcMappingStrategy:
             case RelationalAnnotationNames.TptMappingStrategy:
                 newTableMap = new Dictionary<ITableBase, string>();
-                foreach (var (table, tableReferenceExpression) in TableMap)
+                foreach (var (table, tableAlias) in TableMap)
                 {
                     if (table.EntityTypeMappings.Any(m => m.TypeBase == derivedType))
                     {
-                        newTableMap.Add(table, tableReferenceExpression);
+                        newTableMap.Add(table, tableAlias);
                     }
                 }
 
@@ -330,6 +330,17 @@ public class StructuralTypeProjectionExpression : Expression
         return new StructuralTypeProjectionExpression(
             derivedType, propertyExpressionMap, ownedNavigationMap, complexPropertyCache, newTableMap ?? TableMap, IsNullable, discriminatorExpression);
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual StructuralTypeProjectionExpression UpdateTableMap(IReadOnlyDictionary<ITableBase, string> newTableMap)
+        => new StructuralTypeProjectionExpression(
+            StructuralType, _propertyExpressionMap, _ownedNavigationMap, _complexPropertyCache, newTableMap, IsNullable, DiscriminatorExpression);
 
     /// <summary>
     ///     Binds a property with this structural type projection to get the SQL representation.

--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
@@ -814,6 +814,13 @@ public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixtur
                 AssertEqual(e.Complex?.Two, a.Complex?.Two);
             });
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Entity_with_complex_type_with_group_by_and_first(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().GroupBy(x => x.Id).Select(x => x.First()));
+
     protected DbContext CreateContext()
         => Fixture.CreateContext();
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -1129,6 +1129,29 @@ OUTER APPLY (
         AssertSql("");
     }
 
+    public override async Task Entity_with_complex_type_with_group_by_and_first(bool async)
+    {
+        await base.Entity_with_complex_type_with_group_by_and_first(async);
+
+        AssertSql(
+"""
+SELECT [c3].[Id], [c3].[Name], [c3].[BillingAddress_AddressLine1], [c3].[BillingAddress_AddressLine2], [c3].[BillingAddress_Tags], [c3].[BillingAddress_ZipCode], [c3].[BillingAddress_Country_Code], [c3].[BillingAddress_Country_FullName], [c3].[ShippingAddress_AddressLine1], [c3].[ShippingAddress_AddressLine2], [c3].[ShippingAddress_Tags], [c3].[ShippingAddress_ZipCode], [c3].[ShippingAddress_Country_Code], [c3].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [c].[Id]
+    FROM [Customer] AS [c]
+    GROUP BY [c].[Id]
+) AS [c1]
+LEFT JOIN (
+    SELECT [c2].[Id], [c2].[Name], [c2].[BillingAddress_AddressLine1], [c2].[BillingAddress_AddressLine2], [c2].[BillingAddress_Tags], [c2].[BillingAddress_ZipCode], [c2].[BillingAddress_Country_Code], [c2].[BillingAddress_Country_FullName], [c2].[ShippingAddress_AddressLine1], [c2].[ShippingAddress_AddressLine2], [c2].[ShippingAddress_Tags], [c2].[ShippingAddress_ZipCode], [c2].[ShippingAddress_Country_Code], [c2].[ShippingAddress_Country_FullName]
+    FROM (
+        SELECT [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_Tags], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName], ROW_NUMBER() OVER(PARTITION BY [c0].[Id] ORDER BY [c0].[Id]) AS [row]
+        FROM [Customer] AS [c0]
+    ) AS [c2]
+    WHERE [c2].[row] <= 1
+) AS [c3] ON [c1].[Id] = [c3].[Id]
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -1012,6 +1012,29 @@ LIMIT @__p_0
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async))).Message);
 
+    public override async Task Entity_with_complex_type_with_group_by_and_first(bool async)
+    {
+        await base.Entity_with_complex_type_with_group_by_and_first(async);
+
+        AssertSql(
+"""
+SELECT "c3"."Id", "c3"."Name", "c3"."BillingAddress_AddressLine1", "c3"."BillingAddress_AddressLine2", "c3"."BillingAddress_Tags", "c3"."BillingAddress_ZipCode", "c3"."BillingAddress_Country_Code", "c3"."BillingAddress_Country_FullName", "c3"."ShippingAddress_AddressLine1", "c3"."ShippingAddress_AddressLine2", "c3"."ShippingAddress_Tags", "c3"."ShippingAddress_ZipCode", "c3"."ShippingAddress_Country_Code", "c3"."ShippingAddress_Country_FullName"
+FROM (
+    SELECT "c"."Id"
+    FROM "Customer" AS "c"
+    GROUP BY "c"."Id"
+) AS "c1"
+LEFT JOIN (
+    SELECT "c2"."Id", "c2"."Name", "c2"."BillingAddress_AddressLine1", "c2"."BillingAddress_AddressLine2", "c2"."BillingAddress_Tags", "c2"."BillingAddress_ZipCode", "c2"."BillingAddress_Country_Code", "c2"."BillingAddress_Country_FullName", "c2"."ShippingAddress_AddressLine1", "c2"."ShippingAddress_AddressLine2", "c2"."ShippingAddress_Tags", "c2"."ShippingAddress_ZipCode", "c2"."ShippingAddress_Country_Code", "c2"."ShippingAddress_Country_FullName"
+    FROM (
+        SELECT "c0"."Id", "c0"."Name", "c0"."BillingAddress_AddressLine1", "c0"."BillingAddress_AddressLine2", "c0"."BillingAddress_Tags", "c0"."BillingAddress_ZipCode", "c0"."BillingAddress_Country_Code", "c0"."BillingAddress_Country_FullName", "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_Tags", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName", ROW_NUMBER() OVER(PARTITION BY "c0"."Id" ORDER BY "c0"."Id") AS "row"
+        FROM "Customer" AS "c0"
+    ) AS "c2"
+    WHERE "c2"."row" <= 1
+) AS "c3" ON "c1"."Id" = "c3"."Id"
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Problem was that for group by we clone shaper expression and in case we cloned a table, we assign new aliases to all the columns associated with that table. However, we were not updating TableAlias values on StructuralTypeProjectionExpression. Later, when we try to generate columns for complex properties (in GenerateComplexPropertyShaperExpression) we were using incorrect alias (original one, rather than updated). Fix is to manually update TableMap when cloning StructuralTypeProjectionExpression

Fixes #33183