### PR TITLE
API review changes

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -809,17 +809,21 @@ public static class ScaffoldingModelExtensions
             root = root?.Chain(isCyclic) ?? isCyclic;
         }
 
-        if (sequence.IsCached != Sequence.DefaultIsCached)
+        var cacheSize = sequence.CacheSize;
+        if (cacheSize.HasValue)
         {
-            var useNoCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseNoCache));
+            if (cacheSize != 1 && cacheSize != 0)
+            {
+                var useCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseCache)) { Arguments = { cacheSize } };
 
-            root = root?.Chain(useNoCache) ?? useNoCache;
-        }
-        else
-        {
-            var useCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseCache)) { Arguments = { sequence.CacheSize } };
+                root = root?.Chain(useCache) ?? useCache;
+            }
+            else
+            {
+                var useNoCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseNoCache));
 
-            root = root?.Chain(useCache) ?? useCache;
+                root = root?.Chain(useNoCache) ?? useNoCache;
+            }
         }
 
         return root;

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -778,22 +778,12 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("cyclic: true");
             }
 
-            if (operation.IsCached && operation.CacheSize.HasValue)
+            if (operation.CacheSize != null)
             {
                 builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached))
                     .AppendLine(",")
                     .Append("cacheSize: ")
                     .Append(Code.Literal(operation.CacheSize));
-            }
-            else if (!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached));
             }
 
             if (operation.OldSequence.IncrementBy != 1)
@@ -827,22 +817,12 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("oldCyclic: true");
             }
 
-            if (operation.OldSequence.IsCached && operation.OldSequence.CacheSize.HasValue)
+            if (operation.OldSequence.CacheSize.HasValue)
             {
                 builder
-                    .AppendLine(",")
-                    .Append("oldCached: ")
-                    .Append(Code.Literal(operation.OldSequence.IsCached))
                     .AppendLine(",")
                     .Append("oldCacheSize: ")
                     .Append(Code.Literal(operation.OldSequence.CacheSize));
-            }
-            else if (!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("oldCached: ")
-                    .Append(Code.Literal(operation.OldSequence.IsCached));
             }
 
             builder.Append(")");
@@ -1061,22 +1041,12 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("cyclic: true");
             }
 
-            if (operation.IsCached && operation.CacheSize.HasValue)
+            if (operation.CacheSize.HasValue)
             {
                 builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached))
                     .AppendLine(",")
                     .Append("cacheSize: ")
                     .Append(Code.Literal(operation.CacheSize));
-            }
-            else if(!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached));
             }
 
             builder.Append(")");

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -393,13 +393,7 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                 .Append(".IsCyclic()");
         }
 
-        if (sequence.IsCached != Sequence.DefaultIsCached)
-        {
-            stringBuilder
-                .AppendLine()
-                .Append(".UseNoCache()");
-        }
-        else if (sequence.CacheSize != Sequence.DefaultCacheSize)
+        if (sequence.CacheSize.HasValue)
         {
             stringBuilder
                 .AppendLine()

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -269,17 +269,9 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             builder.IsCyclic(sequence.IsCyclic.Value);
         }
 
-        if (sequence.IsCached.HasValue && !sequence.IsCached.Value)
-        {
-            builder.UseNoCache();
-        }
-        else if (sequence.IsCached.HasValue && sequence.CacheSize.HasValue)
+        if (sequence.CacheSize.HasValue)
         {
             builder.UseCache(sequence.CacheSize);
-        }
-        else
-        {
-            builder.UseCache();
         }
 
         return builder;

--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -1688,22 +1688,12 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
                 .Append("maxValue: ").Append(code.Literal(sequence.MaxValue));
         }
 
-        if (sequence.IsCached && sequence.CacheSize.HasValue)
+        if (sequence.CacheSize.HasValue)
         {
             mainBuilder
-                .AppendLine(",")
-                .Append("cached: ")
-                .Append(code.Literal(sequence.IsCached))
                 .AppendLine(",")
                 .Append("cacheSize: ")
                 .Append(code.Literal(sequence.CacheSize));
-        }
-        else if (!sequence.IsCached)
-        {
-            mainBuilder
-                .AppendLine(",")
-                .Append("cached: ")
-                .Append(code.Literal(sequence.IsCached));
         }
 
         if (sequence.ModelSchema is null && sequence.Schema is not null)

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -331,7 +331,6 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
             sequence.IsCyclic,
             sequence.MinValue,
             sequence.MaxValue,
-            sequence.IsCached,
             sequence.CacheSize,
             sequence.ModelSchema is null);
 

--- a/src/EFCore.Relational/Metadata/IConventionSequence.cs
+++ b/src/EFCore.Relational/Metadata/IConventionSequence.cs
@@ -117,22 +117,6 @@ public interface IConventionSequence : IReadOnlySequence, IConventionAnnotatable
     ConfigurationSource? GetIsCyclicConfigurationSource();
 
     /// <summary>
