### PR TITLE
Debug messages intended for shadow properties should not be logged for indexer properties

### DIFF
--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -437,7 +437,7 @@ public class ModelValidator : IModelValidator
         {
             foreach (var key in entityType.GetDeclaredKeys())
             {
-                if (key.Properties.Any(p => p.IsImplicitlyCreated())
+                if (key.Properties.Any(p => p.IsShadowProperty())
                     && ConfigurationSource.Convention.Overrides(key.GetConfigurationSource())
                     && !key.IsPrimaryKey())
                 {
@@ -1275,7 +1275,8 @@ public class ModelValidator : IModelValidator
         {
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                if (property.IsImplicitlyCreated())
+                if (property.IsShadowProperty()
+                    && property.GetConfigurationSource() == ConfigurationSource.Convention)
                 {
                     var uniquifiedAnnotation = property.FindAnnotation(CoreAnnotationNames.PreUniquificationName);
                     if (uniquifiedAnnotation != null

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -382,6 +382,21 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
                 .GenerateMessage("A", "Key"), modelBuilder, LogLevel.Debug);
     }
 
+    [ConditionalFact] // Issue #33484
+    public virtual void Does_not_log_for_shadow_property_when_creating_indexer_property()
+    {
+        var modelBuilder = CreateConventionlessModelBuilder();
+        var model = (IConventionModel)modelBuilder.Model;
+
+        var entityType = model.AddEntityType("Bag", typeof(Dictionary<string, object>))!;
+        entityType.SetIsKeyless(true);
+        entityType.AddIndexerProperty("Foo", typeof(int));
+
+        VerifyLogDoesNotContain(
+            CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>())
+                .GenerateMessage("Bag (Dictionary<string, object>)", "Foo"), modelBuilder);
+    }
+
     [ConditionalFact]
     public virtual void Warns_on_uniquified_shadow_key_due_to_wrong_type()
     {


### PR DESCRIPTION
We currently log these messages a lot when people are doing many-to-many config, which is unhelpful.

Fixes #33484
