### PR TITLE
Add quotability to all SQL expression types

### DIFF
--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DevelopmentDependency>true</DevelopmentDependency>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>$(NoWarn);EF1003</NoWarn> <!-- Precomiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/Metadata/IRelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/IRelationalModel.cs
@@ -67,6 +67,13 @@ public interface IRelationalModel : IAnnotatable
     ITable? FindTable(string name, string? schema);
 
     /// <summary>
+    ///     Gets the default table with the given name. Returns <see langword="null" /> if no table with the given name is defined.
+    /// </summary>
+    /// <param name="name">The name of the table.</param>
+    /// <returns>The default table with a given name or <see langword="null" /> if no table with the given name is defined.</returns>
+    TableBase? FindDefaultTable(string name);
+
+    /// <summary>
     ///     Gets the view with the given name. Returns <see langword="null" /> if no view with the given name is defined.
     /// </summary>
     /// <param name="name">The name of the view.</param>

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -91,33 +91,28 @@ public class RelationalModel : Annotatable, IRelationalModel
 
     /// <inheritdoc />
     public virtual ITable? FindTable(string name, string? schema)
-        => Tables.TryGetValue((name, schema), out var table)
-            ? table
-            : null;
+        => Tables.GetValueOrDefault((name, schema));
+
+    // TODO: Confirm that this makes sense
+    /// <inheritdoc />
+    public virtual TableBase? FindDefaultTable(string name)
+        => DefaultTables.GetValueOrDefault(name);
 
     /// <inheritdoc />
     public virtual IView? FindView(string name, string? schema)
-        => Views.TryGetValue((name, schema), out var view)
-            ? view
-            : null;
+        => Views.GetValueOrDefault((name, schema));
 
     /// <inheritdoc />
     public virtual ISqlQuery? FindQuery(string name)
-        => Queries.TryGetValue(name, out var query)
-            ? query
-            : null;
+        => Queries.GetValueOrDefault(name);
 
     /// <inheritdoc />
     public virtual IStoreFunction? FindFunction(string name, string? schema, IReadOnlyList<string> parameters)
-        => Functions.TryGetValue((name, schema, parameters), out var function)
-            ? function
-            : null;
+        => Functions.GetValueOrDefault((name, schema, parameters));
 
     /// <inheritdoc />
     public virtual IStoreStoredProcedure? FindStoredProcedure(string name, string? schema)
-        => StoredProcedures.TryGetValue((name, schema), out var storedProcedure)
-            ? storedProcedure
-            : null;
+        => StoredProcedures.GetValueOrDefault((name, schema));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/IRelationalQuotableExpression.cs
+++ b/src/EFCore.Relational/Query/IRelationalQuotableExpression.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Represents an expression that is quotable, that is, capable of returning an expression that, when evaluated, would construct an
+///     expression identical to this one. Used to generate code for precompiled queries, which reconstructs this expression.
+/// </summary>
+[Experimental("EF1003")]
+public interface IRelationalQuotableExpression
+{
+    /// <summary>
+    ///     Quotes the expression; that is, returns an expression that, when evaluated, would construct an expression identical to this
+    ///     one. Used to generate code for precompiled queries, which reconstructs this expression.
+    /// </summary>
+    Expression Quote();
+}

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -443,7 +443,7 @@ public interface ISqlExpressionFactory
     /// <param name="value">A value.</param>
     /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
     /// <returns>An expression representing a constant in a SQL tree.</returns>
-    SqlConstantExpression Constant(object? value, RelationalTypeMapping? typeMapping = null);
+    SqlConstantExpression Constant(object value, RelationalTypeMapping? typeMapping = null);
 
     /// <summary>
     ///     Creates a new <see cref="SqlConstantExpression" /> which represents a constant in a SQL tree.

--- a/src/EFCore.Relational/Query/Internal/FromSqlParameterExpandingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlParameterExpandingExpressionVisitor.cs
@@ -180,7 +180,9 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
             }
 
             return _sqlExpressionFactory.Constant(
-                existingConstantValue, _typeMappingSource.GetMappingForValue(existingConstantValue));
+                existingConstantValue,
+                existingConstantValue?.GetType() ?? typeof(object),
+                _typeMappingSource.GetMappingForValue(existingConstantValue));
         }
     }
 }

--- a/src/EFCore.Relational/Query/Internal/GetValueOrDefaultTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/GetValueOrDefaultTranslator.cs
@@ -45,7 +45,7 @@ public class GetValueOrDefaultTranslator : IMethodCallTranslator
             return _sqlExpressionFactory.Coalesce(
                 instance,
                 arguments.Count == 0
-                    ? new SqlConstantExpression(method.ReturnType.GetDefaultValueConstant(), null)
+                    ? new SqlConstantExpression(method.ReturnType.GetDefaultValue(), method.ReturnType, typeMapping: null)
                     : arguments[0],
                 instance.TypeMapping);
         }

--- a/src/EFCore.Relational/Query/Internal/TpcTablesExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TpcTablesExpression.cs
@@ -139,6 +139,10 @@ public sealed class TpcTablesExpression : TableExpressionBase
         => new(newAlias, EntityType, SelectExpressions, DiscriminatorColumn, DiscriminatorValues, Annotations);
 
     /// <inheritdoc />
