### PR TITLE
Centralize and clean up diagnostic IDs

### DIFF
--- a/src/EFCore.Analyzers/EFDiagnostics.cs
+++ b/src/EFCore.Analyzers/EFDiagnostics.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Contains the IDs of diagnostics emitted by EF Core analyzers, [Experimental] and other mechanisms.
+/// </summary>
+public static class EFDiagnostics
+{
+    public const string InternalUsage = "EF1001";
+    public const string InterpolatedStringUsageInRawQueries = "EF1002";
+    public const string SuppressUninitializedDbSetRule = "EFSPR1001";
+
+    // Diagnostics for [Experimental]
+    public const string ExperimentalApi = "EF9001";
+    public const string ProviderExperimentalApi = "EF9002";
+    public const string PrecompiledQueryExperimental = "EF9100";
+}

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -12,13 +12,11 @@ namespace Microsoft.EntityFrameworkCore;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 {
-    public const string Id = "EF1001";
     private static readonly int EFLen = "EntityFrameworkCore".Length;
 
     private static readonly DiagnosticDescriptor Descriptor
-        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
-        = new DiagnosticDescriptor(
-            Id,
+        = new(
+            EFDiagnostics.InternalUsage,
             title: AnalyzerStrings.InternalUsageTitle,
             messageFormat: AnalyzerStrings.InternalUsageMessageFormat,
             category: "Usage",

--- a/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesCodeFixProvider.cs
+++ b/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesCodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore;
 public sealed class InterpolatedStringUsageInRawQueriesCodeFixProvider : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
-        => ImmutableArray.Create(InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer.Id);
+        => ImmutableArray.Create(EFDiagnostics.InterpolatedStringUsageInRawQueries);
 
     public override FixAllProvider GetFixAllProvider()
         => WellKnownFixAllProviders.BatchFixer;

--- a/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer.cs
@@ -12,12 +12,9 @@ namespace Microsoft.EntityFrameworkCore;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer : DiagnosticAnalyzer
 {
-    public const string Id = "EF1002";
-
     private static readonly DiagnosticDescriptor Descriptor
-        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
-        = new DiagnosticDescriptor(
-            Id,
+        = new(
+            EFDiagnostics.InterpolatedStringUsageInRawQueries,
             title: AnalyzerStrings.InterpolatedStringUsageInRawQueriesAnalyzerTitle,
             messageFormat: AnalyzerStrings.InterpolatedStringUsageInRawQueriesMessageFormat,
             category: "Security",

--- a/src/EFCore.Analyzers/UninitializedDbSetDiagnosticSuppressor.cs
+++ b/src/EFCore.Analyzers/UninitializedDbSetDiagnosticSuppressor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore;
 public sealed class UninitializedDbSetDiagnosticSuppressor : DiagnosticSuppressor
 {
     private static readonly SuppressionDescriptor SuppressUninitializedDbSetRule = new(
-        id: "EFSPR1001",
+        id: EFDiagnostics.SuppressUninitializedDbSetRule,
         suppressedDiagnosticId: "CS8618",
         justification: AnalyzerStrings.UninitializedDbSetWarningSuppressionJustification);
 

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DevelopmentDependency>true</DevelopmentDependency>
     <ImplicitUsings>true</ImplicitUsings>
-    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
+    <NoWarn>EF9100</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
-    <NoWarn>$(NoWarn);EF1003</NoWarn> <!-- Precomiled query is experimental -->
-    <NoWarn>$(NoWarn);EF1004</NoWarn> <!-- Experimental provider-facing feature -->
+    <NoWarn>$(NoWarn);EF9100</NoWarn> <!-- Precomiled query is experimental -->
+    <NoWarn>$(NoWarn);EF9002</NoWarn> <!-- Experimental provider-facing feature -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/Query/IRelationalQuotableExpression.cs
+++ b/src/EFCore.Relational/Query/IRelationalQuotableExpression.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     Represents an expression that is quotable, that is, capable of returning an expression that, when evaluated, would construct an
 ///     expression identical to this one. Used to generate code for precompiled queries, which reconstructs this expression.
 /// </summary>
-[Experimental("EF1003")]
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
 public interface IRelationalQuotableExpression
 {
     /// <summary>

--- a/src/EFCore.Relational/Query/ISqlAliasManagerFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlAliasManagerFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///         for more information and examples.
 ///     </para>
 /// </remarks>
-[Experimental("EF1004")]
+[Experimental(EFDiagnostics.ProviderExperimentalApi)]
 public interface ISqlAliasManagerFactory
 {
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalExpressionQuotingUtilities.cs
+++ b/src/EFCore.Relational/Query/RelationalExpressionQuotingUtilities.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// <summary>
 ///     Utilities used for implementing <see cref="IRelationalQuotableExpression" />.
 /// </summary>
-[Experimental("EF1003")]
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
 public static class RelationalExpressionQuotingUtilities
 {
     private static readonly ParameterExpression RelationalModelParameter

--- a/src/EFCore.Relational/Query/SqlAliasManagerFactory.cs
+++ b/src/EFCore.Relational/Query/SqlAliasManagerFactory.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <inheritdoc />
-[Experimental("EF1004")]
+[Experimental(EFDiagnostics.ProviderExperimentalApi)]
 public class SqlAliasManagerFactory : ISqlAliasManagerFactory
 {
     /// <inheritdoc />

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -9,7 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQL Server</PackageTags>
     <ImplicitUsings>true</ImplicitUsings>
-    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
+    <NoWarn>EF9100</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
+++ b/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
@@ -10,7 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
     <ImplicitUsings>true</ImplicitUsings>
-    <NoWarn>EF1003</NoWarn> <!-- Precompiled query is experimental -->
+    <NoWarn>EF9100</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTests.cs
@@ -50,12 +50,12 @@ class MyClass : {|#0:Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationa
 
         await VerifyCS.VerifyAnalyzerAsync(
             source,
-            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+            VerifyCS.Diagnostic(EFDiagnostics.InternalUsage)
                 .WithLocation(0)
                 .WithSeverity(DiagnosticSeverity.Warning)
                 .WithMessageFormat(AnalyzerStrings.InternalUsageMessageFormat)
                 .WithArguments("Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter"),
-            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+            VerifyCS.Diagnostic(EFDiagnostics.InternalUsage)
                 .WithLocation(1)
                 .WithSeverity(DiagnosticSeverity.Warning)
                 .WithMessageFormat(AnalyzerStrings.InternalUsageMessageFormat)
@@ -69,7 +69,7 @@ class MyClass : {|#0:Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationa
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
-            
+
 class {|#0:MyClass|} : IDbSetSource
 {
     public object Create(DbContext context, Type type) => null;
@@ -125,7 +125,7 @@ class C
     void M()
     {
         void SomeGenericMethod<T>() {}
-            
+
         {|#0:SomeGenericMethod<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager>()|};
     }
 }
@@ -224,7 +224,7 @@ namespace Bar
     private Task VerifySingleInternalUsageAsync(string source, string internalApi)
         => VerifyCS.VerifyAnalyzerAsync(
             source,
-            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+            VerifyCS.Diagnostic(EFDiagnostics.InternalUsage)
                 .WithLocation(0)
                 .WithSeverity(DiagnosticSeverity.Warning)
                 .WithMessageFormat(AnalyzerStrings.InternalUsageMessageFormat)


### PR DESCRIPTION
Centralizes all diagnostic IDs in a new public EFDiagnostics class:

```c#
public static class EFDiagnostics
{
    public const string InternalUsage = "EF1001";
    public const string InterpolatedStringUsageInRawQueries = "EF1002";
    public const string SuppressUninitializedDbSetRule = "EFSPR1001";

    // Diagnostics for [Experimental]
    public const string ExperimentalApi = "EF9001";
    public const string ProviderExperimentalApi = "EF9002";
    public const string PrecompiledQueryExperimental = "EF9100";
}
```

So EF9xxx is for all the experimental stuff, EF9001 is for user-facing experimental APIs which don't have a dedicated ID, EF9002 is for provider-facing ones, and EF9100 and above is for specific experimental feature IDs (such as precompiled queries).