### PR TITLE
Correct value type in hard-coded migrations test

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -486,7 +486,7 @@ public abstract class
 
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', '{TestValue}')");
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, '{TestValue}')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -508,7 +508,7 @@ public abstract class
 
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', '{TestValue}')");
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, '{TestValue}')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -533,7 +533,7 @@ public abstract class
 
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', '{TestValue}')");
+            migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '{TestValue}')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -163,7 +163,7 @@ GO
 BEGIN TRANSACTION;
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
 Empty Lines')
 GO
@@ -178,7 +178,7 @@ GO
 BEGIN TRANSACTION;
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
 Empty Lines')
@@ -194,7 +194,7 @@ GO
 BEGIN TRANSACTION;
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
 Value With
 
 GO
@@ -288,7 +288,7 @@ INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000004_Migration4', N'7.0.0-test');
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
 Empty Lines')
 GO
@@ -297,7 +297,7 @@ INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
 Empty Lines')
@@ -307,7 +307,7 @@ INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000006_Migration6', N'7.0.0-test');
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
 Value With
 
 GO
@@ -534,7 +534,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000005_Migration5'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
     Empty Lines')
 END;
@@ -561,7 +561,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000006_Migration6'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
     Value With
 
     Empty Lines')
@@ -589,7 +589,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000007_Migration7'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
     Value With
 
 END;
@@ -755,7 +755,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000005_Migration5'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
     Empty Lines')
 END;
@@ -776,7 +776,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000006_Migration6'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
     Value With
 
     Empty Lines')
@@ -798,7 +798,7 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'00000000000007_Migration7'
 )
 BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
     Value With
 
 END;

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -95,7 +95,7 @@ COMMIT;
 
 BEGIN TRANSACTION;
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
 Empty Lines')
 
@@ -106,7 +106,7 @@ COMMIT;
 
 BEGIN TRANSACTION;
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
 Empty Lines')
@@ -118,7 +118,7 @@ COMMIT;
 
 BEGIN TRANSACTION;
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
 Value With
 
 GO
@@ -168,14 +168,14 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, ' ', 'Value With
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
 Empty Lines')
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000005_Migration5', '7.0.0-test');
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
 Empty Lines')
@@ -183,7 +183,7 @@ Empty Lines')
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000006_Migration6', '7.0.0-test');
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, ' ', 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
 Value With
 
 GO


### PR DESCRIPTION
Column is created as int, but then used as string. Causing issues for Pomelo MySQL provider.

Fixes #33331