+    public override Expression Quote()
+        => throw new UnreachableException("TpcTablesExpression is a temporary tree representation and should never be quoted");
+
+    /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
     {
         var subSelectExpressions = SelectExpressions.Select(cloningExpressionVisitor.Visit).ToList<SelectExpression>();

--- a/src/EFCore.Relational/Query/PathSegment.cs
+++ b/src/EFCore.Relational/Query/PathSegment.cs
@@ -14,8 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///         not used in application code.
 ///     </para>
 /// </summary>
-public readonly struct PathSegment
+public readonly struct PathSegment : IRelationalQuotableExpression
 {
+    private static ConstructorInfo? _pathSegmentPropertyConstructor, _pathSegmentArrayIndexConstructor;
+
     /// <summary>
     ///     Creates a new <see cref="PathSegment" /> struct representing JSON property access.
     /// </summary>
@@ -45,6 +47,21 @@ public readonly struct PathSegment
     ///     The index of an element which is being accessed in the JSON array.
     /// </summary>
     public SqlExpression? ArrayIndex { get; }
+
+    /// <inheritdoc />
+    public Expression Quote()
+        => this switch
+        {
+            { PropertyName: string propertyName }
+                => Expression.New(
+                    _pathSegmentPropertyConstructor ??= typeof(PathSegment).GetConstructor([typeof(string)])!,
+                    Expression.Constant(propertyName)),
+            { ArrayIndex: SqlExpression arrayIndex }
+                => Expression.New(
+                    _pathSegmentArrayIndexConstructor ??= typeof(PathSegment).GetConstructor([typeof(SqlExpression)])!,
+                    arrayIndex.Quote()),
+            _ => throw new UnreachableException()
+        };
 
     /// <inheritdoc />
     public override string ToString()

--- a/src/EFCore.Relational/Query/RelationalExpressionQuotingUtilities.cs
+++ b/src/EFCore.Relational/Query/RelationalExpressionQuotingUtilities.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using static System.Linq.Expressions.Expression;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Utilities used for implementing <see cref="IRelationalQuotableExpression" />.
+/// </summary>
+[Experimental("EF1003")]
+public static class RelationalExpressionQuotingUtilities
+{
+    private static readonly ParameterExpression RelationalModelParameter
+        = Parameter(typeof(RelationalModel), "relationalModel");
+    private static readonly ParameterExpression RelationalTypeMappingSourceParameter
+        = Parameter(typeof(RelationalTypeMappingSource), "relationalTypeMappingSource");
+
+    private static readonly MethodInfo RelationalModelFindTableMethod
+        = typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindTable), [typeof(string), typeof(string)])!;
+
+    private static readonly MethodInfo RelationalModelFindDefaultTableMethod
+        = typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindDefaultTable), [typeof(string)])!;
+
+    private static readonly MethodInfo RelationalModelFindViewMethod
+        = typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindView), [typeof(string), typeof(string)])!;
+
+    private static readonly MethodInfo RelationalModelFindQueryMethod
+        = typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindQuery), [typeof(string)])!;
+
+    private static readonly MethodInfo RelationalModelFindFunctionMethod
+        = typeof(RelationalModel).GetMethod(
+            nameof(RelationalModel.FindFunction), [typeof(string), typeof(string), typeof(IReadOnlyList<string>)])!;
+
+    private static ConstructorInfo? _annotationConstructor;
+    private static ConstructorInfo? _dictionaryConstructor;
+    private static MethodInfo? _dictionaryAddMethod;
+    private static MethodInfo? _hashSetAddMethod;
+
+    private static readonly MethodInfo RelationalTypeMappingSourceFindMappingMethod
+        = typeof(RelationalTypeMappingSource)
+            .GetMethod(
+                nameof(RelationalTypeMappingSource.FindMapping),
+                [
+                    typeof(Type), typeof(string), typeof(bool), typeof(bool), typeof(int), typeof(bool), typeof(bool), typeof(int),
+                    typeof(int)
+                ])!;
+
+    /// <summary>
+    ///     If <paramref name="expression" /> is <see langword="null" />, returns a <see cref="ConstantExpression" /> with a
+    ///     <see langword="null" /> value. Otherwise, calls <see cref="IRelationalQuotableExpression.Quote" /> and returns the result.
+    /// </summary>
+    public static Expression VisitOrNull<T>(T? expression) where T : IRelationalQuotableExpression
+        => expression is null ? Constant(null, typeof(T)) : expression.Quote();
+
+    /// <summary>
+    ///     Quotes a relational type mapping.
+    /// </summary>
+    public static Expression QuoteTypeMapping(RelationalTypeMapping? typeMapping)
+        => typeMapping is null
+            ? Constant(null, typeof(RelationalTypeMapping))
+            : Call(
+                RelationalTypeMappingSourceParameter,
+                RelationalTypeMappingSourceFindMappingMethod,
+                Constant(typeMapping.ClrType, typeof(Type)),
+                Constant(typeMapping.StoreType, typeof(string)),
+                Constant(false), // TODO: keyOrIndex not accessible
+                Constant(typeMapping.IsUnicode, typeof(bool?)),
+                Constant(typeMapping.Size, typeof(int?)),
+                Constant(false, typeof(bool?)), // TODO: rowversion not accessible
+                Constant(typeMapping.IsFixedLength, typeof(bool?)),
+                Constant(typeMapping.Precision, typeof(int?)),
+                Constant(typeMapping.Scale, typeof(int?)));
+
+    /// <summary>
+    ///     Quotes an <see cref="ITableBase" />.
+    /// </summary>
+    public static Expression QuoteTableBase(ITableBase tableBase)
+        => tableBase switch
+        {
+            ITable table
+                => Call(
+                    RelationalModelParameter,
+                    RelationalModelFindTableMethod,
+                    Constant(table.Name, typeof(string)),
+                    Constant(table.Schema, typeof(string))),
+
+            TableBase table
+                => Call(
+                    RelationalModelParameter,
+                    RelationalModelFindDefaultTableMethod,
+                    Constant(table.Name, typeof(string))),
+
+            IView view
+                => Call(
+                    RelationalModelParameter,
+                    RelationalModelFindViewMethod,
+                    Constant(view.Name, typeof(string)),
+                    Constant(view.Schema, typeof(string))),
+
+            ISqlQuery query
+                => Call(
+                    RelationalModelParameter,
+                    RelationalModelFindQueryMethod,
+                    Constant(query.Name, typeof(string))),
+
+            IStoreFunction function
+                => Call(
+                    RelationalModelParameter,
+                    RelationalModelFindFunctionMethod,
+                    Constant(function.Name, typeof(string)),
+                    Constant(function.Schema, typeof(string)),
+                    NewArrayInit(typeof(string), function.Parameters.Select(p => Constant(p.StoreType)))),
+
+            IStoreStoredProcedure => throw new UnreachableException(),
+
+            _ => throw new UnreachableException()
+        };
+
+    /// <summary>
+    ///     Quotes a set of string tags.
+    /// </summary>
+    public static Expression QuoteTags(ISet<string> tags)
+        => ListInit(
+            New(typeof(HashSet<string>)),
+            tags.Select(
+                t => ElementInit(
+                    _hashSetAddMethod ??= typeof(HashSet<string>).GetMethod(nameof(HashSet<string>.Add))!,
+                    Constant(t))));
+
+    /// <summary>
+    ///     Quotes the annotations on a <see cref="TableExpressionBase" />.
+    /// </summary>
+    public static Expression QuoteAnnotations(IReadOnlyDictionary<string, IAnnotation>? annotations)
+        => annotations is null or { Count: 0 }
+            ? Constant(null, typeof(IReadOnlyDictionary<string, IAnnotation>))
+            : ListInit(
+                New(_dictionaryConstructor ??= typeof(IDictionary<string, IAnnotation>).GetConstructor([])!),
+                annotations.Select(
+                    a => ElementInit(
+                        _dictionaryAddMethod ??= typeof(Dictionary<string, IAnnotation>).GetMethod("Add")!,
+                        Constant(a.Key),
+                        New(
+                            _annotationConstructor ??= typeof(Annotation).GetConstructor([typeof(string), typeof(object)])!,
+                            Constant(a.Key),
+                            Constant(a.Value)))));
+}

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
@@ -430,10 +430,13 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToList();
             var predicate = concreteEntityTypes.Count == 1
                 ? (SqlExpression)_sqlExpressionFactory.Equal(
-                    discriminatorColumn, _sqlExpressionFactory.Constant(concreteEntityTypes[0].GetDiscriminatorValue()))
+                    discriminatorColumn,
+                    _sqlExpressionFactory.Constant(concreteEntityTypes[0].GetDiscriminatorValue(), discriminatorColumn.Type))
                 : _sqlExpressionFactory.In(
                     discriminatorColumn,
-                    concreteEntityTypes.Select(et => _sqlExpressionFactory.Constant(et.GetDiscriminatorValue())).ToArray());
+                    concreteEntityTypes
+                        .Select(et => _sqlExpressionFactory.Constant(et.GetDiscriminatorValue(), discriminatorColumn.Type))
+                        .ToArray());
 
             selectExpression.ApplyPredicate(predicate);
 

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -2482,7 +2482,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                 newRowValues[i] = new RowValueExpression(newValues);
             }
 