-    ///     Sets whether the sequence use preallocated values.
-    /// </summary>
-    /// <param name="cached">
-    ///     If <see langword="true" />, then the sequence use preallocated values.
-    /// </param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The configured value.</returns>
-    bool? SetIsCached(bool? cached, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Gets the configuration source for <see cref="IReadOnlySequence.IsCached" />.
-    /// </summary>
-    /// <returns>The configuration source for <see cref="IReadOnlySequence.IsCached" />.</returns>
-    ConfigurationSource? GetIsCachedConfigurationSource();
-
-    /// <summary>
     ///     Sets the amount of preallocated values.
     /// </summary>
     /// <param name="cacheSize">The amount of preallocated values.</param>

--- a/src/EFCore.Relational/Metadata/IMutableSequence.cs
+++ b/src/EFCore.Relational/Metadata/IMutableSequence.cs
@@ -48,11 +48,6 @@ public interface IMutableSequence : IReadOnlySequence, IMutableAnnotatable
     new bool IsCyclic { get; set; }
 
     /// <summary>
-    ///     Gets or sets the value indicating whether the sequence use preallocated values.
-    /// </summary>
-    new bool IsCached { get; set; }
-
-    /// <summary>
     ///     Gets or sets the amount of preallocated values, or <see langword="null" /> if none has been set.
     /// </summary>
     new int? CacheSize { get; set; }

--- a/src/EFCore.Relational/Metadata/IReadOnlySequence.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlySequence.cs
@@ -67,11 +67,6 @@ public interface IReadOnlySequence : IReadOnlyAnnotatable
     bool IsCyclic { get; }
 
     /// <summary>
-    ///     Gets the value indicating whether the sequence use preallocated values.
-    /// </summary>
-    bool IsCached { get; }
-
-    /// <summary>
     ///     Gets the amount of preallocated values, or <see langword="null" /> if none has been set.
     /// </summary>
     int? CacheSize { get; }
@@ -135,18 +130,10 @@ public interface IReadOnlySequence : IReadOnlyAnnotatable
                 .Append(MaxValue);
         }
 
-        if (!IsCached)
-        {
-            builder.Append(" No Cache");
-        }
-        else if (CacheSize != null)
+        if (CacheSize != null)
         {
             builder.Append(" Cache: ")
                 .Append(CacheSize);
-        }
-        else
-        {
-            builder.Append(" Cache");
         }
 
         if ((options & MetadataDebugStringOptions.SingleLine) == 0)

