### PR TITLE
[release/8.0] Fix to #32911 - Incorrect apply projection for complex properties

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocAdvancedMappingsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocAdvancedMappingsQueryInMemoryTest.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class AdHocAdvancedMappingsQueryInMemoryTest : AdHocAdvancedMappingsQueryTestBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => InMemoryTestStoreFactory.Instance;
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
@@ -1,0 +1,230 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class AdHocAdvancedMappingsQueryRelationalTestBase : AdHocAdvancedMappingsQueryTestBase
+{
+    protected TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected void ClearLog()
+        => TestSqlLoggerFactory.Clear();
+
+    protected void AssertSql(params string[] expected)
+        => TestSqlLoggerFactory.AssertBaseline(expected);
+
+    #region 32911
+
+    [ConditionalFact]
+    public virtual async Task Two_similar_complex_properties_projected_with_split_query1()
+    {
+        var contextFactory = await InitializeAsync<Context32911>(seed: c => c.Seed());
+
+        using var context = contextFactory.CreateContext();
+        var query = context.Offers
+            .Include(e => e.Variations)
+            .ThenInclude(v => v.Nested)
+            .AsSplitQuery()
+            .ToList();
+
+        var resultElement = query.Single();
+        foreach (var variation in resultElement.Variations)
+        {
+            Assert.NotEqual(variation.Payment.Brutto, variation.Nested.Payment.Brutto);
+            Assert.NotEqual(variation.Payment.Netto, variation.Nested.Payment.Netto);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task Two_similar_complex_properties_projected_with_split_query2()
+    {
+        var contextFactory = await InitializeAsync<Context32911>(seed: c => c.Seed());
+
+        using var context = contextFactory.CreateContext();
+        var query = context.Offers
+            .Include(e => e.Variations)
+            .ThenInclude(v => v.Nested)
+            .AsSplitQuery()
+            .Single(x => x.Id == 1);
+
+        foreach (var variation in query.Variations)
+        {
+            Assert.NotEqual(variation.Payment.Brutto, variation.Nested.Payment.Brutto);
+            Assert.NotEqual(variation.Payment.Netto, variation.Nested.Payment.Netto);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task Projecting_one_of_two_similar_complex_types_picks_the_correct_one()
+    {
+        var contextFactory = await InitializeAsync<Context32911_2>(seed: c => c.Seed());
+
+        using var context = contextFactory.CreateContext();
+
+        var query = context.Cs
+            .Where(x => x.B.AId.Value == 1)
+            .OrderBy(x => x.Id)
+            .Take(10)
+            .Select(x => new
+            {
+                x.B.A.Id,
+                x.B.Info.Created,
+            }).ToList();
+
+        Assert.Equal(new DateTime(2000, 1, 1), query[0].Created);
+    }
+
+    protected class Context32911(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Offer> Offers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Offer>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<Variation>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<Variation>().ComplexProperty(x => x.Payment, cpb =>
+            {
+                cpb.IsRequired();
+                cpb.Property(p => p.Netto).HasColumnName("payment_netto");
+                cpb.Property(p => p.Brutto).HasColumnName("payment_brutto");
+            });
+            modelBuilder.Entity<NestedEntity>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<NestedEntity>().ComplexProperty(x => x.Payment, cpb =>
+            {
+                cpb.IsRequired();
+                cpb.Property(p => p.Netto).HasColumnName("payment_netto");
+                cpb.Property(p => p.Brutto).HasColumnName("payment_brutto");
+            });
+        }
+
+        public void Seed()
+        {
+            var v1 = new Variation
+            {
+                Id = 1,
+                Payment = new Payment(1, 10),
+                Nested = new NestedEntity
+                {
+                    Id = 1,
+                    Payment = new Payment(10, 100)
+                }
+            };
+
+            var v2 = new Variation
+            {
+                Id = 2,
+                Payment = new Payment(2, 20),
+                Nested = new NestedEntity
+                {
+                    Id = 2,
+                    Payment = new Payment(20, 200)
+                }
+            };
+
+            var v3 = new Variation
+            {
+                Id = 3,
+                Payment = new Payment(3, 30),
+                Nested = new NestedEntity
+                {
+                    Id = 3,
+                    Payment = new Payment(30, 300)
+                }
+            };
+
+            Offers.Add(new Offer { Id = 1, Variations = new List<Variation> { v1, v2, v3 } });
+
+            SaveChanges();
+        }
+
+        public abstract class EntityBase
+        {
+            public int Id { get; set; }
+        }
+
+        public class Offer : EntityBase
+        {
+            public ICollection<Variation> Variations { get; set; }
+        }
+
+        public class Variation : EntityBase
+        {
+            public Payment Payment { get; set; } = new Payment(0, 0);
+
+            public NestedEntity Nested { get; set; }
+        }
+
+        public class NestedEntity : EntityBase
+        {
+            public Payment Payment { get; set; } = new Payment(0, 0);
+        }
+
+        public record Payment(decimal Netto, decimal Brutto);
+    }
+
+    protected class Context32911_2(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<A> As { get; set; }
+        public DbSet<B> Bs { get; set; }
+        public DbSet<C> Cs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<A>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<B>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<C>().Property(x => x.Id).ValueGeneratedNever();
+
+            modelBuilder.Entity<B>(x => x.ComplexProperty(b => b.Info).IsRequired());
+            modelBuilder.Entity<C>(x => x.ComplexProperty(c => c.Info).IsRequired());
+        }
+
+        public void Seed()
+        {
+            var c = new C
+            {
+                Id = 100,
+                Info = new Metadata { Created = new DateTime(2020, 10, 10) },
+                B = new B
+                {
+                    Id = 10,
+                    Info = new Metadata { Created = new DateTime(2000, 1, 1) },
+                    A = new A { Id = 1 }
+                }
+            };
+
+            Cs.Add(c);
+            SaveChanges();
+        }
+
+        public class Metadata
+        {
+            public DateTime Created { get; set; }
+        }
+
+        public class A
+        {
+            public int Id { get; set; }
+        }
+
+        public class B
+        {
+            public int Id { get; set; }
+            public Metadata Info { get; set; }
+            public int? AId { get; set; }
+
+            public A A { get; set; }
+        }
+
+        public class C
+        {
+            public int Id { get; set; }
+            public Metadata Info { get; set; }
+            public int BId { get; set; }
+
+            public B B { get; set; }
+        }
+    }
+
+    #endregion
+}

--- a/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class AdHocAdvancedMappingsQueryTestBase : NonSharedModelTestBase
+{
+    protected override string StoreName
+        => "AdHocAdvancedMappingsQueryTests";
+}

--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
@@ -506,6 +506,292 @@ public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixtur
             async,
             ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Union(ss.Set<ValuedCustomer>().Select(c => c.BillingAddress)));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_nested_complex_type_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Distinct()
+                .Select(x => new { x.BA1, x.BA2 }),
+            elementSorter: e => (e.BA1.ZipCode, e.BA2.ZipCode),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_entity_with_nested_complex_type_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   select new { c1, c2 })
+                .Distinct()
+                .Select(x => new { x.c1, x.c2 }),
+            elementSorter: e => (e.c1.Id, e.c2.Id),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_nested_complex_type_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Take(50)
+                .Distinct()
+                .Select(x => new { x.BA1, x.BA2 }),
+            elementSorter: e => (e.BA1.ZipCode, e.BA2.ZipCode),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_entity_with_nested_complex_type_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { c1, c2 })
+                .Take(50)
+                .Distinct()
+                .Select(x => new { x.c1, x.c2 }),
+            elementSorter: e => (e.c1.Id, e.c2.Id),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_struct_nested_complex_type_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<ValuedCustomer>()
+                   from c2 in ss.Set<ValuedCustomer>()
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Distinct()
+                .Select(x => new { x.BA1, x.BA2 }),
+            elementSorter: e => (e.BA1.ZipCode, e.BA2.ZipCode),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_entity_with_struct_nested_complex_type_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<ValuedCustomer>()
+                   from c2 in ss.Set<ValuedCustomer>()
+                   select new { c1, c2 })
+                .Distinct()
+                .Select(x => new { x.c1, x.c2 }),
+            elementSorter: e => (e.c1.Id, e.c2.Id),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<ValuedCustomer>()
+                   from c2 in ss.Set<ValuedCustomer>()
+                   orderby c1.Id, c2.Id
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Take(50)
+                .Distinct()
+                .Select(x => new { x.BA1, x.BA2 }),
+            elementSorter: e => (e.BA1.ZipCode, e.BA2.ZipCode),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_entity_with_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<ValuedCustomer>()
+                   from c2 in ss.Set<ValuedCustomer>()
+                   orderby c1.Id, c2.Id
+                   select new { c1, c2 })
+                .Take(50)
+                .Distinct()
+                .Select(x => new { x.c1, x.c2 }),
+            elementSorter: e => (e.c1.Id, e.c2.Id),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { c1, c2 })
+                .Union(from c1 in ss.Set<Customer>()
+                       from c2 in ss.Set<Customer>()
+                       orderby c1.Id, c2.Id
+                       select new { c1, c2 })
+                .OrderBy(x => x.c1.Id).ThenBy(x => x.c2.Id)
+                .Take(50)
+                .Select(x => new { x.c1, x.c2 }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { c1, c2 })
+                .Union(from c1 in ss.Set<Customer>()
+                       from c2 in ss.Set<Customer>()
+                       orderby c1.Id, c2.Id
+                       select new { c1, c2 })
+                .OrderBy(x => x.c1.Id).ThenBy(x => x.c2.Id)
+                .Take(50)
+                .Select(x => new { x.c1, x.c2 })
+                .Distinct()
+                .OrderBy(x => x.c1.Id).ThenBy(x => x.c2.Id)
+                .Take(50)
+                .Select(x => new { x.c1, x.c2 }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.c1, a.c1);
+                AssertEqual(e.c2, a.c2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_of_same_nested_complex_type_projected_twice_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Union(from c1 in ss.Set<Customer>()
+                       from c2 in ss.Set<Customer>()
+                       orderby c1.Id, c2.Id
+                       select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .OrderBy(x => x.BA1.ZipCode).ThenBy(x => x.BA2.ZipCode)
+                .Take(50)
+                .Select(x => new { x.BA1, x.BA2 }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_of_same_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => (from c1 in ss.Set<Customer>()
+                   from c2 in ss.Set<Customer>()
+                   orderby c1.Id, c2.Id
+                   select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .Union(from c1 in ss.Set<Customer>()
+                       from c2 in ss.Set<Customer>()
+                       orderby c1.Id, c2.Id
+                       select new { BA1 = c1.BillingAddress, BA2 = c2.BillingAddress })
+                .OrderBy(x => x.BA1.ZipCode).ThenBy(x => x.BA2.ZipCode)
+                .Take(50)
+                .Select(x => new { x.BA1, x.BA2 })
+                .Distinct()
+                .OrderBy(x => x.BA1.ZipCode).ThenBy(x => x.BA2.ZipCode)
+                .Take(50)
+                .Select(x => new { x.BA1, x.BA2 }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.BA1, a.BA1);
+                AssertEqual(e.BA2, a.BA2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Same_entity_with_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(x => new
+            {
+                x.Id,
+                Complex = (from c1 in ss.Set<Customer>()
+                           from c2 in ss.Set<Customer>()
+                           orderby c1.Id, c2.Id descending
+                           select new { One = c1, Two = c2 }).FirstOrDefault()
+            }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Complex?.One, a.Complex?.One);
+                AssertEqual(e.Complex?.Two, a.Complex?.Two);
+            });
+
+    [ConditionalTheory(Skip = "issue #31376")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(x => new
+            {
+                x.Id,
+                Complex = (from c1 in ss.Set<Customer>()
+                           from c2 in ss.Set<Customer>()
+                           orderby c1.Id, c2.Id descending
+                           select new { One = c1.BillingAddress, Two = c2.BillingAddress }).FirstOrDefault()
+            }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Complex?.One, a.Complex?.One);
+                AssertEqual(e.Complex?.Two, a.Complex?.Two);
+            });
+
     protected DbContext CreateContext()
         => Fixture.CreateContext();
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class AdHocAdvancedMappingsQuerySqlServerTest : AdHocAdvancedMappingsQueryRelationalTestBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public override async Task Two_similar_complex_properties_projected_with_split_query1()
+    {
+        await base.Two_similar_complex_properties_projected_with_split_query1();
+
+        AssertSql(
+"""
+SELECT [o].[Id]
+FROM [Offers] AS [o]
+ORDER BY [o].[Id]
+""",
+                //
+                """
+SELECT [t].[Id], [t].[NestedId], [t].[OfferId], [t].[payment_brutto], [t].[payment_netto], [t].[Id0], [t].[payment_brutto0], [t].[payment_netto0], [o].[Id]
+FROM [Offers] AS [o]
+INNER JOIN (
+    SELECT [v].[Id], [v].[NestedId], [v].[OfferId], [v].[payment_brutto], [v].[payment_netto], [n].[Id] AS [Id0], [n].[payment_brutto] AS [payment_brutto0], [n].[payment_netto] AS [payment_netto0]
+    FROM [Variation] AS [v]
+    LEFT JOIN [NestedEntity] AS [n] ON [v].[NestedId] = [n].[Id]
+) AS [t] ON [o].[Id] = [t].[OfferId]
+ORDER BY [o].[Id]
+""");
+    }
+
+    public override async Task Two_similar_complex_properties_projected_with_split_query2()
+    {
+        await base.Two_similar_complex_properties_projected_with_split_query2();
+
+        AssertSql(
+"""
+SELECT TOP(2) [o].[Id]
+FROM [Offers] AS [o]
+WHERE [o].[Id] = 1
+ORDER BY [o].[Id]
+""",
+                //
+                """
+SELECT [t0].[Id], [t0].[NestedId], [t0].[OfferId], [t0].[payment_brutto], [t0].[payment_netto], [t0].[Id0], [t0].[payment_brutto0], [t0].[payment_netto0], [t].[Id]
+FROM (
+    SELECT TOP(1) [o].[Id]
+    FROM [Offers] AS [o]
+    WHERE [o].[Id] = 1
+) AS [t]
+INNER JOIN (
+    SELECT [v].[Id], [v].[NestedId], [v].[OfferId], [v].[payment_brutto], [v].[payment_netto], [n].[Id] AS [Id0], [n].[payment_brutto] AS [payment_brutto0], [n].[payment_netto] AS [payment_netto0]
+    FROM [Variation] AS [v]
+    LEFT JOIN [NestedEntity] AS [n] ON [v].[NestedId] = [n].[Id]
+) AS [t0] ON [t].[Id] = [t0].[OfferId]
+ORDER BY [t].[Id]
+""");
+    }
+
+    public override async Task Projecting_one_of_two_similar_complex_types_picks_the_correct_one()
+    {
+        await base.Projecting_one_of_two_similar_complex_types_picks_the_correct_one();
+
+        AssertSql(
+"""
+@__p_0='10'
+
+SELECT [a].[Id], [t].[Info_Created0] AS [Created]
+FROM (
+    SELECT TOP(@__p_0) [c].[Id], [b].[AId], [b].[Info_Created] AS [Info_Created0]
+    FROM [Cs] AS [c]
+    INNER JOIN [Bs] AS [b] ON [c].[BId] = [b].[Id]
+    WHERE [b].[AId] = 1
+    ORDER BY [c].[Id]
+) AS [t]
+LEFT JOIN [As] AS [a] ON [t].[AId] = [a].[Id]
+ORDER BY [t].[Id]
+""");
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -858,6 +858,276 @@ WHERE [c].[ShippingAddress_ZipCode] = 7728
                 """).Select(c => c.ShippingAddress).Distinct(),
             ss => ss.Set<Customer>().Select(c => c.ShippingAddress).Distinct());
 
+    public override async Task Project_same_entity_with_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+    FROM [Customer] AS [c]
+    CROSS JOIN [Customer] AS [c0]
+) AS [t]
+""");
+    }
+
+    public override async Task Project_same_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+    FROM [Customer] AS [c]
+    CROSS JOIN [Customer] AS [c0]
+) AS [t]
+""");
+    }
+
+    public override async Task Project_same_entity_with_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT [t0].[Id], [t0].[Name], [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[ShippingAddress_AddressLine1], [t0].[ShippingAddress_AddressLine2], [t0].[ShippingAddress_ZipCode], [t0].[ShippingAddress_Country_Code], [t0].[ShippingAddress_Country_FullName], [t0].[Id0], [t0].[Name0], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0], [t0].[ShippingAddress_AddressLine10], [t0].[ShippingAddress_AddressLine20], [t0].[ShippingAddress_ZipCode0], [t0].[ShippingAddress_Country_Code0], [t0].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+        FROM [Customer] AS [c]
+        CROSS JOIN [Customer] AS [c0]
+        ORDER BY [c].[Id], [c0].[Id]
+    ) AS [t]
+) AS [t0]
+""");
+    }
+
+    public override async Task Project_same_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+        FROM [Customer] AS [c]
+        CROSS JOIN [Customer] AS [c0]
+        ORDER BY [c].[Id], [c0].[Id]
+    ) AS [t]
+) AS [t0]
+""");
+    }
+
+    public override async Task Project_same_entity_with_struct_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_struct_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName], [v0].[Id] AS [Id0], [v0].[Name] AS [Name0], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [v0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [v0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [v0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [v0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [v0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+    FROM [ValuedCustomer] AS [v]
+    CROSS JOIN [ValuedCustomer] AS [v0]
+) AS [t]
+""");
+    }
+
+    public override async Task Project_same_struct_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_struct_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+    FROM [ValuedCustomer] AS [v]
+    CROSS JOIN [ValuedCustomer] AS [v0]
+) AS [t]
+""");
+    }
+
+    public override async Task Project_same_entity_with_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_struct_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT [t0].[Id], [t0].[Name], [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[ShippingAddress_AddressLine1], [t0].[ShippingAddress_AddressLine2], [t0].[ShippingAddress_ZipCode], [t0].[ShippingAddress_Country_Code], [t0].[ShippingAddress_Country_FullName], [t0].[Id0], [t0].[Name0], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0], [t0].[ShippingAddress_AddressLine10], [t0].[ShippingAddress_AddressLine20], [t0].[ShippingAddress_ZipCode0], [t0].[ShippingAddress_Country_Code0], [t0].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName], [v0].[Id] AS [Id0], [v0].[Name] AS [Name0], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [v0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [v0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [v0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [v0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [v0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+        FROM [ValuedCustomer] AS [v]
+        CROSS JOIN [ValuedCustomer] AS [v0]
+        ORDER BY [v].[Id], [v0].[Id]
+    ) AS [t]
+) AS [t0]
+""");
+    }
+
+    public override async Task Project_same_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_struct_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+        FROM [ValuedCustomer] AS [v]
+        CROSS JOIN [ValuedCustomer] AS [v0]
+        ORDER BY [v].[Id], [v0].[Id]
+    ) AS [t]
+) AS [t0]
+""");
+    }
+
+    public override async Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_pushdown(bool async)
+    {
+        await base.Union_of_same_entity_with_nested_complex_type_projected_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT TOP(@__p_0) [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+    FROM [Customer] AS [c]
+    CROSS JOIN [Customer] AS [c0]
+    UNION
+    SELECT [c1].[Id], [c1].[Name], [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c1].[ShippingAddress_AddressLine1], [c1].[ShippingAddress_AddressLine2], [c1].[ShippingAddress_ZipCode], [c1].[ShippingAddress_Country_Code], [c1].[ShippingAddress_Country_FullName], [c2].[Id] AS [Id0], [c2].[Name] AS [Name0], [c2].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c2].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c2].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c2].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c2].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c2].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c2].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c2].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c2].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c2].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+    FROM [Customer] AS [c1]
+    CROSS JOIN [Customer] AS [c2]
+) AS [t]
+ORDER BY [t].[Id], [t].[Id0]
+""");
+    }
+
+    public override async Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+    {
+        await base.Union_of_same_entity_with_nested_complex_type_projected_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT TOP(@__p_0) [t1].[Id], [t1].[Name], [t1].[BillingAddress_AddressLine1], [t1].[BillingAddress_AddressLine2], [t1].[BillingAddress_ZipCode], [t1].[BillingAddress_Country_Code], [t1].[BillingAddress_Country_FullName], [t1].[ShippingAddress_AddressLine1], [t1].[ShippingAddress_AddressLine2], [t1].[ShippingAddress_ZipCode], [t1].[ShippingAddress_Country_Code], [t1].[ShippingAddress_Country_FullName], [t1].[Id0], [t1].[Name0], [t1].[BillingAddress_AddressLine10], [t1].[BillingAddress_AddressLine20], [t1].[BillingAddress_ZipCode0], [t1].[BillingAddress_Country_Code0], [t1].[BillingAddress_Country_FullName0], [t1].[ShippingAddress_AddressLine10], [t1].[ShippingAddress_AddressLine20], [t1].[ShippingAddress_ZipCode0], [t1].[ShippingAddress_Country_Code0], [t1].[ShippingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t0].[Id], [t0].[Name], [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[ShippingAddress_AddressLine1], [t0].[ShippingAddress_AddressLine2], [t0].[ShippingAddress_ZipCode], [t0].[ShippingAddress_Country_Code], [t0].[ShippingAddress_Country_FullName], [t0].[Id0], [t0].[Name0], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0], [t0].[ShippingAddress_AddressLine10], [t0].[ShippingAddress_AddressLine20], [t0].[ShippingAddress_ZipCode0], [t0].[ShippingAddress_Country_Code0], [t0].[ShippingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0]
+        FROM (
+            SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+            FROM [Customer] AS [c]
+            CROSS JOIN [Customer] AS [c0]
+            UNION
+            SELECT [c1].[Id], [c1].[Name], [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c1].[ShippingAddress_AddressLine1], [c1].[ShippingAddress_AddressLine2], [c1].[ShippingAddress_ZipCode], [c1].[ShippingAddress_Country_Code], [c1].[ShippingAddress_Country_FullName], [c2].[Id] AS [Id0], [c2].[Name] AS [Name0], [c2].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c2].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c2].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c2].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c2].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c2].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c2].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c2].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c2].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c2].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+            FROM [Customer] AS [c1]
+            CROSS JOIN [Customer] AS [c2]
+        ) AS [t]
+        ORDER BY [t].[Id], [t].[Id0]
+    ) AS [t0]
+) AS [t1]
+ORDER BY [t1].[Id], [t1].[Id0]
+""");
+    }
+
+    public override async Task Union_of_same_nested_complex_type_projected_twice_with_pushdown(bool async)
+    {
+        await base.Union_of_same_nested_complex_type_projected_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT TOP(@__p_0) [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+    FROM [Customer] AS [c]
+    CROSS JOIN [Customer] AS [c0]
+    UNION
+    SELECT [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c2].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c2].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c2].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c2].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c2].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+    FROM [Customer] AS [c1]
+    CROSS JOIN [Customer] AS [c2]
+) AS [t]
+ORDER BY [t].[BillingAddress_ZipCode], [t].[BillingAddress_ZipCode0]
+""");
+    }
+
+    public override async Task Union_of_same_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+    {
+        await base.Union_of_same_nested_complex_type_projected_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT TOP(@__p_0) [t1].[BillingAddress_AddressLine1], [t1].[BillingAddress_AddressLine2], [t1].[BillingAddress_ZipCode], [t1].[BillingAddress_Country_Code], [t1].[BillingAddress_Country_FullName], [t1].[BillingAddress_AddressLine10], [t1].[BillingAddress_AddressLine20], [t1].[BillingAddress_ZipCode0], [t1].[BillingAddress_Country_Code0], [t1].[BillingAddress_Country_FullName0]
+FROM (
+    SELECT DISTINCT [t0].[BillingAddress_AddressLine1], [t0].[BillingAddress_AddressLine2], [t0].[BillingAddress_ZipCode], [t0].[BillingAddress_Country_Code], [t0].[BillingAddress_Country_FullName], [t0].[BillingAddress_AddressLine10], [t0].[BillingAddress_AddressLine20], [t0].[BillingAddress_ZipCode0], [t0].[BillingAddress_Country_Code0], [t0].[BillingAddress_Country_FullName0]
+    FROM (
+        SELECT TOP(@__p_0) [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0]
+        FROM (
+            SELECT [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+            FROM [Customer] AS [c]
+            CROSS JOIN [Customer] AS [c0]
+            UNION
+            SELECT [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c2].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c2].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c2].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c2].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c2].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+            FROM [Customer] AS [c1]
+            CROSS JOIN [Customer] AS [c2]
+        ) AS [t]
+        ORDER BY [t].[BillingAddress_ZipCode], [t].[BillingAddress_ZipCode0]
+    ) AS [t0]
+) AS [t1]
+ORDER BY [t1].[BillingAddress_ZipCode], [t1].[BillingAddress_ZipCode0]
+""");
+    }
+
+    public override async Task Same_entity_with_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+    {
+        await base.Same_entity_with_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async);
+
+        AssertSql(
+"""
+SELECT [c].[Id], [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName], [t].[Id0], [t].[Name0], [t].[BillingAddress_AddressLine10], [t].[BillingAddress_AddressLine20], [t].[BillingAddress_ZipCode0], [t].[BillingAddress_Country_Code0], [t].[BillingAddress_Country_FullName0], [t].[ShippingAddress_AddressLine10], [t].[ShippingAddress_AddressLine20], [t].[ShippingAddress_ZipCode0], [t].[ShippingAddress_Country_Code0], [t].[ShippingAddress_Country_FullName0], [t].[c]
+FROM [Customer] AS [c]
+OUTER APPLY (
+    SELECT TOP(1) [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName], [c1].[Id] AS [Id0], [c1].[Name] AS [Name0], [c1].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c1].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c1].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c1].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c1].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c1].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c1].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c1].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c1].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c1].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0], 1 AS [c]
+    FROM [Customer] AS [c0]
+    CROSS JOIN [Customer] AS [c1]
+    ORDER BY [c0].[Id], [c1].[Id] DESC
+) AS [t]
+""");
+    }
+
+    public override async Task Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+    {
+        await base.Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async);
+
+        AssertSql("");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqliteTest.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class AdHocAdvancedMappingsQuerySqliteTest : AdHocAdvancedMappingsQueryRelationalTestBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class ComplexTypeQuerySqliteTest : ComplexTypeQueryRelationalTestBase<
@@ -739,6 +741,274 @@ FROM "ValuedCustomer" AS "v0"
 
         AssertSql();
     }
+
+    public override async Task Project_same_entity_with_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName", "c0"."Id" AS "Id0", "c0"."Name" AS "Name0", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+    FROM "Customer" AS "c"
+    CROSS JOIN "Customer" AS "c0"
+) AS "t"
+""");
+    }
+
+    public override async Task Project_same_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+    FROM "Customer" AS "c"
+    CROSS JOIN "Customer" AS "c0"
+) AS "t"
+""");
+    }
+
+    public override async Task Project_same_entity_with_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t0"."Id", "t0"."Name", "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."ShippingAddress_AddressLine1", "t0"."ShippingAddress_AddressLine2", "t0"."ShippingAddress_ZipCode", "t0"."ShippingAddress_Country_Code", "t0"."ShippingAddress_Country_FullName", "t0"."Id0", "t0"."Name0", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0", "t0"."ShippingAddress_AddressLine10", "t0"."ShippingAddress_AddressLine20", "t0"."ShippingAddress_ZipCode0", "t0"."ShippingAddress_Country_Code0", "t0"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+    FROM (
+        SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName", "c0"."Id" AS "Id0", "c0"."Name" AS "Name0", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+        FROM "Customer" AS "c"
+        CROSS JOIN "Customer" AS "c0"
+        ORDER BY "c"."Id", "c0"."Id"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+""");
+    }
+
+    public override async Task Project_same_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+    FROM (
+        SELECT "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+        FROM "Customer" AS "c"
+        CROSS JOIN "Customer" AS "c0"
+        ORDER BY "c"."Id", "c0"."Id"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+""");
+    }
+
+    public override async Task Project_same_entity_with_struct_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_struct_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName", "v0"."Id" AS "Id0", "v0"."Name" AS "Name0", "v0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "v0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "v0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "v0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "v0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "v0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "v0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "v0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "v0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "v0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+    FROM "ValuedCustomer" AS "v"
+    CROSS JOIN "ValuedCustomer" AS "v0"
+) AS "t"
+""");
+    }
+
+    public override async Task Project_same_struct_nested_complex_type_twice_with_pushdown(bool async)
+    {
+        await base.Project_same_struct_nested_complex_type_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "v0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "v0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "v0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "v0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+    FROM "ValuedCustomer" AS "v"
+    CROSS JOIN "ValuedCustomer" AS "v0"
+) AS "t"
+""");
+    }
+
+    public override async Task Project_same_entity_with_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_entity_with_struct_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t0"."Id", "t0"."Name", "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."ShippingAddress_AddressLine1", "t0"."ShippingAddress_AddressLine2", "t0"."ShippingAddress_ZipCode", "t0"."ShippingAddress_Country_Code", "t0"."ShippingAddress_Country_FullName", "t0"."Id0", "t0"."Name0", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0", "t0"."ShippingAddress_AddressLine10", "t0"."ShippingAddress_AddressLine20", "t0"."ShippingAddress_ZipCode0", "t0"."ShippingAddress_Country_Code0", "t0"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+    FROM (
+        SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName", "v0"."Id" AS "Id0", "v0"."Name" AS "Name0", "v0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "v0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "v0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "v0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "v0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "v0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "v0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "v0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "v0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "v0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+        FROM "ValuedCustomer" AS "v"
+        CROSS JOIN "ValuedCustomer" AS "v0"
+        ORDER BY "v"."Id", "v0"."Id"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+""");
+    }
+
+    public override async Task Project_same_struct_nested_complex_type_twice_with_double_pushdown(bool async)
+    {
+        await base.Project_same_struct_nested_complex_type_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+    FROM (
+        SELECT "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "v0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "v0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "v0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "v0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+        FROM "ValuedCustomer" AS "v"
+        CROSS JOIN "ValuedCustomer" AS "v0"
+        ORDER BY "v"."Id", "v0"."Id"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+""");
+    }
+
+    public override async Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_pushdown(bool async)
+    {
+        await base.Union_of_same_entity_with_nested_complex_type_projected_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName", "c0"."Id" AS "Id0", "c0"."Name" AS "Name0", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+    FROM "Customer" AS "c"
+    CROSS JOIN "Customer" AS "c0"
+    UNION
+    SELECT "c1"."Id", "c1"."Name", "c1"."BillingAddress_AddressLine1", "c1"."BillingAddress_AddressLine2", "c1"."BillingAddress_ZipCode", "c1"."BillingAddress_Country_Code", "c1"."BillingAddress_Country_FullName", "c1"."ShippingAddress_AddressLine1", "c1"."ShippingAddress_AddressLine2", "c1"."ShippingAddress_ZipCode", "c1"."ShippingAddress_Country_Code", "c1"."ShippingAddress_Country_FullName", "c2"."Id" AS "Id0", "c2"."Name" AS "Name0", "c2"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c2"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c2"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c2"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c2"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c2"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c2"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c2"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c2"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c2"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+    FROM "Customer" AS "c1"
+    CROSS JOIN "Customer" AS "c2"
+) AS "t"
+ORDER BY "t"."Id", "t"."Id0"
+LIMIT @__p_0
+""");
+    }
+
+    public override async Task Union_of_same_entity_with_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+    {
+        await base.Union_of_same_entity_with_nested_complex_type_projected_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t1"."Id", "t1"."Name", "t1"."BillingAddress_AddressLine1", "t1"."BillingAddress_AddressLine2", "t1"."BillingAddress_ZipCode", "t1"."BillingAddress_Country_Code", "t1"."BillingAddress_Country_FullName", "t1"."ShippingAddress_AddressLine1", "t1"."ShippingAddress_AddressLine2", "t1"."ShippingAddress_ZipCode", "t1"."ShippingAddress_Country_Code", "t1"."ShippingAddress_Country_FullName", "t1"."Id0", "t1"."Name0", "t1"."BillingAddress_AddressLine10", "t1"."BillingAddress_AddressLine20", "t1"."BillingAddress_ZipCode0", "t1"."BillingAddress_Country_Code0", "t1"."BillingAddress_Country_FullName0", "t1"."ShippingAddress_AddressLine10", "t1"."ShippingAddress_AddressLine20", "t1"."ShippingAddress_ZipCode0", "t1"."ShippingAddress_Country_Code0", "t1"."ShippingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t0"."Id", "t0"."Name", "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."ShippingAddress_AddressLine1", "t0"."ShippingAddress_AddressLine2", "t0"."ShippingAddress_ZipCode", "t0"."ShippingAddress_Country_Code", "t0"."ShippingAddress_Country_FullName", "t0"."Id0", "t0"."Name0", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0", "t0"."ShippingAddress_AddressLine10", "t0"."ShippingAddress_AddressLine20", "t0"."ShippingAddress_ZipCode0", "t0"."ShippingAddress_Country_Code0", "t0"."ShippingAddress_Country_FullName0"
+    FROM (
+        SELECT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName", "t"."Id0", "t"."Name0", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0", "t"."ShippingAddress_AddressLine10", "t"."ShippingAddress_AddressLine20", "t"."ShippingAddress_ZipCode0", "t"."ShippingAddress_Country_Code0", "t"."ShippingAddress_Country_FullName0"
+        FROM (
+            SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName", "c0"."Id" AS "Id0", "c0"."Name" AS "Name0", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c0"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c0"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c0"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c0"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c0"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+            FROM "Customer" AS "c"
+            CROSS JOIN "Customer" AS "c0"
+            UNION
+            SELECT "c1"."Id", "c1"."Name", "c1"."BillingAddress_AddressLine1", "c1"."BillingAddress_AddressLine2", "c1"."BillingAddress_ZipCode", "c1"."BillingAddress_Country_Code", "c1"."BillingAddress_Country_FullName", "c1"."ShippingAddress_AddressLine1", "c1"."ShippingAddress_AddressLine2", "c1"."ShippingAddress_ZipCode", "c1"."ShippingAddress_Country_Code", "c1"."ShippingAddress_Country_FullName", "c2"."Id" AS "Id0", "c2"."Name" AS "Name0", "c2"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c2"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c2"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c2"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c2"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0", "c2"."ShippingAddress_AddressLine1" AS "ShippingAddress_AddressLine10", "c2"."ShippingAddress_AddressLine2" AS "ShippingAddress_AddressLine20", "c2"."ShippingAddress_ZipCode" AS "ShippingAddress_ZipCode0", "c2"."ShippingAddress_Country_Code" AS "ShippingAddress_Country_Code0", "c2"."ShippingAddress_Country_FullName" AS "ShippingAddress_Country_FullName0"
+            FROM "Customer" AS "c1"
+            CROSS JOIN "Customer" AS "c2"
+        ) AS "t"
+        ORDER BY "t"."Id", "t"."Id0"
+        LIMIT @__p_0
+    ) AS "t0"
+) AS "t1"
+ORDER BY "t1"."Id", "t1"."Id0"
+LIMIT @__p_0
+""");
+    }
+
+    public override async Task Union_of_same_nested_complex_type_projected_twice_with_pushdown(bool async)
+    {
+        await base.Union_of_same_nested_complex_type_projected_twice_with_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+    FROM "Customer" AS "c"
+    CROSS JOIN "Customer" AS "c0"
+    UNION
+    SELECT "c1"."BillingAddress_AddressLine1", "c1"."BillingAddress_AddressLine2", "c1"."BillingAddress_ZipCode", "c1"."BillingAddress_Country_Code", "c1"."BillingAddress_Country_FullName", "c2"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c2"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c2"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c2"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c2"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+    FROM "Customer" AS "c1"
+    CROSS JOIN "Customer" AS "c2"
+) AS "t"
+ORDER BY "t"."BillingAddress_ZipCode", "t"."BillingAddress_ZipCode0"
+LIMIT @__p_0
+""");
+    }
+
+    public override async Task Union_of_same_nested_complex_type_projected_twice_with_double_pushdown(bool async)
+    {
+        await base.Union_of_same_nested_complex_type_projected_twice_with_double_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='50'
+
+SELECT "t1"."BillingAddress_AddressLine1", "t1"."BillingAddress_AddressLine2", "t1"."BillingAddress_ZipCode", "t1"."BillingAddress_Country_Code", "t1"."BillingAddress_Country_FullName", "t1"."BillingAddress_AddressLine10", "t1"."BillingAddress_AddressLine20", "t1"."BillingAddress_ZipCode0", "t1"."BillingAddress_Country_Code0", "t1"."BillingAddress_Country_FullName0"
+FROM (
+    SELECT DISTINCT "t0"."BillingAddress_AddressLine1", "t0"."BillingAddress_AddressLine2", "t0"."BillingAddress_ZipCode", "t0"."BillingAddress_Country_Code", "t0"."BillingAddress_Country_FullName", "t0"."BillingAddress_AddressLine10", "t0"."BillingAddress_AddressLine20", "t0"."BillingAddress_ZipCode0", "t0"."BillingAddress_Country_Code0", "t0"."BillingAddress_Country_FullName0"
+    FROM (
+        SELECT "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."BillingAddress_AddressLine10", "t"."BillingAddress_AddressLine20", "t"."BillingAddress_ZipCode0", "t"."BillingAddress_Country_Code0", "t"."BillingAddress_Country_FullName0"
+        FROM (
+            SELECT "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c0"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c0"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c0"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c0"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c0"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+            FROM "Customer" AS "c"
+            CROSS JOIN "Customer" AS "c0"
+            UNION
+            SELECT "c1"."BillingAddress_AddressLine1", "c1"."BillingAddress_AddressLine2", "c1"."BillingAddress_ZipCode", "c1"."BillingAddress_Country_Code", "c1"."BillingAddress_Country_FullName", "c2"."BillingAddress_AddressLine1" AS "BillingAddress_AddressLine10", "c2"."BillingAddress_AddressLine2" AS "BillingAddress_AddressLine20", "c2"."BillingAddress_ZipCode" AS "BillingAddress_ZipCode0", "c2"."BillingAddress_Country_Code" AS "BillingAddress_Country_Code0", "c2"."BillingAddress_Country_FullName" AS "BillingAddress_Country_FullName0"
+            FROM "Customer" AS "c1"
+            CROSS JOIN "Customer" AS "c2"
+        ) AS "t"
+        ORDER BY "t"."BillingAddress_ZipCode", "t"."BillingAddress_ZipCode0"
+        LIMIT @__p_0
+    ) AS "t0"
+) AS "t1"
+ORDER BY "t1"."BillingAddress_ZipCode", "t1"."BillingAddress_ZipCode0"
+LIMIT @__p_0
+""");
+    }
+
+    public override async Task Same_entity_with_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Same_entity_with_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async))).Message);
+
+    public override async Task Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async))).Message);
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/33020 and https://github.com/dotnet/efcore/pull/33200
Fixes https://github.com/dotnet/efcore/issues/32911

**Description**

Some context:
pushdown is process we do during query translation, where a query itself becomes a source of another query above. 

```sql
SELECT c.Id, c.Name
FROM Customers AS c
WHERE c.Name = 'John'
```

becomes

```sql
SELECT subquery.Name
FROM (
    SELECT c.Id, c.Name
    FROM Customers AS c
    WHERE c.Name = 'John') AS subquery
```

We need to do this for various operations like Skip/Take/Distinct. Lifting projection is the process of extracting elements in the SELECT from the inner query (`SELECT c.Id, c.Name`) to the outer (`SELECT subquery.Name`). 

Applying projection is the process of actually populating SELECT with the column values. Initially we generate empty projection (SELECT 1) and try to populate values as late as possible - so we avoid populating with columns that are not needed in the final result.

Problem was that when we lift structural type projection during pushdown, if that projection contains complex types with the same column names (e.g. cross join of same entities - it's perfectly fine to do in a vacuum, we just alias the columns whose names are repeated) we would lift the projection incorrectly. What we do is go through all the properties, apply the corresponding columns to the `selectExpression` if needed and generate `StructuralTypeProjection` object if the projection needs to be applied one level up. For complex types we would generate a shaper expression and then run it through the same process, BUT the nested complex properties would be added to a flat structure along with the primitive properties, rather than in separate cache dedicated for complex property shapers. This was wrong and not what we expected to see, when processing this structure one level up (i.e. when applying projection to the outer select)

```sql
SELECT [applying_this_projection_was_wrong]
FROM
(
    SELECT c.Id, c.Name, c.ComplexProp, o.ComplexProp as ComplexProp0
    FROM Customers as c
    JOIN Orders as o ON ...
) as s
```

i.e. applying projection once worked fine, but doing it second time did not. The reason why is that we expected to see information about the complex type shape in the complex property shaper cache, rather than flat structure for primitives, but it wasn't there. So we assumed this is the first time we the projection is being applied, so we conjure up the complex type shaper based on table alias and `IColumn` metadata. This results in a situation, where complex property that was aliased is never picked. So we end up with:

```sql
SELECT s.Id, s.Name, s.ComplexProp -- we would also try to add s.ComplexProp again, instead of s.ComplexProp0 but of course we don't add same thing twice FROM
(
    SELECT c.Id, c.Name, c.ComplexProp, o.ComplexProp as ComplexProp0
    FROM Customers as c
    JOIN Orders as o ON ...
) as s
```
This leads to bad data - two different objects with distinct data in them are mapped to the same column in the database.

Fix is to properly build a complex type shaper structure when applying projection instead, so the structure we generate matches expectations. 

Also modified `VisitChildren` and `MakeNullable` methods on `StructuralTypeProjectionExpression` to process/preserve complex type cache information, which was previously gobbled up/ignored.

**Customer impact**
Customers using new "complex types" feature in their queries can be affected by data corruption in several different scenarios. The bug involves two or more complex types with the same structure and the query must be nested. For general case, there is no good workaround, apart from significantly rewriting the query. However some scenarios can be worked-around by slightly altering the model (renaming columns on the complex types so that they differ). Multiple customers were hit by this problem.

"Please consider backporting the fix as this bug is a showstopper for our large, long-standing LOB application. This is the last issue related to our EF6 -> EF Core port."

**How found**
Multiple customer reports on 8.

**Regression**
No, complex type support is a new feature in EF Core 8.

**Testing**
Extensive tests added.

**Risk**
Medium. This fix is definitely riskier than what we usually try to patch for EF queries. There was a design flaw in how we processed complex types, so the design had to be altered. Fix is isolated to scenarios involving complex types. When no complex types are present the code behaves exactly the same as before. However, majority of complex types scenarios are going through the new code path and potentially could be affected by unintended consequences. Added quirk as extra precaution. 