-            return new ValuesExpression(valuesExpression.Alias, newRowValues, newColumnNames, valuesExpression.GetAnnotations());
+            return new ValuesExpression(valuesExpression.Alias, newRowValues, newColumnNames);
         }
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -693,12 +693,12 @@ public class SqlExpressionFactory : ISqlExpressionFactory
         => new(sql);
 
     /// <inheritdoc />
-    public virtual SqlConstantExpression Constant(object? value, RelationalTypeMapping? typeMapping = null)
-        => new(Expression.Constant(value), typeMapping);
+    public virtual SqlConstantExpression Constant(object value, RelationalTypeMapping? typeMapping = null)
+        => new(value, typeMapping);
 
     /// <inheritdoc />
     public virtual SqlConstantExpression Constant(object? value, Type type, RelationalTypeMapping? typeMapping = null)
-        => new(Expression.Constant(value, type), typeMapping);
+        => new(value, type, typeMapping);
 
     /// <inheritdoc />
     public virtual bool TryCreateLeast(

--- a/src/EFCore.Relational/Query/SqlExpressions/AtTimeZoneExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/AtTimeZoneExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class AtTimeZoneExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="AtTimeZoneExpression" /> class.
     /// </summary>
@@ -62,6 +64,16 @@ public class AtTimeZoneExpression : SqlExpression
         => operand != Operand || timeZone != TimeZone
             ? new AtTimeZoneExpression(operand, timeZone, Type, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(AtTimeZoneExpression).GetConstructor(
+                [typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Operand.Quote(),
+            TimeZone.Quote(),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
@@ -16,6 +16,10 @@ public class CaseExpression : SqlExpression
 {
     private readonly List<CaseWhenClause> _whenClauses = [];
 
+    private static ConstructorInfo? _quotingConstructorWithOperand;
+    private static ConstructorInfo? _quotingConstructorWithoutOperand;
+    private static ConstructorInfo? _caseWhenClauseQuotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="CaseExpression" /> class which represents a simple CASE expression.
     /// </summary>
@@ -113,6 +117,32 @@ public class CaseExpression : SqlExpression
                 ? new CaseExpression(whenClauses, elseResult)
                 : new CaseExpression(operand, whenClauses, elseResult))
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+    {
+        var whenClauses = NewArrayInit(
+            typeof(CaseWhenClause),
+            initializers: WhenClauses
+                .Select(c => New(
+                    _caseWhenClauseQuotingConstructor ??=
+                        typeof(CaseWhenClause).GetConstructor([typeof(SqlExpression), typeof(SqlExpression)])!,
+                    c.Test.Quote(),
+                    c.Result.Quote())));
+
+        return Operand is null
+            ? New(
+                _quotingConstructorWithoutOperand ??=
+                    typeof(CaseExpression).GetConstructor([typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression)])!,
+                whenClauses,
+                RelationalExpressionQuotingUtilities.VisitOrNull(ElseResult))
+            : New(
+                _quotingConstructorWithOperand ??= typeof(CaseExpression).GetConstructor(
+                    [typeof(SqlExpression), typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression)])!,
+                Operand.Quote(),
+                whenClauses,
+                RelationalExpressionQuotingUtilities.VisitOrNull(ElseResult));
+    }
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/CollateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CollateExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class CollateExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="CollateExpression" /> class.
     /// </summary>
@@ -50,6 +52,13 @@ public class CollateExpression : SqlExpression
         => operand != Operand
             ? new CollateExpression(operand, Collation)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(CollateExpression).GetConstructor([typeof(SqlExpression), typeof(string)])!,
+            Operand.Quote(),
+            Constant(Collation));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -15,6 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 [DebuggerDisplay("{TableAlias}.{Name}")]
 public class ColumnExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="ColumnExpression" /> class.
     /// </summary>
@@ -69,6 +71,17 @@ public class ColumnExpression : SqlExpression
     /// <returns>A new expression which has supplied type mapping.</returns>
     public virtual SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
         => new ColumnExpression(Name, TableAlias, Type, typeMapping, IsNullable);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(ColumnExpression).GetConstructor(
+                [typeof(string), typeof(string), typeof(Type), typeof(RelationalTypeMapping), typeof(bool)])!,
+            Constant(Name),
+            Constant(TableAlias),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping),
+            Constant(IsNullable));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class CrossApplyExpression : JoinExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="CrossApplyExpression" /> class.
     /// </summary>