--- a/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
@@ -198,8 +198,7 @@ public class InternalSequenceBuilder : AnnotatableBuilder<Sequence, IConventionM
     {
         if (CanSetNoCache(configurationSource))
         {
-            Metadata.SetIsCached(false, configurationSource);
-            Metadata.SetCacheSize(null, configurationSource);
+            Metadata.SetCacheSize(1, configurationSource);
             return this;
         }
         return null;
@@ -212,8 +211,7 @@ public class InternalSequenceBuilder : AnnotatableBuilder<Sequence, IConventionM
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool CanSetNoCache(ConfigurationSource configurationSource)
-                => configurationSource.Overrides(Metadata.GetIsCachedConfigurationSource())
-            || Metadata.IsCached == false;
+        => configurationSource.Overrides(Metadata.GetCacheSizeConfigurationSource());
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -225,7 +223,6 @@ public class InternalSequenceBuilder : AnnotatableBuilder<Sequence, IConventionM
     {
         if (CanSetCacheSize(cacheSize, configurationSource))
         {
-            Metadata.SetIsCached(true, configurationSource);
             Metadata.SetCacheSize(cacheSize, configurationSource);
             return this;
         }

--- a/src/EFCore.Relational/Metadata/RuntimeSequence.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeSequence.cs
@@ -21,7 +21,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     private readonly long? _maxValue;
     private readonly bool _isCyclic;
     private readonly int? _cacheSize;
-    private readonly bool _isCached;
     private readonly bool _modelSchemaIsNull;
 
     /// <summary>
@@ -37,7 +36,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     /// <param name="minValue">The minimum value.</param>
     /// <param name="maxValue">The maximum value.</param>
     /// <param name="cacheSize">The cache size.</param>
-    /// <param name="cached">Whether the sequence use preallocated values.</param>
     /// <param name="modelSchemaIsNull">A value indicating whether <see cref="ModelSchema" /> is null.</param>
     public RuntimeSequence(
         string name,
@@ -49,7 +47,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
         bool cyclic = false,
         long? minValue = null,
         long? maxValue = null,
-        bool cached = true,
         int? cacheSize = null,
         bool modelSchemaIsNull = false)
     {
@@ -62,7 +59,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
         _isCyclic = cyclic;
         _minValue = minValue;
         _maxValue = maxValue;
-        _isCached = cached;
         _cacheSize = cacheSize;
         _modelSchemaIsNull = modelSchemaIsNull;
     }
@@ -162,13 +158,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     {
         [DebuggerStepThrough]
         get => _isCyclic;
-    }
-
-    /// <inheritdoc />
-    bool IReadOnlySequence.IsCached
-    {
-        [DebuggerStepThrough]
-        get => _isCached;
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1727,7 +1727,6 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
             || source.MaxValue != target.MaxValue
             || source.MinValue != target.MinValue
             || source.IsCyclic != target.IsCyclic
-            || source.IsCached != target.IsCached
             || source.CacheSize != target.CacheSize
             || HasDifferences(sourceMigrationsAnnotations, targetMigrationsAnnotations))
         {
@@ -1782,7 +1781,6 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
         sequenceOperation.MinValue = sequence.MinValue;
         sequenceOperation.MaxValue = sequence.MaxValue;
         sequenceOperation.IsCyclic = sequence.IsCyclic;
-        sequenceOperation.IsCached = sequence.IsCached;
         sequenceOperation.CacheSize = sequence.CacheSize;
         sequenceOperation.AddAnnotations(migrationsAnnotations);
 

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -522,9 +522,7 @@ public class MigrationBuilder
     /// <param name="oldMinValue">The previous minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="oldMaxValue">The previous maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="oldCyclic">Indicates whether or not the sequence would previously re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
     /// <param name="cacheSize">The amount of preallocated values.</param>
-    /// <param name="oldCached">Indicates whether the sequence previously used preallocated values</param>
     /// <param name="oldCacheSize">The previous amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual AlterOperationBuilder<AlterSequenceOperation> AlterSequence(
@@ -538,9 +536,7 @@ public class MigrationBuilder
         long? oldMinValue = null,
         long? oldMaxValue = null,
         bool oldCyclic = false,
-        bool cached = true,
         int? cacheSize = null,
-        bool oldCached = true,
         int? oldCacheSize = null)
     {
         Check.NotEmpty(name, nameof(name));
@@ -553,7 +549,6 @@ public class MigrationBuilder
             MinValue = minValue,
             MaxValue = maxValue,
             IsCyclic = cyclic,
-            IsCached = cached,
             CacheSize = cacheSize,
             OldSequence = new CreateSequenceOperation
             {
@@ -561,7 +556,6 @@ public class MigrationBuilder
                 MinValue = oldMinValue,
                 MaxValue = oldMaxValue,
                 IsCyclic = oldCyclic,
-                IsCached = oldCached,
                 CacheSize = oldCacheSize,
             }
         };
@@ -714,7 +708,6 @@ public class MigrationBuilder
     /// <param name="minValue">The minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="maxValue">The maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="cyclic">Indicates whether or not the sequence will re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
     /// <param name="cacheSize">The amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateSequenceOperation> CreateSequence(
@@ -725,9 +718,8 @@ public class MigrationBuilder
         long? minValue = null,
         long? maxValue = null,
         bool cyclic = false,
-        bool cached = true,
         int? cacheSize = null)
-        => CreateSequence<long>(name, schema, startValue, incrementBy, minValue, maxValue, cyclic, cached, cacheSize);
+        => CreateSequence<long>(name, schema, startValue, incrementBy, minValue, maxValue, cyclic, cacheSize);
 
     /// <summary>
     ///     Builds a <see cref="CreateSequenceOperation" /> to create a new sequence.
@@ -743,7 +735,6 @@ public class MigrationBuilder
     /// <param name="minValue">The minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="maxValue">The maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="cyclic">Indicates whether or not the sequence will re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
     /// <param name="cacheSize">The amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateSequenceOperation> CreateSequence<T>(
@@ -754,7 +745,6 @@ public class MigrationBuilder
         long? minValue = null,
         long? maxValue = null,
         bool cyclic = false,
-        bool cached = true,
         int? cacheSize = null)
     {
         Check.NotEmpty(name, nameof(name));
@@ -769,7 +759,6 @@ public class MigrationBuilder
             MinValue = minValue,
             MaxValue = maxValue,
             IsCyclic = cyclic,
-            IsCached = cached,
             CacheSize = cacheSize
         };
         Operations.Add(operation);

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1295,21 +1295,24 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
 
         builder.Append(operation.IsCyclic ? " CYCLE" : " NO CYCLE");
 
-        if (!operation.IsCached)
+        if (operation.CacheSize != null)
         {
-            builder
-                .Append(" NO CACHE");
-        }
-        else if (operation.CacheSize != null)
-        {
-            builder
-                .Append(" CACHE ")
-                .Append(intTypeMapping.GenerateSqlLiteral(operation.CacheSize.Value));
+            var cacheSize = operation.CacheSize;
+            if (cacheSize != 1 && cacheSize != 0)
+            {
+                builder
+                    .Append(" CACHE ")
+                    .Append(intTypeMapping.GenerateSqlLiteral(cacheSize));
+            }
+            else
+            {
+                builder
+                    .Append(" NO CACHE");
+            }
         }
         else if (forAlter)
         {
-            builder
-                .Append(" CACHE");
+            builder.Append(" CACHE");
         }
     }
 

--- a/src/EFCore.Relational/Migrations/Operations/SequenceOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/SequenceOperation.cs
@@ -33,11 +33,6 @@ public abstract class SequenceOperation : MigrationOperation
     public virtual bool IsCyclic { get; set; }
 
     /// <summary>
-    ///     Indicates whether the sequence use preallocated values.
-    /// </summary>
-    public virtual bool IsCached { get; set; } = true;
-
-    /// <summary>
     ///     The amount of preallocated values of the sequence, or <see langword="null" /> if not specified.
     /// </summary>
     public virtual int? CacheSize { get; set; }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
@@ -58,11 +58,6 @@ public class DatabaseSequence : Annotatable
     public virtual bool? IsCyclic { get; set; }
 
     /// <summary>
