### PR TITLE
33196 command timeout allow zero

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -162,7 +162,7 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
     /// <returns>A new instance with the option changed.</returns>
     public virtual RelationalOptionsExtension WithCommandTimeout(int? commandTimeout)
     {
-        if (commandTimeout is <= 0)
+        if (commandTimeout is < 0)
         {
             throw new InvalidOperationException(RelationalStrings.InvalidCommandTimeout(commandTimeout));
         }

--- a/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
@@ -889,6 +889,26 @@ public class RelationalConnectionTest
     }
 
     [ConditionalFact]
+    public void Can_create_new_connection_with_CommandTimeout_set_to_zero()
+    {
+        using var connection = new FakeRelationalConnection(
+            CreateOptions(
+                new FakeRelationalOptionsExtension()
+                    .WithConnectionString("Database=FrodoLives")
+                    .WithCommandTimeout(0)));
+        Assert.Equal(0, connection.CommandTimeout);
+    }
+
+    [ConditionalFact]
+    public void Throws_if_create_new_connection_with_CommandTimeout_negative()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => new FakeRelationalOptionsExtension()
+                .WithConnectionString("Database=FrodoLives")
+                .WithCommandTimeout(-1));
+    }
+
+    [ConditionalFact]
     public void Can_set_CommandTimeout()
     {
         using var connection = new FakeRelationalConnection(
@@ -896,6 +916,16 @@ public class RelationalConnectionTest
         connection.CommandTimeout = 88;
 
         Assert.Equal(88, connection.CommandTimeout);
+    }
+
+    [ConditionalFact]
+    public void Can_set_CommandTimeout_to_zero()
+    {
+        using var connection = new FakeRelationalConnection(
+            CreateOptions(new FakeRelationalOptionsExtension().WithConnectionString("Database=FrodoLives")));
+        connection.CommandTimeout = 0;
+
+        Assert.Equal(0, connection.CommandTimeout);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Allow zero for WithCommandTimeout.
Tests to check that WithCommandTimeout allows zero and rejects negative values


Fixes #33196 