@@ -46,6 +48,15 @@ public class CrossApplyExpression : JoinExpressionBase
     /// <inheritdoc />
     protected override CrossApplyExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
         => new(Table, annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??=
+                typeof(CrossApplyExpression).GetConstructor(
+                    [typeof(TableExpressionBase), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Table.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class CrossJoinExpression : JoinExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="CrossJoinExpression" /> class.
     /// </summary>
@@ -46,6 +48,15 @@ public class CrossJoinExpression : JoinExpressionBase
     /// <inheritdoc />
     protected override CrossJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
         => new(Table, Annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??=
+                typeof(CrossJoinExpression).GetConstructor(
+                    [typeof(TableExpressionBase), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Table.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
@@ -11,8 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///         This type is typically used by database providers (and other extensions). It is generally not used in application code.
 ///     </para>
 /// </summary>
-public sealed class DeleteExpression : Expression, IPrintableExpression
+public sealed class DeleteExpression : Expression, IRelationalQuotableExpression, IPrintableExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="DeleteExpression" /> class.
     /// </summary>
@@ -81,6 +83,19 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
             : new DeleteExpression(table, selectExpression, Tags);
 
     /// <inheritdoc />
+    public Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(DeleteExpression).GetConstructor(
+            [
+                typeof(TableExpression),
+                typeof(SelectExpression),
+                typeof(ISet<string>)
+            ])!,
+            Table.Quote(),
+            SelectExpression.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteTags(Tags));
+
+    /// <inheritdoc />
     public void Print(ExpressionPrinter expressionPrinter)
     {
         foreach (var tag in Tags)
@@ -107,4 +122,5 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     /// <inheritdoc />
     public override int GetHashCode()
         => HashCode.Combine(Table, SelectExpression);
+
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/DistinctExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/DistinctExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class DistinctExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="DistinctExpression" /> class.
     /// </summary>
@@ -53,6 +55,12 @@ public class DistinctExpression : SqlExpression
             ? new DistinctExpression(operand)
             : this;
     }
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(DistinctExpression).GetConstructor([typeof(SqlExpression)])!,
+            Operand.Quote());
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class ExceptExpression : SetOperationBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="ExceptExpression" /> class.
     /// </summary>
@@ -76,6 +78,23 @@ public class ExceptExpression : SetOperationBase
     /// <inheritdoc />
     public override ExceptExpression WithAlias(string newAlias)
         => new(newAlias, Source1, Source2, IsDistinct);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(ExceptExpression).GetConstructor(
+            [
+                typeof(string),
+                typeof(SelectExpression),
+                typeof(SelectExpression),
+                typeof(bool),
+                typeof(IReadOnlyDictionary<string, IAnnotation>)
+            ])!,
+            Constant(Alias, typeof(string)),
+            Source1.Quote(),
+            Source2.Quote(),
+            Constant(IsDistinct),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class ExistsExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="ExistsExpression" /> class.
     /// </summary>
@@ -48,6 +50,14 @@ public class ExistsExpression : SqlExpression
         => subquery != Subquery
             ? new ExistsExpression(subquery, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??=
+                typeof(ExistsExpression).GetConstructor([typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping)])!,
+            Subquery.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
@@ -14,6 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class InExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructorWithSubquery;
+    private static ConstructorInfo? _quotingConstructorWithValues;
+    private static ConstructorInfo? _quotingConstructorWithValuesParameter;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="InExpression" /> class, representing a SQL <c>IN</c> expression with a subquery.
     /// </summary>
@@ -193,6 +197,34 @@ public class InExpression : SqlExpression
             ? this
             : new InExpression(item, subquery, values, valuesParameter, TypeMapping);
     }
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => this switch
+        {
+            { Subquery: not null } => New(
+                _quotingConstructorWithSubquery ??= typeof(InExpression).GetConstructor(
+                    [typeof(SqlExpression), typeof(SelectExpression), typeof(RelationalTypeMapping)])!,
+                Item.Quote(),
+                Subquery.Quote(),
+                RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping)),
+
+            { Values: not null } => New(
+                _quotingConstructorWithValues ??= typeof(InExpression).GetConstructor(
+                    [typeof(SqlExpression), typeof(IReadOnlyList<SqlExpression>), typeof(RelationalTypeMapping)])!,
+                Item.Quote(),
+                NewArrayInit(typeof(SqlExpression), initializers: Values.Select(v => v.Quote())),
+                RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping)),
+
+            { ValuesParameter: not null } => New(
+                _quotingConstructorWithValuesParameter ??= typeof(InExpression).GetConstructor(
+                    [typeof(SqlExpression), typeof(SqlParameterExpression), typeof(RelationalTypeMapping)])!,
+                Item.Quote(),
+                ValuesParameter.Quote(),
+                RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping)),
+
+            _ => throw new UnreachableException()
+        };
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class InnerJoinExpression : PredicateJoinExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="InnerJoinExpression" /> class.
     /// </summary>