-    ///     Indicates whether the sequence use preallocated values, or <see langword="null" /> if not set.
-    /// </summary>
-    public virtual bool? IsCached { get; set; }
-
-    /// <summary>
     ///     The amount of preallocated values, or <see langword="null" /> if not set.
     /// </summary>
     public virtual int? CacheSize { get; set; }

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -184,7 +184,7 @@ public class ColumnModification : IColumnModification
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static object? GetOriginalValue(IUpdateEntry entry, IProperty property)
-        => entry.GetOriginalOrCurrentValue(property);
+        => entry.CanHaveOriginalValue(property) ? entry.GetOriginalValue(property) : entry.GetCurrentValue(property);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
@@ -487,7 +487,6 @@ public static class SqlServerLoggerExtensions
         long start,
         long min,
         long max,
-        bool cached,
         int? cacheSize)
     {
         // No DiagnosticsSource events because these are purely design-time messages
@@ -508,7 +507,6 @@ public static class SqlServerLoggerExtensions
                     start,
                     min,
                     max,
-                    cached,
                     cacheSize));
         }
     }

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1550,20 +1550,24 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
         builder.Append(operation.IsCyclic ? " CYCLE" : " NO CYCLE");
 
-        if (!operation.IsCached)
+        var cacheSize = operation.CacheSize;
+        if (cacheSize != null)
         {
-            builder.Append(" NO CACHE");
-        }
-        else if (operation.CacheSize.HasValue)
-        {
-            builder
-            .Append(" CACHE ")
-                .Append(IntegerConstant(operation.CacheSize.Value));
+            if (cacheSize != 1 && cacheSize != 0)
+            {
+                builder
+                    .Append(" CACHE ")
+                    .Append(IntegerConstant(cacheSize.Value));
+            }
+            else
+            {
+                builder
+                    .Append(" NO CACHE");
+            }
         }
         else if (forAlter)
         {
-            builder
-                .Append(" CACHE");
+            builder.Append(" CACHE");
         }
     }
 

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -243,8 +243,8 @@
     <comment>Debug SqlServerEventId.PrimaryKeyFound string string</comment>
   </data>
   <data name="LogFoundSequence" xml:space="preserve">
-    <value>Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}, cached: {cached}, cacheSize: {cacheSize}.</value>
-    <comment>Debug SqlServerEventId.SequenceFound string string bool int long long long bool int</comment>
+    <value>Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}, cacheSize: {cacheSize}.</value>
+    <comment>Debug SqlServerEventId.SequenceFound string string bool int long long long int</comment>
   </data>
   <data name="LogFoundTable" xml:space="preserve">
     <value>Found table with name '{name}'.</value>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -457,8 +457,8 @@ WHERE "
             var startValue = reader.GetValueOrDefault<long>("start_value");
             var minValue = reader.GetValueOrDefault<long>("minimum_value");
             var maxValue = reader.GetValueOrDefault<long>("maximum_value");
-            var cached = reader.GetValueOrDefault<bool>("is_cached");
-            var cacheSize = reader.GetValueOrDefault<int?>("cache_size");
+            var cacheSize = reader.GetValueOrDefault<int?>("cache_size")
+                ?? (reader.GetValueOrDefault<bool>("is_cached") ? null : 1);
 
             // Swap store type if type alias is used
             if (typeAliases.TryGetValue($"[{storeTypeSchema}].[{storeType}]", out var value))
@@ -468,7 +468,7 @@ WHERE "
 
             storeType = GetStoreType(storeType, maxLength: 0, precision: precision, scale: scale);
 
-            _logger.SequenceFound(DisplayName(schema, name), storeType, cyclic, incrementBy, startValue, minValue, maxValue, cached, cacheSize);
+            _logger.SequenceFound(DisplayName(schema, name), storeType, cyclic, incrementBy, startValue, minValue, maxValue, cacheSize);
 
             var sequence = new DatabaseSequence
             {
@@ -481,7 +481,6 @@ WHERE "
                 StartValue = startValue,
                 MinValue = minValue,
                 MaxValue = maxValue,
-                IsCached = cached,
                 CacheSize = cacheSize
             };
 

--- a/src/EFCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
@@ -99,7 +99,7 @@ public class CompositePrincipalKeyValueFactory : CompositeValueFactory, IPrincip
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IReadOnlyList<object?> CreateFromOriginalValues(IUpdateEntry entry)
-        => CreateFromEntry(entry, (e, p) => e.GetOriginalOrCurrentValue(p));
+        => CreateFromEntry(entry, (e, p) => e.CanHaveOriginalValue(p) ? e.GetOriginalValue(p) : e.GetCurrentValue(p));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
@@ -91,7 +91,7 @@ public class CompositeValueFactory : IDependentKeyValueFactory<IReadOnlyList<obj
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool TryCreateFromOriginalValues(IUpdateEntry entry, [NotNullWhen(true)] out IReadOnlyList<object?>? key)
-        => TryCreateFromEntry(entry, (e, p) => e.GetOriginalOrCurrentValue(p), out key);
+        => TryCreateFromEntry(entry, (e, p) => e.CanHaveOriginalValue(p) ? e.GetOriginalValue(p) : e.GetCurrentValue(p), out key);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1142,10 +1142,8 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public object? GetOriginalOrCurrentValue(IPropertyBase propertyBase)
-        => propertyBase.GetOriginalValueIndex() >= 0
-            ? _originalValues.GetValue(this, (IProperty)propertyBase)
-            : GetCurrentValue(propertyBase);
+    public bool CanHaveOriginalValue(IPropertyBase propertyBase)
+        => propertyBase.GetOriginalValueIndex() >= 0;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Update/IUpdateEntry.cs
+++ b/src/EFCore/Update/IUpdateEntry.cs
@@ -95,12 +95,11 @@ public interface IUpdateEntry
     object? GetOriginalValue(IPropertyBase propertyBase);
 
     /// <summary>