@@ -60,6 +62,16 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     /// <inheritdoc />
     protected override InnerJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
         => new(Table, JoinPredicate, IsPrunable, annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(InnerJoinExpression).GetConstructor(
+                [typeof(TableExpressionBase), typeof(SqlExpression), typeof(bool), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Table.Quote(),
+            JoinPredicate.Quote(),
+            Constant(IsPrunable),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class IntersectExpression : SetOperationBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="IntersectExpression" /> class.
     /// </summary>
@@ -76,6 +78,17 @@ public class IntersectExpression : SetOperationBase
     /// <inheritdoc />
     public override IntersectExpression WithAlias(string newAlias)
         => new(newAlias, Source1, Source2, IsDistinct);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(IntersectExpression).GetConstructor(
+                [typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Constant(Alias, typeof(string)),
+            Source1.Quote(),
+            Source2.Quote(),
+            Constant(IsDistinct),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class LeftJoinExpression : PredicateJoinExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="LeftJoinExpression" /> class.
     /// </summary>
@@ -60,6 +62,15 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     /// <inheritdoc />
     protected override LeftJoinExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
         => new(Table, JoinPredicate, IsPrunable, annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(LeftJoinExpression).GetConstructor([typeof(TableExpressionBase), typeof(SqlExpression), typeof(bool), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Table.Quote(),
+            JoinPredicate.Quote(),
+            Constant(IsPrunable),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class LikeExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="LikeExpression" /> class.
     /// </summary>
@@ -73,6 +75,16 @@ public class LikeExpression : SqlExpression
         => match != Match || pattern != Pattern || escapeChar != EscapeChar
             ? new LikeExpression(match, pattern, escapeChar, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(LikeExpression).GetConstructor(
+                [typeof(SqlExpression), typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping)])!,
+            Match.Quote(),
+            Pattern.Quote(),
+            RelationalExpressionQuotingUtilities.VisitOrNull(EscapeChar),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
@@ -13,8 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     </para>
 /// </summary>
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public class OrderingExpression : Expression, IPrintableExpression
+public class OrderingExpression : Expression, IRelationalQuotableExpression, IPrintableExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="OrderingExpression" /> class.
     /// </summary>
@@ -58,6 +60,14 @@ public class OrderingExpression : Expression, IPrintableExpression
         => expression != Expression
             ? new OrderingExpression(expression, IsAscending)
             : this;
+
+
+    /// <inheritdoc />
+    public Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(OrderingExpression).GetConstructor([typeof(SqlExpression), typeof(bool)])!,
+            Expression.Quote(),
+            Constant(IsAscending));
 
     /// <inheritdoc />
     void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class OuterApplyExpression : JoinExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="OuterApplyExpression" /> class.
     /// </summary>
@@ -46,6 +48,13 @@ public class OuterApplyExpression : JoinExpressionBase
     /// <inheritdoc />
     protected override OuterApplyExpression WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
         => new(Table, annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(OuterApplyExpression).GetConstructor([typeof(TableExpressionBase), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Table.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
@@ -13,9 +13,18 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     <see href="https://github.com/dotnet/efcore">github.com/dotnet/efcore</see>.
 /// </remarks>
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public sealed class ProjectionExpression : Expression, IPrintableExpression
+public sealed class ProjectionExpression : Expression, IRelationalQuotableExpression, IPrintableExpression
 {
-    internal ProjectionExpression(SqlExpression expression, string alias)
+    private static ConstructorInfo? _quotingConstructor;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public ProjectionExpression(SqlExpression expression, string alias)
     {
         Expression = expression;
         Alias = alias;
@@ -53,6 +62,13 @@ public sealed class ProjectionExpression : Expression, IPrintableExpression
         => expression != Expression
             ? new ProjectionExpression(expression, Alias)
             : this;
+
+    /// <inheritdoc />
+    public Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(ProjectionExpression).GetConstructor([typeof(SqlExpression), typeof(string)])!,
+            Expression.Quote(),
+            Constant(Alias));
 
     /// <inheritdoc />
     void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class RowNumberExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="RowNumberExpression" /> class.
     /// </summary>
@@ -80,6 +82,14 @@ public class RowNumberExpression : SqlExpression
             && Orderings.SequenceEqual(orderings)
                 ? this
                 : new RowNumberExpression(partitions, orderings, TypeMapping);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(RowNumberExpression).GetConstructor(
+                [typeof(IReadOnlyList<SqlExpression>), typeof(IReadOnlyList<OrderingExpression>), typeof(RelationalTypeMapping)])!,
+            NewArrayInit(typeof(SqlExpression), initializers: Orderings.Select(o => o.Quote())),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class RowValueExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     The values of this row.
     /// </summary>
@@ -46,6 +48,12 @@ public class RowValueExpression : SqlExpression
         => values.Count == Values.Count && values.Zip(Values, (x, y) => (x, y)).All(tup => tup.x == tup.y)
             ? this
             : new RowValueExpression(values);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(RowValueExpression).GetConstructor([typeof(IReadOnlyList<SqlExpression>)])!,
+            NewArrayInit(typeof(SqlExpression), Values.Select(v => v.Quote())));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class ScalarSubqueryExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="ScalarSubqueryExpression" /> class.
     /// </summary>
@@ -69,6 +71,12 @@ public class ScalarSubqueryExpression : SqlExpression
         => subquery != Subquery
             ? new ScalarSubqueryExpression(subquery)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(ScalarSubqueryExpression).GetConstructor([typeof(SelectExpression)])!,
+            Subquery.Quote());
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
@@ -38,6 +38,8 @@ public class SqlBinaryExpression : SqlExpression
         //ExpressionType.LeftShift,
     };
 
+    private static ConstructorInfo? _quotingConstructor;
+
     internal static bool IsValidOperator(ExpressionType operatorType)
         => AllowedOperators.Contains(operatorType);
 
@@ -104,6 +106,17 @@ public class SqlBinaryExpression : SqlExpression
         => left != Left || right != Right
             ? new SqlBinaryExpression(OperatorType, left, right, Type, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqlBinaryExpression).GetConstructor(
+                [typeof(ExpressionType), typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Constant(OperatorType),
+            Left.Quote(),
+            Right.Quote(),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     </para>
 /// </summary>
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public abstract class SqlExpression : Expression, IPrintableExpression
+public abstract class SqlExpression : Expression, IRelationalQuotableExpression, IPrintableExpression
 {
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlExpression" /> class.
@@ -43,6 +43,9 @@ public abstract class SqlExpression : Expression, IPrintableExpression
     /// <inheritdoc />
     public sealed override ExpressionType NodeType
         => ExpressionType.Extension;
+
+    /// <inheritdoc />
+    public abstract Expression Quote();
 
     /// <summary>
     ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter" />.

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class SqlFragmentExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlFragmentExpression" /> class.
     /// </summary>
@@ -32,6 +34,12 @@ public class SqlFragmentExpression : SqlExpression
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
         => this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqlFragmentExpression).GetConstructor([typeof(string)])!,
+            Constant(Sql)); // TODO: The new type mapping once that's merged
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -16,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class SqlFunctionExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlFunctionExpression" /> class which represents a built-in niladic function.
     /// </summary>
@@ -327,6 +329,31 @@ public class SqlFunctionExpression : SqlExpression
                 Type,
                 TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqlFunctionExpression).GetConstructor(
+            [
+                typeof(SqlExpression), typeof(string), typeof(string), typeof(bool), typeof(IEnumerable<SqlExpression>),
+                typeof(bool), typeof(bool), typeof(IEnumerable<bool>), typeof(bool), typeof(Type), typeof(RelationalTypeMapping)
+            ])!,
+            RelationalExpressionQuotingUtilities.VisitOrNull(Instance),
+            Constant(Schema, typeof(string)),
+            Constant(Name),
+            Constant(IsNiladic),
+            Arguments is null
+                ? Constant(null, typeof(IEnumerable<SqlExpression>))
+                : NewArrayInit(typeof(SqlExpression), initializers: Arguments.Select(a => a.Quote())),
+            Constant(IsNullable),
+            Constant(InstancePropagatesNullability, typeof(bool?)),
+            ArgumentsPropagateNullability is null
+                ? Constant(null, typeof(IEnumerable<bool>))
+                : NewArrayInit(
+                    typeof(bool), initializers: ArgumentsPropagateNullability.Select(n => Constant(n))),
+            Constant(IsBuiltIn),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -8,6 +8,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public sealed class SqlParameterExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlParameterExpression" /> class.
     /// </summary>
@@ -47,6 +49,15 @@ public sealed class SqlParameterExpression : SqlExpression
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
         => this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqlParameterExpression).GetConstructor(
+                [typeof(string), typeof(Type), typeof(RelationalTypeMapping) ])!, // TODO: There's a dead IsNullable there...
+            Constant(Name, typeof(string)),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class SqlUnaryExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     private static readonly ISet<ExpressionType> AllowedOperators = new HashSet<ExpressionType>
     {
         ExpressionType.Equal,
@@ -75,6 +77,16 @@ public class SqlUnaryExpression : SqlExpression
         => operand != Operand
             ? new SqlUnaryExpression(OperatorType, operand, Type, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqlUnaryExpression).GetConstructor(
+                [typeof(ExpressionType), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Constant(OperatorType),
+            Operand.Quote(),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     </para>
 /// </summary>
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public abstract class TableExpressionBase : Expression, IPrintableExpression
+public abstract class TableExpressionBase : Expression, IRelationalQuotableExpression, IPrintableExpression
 {
     /// <summary>
     ///     An indexed collection of annotations associated with this table expression.
@@ -84,6 +84,9 @@ public abstract class TableExpressionBase : Expression, IPrintableExpression
     /// </summary>
     /// <param name="newAlias">The alias to apply to the returned <see cref="TableExpressionBase" />.</param>
     public abstract TableExpressionBase WithAlias(string newAlias);
+
+    /// <inheritdoc />
+    public abstract Expression Quote();
 
     /// <summary>
     ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter" />.

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class UnionExpression : SetOperationBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="UnionExpression" /> class.
     /// </summary>
@@ -76,6 +78,17 @@ public class UnionExpression : SetOperationBase
     /// <inheritdoc />
     public override UnionExpression WithAlias(string newAlias)
         => new(newAlias, Source1, Source2, IsDistinct);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(UnionExpression).GetConstructor(
+                [typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool), typeof(IReadOnlyDictionary<string, IAnnotation>)])!,
+            Constant(Alias, typeof(string)),
+            Source1.Quote(),
+            Source2.Quote(),
+            Constant(IsDistinct),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
@@ -16,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class ValuesExpression : TableExpressionBase
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     The row values for this table.
     /// </summary>
@@ -32,13 +34,11 @@ public class ValuesExpression : TableExpressionBase
     /// <param name="alias">A string alias for the table source.</param>
     /// <param name="rowValues">The row values for this table.</param>
     /// <param name="columnNames">The names of the columns contained in this table.</param>
-    /// <param name="annotations">A collection of annotations associated with this expression.</param>
     public ValuesExpression(
         string? alias,
         IReadOnlyList<RowValueExpression> rowValues,
-        IReadOnlyList<string> columnNames,
-        IEnumerable<IAnnotation>? annotations = null)
-        : base(alias, annotations)
+        IReadOnlyList<string> columnNames)
+        : base(alias, annotations: (IReadOnlyDictionary<string, IAnnotation>?)null)
     {
         Check.DebugAssert(
             rowValues.All(rv => rv.Values.Count == columnNames.Count),
@@ -48,7 +48,14 @@ public class ValuesExpression : TableExpressionBase
         ColumnNames = columnNames;
     }
 
-    private ValuesExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public ValuesExpression(
         string? alias,
         IReadOnlyList<RowValueExpression> rowValues,
         IReadOnlyList<string> columnNames,
@@ -92,6 +99,21 @@ public class ValuesExpression : TableExpressionBase
     /// <inheritdoc />
     public override ValuesExpression WithAlias(string newAlias)
         => new(newAlias, RowValues, ColumnNames, Annotations);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(ValuesExpression).GetConstructor(
+            [
+                typeof(string),
+                typeof(IReadOnlyList<RowValueExpression>),
+                typeof(IReadOnlyList<string>),
+                typeof(IReadOnlyDictionary<string, IAnnotation>)
+            ])!,
+            Constant(Alias, typeof(string)),
+            NewArrayInit(typeof(RowValueExpression), RowValues.Select(rv => rv.Quote())),
+            NewArrayInit(typeof(string), ColumnNames.Select(Constant)),
+            RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
     /// <inheritdoc />
     public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -557,7 +557,7 @@ public class SqlNullabilityProcessor
         // - if there is no Else block, return null
         if (whenClauses.Count == 0)
         {
-            return elseResult ?? _sqlExpressionFactory.Constant(null, caseExpression.TypeMapping);
+            return elseResult ?? _sqlExpressionFactory.Constant(null, caseExpression.Type, caseExpression.TypeMapping);
         }
 
         // if there is only one When clause and it's test evaluates to 'true' AND there is no else block, simply return the result
@@ -925,7 +925,7 @@ public class SqlNullabilityProcessor
                         continue;
                     }
 
-                    processedValues.Add(_sqlExpressionFactory.Constant(value, typeMapping));
+                    processedValues.Add(_sqlExpressionFactory.Constant(value, value?.GetType() ?? typeof(object), typeMapping));
                 }
             }
             else
@@ -1415,7 +1415,7 @@ public class SqlNullabilityProcessor
         nullable = ParameterValues[sqlParameterExpression.Name] == null;
 
         return nullable
-            ? _sqlExpressionFactory.Constant(null, sqlParameterExpression.TypeMapping)
+            ? _sqlExpressionFactory.Constant(null, sqlParameterExpression.Type, sqlParameterExpression.TypeMapping)
             : sqlParameterExpression;
     }
 

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -9,6 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQL Server</PackageTags>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
@@ -88,7 +88,7 @@ public class SqlServerObjectToStringTranslator : IMethodCallTranslator
                             _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(true)),
                             _sqlExpressionFactory.Constant(true.ToString()))
                     },
-                    _sqlExpressionFactory.Constant(null));
+                    _sqlExpressionFactory.Constant(null, typeof(string)));
             }
 
             return _sqlExpressionFactory.Case(

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -227,7 +227,9 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                     // simple LIKE
                     translation = patternConstant.Value switch
                     {
-                        null => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant(null, stringTypeMapping)),
+                        null => _sqlExpressionFactory.Like(
+                            translatedInstance,
+                            _sqlExpressionFactory.Constant(null, typeof(string), stringTypeMapping)),
 
                         // In .NET, all strings start with/end with/contain the empty string, but SQL LIKE return false for empty patterns.
                         // Return % which always matches instead.

--- a/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
+++ b/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
@@ -10,6 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteObjectToStringTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteObjectToStringTranslator.cs
@@ -85,7 +85,7 @@ public class SqliteObjectToStringTranslator : IMethodCallTranslator
                             _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(true)),
                             _sqlExpressionFactory.Constant(true.ToString()))
                     },
-                    _sqlExpressionFactory.Constant(null));
+                    _sqlExpressionFactory.Constant(null, typeof(string)));
             }
 
             return _sqlExpressionFactory.Case(

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -80,7 +80,7 @@ public class SqliteQuerySqlGenerator : QuerySqlGenerator
 
             Visit(
                 selectExpression.Limit
-                ?? new SqlConstantExpression(Expression.Constant(-1), selectExpression.Offset!.TypeMapping));
+                ?? new SqlConstantExpression(-1, selectExpression.Offset!.TypeMapping));
 
             if (selectExpression.Offset != null)
             {

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -292,7 +292,9 @@ public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
                     // simple LIKE
                     translation = patternConstant.Value switch
                     {
-                        null => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant(null, stringTypeMapping)),
+                        null => _sqlExpressionFactory.Like(
+                            translatedInstance,
+                            _sqlExpressionFactory.Constant(null, typeof(string), stringTypeMapping)),
 
                         // In .NET, all strings start with/end with/contain the empty string, but SQL LIKE return false for empty patterns.
                         // Return % which always matches instead.

--- a/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/GlobExpression.cs
+++ b/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/GlobExpression.cs
@@ -13,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.SqlExpressions.Internal;
 /// </summary>
 public class GlobExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -75,6 +77,15 @@ public class GlobExpression : SqlExpression
         => match != Match || pattern != Pattern
             ? new GlobExpression(match, pattern, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(GlobExpression).GetConstructor(
+                [typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping)])!,
+            Match.Quote(),
+            Pattern.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/RegexpExpression.cs
+++ b/src/EFCore.Sqlite.Core/Query/SqlExpressions/Internal/RegexpExpression.cs
@@ -13,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.SqlExpressions.Internal;
 /// </summary>
 public class RegexpExpression : SqlExpression
 {
+    private static ConstructorInfo? _quotingConstructor;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -75,6 +77,15 @@ public class RegexpExpression : SqlExpression
         => match != Match || pattern != Pattern
             ? new RegexpExpression(match, pattern, TypeMapping)
             : this;
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(RegexpExpression).GetConstructor(
+                [typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping)])!,
+            Match.Quote(),
+            Pattern.Quote(),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -292,9 +292,9 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
                         args.First(),
                         new[]
                         {
-                            new SqlConstantExpression(Expression.Constant(abc[0]), typeMapping: null),
-                            new SqlConstantExpression(Expression.Constant(abc[1]), typeMapping: null),
-                            new SqlConstantExpression(Expression.Constant(abc[2]), typeMapping: null)
+                            new SqlConstantExpression(abc[0], typeMapping: null),
+                            new SqlConstantExpression(abc[1], typeMapping: null),
+                            new SqlConstantExpression(abc[2], typeMapping: null)
                         }, // args.First().TypeMapping)
                         typeMapping: null));
 