-    ///     Gets the value assigned to the property when it was retrieved from the database, or
-    ///     the current value if the original value is not being stored.
+    /// Returns <see langword="true"/> only if the property has storage for an original value.
     /// </summary>
-    /// <param name="propertyBase">The property to get the value for.</param>
-    /// <returns>The value for the property.</returns>
-    object? GetOriginalOrCurrentValue(IPropertyBase propertyBase);
+    /// <param name="propertyBase">The property.</param>
+    /// <returns><see langword="true"/> if the property may have an original value; <see langword="false"/> if it never can.</returns>
+    bool CanHaveOriginalValue(IPropertyBase propertyBase);
 
     /// <summary>
     ///     Gets the value assigned to the property.

--- a/src/EFCore/Update/UpdateEntryExtensions.cs
+++ b/src/EFCore/Update/UpdateEntryExtensions.cs
@@ -49,7 +49,10 @@ public static class UpdateEntryExtensions
     /// <returns>The value for the property.</returns>
     public static object? GetOriginalProviderValue(this IUpdateEntry updateEntry, IProperty property)
     {
-        var value = updateEntry.GetOriginalOrCurrentValue(property);
+        var value = updateEntry.CanHaveOriginalValue(property)
+            ? updateEntry.GetOriginalValue(property)
+            : updateEntry.GetCurrentValue(property);
+
         var typeMapping = property.GetTypeMapping();
         value = value?.GetType().IsInteger() == true && typeMapping.ClrType.UnwrapNullableType().IsEnum
             ? Enum.ToObject(typeMapping.ClrType.UnwrapNullableType(), value)

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -332,7 +332,7 @@ public class CosmosTestStore : TestStore
         public object GetCurrentValue(IPropertyBase propertyBase)
             => throw new NotImplementedException();
 
-        public object GetOriginalOrCurrentValue(IPropertyBase propertyBase)
+        public bool CanHaveOriginalValue(IPropertyBase propertyBase)
             => throw new NotImplementedException();
 
         public TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -791,13 +791,11 @@ mb.AlterSequence(
                 Assert.Null(o.MinValue);
                 Assert.Null(o.MaxValue);
                 Assert.False(o.IsCyclic);
-                Assert.True(o.IsCached);
                 Assert.Null(o.CacheSize);
                 Assert.Equal(1, o.OldSequence.IncrementBy);
                 Assert.Null(o.OldSequence.MinValue);
                 Assert.Null(o.OldSequence.MaxValue);
                 Assert.False(o.OldSequence.IsCyclic);
-                Assert.True(o.OldSequence.IsCached);
                 Assert.Null(o.OldSequence.CacheSize);
             });
 
@@ -812,7 +810,6 @@ mb.AlterSequence(
                 MinValue = 2,
                 MaxValue = 4,
                 IsCyclic = true,
-                IsCached = true,
                 CacheSize = 20,
                 OldSequence =
                 {
@@ -820,7 +817,6 @@ mb.AlterSequence(
                     MinValue = 3,
                     MaxValue = 5,
                     IsCyclic = true,
-                    IsCached = true,
                     CacheSize = 2
                 }
             },
@@ -832,13 +828,11 @@ mb.AlterSequence(
     minValue: 2L,
     maxValue: 4L,
     cyclic: true,
-    cached: true,
     cacheSize: 20,
     oldIncrementBy: 4,
     oldMinValue: 3L,
     oldMaxValue: 5L,
     oldCyclic: true,
-    oldCached: true,
     oldCacheSize: 2);
 """,
             o =>
@@ -849,13 +843,11 @@ mb.AlterSequence(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
                 Assert.Equal(20, o.CacheSize);
                 Assert.Equal(4, o.OldSequence.IncrementBy);
                 Assert.Equal(3, o.OldSequence.MinValue);
                 Assert.Equal(5, o.OldSequence.MaxValue);
                 Assert.True(o.OldSequence.IsCyclic);
-                Assert.True(o.OldSequence.IsCached);
                 Assert.Equal(2, o.OldSequence.CacheSize);
             });
 
@@ -1029,7 +1021,6 @@ mb.CreateSequence<int>(
                 MinValue = 2,
                 MaxValue = 4,
                 IsCyclic = true,
-                IsCached = true,
                 CacheSize = 20
             },
             """
@@ -1041,7 +1032,6 @@ mb.CreateSequence(
     minValue: 2L,
     maxValue: 4L,
     cyclic: true,
-    cached: true,
     cacheSize: 20);
 """,
             o =>
@@ -1054,7 +1044,6 @@ mb.CreateSequence(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
                 Assert.Equal(20, o.CacheSize);
             });
 
@@ -1066,19 +1055,16 @@ mb.CreateSequence(
             Name = "EntityFrameworkHiLoSequence",
             Schema = "dbo",
             ClrType = typeof(long),
-            IsCached = true,
             CacheSize = 20
         },
         """
 mb.CreateSequence(
     name: "EntityFrameworkHiLoSequence",
     schema: "dbo",
-    cached: true,
     cacheSize: 20);
 """,
         o =>
         {
-            Assert.True(o.IsCached);
             Assert.Equal(20, o.CacheSize);
         });
 
@@ -1090,18 +1076,17 @@ mb.CreateSequence(
             Name = "EntityFrameworkHiLoSequence",
             Schema = "dbo",
             ClrType = typeof(long),
-            IsCached = false,
+            CacheSize = 1,
         },
         """
 mb.CreateSequence(
     name: "EntityFrameworkHiLoSequence",
     schema: "dbo",
-    cached: false);
+    cacheSize: 1);
 """,
         o =>
         {
-            Assert.False(o.IsCached);
-            Assert.Null(o.CacheSize);
+            Assert.Equal(1, o.CacheSize);
         });
 
     [ConditionalFact]
@@ -1112,7 +1097,6 @@ mb.CreateSequence(
             Name = "EntityFrameworkHiLoSequence",
             Schema = "dbo",
             ClrType = typeof(long),
-            IsCached = true
         },
         """
 mb.CreateSequence(
@@ -1121,7 +1105,6 @@ mb.CreateSequence(
 """,
         o =>
         {
-            Assert.True(o.IsCached);
             Assert.Null(o.CacheSize);
         });
 
@@ -1139,7 +1122,6 @@ mb.CreateSequence(
                 MinValue = 2,
                 MaxValue = 4,
                 IsCyclic = true,
-                IsCached = true,
                 CacheSize = 20
             },
             """
@@ -1151,7 +1133,6 @@ mb.CreateSequence<int>(
     minValue: 2L,
     maxValue: 4L,
     cyclic: true,
-    cached: true,
     cacheSize: 20);
 """,
             o =>
@@ -1164,7 +1145,6 @@ mb.CreateSequence<int>(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
                 Assert.Equal(20, o.CacheSize);
             });
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -1804,7 +1804,6 @@ namespace RootNamespace
                 Assert.Equal(3, sequence.MaxValue);
                 Assert.Equal(2, sequence.IncrementBy);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
                 Assert.Equal("bar", sequence["foo"]);
             });

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1415,7 +1415,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 => modelBuilder
                     .HasAnnotation("ChangeDetector.SkipDetectChanges", "true")
                     .HasAnnotation("ProductVersion", "1.1.6")
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
         }
 
@@ -1428,7 +1428,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     .HasAnnotation("ChangeDetector.SkipDetectChanges", "true")
                     .HasAnnotation("ProductVersion", "2.2.2-servicing-10034")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 #pragma warning restore 612, 618
             }
@@ -1442,7 +1442,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 modelBuilder
                     .HasAnnotation("ProductVersion", "3.1.1")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 #pragma warning restore 612, 618
             }
@@ -1459,8 +1459,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     .HasMin(1)
                     .HasMax(3)
                     .IncrementsBy(2)
-                    .IsCyclic()
-                    .UseCache(20);
+                    .IsCyclic();
         }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1199,7 +1199,6 @@ public partial class TestDbContext : DbContext
                     Assert.Equal(2, sequence.MinValue);
                     Assert.Equal(100, sequence.MaxValue);
                     Assert.True(sequence.IsCyclic);
-                    Assert.True(sequence.IsCached);
                     Assert.Equal(20, sequence.CacheSize);
                 });
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1620,7 +1620,6 @@ public class RelationalScaffoldingModelFactoryTest
                 Assert.Null(first.MaxValue);
                 Assert.Null(first.MinValue);
                 Assert.False(first.IsCyclic);
-                Assert.True(first.IsCached);
                 Assert.Null(first.CacheSize);
             });
     }

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -2417,7 +2417,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var sequence = Assert.Single(model.Sequences);
                 Assert.Equal("Alpha", sequence.Name);
-                Assert.False(sequence.IsCached);
+                Assert.Equal(1, sequence.CacheSize);
             });
 
 
@@ -2430,7 +2430,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var sequence = Assert.Single(model.Sequences);
                 Assert.Equal("Beta", sequence.Name);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
             });
 
@@ -2443,7 +2442,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var sequence = Assert.Single(model.Sequences);
                 Assert.Equal("Gamma", sequence.Name);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
             });
 
@@ -2468,7 +2466,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal(2, sequence.MinValue);
                 Assert.Equal(916, sequence.MaxValue);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
             });
 
@@ -2492,7 +2489,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal(-5, sequence.MinValue);
                 Assert.Equal(10, sequence.MaxValue);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
             });
 
@@ -2506,6 +2502,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var sequence = Assert.Single(model.Sequences);
                 Assert.Equal(2, sequence.IncrementBy);
+                Assert.Null(sequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -2517,7 +2514,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
             });
 
@@ -2531,8 +2527,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.False(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
+                Assert.Equal(1, sequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -2544,8 +2539,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.False(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
+                Assert.Equal(1, sequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -2557,7 +2551,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
             });
 
@@ -2570,7 +2563,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
                 Assert.Equal(20, sequence.CacheSize);
             });
 
@@ -2583,7 +2575,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
             });
 

--- a/test/EFCore.Relational.Tests/Extensions/RelationalBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalBuilderExtensionsTest.cs
@@ -1020,7 +1020,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -1117,7 +1116,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Equal(2222, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
     }
 
@@ -1483,7 +1481,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Equal(111, sequence.MinValue);
         Assert.Equal(2222, sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
         Assert.Same(typeof(int), sequence.Type);
     }

--- a/test/EFCore.Relational.Tests/Extensions/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalMetadataExtensionsTest.cs
@@ -448,7 +448,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.True(((IConventionSequence)sequence).IsInModel);
 
@@ -460,7 +459,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
         sequence.IsCyclic = false;
-        sequence.IsCached = true;
         sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
@@ -471,7 +469,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
 
         Assert.Same(sequence, model.RemoveSequence("Foo"));
@@ -500,7 +497,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(sequence, model.FindSequence("Foo", "Smoo"));
 
@@ -510,7 +506,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
         sequence.IsCyclic = false;
-        sequence.IsCached = true;
         sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
@@ -521,7 +516,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
     }
 
@@ -546,7 +540,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
         Assert.Same(typeof(long), sequence.Type);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
     }
 
@@ -570,7 +563,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
 
         model.SetDefaultSchema("Smoo");
@@ -583,7 +575,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
         sequence.IsCyclic = true;
-        sequence.IsCached = true;
         sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
@@ -594,7 +585,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.True(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
     }
 

--- a/test/EFCore.Relational.Tests/Metadata/SequenceTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/SequenceTest.cs
@@ -22,7 +22,6 @@ public class SequenceTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(model, sequence.Model);
 
@@ -38,7 +37,6 @@ public class SequenceTest
         Assert.Null(conventionSequence.GetMaxValueConfigurationSource());
         Assert.Null(conventionSequence.GetTypeConfigurationSource());
         Assert.Null(conventionSequence.GetIsCyclicConfigurationSource());
-        Assert.Null(conventionSequence.GetIsCachedConfigurationSource());
         Assert.Null(conventionSequence.GetCacheSizeConfigurationSource());
     }
 
@@ -56,7 +54,6 @@ public class SequenceTest
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
         sequence.IsCyclic = true;
-        sequence.IsCached = true;
         sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
@@ -67,7 +64,6 @@ public class SequenceTest
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.True(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
 
         var conventionSequence = (IConventionSequence)sequence;
@@ -78,7 +74,6 @@ public class SequenceTest
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetMaxValueConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetTypeConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetIsCyclicConfigurationSource());
-        Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetIsCachedConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetCacheSizeConfigurationSource());
     }
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -4303,7 +4303,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(20, operation.CacheSize);
             });
 
@@ -4383,7 +4382,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
@@ -4416,7 +4414,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(5, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
@@ -4449,7 +4446,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(5, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(20, operation.CacheSize);
             });
 
@@ -4481,7 +4477,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.False(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
@@ -4515,7 +4510,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
                 Assert.Equal(5, operation.CacheSize);
             });
 
@@ -4549,8 +4543,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.False(operation.IsCached);
-                Assert.Null(operation.CacheSize);
+                Assert.Equal(1, operation.CacheSize);
             });
 
     [ConditionalFact]
@@ -4581,7 +4574,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Equal(1, operation.MinValue);
             Assert.Equal(4, operation.MaxValue);
             Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
             Assert.Equal(20, operation.CacheSize);
         });
 
@@ -4615,7 +4607,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Equal(1, operation.MinValue);
             Assert.Equal(4, operation.MaxValue);
             Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
             Assert.Equal(20, operation.CacheSize);
         });
 
@@ -4648,7 +4639,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Equal(1, operation.MinValue);
             Assert.Equal(4, operation.MaxValue);
             Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
             Assert.Null(operation.CacheSize);
         });
 
@@ -4680,7 +4670,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Equal(1, operation.MinValue);
             Assert.Equal(4, operation.MaxValue);
             Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
             Assert.Null(operation.CacheSize);
         });
 
@@ -4712,8 +4701,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Equal(1, operation.MinValue);
             Assert.Equal(4, operation.MaxValue);
             Assert.True(operation.IsCyclic);
-            Assert.False(operation.IsCached);
-            Assert.Null(operation.CacheSize);
+            Assert.Equal(1, operation.CacheSize);
         });
 
     [ConditionalFact]
@@ -4750,7 +4738,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, createOperation.MinValue);
                 Assert.Equal(4, createOperation.MaxValue);
                 Assert.True(createOperation.IsCyclic);
-                Assert.True(createOperation.IsCached);
                 Assert.Equal(20, createOperation.CacheSize);
             },
             skipSourceConventions: true);

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -50,7 +50,6 @@ CREATE SEQUENCE db2.CustomFacetsSequence
                 Assert.Null(defaultSequence.StartValue);
                 Assert.Null(defaultSequence.MinValue);
                 Assert.Null(defaultSequence.MaxValue);
-                Assert.True(defaultSequence.IsCached);
                 Assert.Null(defaultSequence.CacheSize);
 
                 var customSequence = dbModel.Sequences.First(ds => ds.Name == "CustomFacetsSequence");
@@ -89,7 +88,6 @@ CREATE SEQUENCE db2.CustomFacetsSequence
                         Assert.Null(s.MinValue);
                         Assert.Null(s.MaxValue);
                     });
-                Assert.True(customSequence.IsCached);
                 Assert.Equal(20, customSequence.CacheSize);
             },
             @"
@@ -122,7 +120,6 @@ CREATE SEQUENCE db2.CacheSequence
             Assert.Null(defaultCacheSequence.StartValue);
             Assert.Null(defaultCacheSequence.MinValue);
             Assert.Null(defaultCacheSequence.MaxValue);
-            Assert.True(defaultCacheSequence.IsCached);
             Assert.Null(defaultCacheSequence.CacheSize);
 
             var noCacheSequence = dbModel.Sequences.First(ds => ds.Name == "NoCacheSequence");
@@ -134,8 +131,7 @@ CREATE SEQUENCE db2.CacheSequence
             Assert.Null(noCacheSequence.StartValue);
             Assert.Null(noCacheSequence.MinValue);
             Assert.Null(noCacheSequence.MaxValue);
-            Assert.False(noCacheSequence.IsCached);
-            Assert.Null(noCacheSequence.CacheSize);
+            Assert.Equal(1, noCacheSequence.CacheSize);
 
             var cacheSequence = dbModel.Sequences.First(ds => ds.Name == "CacheSequence");
             Assert.Equal("db2", cacheSequence.Schema);
@@ -146,7 +142,6 @@ CREATE SEQUENCE db2.CacheSequence
             Assert.Null(cacheSequence.StartValue);
             Assert.Null(cacheSequence.MinValue);
             Assert.Null(cacheSequence.MaxValue);
-            Assert.True(cacheSequence.IsCached);
             Assert.Equal(20, cacheSequence.CacheSize);
         },
         @"
@@ -180,7 +175,6 @@ CREATE SEQUENCE [BigIntSequence] AS bigint;",
                         Assert.Null(s.MinValue);
                         Assert.Null(s.MaxValue);
                         Assert.False(s.IsCyclic);
-                        Assert.True(s.IsCached);
                         Assert.Null(s.CacheSize);
                     });
 
@@ -261,7 +255,6 @@ CREATE SEQUENCE [NumericSequence] AS numeric;",
                         Assert.NotNull(s.MinValue);
                         Assert.NotNull(s.MaxValue);
                         Assert.False(s.IsCyclic);
-                        Assert.True(s.IsCached);
                         Assert.Null(s.CacheSize);
                     });
 
@@ -322,7 +315,6 @@ CREATE SEQUENCE [dbo].[HighDecimalSequence]
                         Assert.Equal(long.MinValue, s.MinValue);
                         Assert.NotNull(s.MaxValue);
                         Assert.Equal(long.MaxValue, s.MaxValue);
-                        Assert.True(s.IsCached);
                         Assert.Null(s.CacheSize);
                     });
 
@@ -369,7 +361,6 @@ CREATE SEQUENCE [TypeAliasSequence] AS [dbo].[TestTypeAlias];",
                 Assert.Null(sequence.StartValue);
                 Assert.Null(sequence.MinValue);
                 Assert.Null(sequence.MaxValue);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());
@@ -409,7 +400,6 @@ CREATE SEQUENCE [TypeFacetSequence] AS decimal(10, 0);",
                 Assert.Equal("decimal(10, 0)", sequence.StoreType);
                 Assert.False(sequence.IsCyclic);
                 Assert.Equal(1, sequence.IncrementBy);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());
@@ -449,7 +439,6 @@ CREATE SEQUENCE [db2].[Sequence]",
                 Assert.Equal("bigint", sequence.StoreType);
                 Assert.False(sequence.IsCyclic);
                 Assert.Equal(1, sequence.IncrementBy);
-                Assert.True(sequence.IsCached);
                 Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -310,7 +310,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -339,7 +338,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -458,7 +456,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -526,7 +523,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(111, sequence.MinValue);
         Assert.Equal(2222, sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Equal(20, sequence.CacheSize);
         Assert.Same(typeof(int), sequence.Type);
     }
@@ -633,7 +629,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -666,7 +661,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -840,7 +834,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
@@ -875,7 +868,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
         Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }

--- a/test/EFCore.Sqlite.Tests/Diagnostics/SqliteEventIdTest.cs
+++ b/test/EFCore.Sqlite.Tests/Diagnostics/SqliteEventIdTest.cs
@@ -68,9 +68,6 @@ public class SqliteEventIdTest : EventIdTestBase
         public bool IsCyclic
             => throw new NotImplementedException();
 
-        public bool IsCached
-            => throw new NotImplementedException();
-
         public int? CacheSize
             => throw new NotImplementedException();
     }

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -130,7 +130,7 @@ public class ExceptionTest
         public object GetOriginalValue(IPropertyBase propertyBase)
             => throw new NotImplementedException();
 
-        public object GetOriginalOrCurrentValue(IPropertyBase propertyBase)
+        public bool CanHaveOriginalValue(IPropertyBase propertyBase)
             => throw new NotImplementedException();
 
         public TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)


### PR DESCRIPTION
Part of #33220

- Replace `IUpdateEntry.GetOriginalOrCurrentValue` with `HasOriginalValue`
- Review whether we really need `MigrationsSqlGenerator.SequenceOptions` overload with `forAlter`. Move logic to other methods otherwise.
- Remove `IReadOnlySequence.IsCached`. `CacheSize` of `0` or `1`, indicates no caching, all other non-`null` values indicate caching