@@ -306,15 +306,15 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
                             args.First(),
                             new[]
                             {
-                                new SqlConstantExpression(Expression.Constant(abc[0]), args.First().TypeMapping),
-                                new SqlConstantExpression(Expression.Constant(abc[1]), args.First().TypeMapping),
-                                new SqlConstantExpression(Expression.Constant(abc[2]), args.First().TypeMapping)
+                                new SqlConstantExpression(abc[0], args.First().TypeMapping),
+                                new SqlConstantExpression(abc[1], args.First().TypeMapping),
+                                new SqlConstantExpression(abc[2], args.First().TypeMapping)
                             },
                             typeMapping: null),
                         new[]
                         {
-                            new SqlConstantExpression(Expression.Constant(trueFalse[0]), typeMapping: null),
-                            new SqlConstantExpression(Expression.Constant(trueFalse[1]), typeMapping: null)
+                            new SqlConstantExpression(trueFalse[0], typeMapping: null),
+                            new SqlConstantExpression(trueFalse[1], typeMapping: null)
                         },
                         typeMapping: null));
 

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
@@ -126,6 +126,9 @@ public class RelationalEventIdTest : EventIdTestBase
         {
         }
 
+        public override Expression Quote()
+            => throw new NotSupportedException();
+
         protected override void Print(ExpressionPrinter expressionPrinter)
             => expressionPrinter.Append("FakeSqlExpression");
     }


### PR DESCRIPTION
Here's the next building block in the precompiled query story: this adds quoting functionality (`Quote()`) to all nodes which can appear in the SQL tree (see #33008 for more background). Although large, this PR is pretty straightforward, just adding the proper functionality to all nodes.

Note that I'm working on good testing infra in parallel, but as it's end-to-end testing, it depends on various things that are still to come (e.g. actually generating the interceptors etc.). If interested, check out https://github.com/roji/efcore/blob/PrecompiledQueries/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs#L14, which is where the ongoing work on the tests is happening. We'll definitely have to do another pass at some point to verify that everything is properly covered.

Closes #33008

