### PR TITLE
Curious case of borked comparers

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -309,6 +309,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Includable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=liftable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lite_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializers/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
-using Microsoft.EntityFrameworkCore.Internal;
 using ExpressionExtensions = Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -63,6 +63,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             { typeof(IQuerySqlGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IModificationCommandFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ISqlAliasManagerFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IRelationalLiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ICommandBatchPreparer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalSqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -189,6 +190,9 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IQueryCompilationContextFactory, RelationalQueryCompilationContextFactory>();
         TryAdd<IAdHocMapper, RelationalAdHocMapper>();
         TryAdd<ISqlAliasManagerFactory, SqlAliasManagerFactory>();
+        TryAdd<ILiftableConstantFactory>(p => p.GetRequiredService<IRelationalLiftableConstantFactory>());
+        TryAdd<IRelationalLiftableConstantFactory, RelationalLiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, RelationalLiftableConstantProcessor>();
 
         ServiceCollectionMap.GetInfrastructure()
             .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()
@@ -204,6 +208,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             .AddDependencySingleton<RelationalEvaluatableExpressionFilterDependencies>()
             .AddDependencySingleton<RelationalModelDependencies>()
             .AddDependencySingleton<RelationalModelRuntimeInitializerDependencies>()
+            .AddDependencySingleton<RelationalLiftableConstantExpressionDependencies>()
             .AddDependencyScoped<MigrationsSqlGeneratorDependencies>()
             .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
             .AddDependencyScoped<ModificationCommandBatchFactoryDependencies>()

--- a/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public interface IRelationalLiftableConstantFactory : ILiftableConstantFactory
+{
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    LiftableConstantExpression CreateLiftableConstant(
+        object? originalValue,
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
+++ b/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
@@ -836,10 +836,7 @@ public class BufferedDataReader : DbDataReader
         public object GetValue(int ordinal)
             => GetFieldValue<object>(ordinal);
 
-#pragma warning disable IDE0060 // Remove unused parameter
-        public static int GetValues(object[] values)
-#pragma warning restore IDE0060 // Remove unused parameter
-            => throw new NotSupportedException();
+        public static int GetValues(object[] values) => throw new NotSupportedException();
 
         public T GetFieldValue<T>(int ordinal)
             => (_columnTypeCases[ordinal]) switch

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -12,6 +12,42 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+public static class FromSqlQueryingEnumerable
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static FromSqlQueryingEnumerable<T> Create<T>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        IReadOnlyList<string> columnNames,
+        Func<QueryContext, DbDataReader, int[], T> shaper,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            columnNames,
+            shaper,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
 public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IRelationalQueryingEnumerable
 {
     private readonly RelationalQueryContext _relationalQueryContext;

--- a/src/EFCore.Relational/Query/Internal/GroupBySingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/GroupBySingleQueryingEnumerable.cs
@@ -12,6 +12,46 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+public static class GroupBySingleQueryingEnumerable
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static GroupBySingleQueryingEnumerable<TKey, TElement> Create<TKey, TElement>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        Func<QueryContext, DbDataReader, TKey> keySelector,
+        Func<QueryContext, DbDataReader, object[]> keyIdentifier,
+        IReadOnlyList<Func<object, object, bool>> keyIdentifierValueComparers,
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TElement> elementSelector,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            keySelector,
+            keyIdentifier,
+            keyIdentifierValueComparers,
+            elementSelector,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
 public class GroupBySingleQueryingEnumerable<TKey, TElement>
     : IEnumerable<IGrouping<TKey, TElement>>, IAsyncEnumerable<IGrouping<TKey, TElement>>, IRelationalQueryingEnumerable
 {
@@ -20,7 +60,7 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
     private readonly IReadOnlyList<ReaderColumn?>? _readerColumns;
     private readonly Func<QueryContext, DbDataReader, TKey> _keySelector;
     private readonly Func<QueryContext, DbDataReader, object[]> _keyIdentifier;
-    private readonly IReadOnlyList<ValueComparer> _keyIdentifierValueComparers;
+    private readonly IReadOnlyList<Func<object, object, bool>> _keyIdentifierValueComparers;
     private readonly Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TElement> _elementSelector;
     private readonly Type _contextType;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
@@ -40,7 +80,7 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
         IReadOnlyList<ReaderColumn?>? readerColumns,
         Func<QueryContext, DbDataReader, TKey> keySelector,
         Func<QueryContext, DbDataReader, object[]> keyIdentifier,
-        IReadOnlyList<ValueComparer> keyIdentifierValueComparers,
+        IReadOnlyList<Func<object, object, bool>> keyIdentifierValueComparers,
         Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TElement> elementSelector,
         Type contextType,
         bool standAloneStateManager,
@@ -139,12 +179,12 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
             => GetEnumerator();
     }
 
-    private static bool CompareIdentifiers(IReadOnlyList<ValueComparer> valueComparers, object[] left, object[] right)
+    private static bool CompareIdentifiers(IReadOnlyList<Func<object, object, bool>> valueComparers, object[] left, object[] right)
     {
         // Ignoring size check on all for perf as they should be same unless bug in code.
         for (var i = 0; i < left.Length; i++)
         {
-            if (!valueComparers[i].Equals(left[i], right[i]))
+            if (!valueComparers[i](left[i], right[i]))
             {
                 return false;
             }
@@ -160,7 +200,7 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
         private readonly IReadOnlyList<ReaderColumn?>? _readerColumns;
         private readonly Func<QueryContext, DbDataReader, TKey> _keySelector;
         private readonly Func<QueryContext, DbDataReader, object[]> _keyIdentifier;
-        private readonly IReadOnlyList<ValueComparer> _keyIdentifierValueComparers;
+        private readonly IReadOnlyList<Func<object, object, bool>> _keyIdentifierValueComparers;
         private readonly Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TElement> _elementSelector;
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
@@ -344,7 +384,7 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
         private readonly IReadOnlyList<ReaderColumn?>? _readerColumns;
         private readonly Func<QueryContext, DbDataReader, TKey> _keySelector;
         private readonly Func<QueryContext, DbDataReader, object[]> _keyIdentifier;
-        private readonly IReadOnlyList<ValueComparer> _keyIdentifierValueComparers;
+        private readonly IReadOnlyList<Func<object, object, bool>> _keyIdentifierValueComparers;
         private readonly Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TElement> _elementSelector;
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -653,7 +653,13 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
         return new ProjectionBindingExpression(_selectExpression, existingIndex, type);
     }
 
-    private static T GetParameterValue<T>(QueryContext queryContext, string parameterName)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static T GetParameterValue<T>(QueryContext queryContext, string parameterName)
 #pragma warning restore IDE0052 // Remove unread private members
         => (T)queryContext.ParameterValues[parameterName]!;
 

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -12,6 +12,40 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+public static class SingleQueryingEnumerable
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static SingleQueryingEnumerable<T> Create<T>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            shaper,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
 public class SingleQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IRelationalQueryingEnumerable
 {
     private readonly RelationalQueryContext _relationalQueryContext;

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -12,6 +12,44 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+public static class SplitQueryingEnumerable
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static SplitQueryingEnumerable<T> Create<T>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, T> shaper,
+        Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>? relatedDataLoaders,
+        Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>? relatedDataLoadersAsync,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            shaper,
+            relatedDataLoaders,
+            relatedDataLoadersAsync,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
 public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IRelationalQueryingEnumerable
 {
     private readonly RelationalQueryContext _relationalQueryContext;

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantExpressionDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantExpressionDependencies.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     <para>
+///         Service dependencies parameter class for <see cref="RelationalLiftableConstantFactory" />
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     <para>
+///         Do not construct instances of this class directly from either provider or application code as the
+///         constructor signature may change as new dependencies are added. Instead, use this type in
+///         your constructor so that an instance will be created and injected automatically by the
+///         dependency injection container. To create an instance with some dependent services replaced,
+///         first resolve the object from the dependency injection container, then replace selected
+///         services using the C# 'with' operator. Do not call the constructor at any point in this process.
+///     </para>
+///     <para>
+///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+///     </para>
+/// </remarks>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public sealed record RelationalLiftableConstantExpressionDependencies
+{
+}

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class RelationalLiftableConstantFactory(
+    LiftableConstantExpressionDependencies dependencies,
+    RelationalLiftableConstantExpressionDependencies relationalDependencies) : LiftableConstantFactory(dependencies), IRelationalLiftableConstantFactory
+{
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual RelationalLiftableConstantExpressionDependencies RelationalDependencies { get; } = relationalDependencies;
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        object? originalValue,
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(originalValue, resolverExpression, variableName, type);
+}

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
+{
+    private readonly RelationalMaterializerLiftableConstantContext _relationalMaterializerLiftableConstantContext;
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RelationalLiftableConstantProcessor(
+        ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
+        : base(dependencies)
+        => _relationalMaterializerLiftableConstantContext = new(dependencies, relationalDependencies);
+
+    /// <inheritdoc/>
+    protected override ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<RelationalMaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_relationalMaterializerLiftableConstantContext);
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        return base.InlineConstant(liftableConstant);
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
+++ b/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public record RelationalMaterializerLiftableConstantContext(
+        ShapedQueryCompilingExpressionVisitorDependencies Dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies)
+    : MaterializerLiftableConstantContext(Dependencies);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -11,7 +12,14 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
-    private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
         private static readonly MethodInfo ThrowReadValueExceptionMethod =
             typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ThrowReadValueException))!;
@@ -71,8 +79,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private static readonly MethodInfo InverseCollectionFixupMethod
             = typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(InverseCollectionFixup))!;
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static TValue ThrowReadValueException<TValue>(
+        [EntityFrameworkInternal]
+        public static TValue ThrowReadValueException<TValue>(
             Exception exception,
             object? value,
             Type expectedType,
@@ -122,7 +137,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 exception);
         }
 
-        private static void IncludeReference<TEntity, TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void IncludeReference<TEntity, TIncludingEntity, TIncludedEntity>(
             QueryContext queryContext,
             TEntity entity,
             TIncludedEntity? relatedEntity,
@@ -160,7 +182,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void InitializeIncludeCollection<TParent, TNavigationEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InitializeIncludeCollection<TParent, TNavigationEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -201,7 +230,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             resultCoordinator.SetSingleQueryCollectionContext(collectionId, collectionMaterializationContext);
         }
 
-        private static void PopulateIncludeCollection<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateIncludeCollection<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -209,9 +245,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             Func<QueryContext, DbDataReader, object[]> parentIdentifier,
             Func<QueryContext, DbDataReader, object[]> outerIdentifier,
             Func<QueryContext, DbDataReader, object[]> selfIdentifier,
-            IReadOnlyList<ValueComparer> parentIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> outerIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> selfIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> parentIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> outerIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> selfIdentifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TIncludedEntity> innerShaper,
             INavigationBase? inverseNavigation,
             Action<TIncludingEntity, TIncludedEntity> fixup,
@@ -319,7 +355,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader parentDataReader,
@@ -358,7 +401,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             resultCoordinator.SetSplitQueryCollectionContext(collectionId, splitQueryCollectionContext);
         }
 
-        private static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -367,7 +417,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -442,7 +492,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static async Task PopulateSplitIncludeCollectionAsync<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static async Task PopulateSplitIncludeCollectionAsync<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -451,7 +508,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -538,7 +595,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static TCollection InitializeCollection<TElement, TCollection>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static TCollection InitializeCollection<TElement, TCollection>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -560,7 +624,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return (TCollection)collection;
         }
 
-        private static void PopulateCollection<TCollection, TElement, TRelatedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateCollection<TCollection, TElement, TRelatedEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader dbDataReader,
@@ -568,9 +639,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             Func<QueryContext, DbDataReader, object[]> parentIdentifier,
             Func<QueryContext, DbDataReader, object[]> outerIdentifier,
             Func<QueryContext, DbDataReader, object[]> selfIdentifier,
-            IReadOnlyList<ValueComparer> parentIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> outerIdentifierValueComparers,
-            IReadOnlyList<ValueComparer> selfIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> parentIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> outerIdentifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> selfIdentifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, TRelatedEntity> innerShaper)
             where TRelatedEntity : TElement
             where TCollection : class, ICollection<TElement>
@@ -590,8 +661,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
 
             if (!CompareIdentifiers(
-                    outerIdentifierValueComparers,
-                    outerIdentifier(queryContext, dbDataReader), collectionMaterializationContext.OuterIdentifier))
+                outerIdentifierValueComparers,
+                outerIdentifier(queryContext, dbDataReader), collectionMaterializationContext.OuterIdentifier))
             {
                 // Outer changed so collection has ended. Materialize last element.
                 GenerateCurrentElementIfPending();
@@ -616,8 +687,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             if (collectionMaterializationContext.SelfIdentifier != null)
             {
                 if (CompareIdentifiers(
-                        selfIdentifierValueComparers,
-                        innerKey, collectionMaterializationContext.SelfIdentifier))
+                    selfIdentifierValueComparers,
+                    innerKey, collectionMaterializationContext.SelfIdentifier))
                 {
                     // repeated row for current element
                     // If it is pending materialization then it may have nested elements
@@ -673,7 +744,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static TCollection InitializeSplitCollection<TElement, TCollection>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static TCollection InitializeSplitCollection<TElement, TCollection>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader parentDataReader,
@@ -691,7 +769,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return (TCollection)collection;
         }
 
-        private static void PopulateSplitCollection<TCollection, TElement, TRelatedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateSplitCollection<TCollection, TElement, TRelatedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -700,7 +785,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TRelatedEntity> innerShaper,
             Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>? relatedDataLoaders)
             where TRelatedEntity : TElement
@@ -770,7 +855,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             dataReaderContext.HasNext = false;
         }
 
-        private static async Task PopulateSplitCollectionAsync<TCollection, TElement, TRelatedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static async Task PopulateSplitCollectionAsync<TCollection, TElement, TRelatedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -779,7 +871,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TRelatedEntity> innerShaper,
             Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>? relatedDataLoaders)
             where TRelatedEntity : TElement
@@ -861,7 +953,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             dataReaderContext.HasNext = false;
         }
 
-        private static TEntity? MaterializeJsonEntity<TEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static TEntity? MaterializeJsonEntity<TEntity>(
             QueryContext queryContext,
             object[] keyPropertyValues,
             JsonReaderData? jsonReaderData,
@@ -900,7 +999,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return result;
         }
 
-        private static TResult? MaterializeJsonEntityCollection<TEntity, TResult>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static TResult? MaterializeJsonEntityCollection<TEntity, TResult>(
             QueryContext queryContext,
             object[] keyPropertyValues,
             JsonReaderData? jsonReaderData,
@@ -967,7 +1073,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return result;
         }
 
-        private static void IncludeJsonEntityReference<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void IncludeJsonEntityReference<TIncludingEntity, TIncludedEntity>(
             QueryContext queryContext,
             object[] keyPropertyValues,
             JsonReaderData? jsonReaderData,
@@ -991,7 +1104,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void IncludeJsonEntityCollection<TIncludingEntity, TIncludedCollectionElement>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void IncludeJsonEntityCollection<TIncludingEntity, TIncludedCollectionElement>(
             QueryContext queryContext,
             object[] keyPropertyValues,
             JsonReaderData? jsonReaderData,
@@ -1058,7 +1178,31 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             manager.CaptureState();
         }
 
-        private static async Task TaskAwaiter(Func<Task>[] taskFactories)
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static bool Any(IEnumerable source)
+        {
+            foreach (var _ in source)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static async Task TaskAwaiter(Func<Task>[] taskFactories)
         {
             for (var i = 0; i < taskFactories.Length; i++)
             {
@@ -1066,12 +1210,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static bool CompareIdentifiers(IReadOnlyList<ValueComparer> valueComparers, object[] left, object[] right)
+        private static bool CompareIdentifiers(IReadOnlyList<Func<object, object, bool>> valueComparers, object[] left, object[] right)
         {
             // Ignoring size check on all for perf as they should be same unless bug in code.
             for (var i = 0; i < left.Length; i++)
             {
-                if (!valueComparers[i].Equals(left[i], right[i]))
+                if (!valueComparers[i](left[i], right[i]))
                 {
                     return false;
                 }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -14,7 +15,13 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
-    private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
         /// <summary>
         ///     Reading database values
@@ -22,6 +29,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private static readonly MethodInfo IsDbNullMethod =
             typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.IsDBNull), [typeof(int)])!;
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static readonly MethodInfo GetFieldValueMethod =
             typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), [typeof(int)])!;
 
@@ -76,6 +89,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
         private static readonly MethodInfo EnumParseMethodInfo
             = typeof(Enum).GetMethod(nameof(Enum.Parse), [typeof(Type), typeof(string)])!;
+
+        private static readonly MethodInfo ReadColumnCreateMethod
+            = typeof(ReaderColumn).GetMethod(nameof(ReaderColumn.Create))!;
+
+        private readonly static MethodInfo PropertyGetJsonValueReaderWriterMethod =
+            typeof(IReadOnlyProperty).GetMethod(nameof(IReadOnlyProperty.GetJsonValueReaderWriter), [])!;
+
+        private readonly static MethodInfo PropertyGetTypeMappingMethod =
+            typeof(IReadOnlyProperty).GetMethod(nameof(IReadOnlyProperty.GetTypeMapping), [])!;
 
         private readonly RelationalShapedQueryCompilingExpressionVisitor _parentVisitor;
         private readonly ISet<string>? _tags;
@@ -160,6 +182,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         /// </summary>
         private readonly Dictionary<int, ParameterExpression> _jsonArrayNonConstantElementAccessMap = new();
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public ShaperProcessingExpressionVisitor(
             RelationalShapedQueryCompilingExpressionVisitor parentVisitor,
             SelectExpression selectExpression,
@@ -172,7 +200,6 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             _resultCoordinatorParameter = Parameter(
                 splitQuery ? typeof(SplitQueryResultCoordinator) : typeof(SingleQueryResultCoordinator), "resultCoordinator");
             _executionStrategyParameter = splitQuery ? Parameter(typeof(IExecutionStrategy), "executionStrategy") : null;
-
             _selectExpression = selectExpression;
             _tags = tags;
             _dataReaderParameter = Parameter(typeof(DbDataReader), "dataReader");
@@ -247,9 +274,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             _selectExpression.ApplyTags(_tags);
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public LambdaExpression ProcessRelationalGroupingResult(
             RelationalGroupByResultExpression relationalGroupByResultExpression,
-            out RelationalCommandCache relationalCommandCache,
+            out Expression relationalCommandCache,
             out IReadOnlyList<ReaderColumn?>? readerColumns,
             out LambdaExpression keySelector,
             out LambdaExpression keyIdentifier,
@@ -277,9 +310,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 ref collectionId);
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public LambdaExpression ProcessShaper(
             Expression shaperExpression,
-            out RelationalCommandCache? relationalCommandCache,
+            out Expression relationalCommandCache,
             out IReadOnlyList<ReaderColumn?>? readerColumns,
             out LambdaExpression? relatedDataLoaders,
             ref int collectionId)
@@ -293,12 +332,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 _expressions.Add(result);
                 result = Block(_variables, _expressions);
 
-                relationalCommandCache = new RelationalCommandCache(
-                    _parentVisitor.Dependencies.MemoryCache,
-                    _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                    _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                    _selectExpression,
-                    _parentVisitor._useRelationalNulls);
+                relationalCommandCache = _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression);
                 readerColumns = _readerColumns;
 
                 return Lambda(
@@ -320,13 +354,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 result = Block(_variables, _expressions);
 
                 relationalCommandCache = _generateCommandCache
-                    ? new RelationalCommandCache(
-                        _parentVisitor.Dependencies.MemoryCache,
-                        _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                        _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                        _selectExpression,
-                        _parentVisitor._useRelationalNulls)
-                    : null;
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
+                    : Constant(null, typeof(RelationalCommandCache));
                 readerColumns = _readerColumns;
 
                 return Lambda(
@@ -408,13 +437,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
 
                 relationalCommandCache = _generateCommandCache
-                    ? new RelationalCommandCache(
-                        _parentVisitor.Dependencies.MemoryCache,
-                        _parentVisitor.RelationalDependencies.QuerySqlGeneratorFactory,
-                        _parentVisitor.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                        _selectExpression,
-                        _parentVisitor._useRelationalNulls)
-                    : null;
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
+                    : Constant(null, typeof(RelationalCommandCache));;
                 readerColumns = _readerColumns;
 
                 collectionId = _collectionId;
@@ -428,6 +452,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
             switch (binaryExpression)
@@ -452,8 +482,16 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 ? value
                                 : propertyMap.Values.Max() + 1;
 
-                        var updatedExpression = newExpression.Update(
-                            new[] { Constant(ValueBuffer.Empty), newExpression.Arguments[1] });
+                    var updatedExpression = newExpression.Update(
+                        new[]
+                        {
+                            _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                ValueBuffer.Empty,
+                                static _ => ValueBuffer.Empty,
+                                "emptyValueBuffer",
+                                typeof(ValueBuffer)),
+                            newExpression.Arguments[1]
+                        });
 
                         return Assign(binaryExpression.Left, updatedExpression);
                     }
@@ -465,7 +503,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         _jsonMaterializationContextToJsonReaderDataAndKeyValuesParameterMapping[parameterExpression] = mappedParameter;
 
                         var updatedExpression = newExpression.Update(
-                            new[] { Constant(ValueBuffer.Empty), newExpression.Arguments[1] });
+                            new[]
+                            {
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    ValueBuffer.Empty,
+                                    static _ => ValueBuffer.Empty,
+                                    "emptyValueBuffer",
+                                    typeof(ValueBuffer)),
+                                newExpression.Arguments[1]
+                            });
 
                         return Assign(binaryExpression.Left, updatedExpression);
                     }
@@ -497,6 +543,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return base.VisitBinary(binaryExpression);
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         protected override Expression VisitExtension(Expression extensionExpression)
         {
             switch (extensionExpression)
@@ -597,7 +649,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         }
                         else
                         {
-                            var entityParameter = Parameter(shaper.Type);
+                            var entityParameter = Parameter(shaper.Type, "entity");
                             _variables.Add(entityParameter);
                             if (shaper.StructuralType is IEntityType entityType
                                 && entityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
@@ -718,7 +770,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     var projection = _selectExpression.Projection[projectionIndex];
                     var nullable = IsNullableProjection(projection);
 
-                    var valueParameter = Parameter(projectionBindingExpression.Type);
+                    var valueParameter = Parameter(projectionBindingExpression.Type, "value" + (_variables.Count + 1));
                     _variables.Add(valueParameter);
 
                     _expressions.Add(
@@ -769,13 +821,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 _readerColumns)
                             .ProcessShaper(relationalCollectionShaperExpression.InnerShaper, out _, out _, out _, ref _collectionId);
 
-                        var entityType = entity.Type;
+                        var entityClrType = entity.Type;
                         var navigation = includeExpression.Navigation;
-                        var includingEntityType = navigation.DeclaringEntityType.ClrType;
-                        if (includingEntityType != entityType
-                            && includingEntityType.IsAssignableFrom(entityType))
+                        var includingEntityClrType = navigation.DeclaringEntityType.ClrType;
+                        if (includingEntityClrType != entityClrType
+                            && includingEntityClrType.IsAssignableFrom(entityClrType))
                         {
-                            includingEntityType = entityType;
+                            includingEntityClrType = entityClrType;
                         }
 
                         _inline = true;
@@ -799,51 +851,60 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         _includeExpressions.Add(
                             Call(
-                                InitializeIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityType),
+                                InitializeIncludeCollectionMethodInfo.MakeGenericMethod(entityClrType, includingEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
                                 entity,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(outerIdentifierLambda.Compile()),
-                                Constant(navigation),
-                                Constant(
-                                    navigation.IsShadowProperty()
-                                        ? null
-                                        : navigation.GetCollectionAccessor(), typeof(IClrCollectionAccessor)),
+                                parentIdentifierLambda,
+                                outerIdentifierLambda,
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    navigation,
+                                    LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(navigation),
+                                    navigation.Name + "Navigation",
+                                    typeof(INavigationBase)),
+                                navigation.IsShadowProperty()
+                                    ? Constant(null, typeof(IClrCollectionAccessor))
+                                    : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        navigation.GetCollectionAccessor(),
+                                        LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                                        navigation.Name + "NavigationCollectionAccessor",
+                                        typeof(IClrCollectionAccessor)),
                                 Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
                                 Constant(includeExpression.SetLoaded)));
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-                        var relatedEntityType = innerShaper.ReturnType;
+                        var relatedEntityClrType = innerShaper.ReturnType;
                         var inverseNavigation = navigation.Inverse;
 
                         _collectionPopulatingExpressions!.Add(
                             Call(
-                                PopulateIncludeCollectionMethodInfo.MakeGenericMethod(includingEntityType, relatedEntityType),
+                                PopulateIncludeCollectionMethodInfo.MakeGenericMethod(includingEntityClrType, relatedEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(outerIdentifierLambda.Compile()),
-                                Constant(selfIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalCollectionShaperExpression.ParentIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.OuterIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.SelfIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile()),
-                                Constant(inverseNavigation, typeof(INavigationBase)),
-                                Constant(
-                                    GenerateFixup(
-                                        includingEntityType, relatedEntityType, navigation, inverseNavigation).Compile()),
+                                parentIdentifierLambda,
+                                outerIdentifierLambda,
+                                selfIdentifierLambda,
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.ParentIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.OuterIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.SelfIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                innerShaper,
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    inverseNavigation,
+                                    LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(inverseNavigation),
+                                    (inverseNavigation?.Name ?? "null") + "InverseNavigation",
+                                    typeof(INavigationBase)),
+                                GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Constant(_isTracking)));
                     }
                     else if (includeExpression.NavigationExpression is RelationalSplitCollectionShaperExpression
@@ -862,11 +923,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         var entityType = entity.Type;
                         var navigation = includeExpression.Navigation;
-                        var includingEntityType = navigation.DeclaringEntityType.ClrType;
-                        if (includingEntityType != entityType
-                            && includingEntityType.IsAssignableFrom(entityType))
+                        var includingEntityClrType = navigation.DeclaringEntityType.ClrType;
+                        if (includingEntityClrType != entityType
+                            && includingEntityClrType.IsAssignableFrom(entityType))
                         {
-                            includingEntityType = entityType;
+                            includingEntityClrType = entityType;
                         }
 
                         _inline = true;
@@ -889,48 +950,57 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         _includeExpressions.Add(
                             Call(
-                                InitializeSplitIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityType),
+                                InitializeSplitIncludeCollectionMethodInfo.MakeGenericMethod(entityType, includingEntityClrType),
                                 collectionIdConstant,
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
                                 entity,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(navigation),
-                                Constant(navigation.GetCollectionAccessor()),
+                                parentIdentifierLambda,
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    navigation,
+                                    LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(navigation),
+                                    navigation.Name + "Navigation",
+                                    typeof(INavigationBase)),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    navigation.GetCollectionAccessor(),
+                                    LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                                    navigation.Name + "NavigationCollectionAccessor",
+                                    typeof(IClrCollectionAccessor)),
                                 Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
                                 Constant(includeExpression.SetLoaded)));
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-                        var relatedEntityType = innerShaper.ReturnType;
+                        var relatedEntityClrType = innerShaper.ReturnType;
                         var inverseNavigation = navigation.Inverse;
 
                         _collectionPopulatingExpressions!.Add(
                             Call(
                                 (_isAsync ? PopulateSplitIncludeCollectionAsyncMethodInfo : PopulateSplitIncludeCollectionMethodInfo)
-                                .MakeGenericMethod(includingEntityType, relatedEntityType),
+                                .MakeGenericMethod(includingEntityClrType, relatedEntityClrType),
                                 collectionIdConstant,
                                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
                                 _executionStrategyParameter!,
-                                Constant(relationalCommandCache),
-                                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                                relationalCommandCache,
+                                CreateReaderColumnsExpression(readerColumns, _parentVisitor.Dependencies.LiftableConstantFactory),
                                 Constant(_detailedErrorsEnabled),
                                 _resultCoordinatorParameter,
-                                Constant(childIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalSplitCollectionShaperExpression.IdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile()),
-                                Constant(
-                                    relatedDataLoaders?.Compile(),
+                                childIdentifierLambda,
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalSplitCollectionShaperExpression.IdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                innerShaper,
+                                relatedDataLoaders ?? (Expression)Constant(null,
                                     _isAsync
                                         ? typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>)
                                         : typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>)),
-                                Constant(inverseNavigation, typeof(INavigationBase)),
-                                Constant(
-                                    GenerateFixup(
-                                        includingEntityType, relatedEntityType, navigation, inverseNavigation).Compile()),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    inverseNavigation,
+                                    LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(inverseNavigation),
+                                    (inverseNavigation?.Name ?? "null") + "InverseNavigation",
+                                    typeof(INavigationBase)),
+                                GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Constant(_isTracking)));
                     }
                     else
@@ -982,11 +1052,17 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                             QueryCompilationContext.QueryContextParameter,
                             entity,
                             navigationExpression,
-                            Constant(navigation),
-                            Constant(inverseNavigation, typeof(INavigationBase)),
-                            Constant(
-                                GenerateFixup(
-                                    includingType, relatedEntityType, navigation, inverseNavigation).Compile()),
+                            _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                navigation,
+                                LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(navigation),
+                                navigation.Name + "Navigation",
+                                typeof(INavigation)),
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    inverseNavigation,
+                                    LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(inverseNavigation),
+                                    (inverseNavigation?.Name ?? "null") + "InverseNavigation",
+                                    typeof(INavigation)),
+                            GenerateFixup(includingType, relatedEntityType, navigation, inverseNavigation),
                             Constant(_isTracking));
 
                         _includeExpressions.Add(updatedExpression);
@@ -1042,9 +1118,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     QueryCompilationContext.QueryContextParameter,
                                     _dataReaderParameter,
                                     _resultCoordinatorParameter,
-                                    Constant(parentIdentifierLambda.Compile()),
-                                    Constant(outerIdentifierLambda.Compile()),
-                                    Constant(collectionAccessor, typeof(IClrCollectionAccessor)))));
+                                    parentIdentifierLambda,
+                                    outerIdentifierLambda,
+                                    _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        collectionAccessor,
+                                        LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                                        (navigation?.Name ?? "null") + "ClrCollectionAccessor",
+                                        typeof(IClrCollectionAccessor)))));
 
                         _valuesArrayInitializers!.Add(collectionParameter);
                         accessor = Convert(
@@ -1060,19 +1140,19 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 QueryCompilationContext.QueryContextParameter,
                                 _dataReaderParameter,
                                 _resultCoordinatorParameter,
-                                Constant(parentIdentifierLambda.Compile()),
-                                Constant(outerIdentifierLambda.Compile()),
-                                Constant(selfIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalCollectionShaperExpression.ParentIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.OuterIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(
-                                    relationalCollectionShaperExpression.SelfIdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile())));
+                                parentIdentifierLambda,
+                                outerIdentifierLambda,
+                                selfIdentifierLambda,
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.ParentIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.OuterIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalCollectionShaperExpression.SelfIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                innerShaper));
 
                         _variableShaperMapping[relationalCollectionShaperExpression] = accessor;
                     }
@@ -1121,6 +1201,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                         var collectionParameter = Parameter(collectionType);
                         _variables.Add(collectionParameter);
+
                         _expressions.Add(
                             Assign(
                                 collectionParameter,
@@ -1130,8 +1211,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     QueryCompilationContext.QueryContextParameter,
                                     _dataReaderParameter,
                                     _resultCoordinatorParameter,
-                                    Constant(parentIdentifierLambda.Compile()),
-                                    Constant(collectionAccessor, typeof(IClrCollectionAccessor)))));
+                                    parentIdentifierLambda,
+                                    _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                        collectionAccessor,
+                                        LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                                        (navigation?.Name ?? "null") + "CollectionAccessor",
+                                        typeof(IClrCollectionAccessor)))));
 
                         _valuesArrayInitializers!.Add(collectionParameter);
                         accessor = Convert(
@@ -1147,20 +1232,20 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 collectionIdConstant,
                                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
                                 _executionStrategyParameter!,
-                                Constant(relationalCommandCache),
-                                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                                relationalCommandCache,
+                                CreateReaderColumnsExpression(readerColumns, _parentVisitor.Dependencies.LiftableConstantFactory),
                                 Constant(_detailedErrorsEnabled),
                                 _resultCoordinatorParameter,
-                                Constant(childIdentifierLambda.Compile()),
-                                Constant(
-                                    relationalSplitCollectionShaperExpression.IdentifierValueComparers,
-                                    typeof(IReadOnlyList<ValueComparer>)),
-                                Constant(innerShaper.Compile()),
-                                Constant(
-                                    relatedDataLoaders?.Compile(),
-                                    _isAsync
+                                childIdentifierLambda,
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalSplitCollectionShaperExpression.IdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                innerShaper,
+                                relatedDataLoaders == null
+                                    ? Constant(null, _isAsync
                                         ? typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>)
-                                        : typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>))));
+                                        : typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>))
+                                    : relatedDataLoaders));
 
                         _variableShaperMapping[relationalSplitCollectionShaperExpression] = accessor;
                     }
@@ -1170,6 +1255,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                 case GroupByShaperExpression:
                     throw new InvalidOperationException(RelationalStrings.ClientGroupByNotSupported);
+
+                case LiftableConstantExpression:
+                    return extensionExpression;
             }
 
             return base.VisitExtension(extensionExpression);
@@ -1190,6 +1278,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
             if (methodCallExpression.Method.IsGenericMethod
@@ -1329,7 +1423,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     ReferenceEqual(Constant(null), shaperCollectionParameter),
                                     IsFalse(
                                         Call(
-                                            typeof(EnumerableExtensions).GetMethod(nameof(EnumerableExtensions.Any))!,
+                                            typeof(ShaperProcessingExpressionVisitor).GetMethod(nameof(Any))!,
                                             shaperCollectionParameter))),
                                 shaperEntityParameter
                                     .MakeMemberAccess(ownedNavigation.GetMemberInfo(forMaterialization: true, forSet: true))
@@ -1396,7 +1490,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 innerShapersMap,
                 innerFixupMap,
                 trackingInnerFixupMap,
-                _queryLogger).Rewrite(entityShaperMaterializer);
+                _queryLogger,
+                _parentVisitor.Dependencies.LiftableConstantFactory).Rewrite(entityShaperMaterializer);
 
             var entityShaperMaterializerVariable = Variable(
                 entityShaperMaterializer.Type,
@@ -1494,7 +1589,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         QueryCompilationContext.QueryContextParameter,
                         keyValuesParameter,
                         jsonReaderDataParameter,
-                        Constant(navigation),
+                        _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                            navigation,
+                            LiftableConstantExpressionHelpers.BuildNavigationAccessLambda(navigation),
+                            navigation.Name + "Navigation",
+                            typeof(INavigation)),
                         shaperLambda);
 
                 return materializeJsonEntityCollectionMethodCall;
@@ -1520,9 +1619,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             private readonly IDictionary<string, LambdaExpression> _innerFixupMap;
             private readonly IDictionary<string, LambdaExpression> _trackingInnerFixupMap;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
+            private readonly ILiftableConstantFactory _liftableConstantFactory;
 
             private static readonly PropertyInfo JsonEncodedTextEncodedUtf8BytesProperty
                 = typeof(JsonEncodedText).GetProperty(nameof(JsonEncodedText.EncodedUtf8Bytes))!;
+
+            private static readonly MethodInfo JsonEncodedTextEncodeMethod
+                = typeof(JsonEncodedText).GetMethod(nameof(JsonEncodedText.Encode), [typeof(string), typeof(JavaScriptEncoder)])!;
 
             // keep track which variable corresponds to which navigation - we need that info for fixup
             // which happens at the end (after we read everything to guarantee that we can instantiate the entity
@@ -1535,7 +1638,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 IDictionary<string, Expression> innerShapersMap,
                 IDictionary<string, LambdaExpression> innerFixupMap,
                 IDictionary<string, LambdaExpression> trackingInnerFixupMap,
-                IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger)
+                IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger,
+                ILiftableConstantFactory liftableConstantFactory)
             {
                 _entityType = entityType;
                 _isTracking = isTracking;
@@ -1544,6 +1648,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 _innerFixupMap = innerFixupMap;
                 _trackingInnerFixupMap = trackingInnerFixupMap;
                 _queryLogger = queryLogger;
+                _liftableConstantFactory = liftableConstantFactory;
             }
 
             public BlockExpression Rewrite(BlockExpression jsonEntityShaperMaterializer)
@@ -1554,10 +1659,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 if (switchExpression.SwitchValue.Type == typeof(IEntityType)
                     && switchExpression is
                     {
-                        Cases: [{ TestValues: [ConstantExpression onlyValue], Body: BlockExpression body }]
+                        Cases:
+                        [
+                            {
+                                Body: BlockExpression { Expressions.Count: > 0 } body,
+                                TestValues: [Expression onlyValueExpression]
+                            }
+                        ]
                     }
-                    && onlyValue.Value == _entityType
-                    && body.Expressions.Count > 0)
+                    && onlyValueExpression.GetConstantValue<object>() == _entityType)
                 {
                     var valueBufferTryReadValueMethodsToProcess =
                         new ValueBufferTryReadValueMethodsFinder(_entityType).FindValueBufferTryReadValueMethods(body);
@@ -1647,7 +1757,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                             New(
                                 JsonReaderManagerConstructor,
                                 _jsonReaderDataParameter,
-                                Constant(_queryLogger))),
+                                _liftableConstantFactory.CreateLiftableConstant(
+                                    _queryLogger,
+                                    static c => c.Dependencies.QueryLogger,
+                                    "queryLogger",
+                                    typeof(IDiagnosticsLogger<DbLoggerCategory.Query>)))),
                         // tokenType = jsonReaderManager.CurrentReader.TokenType
                         Assign(
                             tokenTypeVariable,
@@ -1759,8 +1873,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                     foreach (var valueBufferTryReadValueMethodToProcess in valueBufferTryReadValueMethodsToProcess)
                     {
-                        var property = (IProperty)((ConstantExpression)valueBufferTryReadValueMethodToProcess.Arguments[2]).Value!;
-
+                        var property = valueBufferTryReadValueMethodToProcess.Arguments[2].GetConstantValue<IProperty>();
+                        var jsonPropertyName = property.GetJsonPropertyName()!;
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -1768,7 +1882,18 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     Utf8JsonReaderManagerCurrentReaderField),
                                 Utf8JsonReaderValueTextEqualsMethod,
                                 Property(
-                                    Constant(JsonEncodedText.Encode(property.GetJsonPropertyName()!)),
+                                    _liftableConstantFactory.CreateLiftableConstant(
+                                        JsonEncodedText.Encode(jsonPropertyName),
+                                        Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                                            Convert(
+                                                Call(
+                                                    JsonEncodedTextEncodeMethod,
+                                                    Constant(jsonPropertyName),
+                                                    Default(typeof(JavaScriptEncoder))),
+                                                typeof(object)),
+                                            Parameter(typeof(MaterializerLiftableConstantContext), "_")),
+                                        jsonPropertyName + "EncodedProperty",
+                                        typeof(JsonEncodedText)),
                                     JsonEncodedTextEncodedUtf8BytesProperty)));
 
                         var propertyVariable = Variable(valueBufferTryReadValueMethodToProcess.Type);
@@ -1794,6 +1919,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                     foreach (var innerShaperMapElement in _innerShapersMap)
                     {
+                        var innerShaperMapElementKey = innerShaperMapElement.Key;
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -1801,7 +1927,18 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     Utf8JsonReaderManagerCurrentReaderField),
                                 Utf8JsonReaderValueTextEqualsMethod,
                                 Property(
-                                    Constant(JsonEncodedText.Encode(innerShaperMapElement.Key)),
+                                    _liftableConstantFactory.CreateLiftableConstant(
+                                        JsonEncodedText.Encode(innerShaperMapElementKey),
+                                        Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                                            Convert(
+                                                Call(
+                                                    JsonEncodedTextEncodeMethod,
+                                                    Constant(innerShaperMapElementKey),
+                                                    Default(typeof(JavaScriptEncoder))),
+                                                typeof(object)),
+                                            Parameter(typeof(MaterializerLiftableConstantContext), "_")),
+                                        innerShaperMapElementKey + "EncodedNavigation",
+                                        typeof(JsonEncodedText)),
                                     JsonEncodedTextEncodedUtf8BytesProperty)));
 
                         var propertyVariable = Variable(innerShaperMapElement.Value.Type);
@@ -1813,7 +1950,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         var captureState = Call(managerVariable, Utf8JsonReaderManagerCaptureStateMethod);
                         var assignment = Assign(propertyVariable, innerShaperMapElement.Value);
                         var managerRecreation = Assign(
-                            managerVariable, New(JsonReaderManagerConstructor, _jsonReaderDataParameter, Constant(_queryLogger)));
+                            managerVariable,
+                            New(
+                                JsonReaderManagerConstructor,
+                                _jsonReaderDataParameter,
+                                _liftableConstantFactory.CreateLiftableConstant(
+                                    _queryLogger,
+                                    static c => c.Dependencies.QueryLogger,
+                                    "queryLogger",
+                                    typeof(IDiagnosticsLogger<DbLoggerCategory.Query>))));
 
                         readExpressions.Add(
                             Block(
@@ -2032,7 +2177,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     if (methodCallExpression.Method.IsGenericMethod
                         && methodCallExpression.Method.GetGenericMethodDefinition()
                         == Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod
-                        && ((ConstantExpression)methodCallExpression.Arguments[2]).Value is IProperty property
+                        && methodCallExpression.Arguments[2].GetConstantValue<object>() is IProperty property
                         && _nonKeyProperties.Contains(property))
                     {
                         _valueBufferTryReadValueMethods.Add(methodCallExpression);
@@ -2115,7 +2260,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     if (methodCallExpression.Method.IsGenericMethod
                         && methodCallExpression.Method.GetGenericMethodDefinition()
                         == Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod
-                        && ((ConstantExpression)methodCallExpression.Arguments[2]).Value is IProperty prop
+                        && methodCallExpression.Arguments[2].GetConstantValue<object>() is IProperty prop
                         && _propertyAssignmentMap.TryGetValue(prop, out var param))
                     {
                         property = prop;
@@ -2174,7 +2319,15 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         Default(typeof(JsonReaderData))),
                     Block(
                         Assign(
-                            jsonReaderManagerVariable, New(JsonReaderManagerConstructor, jsonReaderDataVariable, Constant(_queryLogger))),
+                            jsonReaderManagerVariable,
+                            New(
+                                JsonReaderManagerConstructor,
+                                jsonReaderDataVariable,
+                                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                    _queryLogger,
+                                    static c => c.Dependencies.QueryLogger,
+                                    "queryLogger",
+                                    typeof(IDiagnosticsLogger<DbLoggerCategory.Query>)))),
                         Call(jsonReaderManagerVariable, Utf8JsonReaderManagerMoveNextMethod),
                         Call(jsonReaderManagerVariable, Utf8JsonReaderManagerCaptureStateMethod)));
 
@@ -2308,10 +2461,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         Left: MethodCallExpression
                         {
                             Method: { IsGenericMethod: true } method,
-                            Arguments: [_, _, ConstantExpression { Value: IProperty property }]
+                            Arguments: [_, _, Expression leftExpression]
                         },
-                        Right: ConstantExpression { Value: null }
+                        Right: Expression rightExpression
                     }
+                    && leftExpression.TryGetNonNullConstantValue<IProperty>(out var property)
+                    && rightExpression is ConstantExpression or LiftableConstantExpression
+                    && rightExpression.GetConstantValue<object>() == null
                     && method.GetGenericMethodDefinition() == Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod)
                 {
                     return _mappedProperties.Contains(property)
@@ -2327,8 +2483,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 if (methodCallExpression is
                     {
                         Method: { IsGenericMethod: true } method,
-                        Arguments: [_, _, ConstantExpression { Value: IProperty property }]
+                        Arguments: [_, _, Expression  argumentExpression]
                     }
+                    && argumentExpression.TryGetNonNullConstantValue<IProperty>(out var property)
                     && method.GetGenericMethodDefinition() == Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod
                     && !_mappedProperties.Contains(property))
                 {
@@ -2339,7 +2496,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static LambdaExpression GenerateFixup(
+        private LambdaExpression GenerateFixup(
             Type entityType,
             Type relatedEntityType,
             INavigationBase navigation,
@@ -2401,7 +2558,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             return Lambda(Block(typeof(void), expressions), entityParameter, relatedEntityParameter);
         }
 
-        private static void InverseCollectionFixup<TCollectionElement, TEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InverseCollectionFixup<TCollectionElement, TEntity>(
             ICollection<TCollectionElement> collection,
             TEntity entity,
             Action<TCollectionElement, TEntity> elementFixup)
@@ -2418,7 +2582,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             INavigationBase navigation)
             => entity.MakeMemberAccess(navigation.GetMemberInfo(forMaterialization: true, forSet: true)).Assign(relatedEntity);
 
-        private static Expression GetOrCreateCollectionObjectLambda(
+        private Expression GetOrCreateCollectionObjectLambda(
             Type entityType,
             INavigationBase navigation)
         {
@@ -2428,19 +2592,27 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 Block(
                     typeof(void),
                     Call(
-                        Constant(navigation.GetCollectionAccessor()),
+                        _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                            navigation.GetCollectionAccessor(),
+                            LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                            navigation.Name + "NavigationCollectionAccessor",
+                            typeof(IClrCollectionAccessor)),
                         CollectionAccessorGetOrCreateMethodInfo,
                         prm,
                         Constant(true))),
                     prm);
         }
 
-        private static Expression AddToCollectionNavigation(
+        private Expression AddToCollectionNavigation(
             ParameterExpression entity,
             ParameterExpression relatedEntity,
             INavigationBase navigation)
             => Call(
-                Constant(navigation.GetCollectionAccessor()),
+                _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                    navigation.GetCollectionAccessor(),
+                    LiftableConstantExpressionHelpers.BuildClrCollectionAccessorLambda(navigation),
+                    navigation.Name + "NavigationCollectionAccessor",
+                    typeof(IClrCollectionAccessor)),
                 CollectionAccessorAddMethodInfo,
                 entity,
                 relatedEntity,
@@ -2508,7 +2680,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         Lambda(
                             bufferedReaderLambdaExpression,
                             dbDataReader,
-                            _indexMapParameter ?? Parameter(typeof(int[]))).Compile());
+                            _indexMapParameter ?? Parameter(typeof(int[]), "indexMap")));
                 }
 
                 valueExpression = Call(
@@ -2523,17 +2695,66 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             var converter = typeMapping.Converter;
 
+            var converterExpression = default(Expression);
             if (converter != null)
             {
-                if (valueExpression.Type != converter.ProviderClrType)
+                // if IProperty is available, we can reliably get the converter from the model and then incorporate FromProvider(Typed) delegate
+                // into the expression. This way we have consistent behavior between precompiled and normal queries (same code path)
+                // however, if IProperty is not available, we could try to get TypeMapping from TypeMappingSource based on ClrType, but that may
+                // return incorrect mapping. So for that case we would prefer to incorporate the FromProvider lambda, like we used to do before AOT
+                // and only resort to unreliable TypeMappingSource lookup, if the converter expression captures "forbidden" constant
+                var requiresLiftableConstant = new ConstantValidator().RequiresLiftableConstant(converter.ConvertFromProviderExpression.Body);
+                if (property != null || requiresLiftableConstant)
                 {
-                    valueExpression = Convert(valueExpression, converter.ProviderClrType);
-                }
+                    var typeMappingExpression = CreateTypeMappingExpression(property, type, typeMapping, _parentVisitor.Dependencies.LiftableConstantFactory);
+                    converterExpression = Property(typeMappingExpression, nameof(CoreTypeMapping.Converter));
 
-                valueExpression = ReplacingExpressionVisitor.Replace(
-                    converter.ConvertFromProviderExpression.Parameters.Single(),
-                    valueExpression,
-                    converter.ConvertFromProviderExpression.Body);
+                    var converterType = converter.GetType();
+                    var typedConverterType = converterType.GetGenericTypeImplementations(typeof(ValueConverter<,>)).FirstOrDefault();
+                    var invocationExpression = default(Expression);
+
+                    // TODO: do we even need to do this check? can we ever have a custom ValueConverter that is not generic?
+                    if (typedConverterType != null)
+                    {
+                        if (converterExpression.Type != converter.GetType())
+                        {
+                            converterExpression = Convert(converterExpression, converter.GetType());
+                        }
+
+                        if (valueExpression.Type != converter.ProviderClrType)
+                        {
+                            valueExpression = Convert(valueExpression, converter.ProviderClrType);
+                        }
+
+                        invocationExpression = Invoke(
+                            Property(
+                                converterExpression,
+                                nameof(ValueConverter<object, object>.ConvertFromProviderTyped)),
+                            valueExpression);
+                    }
+                    else
+                    {
+                        invocationExpression = Invoke(
+                            Property(
+                                converterExpression,
+                                nameof(ValueConverter.ConvertFromProvider)),
+                            Convert(valueExpression, typeof(object)));
+                    }
+
+                    valueExpression = invocationExpression;
+                }
+                else
+                {
+                    if (valueExpression.Type != converter.ProviderClrType)
+                    {
+                        valueExpression = Convert(valueExpression, converter.ProviderClrType);
+                    }
+
+                    valueExpression = ReplacingExpressionVisitor.Replace(
+                        converter.ConvertFromProviderExpression.Parameters.Single(),
+                        valueExpression,
+                        converter.ConvertFromProviderExpression.Body);
+                }
             }
 
             if (valueExpression.Type != type)
@@ -2546,10 +2767,45 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 Expression replaceExpression;
                 if (converter?.ConvertsNulls == true)
                 {
-                    replaceExpression = ReplacingExpressionVisitor.Replace(
-                        converter.ConvertFromProviderExpression.Parameters.Single(),
-                        Default(converter.ProviderClrType),
-                        converter.ConvertFromProviderExpression.Body);
+                    // we potentially have to repeat logic from above here. We can check if we computed converterExpression before
+                    // if so, it means there are liftable constants in the ConvertFromProvider expression
+                    // we can also reuse converter expression, just switch argument to the Invoke for default(provier type) or object
+                    if (converterExpression != null)
+                    {
+                        var converterType = converter.GetType();
+                        var typedConverterType = converterType.GetGenericTypeImplementations(typeof(ValueConverter<,>)).FirstOrDefault();
+                        var invocationExpression = default(Expression);
+                        if (typedConverterType != null)
+                        {
+                            if (converterExpression.Type != converter.GetType())
+                            {
+                                converterExpression = Convert(converterExpression, converter.GetType());
+                            }
+
+                            invocationExpression = Invoke(
+                                Property(
+                                    converterExpression,
+                                    nameof(ValueConverter<object, object>.ConvertFromProviderTyped)),
+                                Default(converter.ProviderClrType));
+                        }
+                        else
+                        {
+                            invocationExpression = Invoke(
+                                Property(
+                                    converterExpression,
+                                    nameof(ValueConverter.ConvertFromProvider)),
+                                Default(typeof(object)));
+                        }
+
+                        replaceExpression = invocationExpression;
+                    }
+                    else
+                    {
+                        replaceExpression = ReplacingExpressionVisitor.Replace(
+                            converter.ConvertFromProviderExpression.Parameters.Single(),
+                            Default(converter.ProviderClrType),
+                            converter.ConvertFromProviderExpression.Body);
+                    }
 
                     if (replaceExpression.Type != type)
                     {
@@ -2579,23 +2835,104 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         exceptionParameter,
                         Call(dbDataReader, GetFieldValueMethod.MakeGenericMethod(typeof(object)), indexExpression),
                         Constant(valueExpression.Type.MakeNullable(nullable), typeof(Type)),
-                        Constant(property, typeof(IPropertyBase))));
+                        property == null
+                            ? Default(typeof(IPropertyBase))
+                            : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                                property,
+                                LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForProperty(property),
+                                property + "Property",
+                                typeof(IPropertyBase))));
 
                 valueExpression = TryCatch(valueExpression, catchBlock);
             }
 
             return valueExpression;
+
+            static Expression CreateTypeMappingExpression(
+                IPropertyBase? property,
+                Type type,
+                RelationalTypeMapping typeMapping,
+                ILiftableConstantFactory liftableConstantFactory)
+            {
+                Expression typeMappingExpression;
+                if (property != null)
+                {
+                    typeMappingExpression = Call(
+                        Convert(
+                            liftableConstantFactory.CreateLiftableConstant(
+                                property,
+                                LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForProperty(property),
+                                property.Name + "Property",
+                                typeof(IPropertyBase)),
+                            typeof(IReadOnlyProperty)),
+                        PropertyGetTypeMappingMethod);
+                }
+                else
+                {
+                    // NOTE: this is unreliable way to get type mapping. Only doing this as last resort, hoping to "guess" the right one
+                    Expression<Func<MaterializerLiftableConstantContext, Type, object>> resolverTemplate =
+                        (c, _) => (RelationalTypeMapping)c.Dependencies.TypeMappingSource.FindMapping(_, c.Dependencies.Model, null)!;
+
+                    var body = ReplacingExpressionVisitor.Replace(
+                        resolverTemplate.Parameters[1],
+                        Constant(type),
+                        resolverTemplate.Body);
+
+                    typeMappingExpression = liftableConstantFactory.CreateLiftableConstant(
+                        typeMapping,
+                        Lambda<Func<MaterializerLiftableConstantContext, object>>(body, resolverTemplate.Parameters[0]),
+                        "typeMapping",
+                        typeof(RelationalTypeMapping));
+                }
+
+                return typeMappingExpression;
+            }
+        }
+
+        private sealed class ConstantValidator : ExpressionVisitor
+        {
+            private bool _requiresLiftableConstant;
+
+            public bool RequiresLiftableConstant(Expression expression)
+            {
+                _requiresLiftableConstant = false;
+                Visit(expression);
+
+                return _requiresLiftableConstant;
+            }
+
+            protected override Expression VisitConstant(ConstantExpression constantExpression)
+            {
+                if (!_requiresLiftableConstant && !LiftableConstantExpressionHelpers.IsLiteral(constantExpression.Value))
+                {
+                    _requiresLiftableConstant = true;
+                }
+
+                return constantExpression;
+            }
         }
 
         private Expression CreateReadJsonPropertyValueExpression(
             ParameterExpression jsonReaderManagerParameter,
             IProperty property)
         {
-            var nullable = property.IsNullable;
-            var typeMapping = property.GetTypeMapping();
-
-            var jsonReaderWriterExpression = Constant(
-                property.GetJsonValueReaderWriter() ?? property.GetTypeMapping().JsonValueReaderWriter!);
+            var jsonReaderWriter = property.GetJsonValueReaderWriter() ?? property.GetTypeMapping().JsonValueReaderWriter!;
+            var prm = Parameter(typeof(MaterializerLiftableConstantContext), "c");
+            var jsonReaderWriterExpression = _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                property.GetJsonValueReaderWriter() ?? property.GetTypeMapping().JsonValueReaderWriter!,
+                Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                Coalesce(
+                    Call(
+                        LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(property, prm),
+                        PropertyGetJsonValueReaderWriterMethod),
+                    Property(
+                        Call(
+                            LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(property, prm),
+                            PropertyGetTypeMappingMethod),
+                        nameof(CoreTypeMapping.JsonValueReaderWriter))),
+                prm),
+                property.Name + "PropertyName",
+                jsonReaderWriter.GetType());
 
             var fromJsonMethod = jsonReaderWriterExpression.Type.GetMethod(
                 nameof(JsonValueReaderWriter<object>.FromJsonTyped),
@@ -2603,9 +2940,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             Expression resultExpression = Convert(
                 Call(jsonReaderWriterExpression, fromJsonMethod, jsonReaderManagerParameter, Default(typeof(object))),
-                typeMapping.ClrType);
+                property.GetTypeMapping().ClrType);
 
-            if (nullable)
+            if (property.IsNullable)
             {
                 // in case of null value we can't just use the JsonReader method, but rather check the current token type
                 // if it's JsonTokenType.Null means value is null, only if it's not we are safe to read the value

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -70,17 +70,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                 break;
         }
 
-        var relationalCommandCache = new RelationalCommandCache(
-            Dependencies.MemoryCache,
-            RelationalDependencies.QuerySqlGeneratorFactory,
-            RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-            innerExpression,
-            _useRelationalNulls);
+        var relationalCommandCache = CreateRelationalCommandCacheExpression(innerExpression);
 
         return Call(
             QueryCompilationContext.IsAsync ? NonQueryAsyncMethodInfo : NonQueryMethodInfo,
             Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-            Constant(relationalCommandCache),
+            relationalCommandCache,
             Constant(_contextType),
             Constant(nonQueryExpression.CommandSource),
             Constant(_threadSafetyChecksEnabled));
@@ -96,7 +91,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
             .GetDeclaredMethods(nameof(NonQueryResultAsync))
             .Single(mi => mi.GetParameters().Length == 5);
 
-    private static int NonQueryResult(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static int NonQueryResult(
         RelationalQueryContext relationalQueryContext,
         RelationalCommandCache relationalCommandCache,
         Type contextType,
@@ -167,7 +169,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
         }
     }
 
-    private static Task<int> NonQueryResultAsync(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static Task<int> NonQueryResultAsync(
         RelationalQueryContext relationalQueryContext,
         RelationalCommandCache relationalCommandCache,
         Type contextType,
@@ -268,50 +277,53 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                 QueryCompilationContext.Logger.MultipleCollectionIncludeWarning();
             }
 
+            var readerColumnsExpression = CreateReaderColumnsExpression(readerColumns, Dependencies.LiftableConstantFactory);
             if (splitQuery)
             {
-                var relatedDataLoadersParameter = Constant(
-                    QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
-                    typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
+                var relatedDataLoadersParameter = QueryCompilationContext.IsAsync || relatedDataLoaders == null
+                    ? (Expression)Constant(null, typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>))
+                    : relatedDataLoaders;
 
-                var relatedDataLoadersAsyncParameter = Constant(
-                    QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
-                    typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
+                var relatedDataLoadersAsyncParameter = QueryCompilationContext.IsAsync && relatedDataLoaders != null
+                    ? relatedDataLoaders!
+                    : (Expression)Constant(null, typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
-                return New(
-                    typeof(GroupBySplitQueryingEnumerable<,>).MakeGenericType(
-                        keySelector.ReturnType,
-                        elementSelector.ReturnType).GetConstructors()[0],
+                return Call(
+                    typeof(GroupBySplitQueryingEnumerable).GetMethods()
+                        .Single(m => m.Name == nameof(GroupBySplitQueryingEnumerable.Create))
+                        .MakeGenericMethod(keySelector.ReturnType, elementSelector.ReturnType),
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Constant(relationalCommandCache),
-                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Constant(keySelector.Compile()),
-                    Constant(keyIdentifier.Compile()),
-                    Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
-                    Constant(elementSelector.Compile()),
+                    relationalCommandCache,
+                    readerColumnsExpression,
+                    keySelector,
+                    keyIdentifier,
+                    NewArrayInit(
+                        typeof(Func<object, object, bool>),
+                        relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                    elementSelector,
                     relatedDataLoadersParameter,
                     relatedDataLoadersAsyncParameter,
                     Constant(_contextType),
-                    Constant(
-                        QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                    Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                     Constant(_detailedErrorsEnabled),
                     Constant(_threadSafetyChecksEnabled));
             }
 
-            return New(
-                typeof(GroupBySingleQueryingEnumerable<,>).MakeGenericType(
-                    keySelector.ReturnType,
-                    elementSelector.ReturnType).GetConstructors()[0],
+            return Call(
+                typeof(GroupBySingleQueryingEnumerable).GetMethods()
+                    .Single(m => m.Name == nameof(GroupBySingleQueryingEnumerable.Create))
+                    .MakeGenericMethod(keySelector.ReturnType, elementSelector.ReturnType),
                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                Constant(relationalCommandCache),
-                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                Constant(keySelector.Compile()),
-                Constant(keyIdentifier.Compile()),
-                Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
-                Constant(elementSelector.Compile()),
+                relationalCommandCache,
+                readerColumnsExpression,
+                keySelector,
+                keyIdentifier,
+                NewArrayInit(
+                    typeof(Func<object, object, bool>),
+                    relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                elementSelector,
                 Constant(_contextType),
-                Constant(
-                    QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                 Constant(_detailedErrorsEnabled),
                 Constant(_threadSafetyChecksEnabled));
         }
@@ -319,8 +331,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
         {
             var nonComposedFromSql = selectExpression.IsNonComposedFromSql();
             var shaper = new ShaperProcessingExpressionVisitor(this, selectExpression, _tags, splitQuery, nonComposedFromSql).ProcessShaper(
-                shapedQueryExpression.ShaperExpression,
-                out var relationalCommandCache, out var readerColumns, out var relatedDataLoaders, ref collectionCount);
+                shapedQueryExpression.ShaperExpression, out var relationalCommandCache, out var readerColumns,
+                out var relatedDataLoaders, ref collectionCount);
 
             if (querySplittingBehavior == null
                 && collectionCount > 1)
@@ -328,60 +340,134 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                 QueryCompilationContext.Logger.MultipleCollectionIncludeWarning();
             }
 
+            var readerColumnsExpression = CreateReaderColumnsExpression(readerColumns, Dependencies.LiftableConstantFactory);
             if (nonComposedFromSql)
             {
-                return New(
-                    typeof(FromSqlQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
+                return Call(
+                    typeof(FromSqlQueryingEnumerable).GetMethods()
+                        .Single(m => m.Name == nameof(FromSqlQueryingEnumerable.Create))
+                        .MakeGenericMethod(shaper.ReturnType),
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Constant(relationalCommandCache),
-                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Constant(
-                        selectExpression.Projection.Select(pe => ((ColumnExpression)pe.Expression).Name).ToList(),
-                        typeof(IReadOnlyList<string>)),
-                    Constant(shaper.Compile()),
+                    relationalCommandCache,
+                    readerColumnsExpression,
+                    NewArrayInit(
+                        typeof(string),
+                        selectExpression.Projection.Select(pe => Constant(((ColumnExpression)pe.Expression).Name, typeof(string)))),
+                    shaper,
                     Constant(_contextType),
-                    Constant(
-                        QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                    Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                     Constant(_detailedErrorsEnabled),
                     Constant(_threadSafetyChecksEnabled));
             }
 
             if (splitQuery)
             {
-                var relatedDataLoadersParameter = Constant(
-                    QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
-                    typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
+                var relatedDataLoadersParameter =
+                    QueryCompilationContext.IsAsync || relatedDataLoaders is null
+                        ? Constant(null, typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>))
+                        : (Expression)relatedDataLoaders;
 
-                var relatedDataLoadersAsyncParameter = Constant(
-                    QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
-                    typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
+                var relatedDataLoadersAsyncParameter =
+                    QueryCompilationContext.IsAsync && relatedDataLoaders is not null
+                        ? (Expression)relatedDataLoaders
+                        : Constant(null, typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
-                return New(
-                    typeof(SplitQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors().Single(),
+                return Call(
+                    typeof(SplitQueryingEnumerable).GetMethods()
+                        .Single(m => m.Name == nameof(FromSqlQueryingEnumerable.Create))
+                        .MakeGenericMethod(shaper.ReturnType),
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Constant(relationalCommandCache),
-                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Constant(shaper.Compile()),
+                    relationalCommandCache,
+                    readerColumnsExpression,
+                    shaper,
                     relatedDataLoadersParameter,
                     relatedDataLoadersAsyncParameter,
                     Constant(_contextType),
-                    Constant(
-                        QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                    Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                     Constant(_detailedErrorsEnabled),
                     Constant(_threadSafetyChecksEnabled));
             }
 
-            return New(
-                typeof(SingleQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
+            return Call(
+                typeof(SingleQueryingEnumerable).GetMethods()
+                    .Single(m => m.Name == nameof(SingleQueryingEnumerable.Create))
+                    .MakeGenericMethod(shaper.ReturnType),
                 Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                Constant(relationalCommandCache),
-                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                Constant(shaper.Compile()),
+                relationalCommandCache,
+                readerColumnsExpression,
+                shaper,
                 Constant(_contextType),
-                Constant(
-                    QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                 Constant(_detailedErrorsEnabled),
                 Constant(_threadSafetyChecksEnabled));
         }
+    }
+
+    private static Expression CreateReaderColumnsExpression(
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        ILiftableConstantFactory liftableConstantFactory)
+    {
+        if (readerColumns is null)
+        {
+            return Constant(readerColumns, typeof(ReaderColumn?[]));
+        }
+
+        var materializerLiftableConstantContextParameter = Parameter(typeof(MaterializerLiftableConstantContext));
+        var initializers = new List<Expression>();
+
+        foreach (var readerColumn in readerColumns)
+        {
+            var currentReaderColumn = readerColumn;
+            if (currentReaderColumn is null)
+            {
+                initializers.Add(Constant(null, typeof(ReaderColumn)));
+                continue;
+            }
+
+            var propertyExpression = LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
+                currentReaderColumn.Property,
+                materializerLiftableConstantContextParameter);
+
+            initializers.Add(
+                New(
+                    ReaderColumn.GetConstructor(currentReaderColumn.Type),
+                    Constant(currentReaderColumn.IsNullable),
+                    Constant(currentReaderColumn.Name, typeof(string)),
+                    propertyExpression,
+                    currentReaderColumn.GetFieldValueExpression));
+        }
+
+        var result = liftableConstantFactory.CreateLiftableConstant(
+            readerColumns,
+            Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                NewArrayInit(
+                    typeof(ReaderColumn),
+                    initializers),
+                materializerLiftableConstantContextParameter),
+            "readerColumns",
+            typeof(ReaderColumn[]));
+
+        return result;
+    }
+
+    private Expression CreateRelationalCommandCacheExpression(Expression queryExpression)
+    {
+        var relationalCommandCache = new RelationalCommandCache(
+            Dependencies.MemoryCache,
+            RelationalDependencies.QuerySqlGeneratorFactory,
+            RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
+            queryExpression,
+            _useRelationalNulls);
+
+        return RelationalDependencies.RelationalLiftableConstantFactory.CreateLiftableConstant(
+            relationalCommandCache,
+            c => new RelationalCommandCache(
+                c.Dependencies.MemoryCache,
+                c.RelationalDependencies.QuerySqlGeneratorFactory,
+                c.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
+                queryExpression,
+                _useRelationalNulls),
+            "relationalCommandCache",
+            typeof(RelationalCommandCache));
     }
 }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -47,10 +47,12 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     [EntityFrameworkInternal]
     public RelationalShapedQueryCompilingExpressionVisitorDependencies(
         IQuerySqlGeneratorFactory querySqlGeneratorFactory,
-        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory)
+        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory,
+        IRelationalLiftableConstantFactory relationalLiftableConstantFactory)
     {
         QuerySqlGeneratorFactory = querySqlGeneratorFactory;
         RelationalParameterBasedSqlProcessorFactory = relationalParameterBasedSqlProcessorFactory;
+        RelationalLiftableConstantFactory = relationalLiftableConstantFactory;
     }
 
     /// <summary>
@@ -62,4 +64,9 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     ///     The SQL processor based on parameter values.
     /// </summary>
     public IRelationalParameterBasedSqlProcessorFactory RelationalParameterBasedSqlProcessorFactory { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public IRelationalLiftableConstantFactory RelationalLiftableConstantFactory { get; init; }
 }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -2107,7 +2107,14 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             _ => throw new UnreachableException()
         };
 
-    private static T? ParameterValueExtractor<T>(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static T? ParameterValueExtractor<T>(
         QueryContext context,
         string baseParameterName,
         List<IComplexProperty>? complexPropertyChain,
@@ -2131,7 +2138,14 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         return baseValue == null ? (T?)(object?)null : (T?)property.GetGetter().GetClrValue(baseValue);
     }
 
-    private static List<TProperty?>? ParameterListValueExtractor<TEntity, TProperty>(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static List<TProperty?>? ParameterListValueExtractor<TEntity, TProperty>(
         QueryContext context,
         string baseParameterName,
         IProperty property)

--- a/src/EFCore.Relational/Storage/ReaderColumn.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn.cs
@@ -29,12 +29,14 @@ public abstract class ReaderColumn
     /// <param name="nullable">A value indicating if the column is nullable.</param>
     /// <param name="name">The name of the column.</param>
     /// <param name="property">The property being read if any, null otherwise.</param>
-    protected ReaderColumn(Type type, bool nullable, string? name, IPropertyBase? property)
+    /// <param name="getFieldValueExpression">A lambda expression to get field value for the column from the reader.</param>
+    protected ReaderColumn(Type type, bool nullable, string? name, IPropertyBase? property, LambdaExpression getFieldValueExpression)
     {
         Type = type;
         IsNullable = nullable;
         Name = name;
         Property = property;
+        GetFieldValueExpression = getFieldValueExpression;
     }
 
     /// <summary>
@@ -58,6 +60,11 @@ public abstract class ReaderColumn
     public virtual IPropertyBase? Property { get; }
 
     /// <summary>
+    ///     A lambda expression to get field value for the column from the reader.
+    /// </summary>
+    public virtual LambdaExpression GetFieldValueExpression { get; }
+
+    /// <summary>
     ///     Creates an instance of <see cref="ReaderColumn{T}" />.
     /// </summary>
     /// <param name="type">The type of the column.</param>
@@ -73,10 +80,17 @@ public abstract class ReaderColumn
         bool nullable,
         string? columnName,
         IPropertyBase? property,
-        object readFunc)
+        LambdaExpression readFunc)
         => (ReaderColumn)GetConstructor(type).Invoke([nullable, columnName, property, readFunc]);
 
-    private static ConstructorInfo GetConstructor(Type type)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static ConstructorInfo GetConstructor(Type type)
         => Constructors.GetOrAdd(
             type, t => typeof(ReaderColumn<>).MakeGenericType(t).GetConstructors().First(ci => ci.GetParameters().Length == 4));
 }

--- a/src/EFCore.Relational/Storage/ReaderColumn`.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn`.cs
@@ -24,15 +24,15 @@ public class ReaderColumn<T> : ReaderColumn
     /// <param name="nullable">A value indicating if the column is nullable.</param>
     /// <param name="name">The name of the column.</param>
     /// <param name="property">The property being read if any, null otherwise.</param>
-    /// <param name="getFieldValue">A function to get field value for the column from the reader.</param>
+    /// <param name="getFieldValueExpression">A lambda expression to get field value for the column from the reader.</param>
     public ReaderColumn(
         bool nullable,
         string? name,
         IPropertyBase? property,
-        Func<DbDataReader, int[], T> getFieldValue)
-        : base(typeof(T), nullable, name, property)
+        Expression<Func<DbDataReader, int[], T>> getFieldValueExpression)
+        : base(typeof(T), nullable, name, property, getFieldValueExpression)
     {
-        GetFieldValue = getFieldValue;
+        GetFieldValue = getFieldValueExpression.Compile();
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer.HierarchyId/Storage/Json/SqlServerJsonHierarchyIdReaderWriter.cs
+++ b/src/EFCore.SqlServer.HierarchyId/Storage/Json/SqlServerJsonHierarchyIdReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 
@@ -27,4 +28,10 @@ public sealed class SqlServerJsonHierarchyIdReaderWriter : JsonValueReaderWriter
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, HierarchyId value)
         => writer.WriteStringValue(value.ToString());
+
+    private readonly Expression<Func<SqlServerJsonHierarchyIdReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.SqlServer.HierarchyId/Storage/Json/SqlServerJsonSqlHierarchyIdReaderWriter.cs
+++ b/src/EFCore.SqlServer.HierarchyId/Storage/Json/SqlServerJsonSqlHierarchyIdReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using Microsoft.SqlServer.Types;
@@ -28,4 +29,10 @@ public sealed class SqlServerJsonSqlHierarchyIdReaderWriter : JsonValueReaderWri
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, SqlHierarchyId value)
         => writer.WriteStringValue(value.ToString());
+
+    private readonly Expression<Func<SqlServerJsonSqlHierarchyIdReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Json/SqlServerJsonGeometryWktReaderWriter.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Json/SqlServerJsonGeometryWktReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using NetTopologySuite.Geometries;
@@ -31,4 +32,10 @@ public sealed class SqlServerJsonGeometryWktReaderWriter : JsonValueReaderWriter
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, Geometry value)
         => writer.WriteStringValue(value.ToText());
+
+    private readonly Expression<Func<SqlServerJsonGeometryWktReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -51,4 +51,7 @@ public class SqlServerQueryCompilationContext : RelationalQueryCompilationContex
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </remarks>
     public virtual bool InAggregateFunction { get; set; }
+
+    /// <inheritdoc />
+    public override bool SupportsPrecompiledQuery => true;
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -355,7 +355,14 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         }
     }
 
-    private static string? ConstructLikePatternParameter(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static string? ConstructLikePatternParameter(
         QueryContext queryContext,
         string baseParameterName,
         StartsEndsWithContains methodType)
@@ -378,10 +385,37 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
             _ => throw new UnreachableException()
         };
 
-    private enum StartsEndsWithContains
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public enum StartsEndsWithContains
     {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         StartsWith,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         EndsWith,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         Contains
     }
 

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class SqliteServiceCollectionExtensions
             .TryAdd<IRelationalDatabaseCreator, SqliteDatabaseCreator>()
             .TryAdd<IHistoryRepository, SqliteHistoryRepository>()
             .TryAdd<IRelationalQueryStringFactory, SqliteQueryStringFactory>()
+            .TryAdd<IQueryCompilationContextFactory, SqliteQueryCompilationContextFactory>()
             .TryAdd<IMethodCallTranslatorProvider, SqliteMethodCallTranslatorProvider>()
             .TryAdd<IAggregateMethodCallTranslatorProvider, SqliteAggregateMethodCallTranslatorProvider>()
             .TryAdd<IMemberTranslatorProvider, SqliteMemberTranslatorProvider>()

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContext.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContext.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteQueryCompilationContext : RelationalQueryCompilationContext
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteQueryCompilationContext(
+        QueryCompilationContextDependencies dependencies,
+        RelationalQueryCompilationContextDependencies relationalDependencies,
+        bool async)
+        : base(dependencies, relationalDependencies, async)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool SupportsPrecompiledQuery => true;
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContextFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContextFactory.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteQueryCompilationContextFactory : IQueryCompilationContextFactory
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteQueryCompilationContextFactory(
+        QueryCompilationContextDependencies dependencies,
+        RelationalQueryCompilationContextDependencies relationalDependencies)
+    {
+        Dependencies = dependencies;
+        RelationalDependencies = relationalDependencies;
+    }
+
+    /// <summary>
+    ///     Dependencies for this service.
+    /// </summary>
+    protected virtual QueryCompilationContextDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalQueryCompilationContextDependencies RelationalDependencies { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual QueryCompilationContext Create(bool async)
+        => new SqliteQueryCompilationContext(Dependencies, RelationalDependencies, async);
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.SqlExpressions.Internal;

--- a/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonByteArrayReaderWriter.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonByteArrayReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 
@@ -47,4 +48,10 @@ public sealed class SqliteJsonByteArrayReaderWriter : JsonValueReaderWriter<byte
     /// </summary>
     public override void ToJsonTyped(Utf8JsonWriter writer, byte[] value)
         => writer.WriteStringValue(Convert.ToHexString(value));
+
+    private readonly Expression<Func<SqliteJsonByteArrayReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDateTimeOffsetReaderWriter.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDateTimeOffsetReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -56,4 +57,10 @@ public sealed class SqliteJsonDateTimeOffsetReaderWriter : JsonValueReaderWriter
             JsonEncodedText.Encode(
                 string.Format(CultureInfo.InvariantCulture, DateTimeOffsetFormatConst, value),
                 JavaScriptEncoder.UnsafeRelaxedJsonEscaping));
+
+    private readonly Expression<Func<SqliteJsonDateTimeOffsetReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDateTimeReaderWriter.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDateTimeReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
@@ -50,4 +51,10 @@ public sealed class SqliteJsonDateTimeReaderWriter : JsonValueReaderWriter<DateT
     /// </summary>
     public override void ToJsonTyped(Utf8JsonWriter writer, DateTime value)
         => writer.WriteStringValue(string.Format(CultureInfo.InvariantCulture, DateTimeFormatConst, value));
+
+    private readonly Expression<Func<SqliteJsonDateTimeReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDecimalReaderWriter.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonDecimalReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
@@ -50,4 +51,10 @@ public sealed class SqliteJsonDecimalReaderWriter : JsonValueReaderWriter<decima
     /// </summary>
     public override void ToJsonTyped(Utf8JsonWriter writer, decimal value)
         => writer.WriteStringValue(string.Format(CultureInfo.InvariantCulture, DecimalFormatConst, value));
+
+    private readonly Expression<Func<SqliteJsonDecimalReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonGuidReaderWriter.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Json/Internal/SqliteJsonGuidReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 
@@ -47,4 +48,10 @@ public sealed class SqliteJsonGuidReaderWriter : JsonValueReaderWriter<Guid>
     /// </summary>
     public override void ToJsonTyped(Utf8JsonWriter writer, Guid value)
         => writer.WriteStringValue(value.ToString().ToUpperInvariant());
+
+    private readonly Expression<Func<SqliteJsonGuidReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore.Sqlite.NTS/Storage/Json/SqliteJsonGeometryWktReaderWriter.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Json/SqliteJsonGeometryWktReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using NetTopologySuite.Geometries;
@@ -31,4 +32,10 @@ public sealed class SqliteJsonGeometryWktReaderWriter : JsonValueReaderWriter<Ge
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, Geometry value)
         => writer.WriteStringValue(value.ToText());
+
+    private readonly Expression<Func<SqliteJsonGeometryWktReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
@@ -47,7 +47,14 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteCollection, TEleme
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    private static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {

--- a/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
@@ -29,15 +29,27 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteCollection, TEleme
         || (typeof(TConcreteCollection).IsGenericType
             && typeof(TConcreteCollection).GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>));
 
+    private static readonly MethodInfo CompareMethod = typeof(ListOfNullableValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement?>), typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
+
+    private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfNullableValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
+
+    private static readonly MethodInfo SnapshotMethod = typeof(ListOfNullableValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
+
     /// <summary>
     ///     Creates a new instance of the list comparer.
     /// </summary>
     /// <param name="elementComparer">The comparer to use for comparing elements.</param>
     public ListOfNullableValueTypesComparer(ValueComparer elementComparer)
         : base(
-            (a, b) => Compare(a, b, (ValueComparer<TElement?>)elementComparer),
-            o => GetHashCode(o, (ValueComparer<TElement?>)elementComparer),
-            source => Snapshot(source, (ValueComparer<TElement?>)elementComparer))
+            //(a, b) => Compare(a, b, (ValueComparer<TElement?>)elementComparer),
+            //o => GetHashCode(o, (ValueComparer<TElement?>)elementComparer),
+            //source => Snapshot(source, (ValueComparer<TElement?>)elementComparer))
+            CompareLambda(elementComparer),
+            GetHashCodeLambda(elementComparer),
+            SnapshotLambda(elementComparer))
     {
         ElementComparer = elementComparer;
     }
@@ -47,14 +59,55 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteCollection, TEleme
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
+    private static Expression<Func<IEnumerable<TElement?>?, IEnumerable<TElement?>?, bool>> CompareLambda(ValueComparer elementComparer)
+    {
+        var prm1 = Expression.Parameter(typeof(IEnumerable<TElement?>), "a");
+        var prm2 = Expression.Parameter(typeof(IEnumerable<TElement?>), "b");
+
+        //(a, b) => Compare(a, b, (ValueComparer<TElement?>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement?>?, IEnumerable<TElement?>?, bool>>(
+            Expression.Call(
+                CompareMethod,
+                prm1,
+                prm2,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement?>))),
+            prm1,
+            prm2);
+    }
+
+    private static Expression<Func<IEnumerable<TElement?>, int>> GetHashCodeLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(IEnumerable<TElement?>), "o");
+
+        //o => GetHashCode(o, (ValueComparer<TElement?>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement?>, int>>(
+            Expression.Call(
+                GetHashCodeMethod,
+                prm,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement?>))),
+            prm);
+    }
+
+    private static Expression<Func<IEnumerable<TElement?>, IEnumerable<TElement?>>> SnapshotLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(IEnumerable<TElement?>), "source");
+
+        //source => Snapshot(source, (ValueComparer<TElement?>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement?>, IEnumerable<TElement?>>>(
+            Expression.Call(
+                SnapshotMethod,
+                prm,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement?>))),
+            prm);
+    }
+
+    private static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {

--- a/src/EFCore/ChangeTracking/ListOfReferenceTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfReferenceTypesComparer.cs
@@ -29,15 +29,27 @@ public sealed class ListOfReferenceTypesComparer<TConcreteCollection, TElement> 
         || (typeof(TConcreteCollection).IsGenericType
             && typeof(TConcreteCollection).GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>));
 
+    private static readonly MethodInfo CompareMethod = typeof(ListOfReferenceTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(object), typeof(ValueComparer)])!;
+
+    private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfReferenceTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable), typeof(ValueComparer)])!;
+
+    private static readonly MethodInfo SnapshotMethod = typeof(ListOfReferenceTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(ValueComparer)])!;
+
     /// <summary>
     ///     Creates a new instance of the list comparer.
     /// </summary>
     /// <param name="elementComparer">The comparer to use for comparing elements.</param>
     public ListOfReferenceTypesComparer(ValueComparer elementComparer)
         : base(
-            (a, b) => Compare(a, b, elementComparer),
-            o => GetHashCode((IEnumerable)o, elementComparer),
-            source => Snapshot(source, elementComparer))
+            //(a, b) => Compare(a, b, elementComparer),
+            //o => GetHashCode((IEnumerable)o, elementComparer),
+            //source => Snapshot(source, elementComparer))
+    CompareLambda(elementComparer),
+    GetHashCodeLambda(elementComparer),
+    SnapshotLambda(elementComparer))
     {
         ElementComparer = elementComparer;
     }
@@ -46,6 +58,50 @@ public sealed class ListOfReferenceTypesComparer<TConcreteCollection, TElement> 
     ///     The comparer to use for comparing elements.
     /// </summary>
     public ValueComparer ElementComparer { get; }
+
+    private static Expression<Func<object?, object?, bool>> CompareLambda(ValueComparer elementComparer)
+    {
+        var prm1 = Expression.Parameter(typeof(object), "a");
+        var prm2 = Expression.Parameter(typeof(object), "b");
+
+        // (a, b) => Compare(a, b, elementComparer)
+        return Expression.Lambda<Func<object?, object?, bool>>(
+            Expression.Call(
+                CompareMethod,
+                prm1,
+                prm2,
+                elementComparer.ConstructorExpression),
+            prm1,
+            prm2);
+    }
+
+    private static Expression<Func<object, int>> GetHashCodeLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(object), "o");
+
+        //o => GetHashCode((IEnumerable)o, elementComparer)
+        return Expression.Lambda<Func<object, int>>(
+            Expression.Call(
+                GetHashCodeMethod,
+                Expression.Convert(
+                    prm,
+                    typeof(IEnumerable)),
+                elementComparer.ConstructorExpression),
+            prm);
+    }
+
+    private static Expression<Func<object, object>> SnapshotLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(object), "source");
+
+        //source => Snapshot(source, elementComparer)
+        return Expression.Lambda<Func<object, object>>(
+            Expression.Call(
+                SnapshotMethod,
+                prm,
+                elementComparer.ConstructorExpression),
+            prm);
+    }
 
     private static bool Compare(object? a, object? b, ValueComparer elementComparer)
     {

--- a/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
@@ -47,7 +47,14 @@ public sealed class ListOfValueTypesComparer<TConcreteCollection, TElement> : Va
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {

--- a/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
@@ -29,15 +29,27 @@ public sealed class ListOfValueTypesComparer<TConcreteCollection, TElement> : Va
         || (typeof(TConcreteCollection).IsGenericType
             && typeof(TConcreteCollection).GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>));
 
+    private static readonly MethodInfo CompareMethod = typeof(ListOfValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement>), typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
+
+    private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
+
+    private static readonly MethodInfo SnapshotMethod = typeof(ListOfValueTypesComparer<TConcreteCollection, TElement>).GetMethod(
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
+
     /// <summary>
     ///     Creates a new instance of the list comparer.
     /// </summary>
     /// <param name="elementComparer">The comparer to use for comparing elements.</param>
     public ListOfValueTypesComparer(ValueComparer elementComparer)
         : base(
-            (a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer),
-            o => GetHashCode(o, (ValueComparer<TElement>)elementComparer),
-            source => Snapshot(source, (ValueComparer<TElement>)elementComparer))
+            //(a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer),
+            //o => GetHashCode(o, (ValueComparer<TElement>)elementComparer),
+            //source => Snapshot(source, (ValueComparer<TElement>)elementComparer))
+    CompareLambda(elementComparer),
+    GetHashCodeLambda(elementComparer),
+    SnapshotLambda(elementComparer))
     {
         ElementComparer = elementComparer;
     }
@@ -47,14 +59,55 @@ public sealed class ListOfValueTypesComparer<TConcreteCollection, TElement> : Va
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
+    private static Expression<Func<IEnumerable<TElement>?, IEnumerable<TElement>?, bool>> CompareLambda(ValueComparer elementComparer)
+    {
+        var prm1 = Expression.Parameter(typeof(IEnumerable<TElement>), "a");
+        var prm2 = Expression.Parameter(typeof(IEnumerable<TElement>), "b");
+
+        //(a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement>?, IEnumerable<TElement>?, bool>>(
+            Expression.Call(
+                CompareMethod,
+                prm1,
+                prm2,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement>))),
+            prm1,
+            prm2);
+    }
+
+    private static Expression<Func<IEnumerable<TElement>, int>> GetHashCodeLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(IEnumerable<TElement>), "o");
+
+        //o => GetHashCode(o, (ValueComparer<TElement>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement>, int>>(
+            Expression.Call(
+                GetHashCodeMethod,
+                prm,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement>))),
+            prm);
+    }
+
+    private static Expression<Func<IEnumerable<TElement>, IEnumerable<TElement>>> SnapshotLambda(ValueComparer elementComparer)
+    {
+        var prm = Expression.Parameter(typeof(IEnumerable<TElement>), "source");
+
+        //source => Snapshot(source, (ValueComparer<TElement>)elementComparer)
+        return Expression.Lambda<Func<IEnumerable<TElement>, IEnumerable<TElement>>>(
+            Expression.Call(
+                SnapshotMethod,
+                prm,
+                Expression.Convert(
+                    elementComparer.ConstructorExpression,
+                    typeof(ValueComparer<TElement>))),
+            prm);
+    }
+
+    private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -156,6 +156,11 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
     public virtual LambdaExpression EqualsExpression { get; }
 
     /// <summary>
+    ///     The object comparison expression.
+    /// </summary>
+    public abstract LambdaExpression ObjectEqualsExpression { get; }
+
+    /// <summary>
     ///     The hash code expression.
     /// </summary>
     public virtual LambdaExpression HashCodeExpression { get; }

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -311,6 +311,12 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
                 : new ValueComparer<T>(favorStructuralComparisons);
     }
 
+    /// <summary>
+    ///     The expression representing construction of this object.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public abstract Expression ConstructorExpression { get; }
+
     // PublicMethods is required to preserve e.g. GetHashCode
     internal class DefaultValueComparer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T> : ValueComparer<T>
     {

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using ExpressionExtensions = Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions;
+using static System.Linq.Expressions.Expression;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
@@ -38,6 +39,9 @@ public class ValueComparer
     private Func<T?, T?, bool>? _equals;
     private Func<T, int>? _hashCode;
     private Func<T, T>? _snapshot;
+    private LambdaExpression? _objectEqualsExpression;
+    private static readonly PropertyInfo StructuralComparisonsStructuralEqualityComparerProperty =
+        typeof(StructuralComparisons).GetProperty(nameof(StructuralComparisons.StructuralEqualityComparer))!;
 
     /// <summary>
     ///     Creates a new <see cref="ValueComparer{T}" /> with a default comparison
@@ -96,19 +100,19 @@ public class ValueComparer
     protected static Expression<Func<T?, T?, bool>> CreateDefaultEqualsExpression()
     {
         var type = typeof(T);
-        var param1 = Expression.Parameter(type, "v1");
-        var param2 = Expression.Parameter(type, "v2");
+        var param1 = Parameter(type, "v1");
+        var param2 = Parameter(type, "v2");
 
         // We exclude multi-dimensional arrays even though they're IStructuralEquatable because of
         // https://github.com/dotnet/runtime/issues/66472
         if (typeof(IStructuralEquatable).IsAssignableFrom(type))
         {
-            return Expression.Lambda<Func<T?, T?, bool>>(
-                Expression.Call(
-                    Expression.Constant(StructuralComparisons.StructuralEqualityComparer, typeof(IEqualityComparer)),
+            return Lambda<Func<T?, T?, bool>>(
+                Call(
+                    Property(null, StructuralComparisonsStructuralEqualityComparerProperty),
                     EqualityComparerEqualsMethod,
-                    Expression.Convert(param1, typeof(object)),
-                    Expression.Convert(param2, typeof(object))
+                    Convert(param1, typeof(object)),
+                    Convert(param2, typeof(object))
                 ),
                 param1, param2);
         }
@@ -121,8 +125,8 @@ public class ValueComparer
             || unwrappedType == typeof(decimal)
             || unwrappedType == typeof(object))
         {
-            return Expression.Lambda<Func<T?, T?, bool>>(
-                Expression.Equal(param1, param2),
+            return Lambda<Func<T?, T?, bool>>(
+                Equal(param1, param2),
                 param1, param2);
         }
 
@@ -135,18 +139,18 @@ public class ValueComparer
 
         if (typedEquals != null)
         {
-            return Expression.Lambda<Func<T?, T?, bool>>(
+            return Lambda<Func<T?, T?, bool>>(
                 type.IsNullableType()
-                    ? Expression.OrElse(
-                        Expression.AndAlso(
-                            Expression.Equal(param1, Expression.Constant(null, type)),
-                            Expression.Equal(param2, Expression.Constant(null, type))),
-                        Expression.AndAlso(
-                            Expression.AndAlso(
-                                Expression.NotEqual(param1, Expression.Constant(null, type)),
-                                Expression.NotEqual(param2, Expression.Constant(null, type))),
-                            Expression.Call(param1, typedEquals, param2)))
-                    : Expression.Call(param1, typedEquals, param2),
+                    ? OrElse(
+                        AndAlso(
+                            Equal(param1, Constant(null, type)),
+                            Equal(param2, Constant(null, type))),
+                        AndAlso(
+                            AndAlso(
+                                NotEqual(param1, Constant(null, type)),
+                                NotEqual(param2, Constant(null, type))),
+                            Call(param1, typedEquals, param2)))
+                    : Call(param1, typedEquals, param2),
                 param1, param2);
         }
 
@@ -165,10 +169,10 @@ public class ValueComparer
             type = type.BaseType;
         }
 
-        return Expression.Lambda<Func<T?, T?, bool>>(
+        return Lambda<Func<T?, T?, bool>>(
             typedEquals == null
                 ? ExpressionExtensions.CreateEqualsExpression(param1, param2)
-                : Expression.Call(typedEquals, param1, param2),
+                : Call(typedEquals, param1, param2),
             param1, param2);
     }
 
@@ -185,9 +189,9 @@ public class ValueComparer
             return v => v;
         }
 
-        var sourceParameter = Expression.Parameter(typeof(T), "source");
-        return Expression.Lambda<Func<T, T>>(
-            Expression.Call(
+        var sourceParameter = Parameter(typeof(T), "source");
+        return Lambda<Func<T, T>>(
+            Call(
                 EnumerableMethods.ToArray.MakeGenericMethod(typeof(T).GetElementType()!),
                 sourceParameter),
             sourceParameter);
@@ -204,16 +208,16 @@ public class ValueComparer
     {
         var type = typeof(T);
         var unwrappedType = type.UnwrapNullableType();
-        var param = Expression.Parameter(type, "v");
+        var param = Parameter(type, "v");
 
         if (favorStructuralComparisons
             && typeof(IStructuralEquatable).IsAssignableFrom(type))
         {
-            return Expression.Lambda<Func<T, int>>(
-                Expression.Call(
-                    Expression.Constant(StructuralComparisons.StructuralEqualityComparer, typeof(IEqualityComparer)),
+            return Lambda<Func<T, int>>(
+                Call(
+                    Property(null, StructuralComparisonsStructuralEqualityComparerProperty),
                     EqualityComparerHashCodeMethod,
-                    Expression.Convert(param, typeof(object))
+                    Convert(param, typeof(object))
                 ),
                 param);
         }
@@ -228,10 +232,10 @@ public class ValueComparer
                 || unwrappedType == typeof(ushort)
                 || unwrappedType == typeof(sbyte)
                 || unwrappedType == typeof(char)
-                    ? (Expression)Expression.Convert(param, typeof(int))
-                    : Expression.Call(param, ObjectGetHashCodeMethod);
+                    ? (Expression)Convert(param, typeof(int))
+                    : Call(param, ObjectGetHashCodeMethod);
 
-        return Expression.Lambda<Func<T, int>>(expression, param);
+        return Lambda<Func<T, int>>(expression, param);
     }
 
     /// <summary>
@@ -246,6 +250,34 @@ public class ValueComparer
         var v2Null = right == null;
 
         return v1Null || v2Null ? v1Null && v2Null : Equals((T?)left, (T?)right);
+    }
+
+    /// <inheritdoc />
+    public override LambdaExpression ObjectEqualsExpression
+    {
+        get
+        {
+            if (_objectEqualsExpression == null)
+            {
+                var left = Parameter(typeof(object), "left");
+                var right = Parameter(typeof(object), "right");
+
+                _objectEqualsExpression = Lambda<Func<object?, object?, bool>>(
+                    Condition(
+                        Equal(left, Constant(null)),
+                        Equal(right, Constant(null)),
+                        AndAlso(
+                            NotEqual(right, Constant(null)),
+                            Invoke(
+                                EqualsExpression,
+                                Convert(left, typeof(T)),
+                                Convert(right, typeof(T))))),
+                    left,
+                    right);
+            }
+
+            return _objectEqualsExpression;
+        }
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -365,4 +365,10 @@ public class ValueComparer
     /// </remarks>
     public new virtual Expression<Func<T, T>> SnapshotExpression
         => (Expression<Func<T, T>>)base.SnapshotExpression;
+
+    private readonly ConstructorInfo _constructorInfo
+        = typeof(ValueComparer<T>).GetConstructor([typeof(Expression<Func<T?, T?, bool>>), typeof(Expression<Func<T, int>>)])!;
+
+    /// <inheritdoc />
+    public override Expression ConstructorExpression => New(_constructorInfo, EqualsExpression, HashCodeExpression);
 }

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -13,6 +13,7 @@ Microsoft.EntityFrameworkCore.DbSet
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>$(NoWarn);EF9100</NoWarn> <!-- Precompiled query is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -83,6 +83,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IMemoryCache), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(INavigationExpansionExtensibilityHelper), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(ILiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IExceptionDetector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IJsonValueReaderWriterSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IProviderConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -125,6 +126,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IShapedQueryCompilingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IDbContextLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IAdHocMapper), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+            { typeof(ILiftableConstantProcessor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Transient) },
             { typeof(ILazyLoaderFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
@@ -309,6 +311,8 @@ public class EntityFrameworkServicesBuilder
         TryAdd<IExceptionDetector, ExceptionDetector>();
         TryAdd<IAdHocMapper, AdHocMapper>();
         TryAdd<IJsonValueReaderWriterSource, JsonValueReaderWriterSource>();
+        TryAdd<ILiftableConstantFactory, LiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, LiftableConstantProcessor>();
 
         TryAdd(
             p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.DbContextLogger
@@ -329,12 +333,12 @@ public class EntityFrameworkServicesBuilder
             .AddDependencySingleton<ModelCacheKeyFactoryDependencies>()
             .AddDependencySingleton<ValueConverterSelectorDependencies>()
             .AddDependencySingleton<EntityMaterializerSourceDependencies>()
-            .AddDependencySingleton<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencySingleton<EvaluatableExpressionFilterDependencies>()
             .AddDependencySingleton<RuntimeModelDependencies>()
             .AddDependencySingleton<ModelRuntimeInitializerDependencies>()
             .AddDependencySingleton<NavigationExpansionExtensibilityHelperDependencies>()
             .AddDependencySingleton<JsonValueReaderWriterSourceDependencies>()
+            .AddDependencySingleton<LiftableConstantExpressionDependencies>()
             .AddDependencyScoped<ProviderConventionSetBuilderDependencies>()
             .AddDependencyScoped<QueryCompilationContextDependencies>()
             .AddDependencyScoped<StateManagerDependencies>()
@@ -344,6 +348,7 @@ public class EntityFrameworkServicesBuilder
             .AddDependencyScoped<QueryableMethodTranslatingExpressionVisitorDependencies>()
             .AddDependencyScoped<QueryTranslationPreprocessorDependencies>()
             .AddDependencyScoped<QueryTranslationPostprocessorDependencies>()
+            .AddDependencyScoped<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencyScoped<ValueGeneratorSelectorDependencies>()
             .AddDependencyScoped<DatabaseDependencies>()
             .AddDependencyScoped<ModelDependencies>()

--- a/src/EFCore/Query/ILiftableConstantFactory.cs
+++ b/src/EFCore/Query/ILiftableConstantFactory.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public interface ILiftableConstantFactory
+{
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    LiftableConstantExpression CreateLiftableConstant(
+        object? originalValue,
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore/Query/ILiftableConstantProcessor.cs
+++ b/src/EFCore/Query/ILiftableConstantProcessor.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public interface ILiftableConstantProcessor
+{
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="supportsPrecompiledQuery">A value indicating whether precompiled queries are supported by the provider.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    /// </remarks>
+    Expression InlineConstants(Expression expression, bool supportsPrecompiledQuery);
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the liftable constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Constant lifting is performed in the precompiled query pipeline flow.
+    /// </remarks>
+    Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames);
+}

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -87,8 +87,6 @@ public class EntityMaterializerSource : IEntityMaterializerSource
 
         var constructorBinding = ModifyBindings(structuralType, structuralType.ConstructorBinding!);
         var bindingInfo = new ParameterBindingInfo(parameters, materializationContextExpression);
-        var blockExpressions = new List<Expression>();
-
         var instanceVariable = Expression.Variable(constructorBinding.RuntimeType, entityInstanceName);
         bindingInfo.ServiceInstances.Add(instanceVariable);
 
@@ -96,6 +94,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             structuralType.GetProperties().Cast<IPropertyBase>().Where(p => !p.IsShadowProperty())
                 .Concat(structuralType.GetComplexProperties().Where(p => !p.IsShadowProperty())));
 
+        var blockExpressions = new List<Expression>();
         if (structuralType is IEntityType entityType)
         {
             var serviceProperties = entityType.GetServiceProperties().ToList();

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -501,7 +501,7 @@ public partial class NavigationExpandingExpressionVisitor
     private sealed class IncludeExpandingExpressionVisitor : ExpandingExpressionVisitor
     {
         private static readonly MethodInfo FetchJoinEntityMethodInfo =
-            typeof(IncludeExpandingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(FetchJoinEntity))!;
+            typeof(NavigationExpandingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(FetchJoinEntity))!;
 
         private readonly bool _queryStateManager;
         private readonly bool _ignoreAutoIncludes;
@@ -891,11 +891,6 @@ public partial class NavigationExpandingExpressionVisitor
 
             return result;
         }
-
-#pragma warning disable IDE0060 // Remove unused parameter
-        private static TTarget FetchJoinEntity<TJoin, TTarget>(TJoin joinEntity, TTarget targetEntity)
-            => targetEntity;
-#pragma warning restore IDE0060 // Remove unused parameter
 
         private static Expression RemapFilterExpressionForJoinEntity(
             ParameterExpression filterParameter,
@@ -1383,4 +1378,14 @@ public partial class NavigationExpandingExpressionVisitor
             public IEntityType? EntityType { get; }
         }
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static TTarget FetchJoinEntity<TJoin, TTarget>(TJoin joinEntity, TTarget targetEntity)
+        => targetEntity;
 }

--- a/src/EFCore/Query/LiftableConstantExpression.cs
+++ b/src/EFCore/Query/LiftableConstantExpression.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     A node containing an expression expressing how to obtain a constant value, which may get lifted out of an expression tree.
+/// </summary>
+/// <remarks>
+///     <para>
+///         When the expression tree is compiled, the constant value can simply be evaluated beforehand, and a
+///         <see cref="ConstantExpression" /> expression can directly reference the result.
+///     </para>
+///     <para>
+///         When the expression tree is translated to source code instead (in query pre-compilation), the expression can be rendered out
+///         separately, to be assigned to a variable, and this node is replaced by a reference to that variable.
+///     </para>
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class LiftableConstantExpression : Expression, IPrintableExpression
+{
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public LiftableConstantExpression(
+        object? originalValue,
+        LambdaExpression resolverExpression,
+        string variableName,
+        Type type)
+    {
+        OriginalExpression = Constant(originalValue, type);
+        ResolverExpression = resolverExpression;
+        VariableName = char.ToLower(variableName[0]) + variableName[1..];
+        Type = type;
+    }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ConstantExpression OriginalExpression { get; }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual LambdaExpression ResolverExpression { get; }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual string VariableName { get; }
+
+    /// <inheritdoc />
+    public override Type Type { get; }
+
+    /// <inheritdoc />
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    // TODO: Complete other expression stuff (equality, etc.)
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var resolverExpression = (LambdaExpression)visitor.Visit(ResolverExpression);
+
+        return Update(resolverExpression);
+    }
+
+    /// <summary>
+    ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+    ///     return this expression.
+    /// </summary>
+    /// <param name="resolverExpression">The <see cref="ResolverExpression" /> property of the result.</param>
+    /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
+    public virtual LiftableConstantExpression Update(LambdaExpression resolverExpression)
+        => resolverExpression != ResolverExpression
+            ? new LiftableConstantExpression(OriginalExpression, resolverExpression, VariableName, Type)
+            : this;
+
+    /// <inheritdoc />
+    public void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("[LIFTABLE Constant: ");
+        expressionPrinter.Visit(OriginalExpression);
+        expressionPrinter.Append(" | Resolver: ");
+        expressionPrinter.Visit(ResolverExpression);
+        expressionPrinter.Append("]");
+    }
+}

--- a/src/EFCore/Query/LiftableConstantExpressionDependencies.cs
+++ b/src/EFCore/Query/LiftableConstantExpressionDependencies.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     <para>
+///         Service dependencies parameter class for <see cref="LiftableConstantFactory" />
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     <para>
+///         Do not construct instances of this class directly from either provider or application code as the
+///         constructor signature may change as new dependencies are added. Instead, use this type in
+///         your constructor so that an instance will be created and injected automatically by the
+///         dependency injection container. To create an instance with some dependent services replaced,
+///         first resolve the object from the dependency injection container, then replace selected
+///         services using the C# 'with' operator. Do not call the constructor at any point in this process.
+///     </para>
+///     <para>
+///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+///     </para>
+/// </remarks>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public sealed record LiftableConstantExpressionDependencies
+{
+}

--- a/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
+++ b/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
@@ -1,0 +1,292 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Internal;
+using static System.Linq.Expressions.Expression;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class LiftableConstantExpressionHelpers
+{
+    private static readonly MethodInfo ModelFindEntiyTypeMethod =
+        typeof(IModel).GetRuntimeMethod(nameof(IModel.FindEntityType), [typeof(string)])!;
+
+    private static readonly MethodInfo RuntimeModelFindAdHocEntiyTypeMethod =
+        typeof(RuntimeModel).GetRuntimeMethod(nameof(RuntimeModel.FindAdHocEntityType), [typeof(Type)])!;
+
+    private static readonly MethodInfo TypeBaseFindComplexPropertyMethod =
+        typeof(ITypeBase).GetRuntimeMethod(nameof(ITypeBase.FindComplexProperty), [typeof(string)])!;
+
+    private static readonly MethodInfo TypeBaseFindPropertyMethod =
+        typeof(ITypeBase).GetRuntimeMethod(nameof(ITypeBase.FindProperty), [typeof(string)])!;
+
+    private static readonly MethodInfo TypeBaseFindServicePropertyMethod =
+        typeof(IEntityType).GetRuntimeMethod(nameof(IEntityType.FindServiceProperty), [typeof(string)])!;
+
+    private static readonly MethodInfo EntityTypeFindNavigationMethod =
+        typeof(IEntityType).GetRuntimeMethod(nameof(IEntityType.FindNavigation), [typeof(string)])!;
+
+    private static readonly MethodInfo EntityTypeFindSkipNavigationMethod =
+        typeof(IEntityType).GetRuntimeMethod(nameof(IEntityType.FindSkipNavigation), [typeof(string)])!;
+
+    private static readonly MethodInfo NavigationBaseClrCollectionAccessorMethod =
+        typeof(INavigationBase).GetRuntimeMethod(nameof(INavigationBase.GetCollectionAccessor), [])!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool IsLiteral(object? value)
+    {
+        return value switch
+        {
+            int or long or uint or ulong or short or sbyte or ushort or byte or double or float or decimal or string or char or bool => true,
+            null or Type or Enum => true,
+            TimeSpan or DateTime or DateTimeOffset or DateOnly or TimeOnly or Guid => true,
+            ITuple tuple
+                when tuple.GetType() is { IsGenericType: true } tupleType
+                     && tupleType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal)
+                     && tupleType.Namespace == "System"
+                => IsTupleLiteral(tuple),
+
+            Array array => IsCollectionOfLiterals(array),
+            IList list => IsCollectionOfLiterals(list),
+
+            _ => false
+        };
+
+        bool IsTupleLiteral(ITuple tuple)
+        {
+            for (var i = 0; i < tuple.Length; i++)
+            {
+                if (!IsLiteral(tuple[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        bool IsCollectionOfLiterals(IEnumerable enumerable)
+        {
+            foreach (var enumerableElement in enumerable)
+            {
+                if (!IsLiteral(enumerableElement))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression BuildMemberAccessForEntityOrComplexType(ITypeBase targetType, ParameterExpression liftableConstantContextParameter)
+    {
+        var (rootEntityType, complexTypes) = FindPathForEntityOrComplexType(targetType);
+
+        Expression result;
+
+        if (rootEntityType.IsAdHoc())
+        {
+            result = Call(
+                Convert(
+                    Property(
+                        Property(
+                            liftableConstantContextParameter,
+                            nameof(MaterializerLiftableConstantContext.Dependencies)),
+                        nameof(ShapedQueryCompilingExpressionVisitorDependencies.Model)),
+                    typeof(RuntimeModel)),
+                RuntimeModelFindAdHocEntiyTypeMethod,
+                Constant(rootEntityType.ClrType));
+
+        }
+        else
+        {
+            result = Call(
+                Property(
+                    Property(
+                        liftableConstantContextParameter,
+                        nameof(MaterializerLiftableConstantContext.Dependencies)),
+                    nameof(ShapedQueryCompilingExpressionVisitorDependencies.Model)),
+                ModelFindEntiyTypeMethod,
+                Constant(rootEntityType.Name));
+        }
+
+        foreach (var complexType in complexTypes)
+        {
+            var complexPropertyName = complexType.ComplexProperty.Name;
+            result = Property(
+                Call(result, TypeBaseFindComplexPropertyMethod, Constant(complexPropertyName)),
+                nameof(IComplexProperty.ComplexType));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildMemberAccessLambdaForEntityOrComplexType(ITypeBase type)
+    {
+        var prm = Parameter(typeof(MaterializerLiftableConstantContext));
+        var body = BuildMemberAccessForEntityOrComplexType(type, prm);
+
+        return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression BuildMemberAccessForProperty(IPropertyBase? property, ParameterExpression liftableConstantContextParameter)
+    {
+        if (property == null)
+        {
+            return Default(typeof(IPropertyBase));
+        }
+
+        var declaringType = property.DeclaringType;
+        var declaringTypeMemberAccessExpression = BuildMemberAccessForEntityOrComplexType(declaringType, liftableConstantContextParameter);
+
+        return Call(
+            declaringTypeMemberAccessExpression,
+            property is IServiceProperty ? TypeBaseFindServicePropertyMethod : TypeBaseFindPropertyMethod,
+            Constant(property.Name));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildMemberAccessLambdaForProperty(IPropertyBase? property)
+    {
+        var prm = Parameter(typeof(MaterializerLiftableConstantContext));
+        var body = BuildMemberAccessForProperty(property, prm);
+
+        return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression BuildNavigationAccess(INavigationBase? navigation, ParameterExpression liftableConstantContextParameter)
+    {
+        if (navigation == null)
+        {
+            return Default(typeof(INavigationBase));
+        }
+
+        var declaringType = navigation.DeclaringType;
+        var declaringTypeExpression = BuildMemberAccessForEntityOrComplexType(declaringType, liftableConstantContextParameter);
+
+        var result = Call(
+            declaringTypeExpression,
+            navigation is ISkipNavigation ? EntityTypeFindSkipNavigationMethod : EntityTypeFindNavigationMethod,
+            Constant(navigation.Name));
+
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildNavigationAccessLambda(INavigationBase? navigation)
+    {
+        var prm = Parameter(typeof(MaterializerLiftableConstantContext));
+        var body = BuildNavigationAccess(navigation, prm);
+
+        return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression BuildClrCollectionAccessor(INavigationBase? navigation, ParameterExpression liftableConstantContextParameter)
+    {
+        if (navigation == null)
+        {
+            return Default(typeof(IClrCollectionAccessor));
+        }
+
+        var navigationAccessExpression = BuildNavigationAccess(navigation, liftableConstantContextParameter);
+        var result = Call(navigationAccessExpression, NavigationBaseClrCollectionAccessorMethod);
+
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildClrCollectionAccessorLambda(INavigationBase? navigation)
+    {
+        var prm = Parameter(typeof(MaterializerLiftableConstantContext));
+        var body = BuildClrCollectionAccessor(navigation, prm);
+
+        return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
+    }
+
+    private static (IEntityType RootEntity, List<IComplexType> ComplexTypes) FindPathForEntityOrComplexType(ITypeBase targetType)
+    {
+        if (targetType is IEntityType targetEntity)
+        {
+            return (targetEntity, []);
+        }
+
+        var targetComplexType = (IComplexType)targetType;
+        var declaringType = targetComplexType.ComplexProperty.DeclaringType;
+        if (declaringType is IEntityType declaringEntityType)
+        {
+            return (declaringEntityType, [targetComplexType]);
+        }
+
+        var complexTypes = new List<IComplexType>();
+        while (declaringType is IComplexType complexType)
+        {
+            complexTypes.Insert(0, complexType);
+            declaringType = complexType.ComplexProperty.DeclaringType;
+        }
+
+        complexTypes.Add(targetComplexType);
+
+        return ((IEntityType)declaringType, complexTypes);
+    }
+}

--- a/src/EFCore/Query/LiftableConstantFactory.cs
+++ b/src/EFCore/Query/LiftableConstantFactory.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class LiftableConstantFactory(LiftableConstantExpressionDependencies dependencies) : ILiftableConstantFactory
+{
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual LiftableConstantExpressionDependencies Dependencies { get; } = dependencies;
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        object? originalValue,
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(originalValue, resolverExpression, variableName, type);
+}

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -239,12 +239,10 @@ public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantPro
     }
 
 #if DEBUG
-
     // TODO: issue #33482 - we should properly deal with NTS types rather than disabling them here
     // especially using such a crude method
-    // for ValueComparer, we only need it for ListOf(...)Comparer, see issue #33383
     protected override Expression VisitMember(MemberExpression memberExpression)
-        => memberExpression is { Expression: ConstantExpression, Type.Name: "SqlServerBytesReader" or "GaiaGeoReader" or "ValueComparer" }
+        => memberExpression is { Expression: ConstantExpression, Type.Name: "SqlServerBytesReader" or "GaiaGeoReader" }
             ? memberExpression
             : base.VisitMember(memberExpression);
 

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -1,0 +1,487 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#pragma warning disable CS1591
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantProcessor
+{
+    private bool _inline;
+    private bool _precompiledQueriesSupported;
+    private readonly UnsupportedConstantChecker _unsupportedConstantChecker;
+    private readonly MaterializerLiftableConstantContext _materializerLiftableConstantContext;
+
+    private sealed record LiftedConstant(ParameterExpression Parameter, Expression Expression, ParameterExpression? ReplacingParameter = null);
+
+    private readonly List<LiftedConstant> _liftedConstants = new();
+    private readonly LiftedExpressionProcessor _liftedExpressionProcessor = new();
+    private readonly LiftedConstantOptimizer _liftedConstantOptimizer = new();
+    private ParameterExpression? _contextParameter;
+
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; private set; }
+        = Array.Empty<(ParameterExpression Parameter, Expression Expression)>();
+
+    public LiftableConstantProcessor(ShapedQueryCompilingExpressionVisitorDependencies dependencies)
+    {
+        _materializerLiftableConstantContext = new(dependencies);
+        _unsupportedConstantChecker = new(this);
+        _liftedConstants.Clear();
+    }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="supportsPrecompiledQuery">A value indicating whether the provider supports precompiled queries.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     <para>
+    ///         Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
+    public virtual Expression InlineConstants(Expression expression, bool supportsPrecompiledQuery)
+    {
+        _liftedConstants.Clear();
+        _inline = true;
+        _precompiledQueriesSupported = supportsPrecompiledQuery;
+
+        return Visit(expression);
+    }
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the lifted constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    public virtual Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames)
+    {
+        _liftedConstants.Clear();
+
+        _inline = false;
+        _contextParameter = contextParameter;
+
+        var expressionAfterLifting = Visit(expression);
+
+        // All liftable constant nodes have been lifted out.
+        // We'll now optimize them, looking for greatest common denominator tree fragments, in cases where e.g. two lifted constants look up
+        // the same entity type.
+        _liftedConstantOptimizer.Optimize(_liftedConstants);
+
+        // Uniquify all variable names, taking into account possible remapping done in the optimization phase above
+        var replacedParameters = new Dictionary<ParameterExpression, ParameterExpression>();
+        // var (originalParameters, newParameters) = (new List<Expression>(), new List<Expression>());
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+
+            if (liftedConstant.ReplacingParameter is not null)
+            {
+                // This lifted constant is being removed, since it's a duplicate of another with the same expression.
+                // We still need to remap the parameter in the expression, but no uniquification etc.
+                replacedParameters.Add(liftedConstant.Parameter,
+                    replacedParameters.TryGetValue(liftedConstant.ReplacingParameter, out var replacedReplacingParameter)
+                        ? replacedReplacingParameter
+                        : liftedConstant.ReplacingParameter);
+                _liftedConstants.RemoveAt(i--);
+                continue;
+            }
+
+            var name = liftedConstant.Parameter.Name ?? "unknown";
+            var baseName = name;
+            for (var j = 0; variableNames.Contains(name); j++)
+            {
+                name = baseName + j;
+            }
+
+            variableNames.Add(name);
+
+            if (name != liftedConstant.Parameter.Name)
+            {
+                var newParameter = Expression.Parameter(liftedConstant.Parameter.Type, name);
+                _liftedConstants[i] = liftedConstant with { Parameter = newParameter };
+                replacedParameters.Add(liftedConstant.Parameter, newParameter);
+            }
+        }
+
+        // Finally, apply all remapping (optimization, uniquification) to both the expression tree and to the lifted constant variable
+        // themselves.
+
+        // var (originalParametersArray, newParametersArray) = (originalParameters.ToArray(), newParameters.ToArray());
+        // var remappedExpression = ReplacingExpressionVisitor.Replace(originalParametersArray, newParametersArray, expressionAfterLifting);
+        var originalParameters = new Expression[replacedParameters.Count];
+        var newParameters = new Expression[replacedParameters.Count];
+        var index = 0;
+        foreach (var (originalParameter, newParameter) in replacedParameters)
+        {
+            originalParameters[index] = originalParameter;
+            newParameters[index] = newParameter;
+            index++;
+        }
+        var remappedExpression = ReplacingExpressionVisitor.Replace(originalParameters, newParameters, expressionAfterLifting);
+
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+            var remappedLiftedConstantExpression =
+                ReplacingExpressionVisitor.Replace(originalParameters, newParameters, liftedConstant.Expression);
+
+            if (remappedLiftedConstantExpression != liftedConstant.Expression)
+            {
+                _liftedConstants[i] = liftedConstant with { Expression = remappedLiftedConstantExpression };
+            }
+        }
+
+        LiftedConstants = _liftedConstants.Select(c => (c.Parameter, c.Expression)).ToArray();
+        return remappedExpression;
+    }
+
+    protected override Expression VisitExtension(Expression node)
+    {
+        if (node is LiftableConstantExpression liftedConstant)
+        {
+            return _inline
+                ? InlineConstant(liftedConstant)
+                : LiftConstant(liftedConstant);
+        }
+
+        return base.VisitExtension(node);
+    }
+
+    protected virtual ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<MaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            // Make sure there aren't any problematic un-lifted constants within the resolver expression.
+            _unsupportedConstantChecker.Check(resolverExpression);
+
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_materializerLiftableConstantContext);
+
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        throw new InvalidOperationException(
+            $"Unknown resolved expression of type {liftableConstant.ResolverExpression.GetType().Name} found on liftable constant expression");
+    }
+
+    protected virtual ParameterExpression LiftConstant(LiftableConstantExpression liftableConstant)
+    {
+        var resolverLambda = liftableConstant.ResolverExpression;
+        var parameter = resolverLambda.Parameters[0];
+
+        // Extract the lambda body, replacing the lambda parameter with our lifted constant context parameter, and also inline any captured
+        // literals
+        var body = _liftedExpressionProcessor.Process(resolverLambda.Body, parameter, _contextParameter!);
+
+        // If the lambda returns a value type, a Convert to object node gets needed that we need to unwrap
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } convertNode
+            && convertNode.Type == typeof(object))
+        {
+            body = convertNode.Operand;
+        }
+
+        // Register the lifted constant; note that the name will be uniquified later
+        var variableParameter = Expression.Parameter(liftableConstant.Type, liftableConstant.VariableName);
+        _liftedConstants.Add(new(variableParameter, body));
+
+        return variableParameter;
+    }
+
+    protected override Expression VisitBinary(BinaryExpression binaryExpression)
+    {
+        var left = Visit(binaryExpression.Left);
+        var right = Visit(binaryExpression.Right);
+        var conversion = (LambdaExpression?)Visit(binaryExpression.Conversion);
+
+        return binaryExpression.NodeType is ExpressionType.Assign
+            && left is MemberExpression { Member: FieldInfo { IsInitOnly: true } } initFieldMember
+            ? initFieldMember.Assign(right)
+            : binaryExpression.Update(left, conversion, right);
+    }
+
+#if DEBUG
+
+    // TODO: issue #33482 - we should properly deal with NTS types rather than disabling them here
+    // especially using such a crude method
+    // for ValueComparer, we only need it for ListOf(...)Comparer, see issue #33383
+    protected override Expression VisitMember(MemberExpression memberExpression)
+        => memberExpression is { Expression: ConstantExpression, Type.Name: "SqlServerBytesReader" or "GaiaGeoReader" or "ValueComparer" }
+            ? memberExpression
+            : base.VisitMember(memberExpression);
+
+    protected override Expression VisitConstant(ConstantExpression node)
+    {
+        _unsupportedConstantChecker.Check(node);
+        return node;
+    }
+#endif
+
+    private sealed class UnsupportedConstantChecker(LiftableConstantProcessor liftableConstantProcessor) : ExpressionVisitor
+    {
+        [Conditional("DEBUG")]
+        public void Check(Expression expression)
+        {
+            if (liftableConstantProcessor._precompiledQueriesSupported)
+            {
+                Visit(expression);
+            }
+        }
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            if (LiftableConstantExpressionHelpers.IsLiteral(node.Value)
+                // TODO: this part is temporary - we can't inline these constants but we need proper way to deal with them,
+                // without risk breaking existing scenarios
+                || node.Value is ParameterBindingInfo or RuntimeServiceProperty or IMaterializationInterceptor or IInstantiationBindingInterceptor
+                || node.Type.Name == "ProxyFactory")
+            {
+                return node;
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Shaper expression contains a non-literal constant of type '{node.Value!.GetType().Name}'. " +
+                    $"Use a {nameof(LiftableConstantExpression)} to reference any non-literal constants.");
+            }
+        }
+    }
+
+    private sealed class LiftedConstantOptimizer : ExpressionVisitor
+    {
+        private List<LiftedConstant> _liftedConstants = null!;
+
+        private sealed record ExpressionInfo(ExpressionStatus Status, ParameterExpression? Parameter = null, string? PreferredName = null);
+        private readonly Dictionary<Expression, ExpressionInfo> _indexedExpressions = new(ExpressionEqualityComparer.Instance);
+        private LiftedConstant _currentLiftedConstant = null!;
+        private bool _firstPass;
+        private int _index;
+
+        public void Optimize(List<LiftedConstant> liftedConstants)
+        {
+            _liftedConstants = liftedConstants;
+            _indexedExpressions.Clear();
+
+            _firstPass = true;
+
+            // Phase 1: recursively seek out tree fragments which appear more than once across the lifted constants. These will be extracted
+            // out to separate variables.
+            foreach (var liftedConstant in liftedConstants)
+            {
+                _currentLiftedConstant = liftedConstant;
+                Visit(liftedConstant.Expression);
+            }
+
+            // Filter out fragments which don't appear at least once
+            foreach (var (expression, expressionInfo) in _indexedExpressions)
+            {
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce)
+                {
+                    _indexedExpressions.Remove(expression);
+                    continue;
+                }
+
+                Check.DebugAssert(expressionInfo.Status == ExpressionStatus.SeenMultipleTimes,
+                    "expressionInfo.Status == ExpressionStatus.SeenMultipleTimes");
+            }
+
+            // Second pass: extract common denominator tree fragments to separate variables
+            _firstPass = false;
+            for (_index = 0; _index < liftedConstants.Count; _index++)
+            {
+                _currentLiftedConstant = _liftedConstants[_index];
+                if (_indexedExpressions.TryGetValue(_currentLiftedConstant.Expression, out var expressionInfo)
+                    && expressionInfo.Status == ExpressionStatus.Extracted)
+                {
+                    // This entire lifted constant has already been extracted before, so we no longer need it as a separate variable.
+                    _liftedConstants[_index] = _currentLiftedConstant with { ReplacingParameter = expressionInfo.Parameter };
+
+                    continue;
+                }
+
+                var optimizedExpression = Visit(_currentLiftedConstant.Expression);
+                if (optimizedExpression != _currentLiftedConstant.Expression)
+                {
+                    _liftedConstants[_index] = _currentLiftedConstant with { Expression = optimizedExpression };
+                }
+            }
+        }
+
+        [return: NotNullIfNotNull(nameof(node))]
+        public override Expression? Visit(Expression? node)
+        {
+            if (node is null)
+            {
+                return null;
+            }
+
+            if (node is ParameterExpression or ConstantExpression || node.Type.IsAssignableTo(typeof(LambdaExpression)))
+            {
+                return node;
+            }
+
+            if (_firstPass)
+            {
+                var preferredName = ReferenceEquals(node, _currentLiftedConstant.Expression)
+                    ? _currentLiftedConstant.Parameter.Name
+                    : null;
+
+                if (!_indexedExpressions.TryGetValue(node, out var expressionInfo))
+                {
+                    // Unseen expression, add it to the dictionary with a null value, to indicate it's only a candidate at this point.
+                    _indexedExpressions[node] = new(ExpressionStatus.SeenOnce, PreferredName: preferredName);
+                    return base.Visit(node);
+                }
+
+                // We've already seen this expression.
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce
+                    || expressionInfo.PreferredName is null && preferredName is not null)
+                {
+                    // This is the 2nd time we're seeing the expression - mark it as a common denominator
+                    _indexedExpressions[node] = _indexedExpressions[node] with
+                    {
+                        Status = ExpressionStatus.SeenMultipleTimes,
+                        PreferredName = preferredName
+                    };
+                }
+
+                // We've already seen and indexed this expression, no need to do it again
+                return node;
+            }
+            else
+            {
+                // 2nd pass
+                if (_indexedExpressions.TryGetValue(node, out var expressionInfo) && expressionInfo.Status != ExpressionStatus.SeenOnce)
+                {
+                    // This fragment is common across multiple lifted constants.
+                    if (expressionInfo.Status == ExpressionStatus.SeenMultipleTimes)
+                    {
+                        // This fragment hasn't yet been extracted out to its own variable in the 2nd pass.
+
+                        // If this happens to be a top-level node in the lifted constant, no need to extract an additional variable - just
+                        // use that as the "extracted" parameter further down.
+                        if (ReferenceEquals(node, _currentLiftedConstant.Expression))
+                        {
+                            _indexedExpressions[node] = new(ExpressionStatus.Extracted, _currentLiftedConstant.Parameter);
+                            return base.Visit(node);
+                        }
+
+                        // Otherwise, we need to extract a new variable, integrating it just before this one.
+                        var parameter = Expression.Parameter(node.Type, node switch
+                        {
+                            _ when expressionInfo.PreferredName is not null => expressionInfo.PreferredName,
+                            MemberExpression me => char.ToLowerInvariant(me.Member.Name[0]) + me.Member.Name[1..],
+                            MethodCallExpression mce => char.ToLowerInvariant(mce.Method.Name[0]) + mce.Method.Name[1..],
+                            _ => "unknown"
+                        });
+
+                        var visitedNode = base.Visit(node);
+                        _liftedConstants.Insert(_index++, new(parameter, visitedNode));
+
+                        // Mark this node as having been extracted, to prevent it from getting extracted again
+                        expressionInfo = _indexedExpressions[node] = new(ExpressionStatus.Extracted, parameter);
+                    }
+
+                    Check.DebugAssert(expressionInfo.Parameter is not null, "expressionInfo.Parameter is not null");
+
+                    return expressionInfo.Parameter;
+                }
+
+                // This specific fragment only appears once across the lifted constants; keep going down.
+                return base.Visit(node);
+            }
+        }
+
+        private enum ExpressionStatus
+        {
+            SeenOnce,
+            SeenMultipleTimes,
+            Extracted
+        }
+    }
+
+    private sealed class LiftedExpressionProcessor : ExpressionVisitor
+    {
+        private ParameterExpression _originalParameter = null!;
+        private ParameterExpression _replacingParameter = null!;
+
+        public Expression Process(Expression expression, ParameterExpression originalParameter, ParameterExpression replacingParameter)
+        {
+            _originalParameter = originalParameter;
+            _replacingParameter = replacingParameter;
+
+            return Visit(expression);
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            // The expression to be lifted may contain a captured variable; for limited literal scenarios, inline that variable into the
+            // expression so we can render it out to C#.
+
+            // TODO: For the general case, this needs to be a full blown "evaluatable" identifier (like ParameterExtractingEV), which can
+            // identify any fragments of the tree which don't depend on the lambda parameter, and evaluate them.
+            // But for now we're doing a reduced version.
+
+            var visited = base.VisitMember(node);
+
+            if (visited is MemberExpression
+                {
+                    Expression: ConstantExpression { Value: { } constant },
+                    Member: var member
+                })
+            {
+                return member switch
+                {
+                    FieldInfo fi => Expression.Constant(fi.GetValue(constant), node.Type),
+                    PropertyInfo pi => Expression.Constant(pi.GetValue(constant), node.Type),
+                    _ => visited
+                };
+            }
+
+            return visited;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+            => ReferenceEquals(node, _originalParameter)
+                ? _replacingParameter
+                : base.VisitParameter(node);
+    }
+}

--- a/src/EFCore/Query/MaterializerLiftableConstantContext.cs
+++ b/src/EFCore/Query/MaterializerLiftableConstantContext.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public record MaterializerLiftableConstantContext(ShapedQueryCompilingExpressionVisitorDependencies Dependencies);

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -53,6 +53,8 @@ public sealed record QueryCompilationContextDependencies
         IQueryableMethodTranslatingExpressionVisitorFactory queryableMethodTranslatingExpressionVisitorFactory,
         IQueryTranslationPostprocessorFactory queryTranslationPostprocessorFactory,
         IShapedQueryCompilingExpressionVisitorFactory shapedQueryCompilingExpressionVisitorFactory,
+        ILiftableConstantFactory liftableConstantFactory,
+        ILiftableConstantProcessor liftableConstantProcessor,
         IExecutionStrategy executionStrategy,
         ICurrentDbContext currentContext,
         IDbContextOptions contextOptions,
@@ -65,6 +67,8 @@ public sealed record QueryCompilationContextDependencies
         QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
         QueryTranslationPostprocessorFactory = queryTranslationPostprocessorFactory;
         ShapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
+        LiftableConstantFactory = liftableConstantFactory;
+        LiftableConstantProcessor = liftableConstantProcessor;
         IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
         ContextOptions = contextOptions;
         Logger = logger;
@@ -113,6 +117,16 @@ public sealed record QueryCompilationContextDependencies
     ///     The shaped-query compiling expression visitor factory.
     /// </summary>
     public IShapedQueryCompilingExpressionVisitorFactory ShapedQueryCompilingExpressionVisitorFactory { get; init; }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public ILiftableConstantFactory LiftableConstantFactory { get; init; }
+
+    /// <summary>
+    ///     The liftable constant processor.
+    /// </summary>
+    public ILiftableConstantProcessor LiftableConstantProcessor { get; init; }
 
     /// <summary>
     ///     Whether the configured execution strategy can retry.

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -34,6 +34,16 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
         => new ReplacingExpressionVisitor(new[] { original }, new[] { replacement }).Visit(tree);
 
     /// <summary>
+    ///     Replaces one expression with another in given expression tree.
+    /// </summary>
+    /// <param name="originals">A list of original expressions to replace.</param>
+    /// <param name="replacements">A list of expressions to be used as replacements.</param>
+    /// <param name="tree">The expression tree in which replacement is going to be performed.</param>
+    /// <returns>An expression tree with replacements made.</returns>
+    public static Expression Replace(Expression[] originals, Expression[] replacements, Expression tree)
+        => new ReplacingExpressionVisitor(originals, replacements).Visit(tree);
+
+    /// <summary>
     ///     Creates a new instance of the <see cref="ReplacingExpressionVisitor" /> class.
     /// </summary>
     /// <param name="originals">A list of original expressions to replace.</param>
@@ -48,7 +58,7 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
     [return: NotNullIfNotNull("expression")]
     public override Expression? Visit(Expression? expression)
     {
-        if (expression is null or ShapedQueryExpression or StructuralTypeShaperExpression or GroupByShaperExpression)
+        if (expression is null or ShapedQueryExpression or StructuralTypeShaperExpression or GroupByShaperExpression or LiftableConstantExpression)
         {
             return expression;
         }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using static System.Linq.Expressions.Expression;
 
@@ -39,6 +42,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
     private readonly Expression _cancellationTokenParameter;
     private readonly EntityMaterializerInjectingExpressionVisitor _entityMaterializerInjectingExpressionVisitor;
     private readonly ConstantVerifyingExpressionVisitor _constantVerifyingExpressionVisitor;
+    private readonly MaterializationConditionConstantLifter _materializationConditionConstantLifter;
 
     /// <summary>
     ///     Creates a new instance of the <see cref="ShapedQueryCompilingExpressionVisitor" /> class.
@@ -55,9 +59,12 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         _entityMaterializerInjectingExpressionVisitor =
             new EntityMaterializerInjectingExpressionVisitor(
                 dependencies.EntityMaterializerSource,
-                queryCompilationContext.QueryTrackingBehavior);
+                dependencies.LiftableConstantFactory,
+                queryCompilationContext.QueryTrackingBehavior,
+                queryCompilationContext.SupportsPrecompiledQuery);
 
-        _constantVerifyingExpressionVisitor = new ConstantVerifyingExpressionVisitor(dependencies.TypeMappingSource);
+        _constantVerifyingExpressionVisitor = new(dependencies.TypeMappingSource);
+        _materializationConditionConstantLifter = new(dependencies.LiftableConstantFactory);
 
         if (queryCompilationContext.IsAsync)
         {
@@ -128,7 +135,14 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             .GetDeclaredMethods(nameof(SingleOrDefaultAsync))
             .Single(mi => mi.GetParameters().Length == 2);
 
-    private static async Task<TSource> SingleAsync<TSource>(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static async Task<TSource> SingleAsync<TSource>(
         IAsyncEnumerable<TSource> asyncEnumerable,
         CancellationToken cancellationToken = default)
     {
@@ -150,7 +164,14 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         return result;
     }
 
-    private static async Task<TSource?> SingleOrDefaultAsync<TSource>(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static async Task<TSource?> SingleOrDefaultAsync<TSource>(
         IAsyncEnumerable<TSource> asyncEnumerable,
         CancellationToken cancellationToken = default)
     {
@@ -189,7 +210,55 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
     {
         VerifyNoClientConstant(expression);
 
-        return _entityMaterializerInjectingExpressionVisitor.Inject(expression);
+        var materializerExpression = _entityMaterializerInjectingExpressionVisitor.Inject(expression);
+        if (QueryCompilationContext.SupportsPrecompiledQuery)
+        {
+            materializerExpression = _materializationConditionConstantLifter.Visit(materializerExpression);
+        }
+
+        return materializerExpression;
+    }
+
+    private sealed class MaterializationConditionConstantLifter(ILiftableConstantFactory liftableConstantFactory) : ExpressionVisitor
+    {
+        private static readonly MethodInfo ServiceProviderGetService =
+            typeof(IServiceProvider).GetMethod(nameof(IServiceProvider.GetService), [typeof(Type)])!;
+
+        protected override Expression VisitConstant(ConstantExpression constantExpression)
+            => constantExpression switch
+            {
+                { Value: IEntityType entityTypeValue } => liftableConstantFactory.CreateLiftableConstant(
+                    constantExpression.Value,
+                    LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForEntityOrComplexType(entityTypeValue),
+                    entityTypeValue.Name + "EntityType",
+                    constantExpression.Type),
+                { Value: IComplexType complexTypeValue } => liftableConstantFactory.CreateLiftableConstant(
+                    constantExpression.Value,
+                    LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForEntityOrComplexType(complexTypeValue),
+                    complexTypeValue.Name + "ComplexType",
+                    constantExpression.Type),
+                { Value: IProperty propertyValue } => liftableConstantFactory.CreateLiftableConstant(
+                    constantExpression.Value,
+                    LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForProperty(propertyValue),
+                    propertyValue.Name + "Property",
+                    constantExpression.Type),
+                _ => base.VisitConstant(constantExpression)
+            };
+
+        protected override Expression VisitBinary(BinaryExpression binaryExpression)
+        {
+            var left = Visit(binaryExpression.Left);
+            var right = Visit(binaryExpression.Right);
+            var conversion = (LambdaExpression?)Visit(binaryExpression.Conversion);
+
+            return binaryExpression.NodeType is ExpressionType.Assign
+                && left is MemberExpression { Member: FieldInfo { IsInitOnly: true } } initFieldMember
+                ? initFieldMember.Assign(right)
+                : binaryExpression.Update(left, conversion, right);
+        }
+
+        protected override Expression VisitExtension(Expression node)
+            => node is LiftableConstantExpression ? node : base.VisitExtension(node);
     }
 
     /// <summary>
@@ -198,6 +267,35 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
     /// <param name="expression">An expression to verify.</param>
     protected virtual void VerifyNoClientConstant(Expression expression)
         => _constantVerifyingExpressionVisitor.Visit(expression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [UsedImplicitly]
+    [EntityFrameworkInternal]
+    public static Exception CreateNullKeyValueInNoTrackingQuery(
+        IEntityType entityType,
+        IReadOnlyList<IProperty> properties,
+        object?[] keyValues)
+    {
+        var index = -1;
+        for (var i = 0; i < keyValues.Length; i++)
+        {
+            if (keyValues[i] == null)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        var property = properties[index];
+
+        throw new InvalidOperationException(
+            CoreStrings.InvalidKeyValue(entityType.DisplayName(), property.Name));
+    }
 
     private sealed class ConstantVerifyingExpressionVisitor : ExpressionVisitor
     {
@@ -289,23 +387,33 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                 nameof(QueryContext.StartTracking), [typeof(IEntityType), typeof(object), typeof(ISnapshot).MakeByRefType()])!;
 
         private static readonly MethodInfo CreateNullKeyValueInNoTrackingQueryMethod
-            = typeof(EntityMaterializerInjectingExpressionVisitor)
+            = typeof(ShapedQueryCompilingExpressionVisitor)
                 .GetTypeInfo().GetDeclaredMethod(nameof(CreateNullKeyValueInNoTrackingQuery))!;
 
+        private static readonly MethodInfo EntityTypeFindPrimaryKeyMethod =
+            typeof(IEntityType).GetMethod(nameof(IEntityType.FindPrimaryKey), [])!;
+
         private readonly IEntityMaterializerSource _entityMaterializerSource;
+        private readonly ILiftableConstantFactory _liftableConstantFactory;
         private readonly QueryTrackingBehavior _queryTrackingBehavior;
         private readonly bool _queryStateManager;
         private readonly ISet<IEntityType> _visitedEntityTypes = new HashSet<IEntityType>();
+        private readonly MaterializationConditionConstantLifter _materializationConditionConstantLifter;
+        private readonly bool _supportsPrecompiledQuery;
         private int _currentEntityIndex;
 
         public EntityMaterializerInjectingExpressionVisitor(
             IEntityMaterializerSource entityMaterializerSource,
-            QueryTrackingBehavior queryTrackingBehavior)
+            ILiftableConstantFactory liftableConstantFactory,
+            QueryTrackingBehavior queryTrackingBehavior,
+            bool supportsPrecompiledQuery)
         {
             _entityMaterializerSource = entityMaterializerSource;
+            _liftableConstantFactory = liftableConstantFactory;
             _queryTrackingBehavior = queryTrackingBehavior;
-            _queryStateManager =
-                queryTrackingBehavior is QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+            _queryStateManager = queryTrackingBehavior is QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+            _materializationConditionConstantLifter = new(liftableConstantFactory);
+            _supportsPrecompiledQuery = supportsPrecompiledQuery;
         }
 
         public Expression Inject(Expression expression)
@@ -378,13 +486,24 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                 variables.Add(entryVariable);
                 variables.Add(hasNullKeyVariable);
 
+                var resolverPrm = Parameter(typeof(MaterializerLiftableConstantContext), "c");
                 expressions.Add(
                     Assign(
                         entryVariable,
                         Call(
                             QueryCompilationContext.QueryContextParameter,
                             TryGetEntryMethodInfo,
-                            Constant(primaryKey),
+                            _supportsPrecompiledQuery
+                            ? _liftableConstantFactory.CreateLiftableConstant(
+                                primaryKey,
+                                Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                                    Call(
+                                        LiftableConstantExpressionHelpers.BuildMemberAccessForEntityOrComplexType(typeBase, resolverPrm),
+                                        EntityTypeFindPrimaryKeyMethod),
+                                    resolverPrm),
+                                typeBase.Name + "Key",
+                                typeof(IKey))
+                            : Constant(primaryKey),
                             NewArrayInit(
                                 typeof(object),
                                 primaryKey.Properties
@@ -432,6 +551,8 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                     else
                     {
                         var keyValuesVariable = Variable(typeof(object[]), "keyValues" + _currentEntityIndex);
+                        var resolverPrm = Parameter(typeof(MaterializerLiftableConstantContext), "c");
+
                         expressions.Add(
                             IfThenElse(
                                 primaryKey.Properties.Select(
@@ -454,8 +575,26 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                                                     typeof(object), p.GetIndex(), p)))),
                                     Call(
                                         CreateNullKeyValueInNoTrackingQueryMethod,
-                                        Constant(typeBase),
-                                        Constant(primaryKey.Properties),
+                                        _supportsPrecompiledQuery
+                                        ? _liftableConstantFactory.CreateLiftableConstant(
+                                            typeBase,
+                                            LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForEntityOrComplexType(typeBase),
+                                            typeBase.Name + "EntityType",
+                                            typeof(IEntityType))
+                                        : Constant(typeBase),
+                                        _supportsPrecompiledQuery
+                                        ? _liftableConstantFactory.CreateLiftableConstant(
+                                            primaryKey.Properties,
+                                            Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                                                Property(
+                                                    Call(
+                                                        LiftableConstantExpressionHelpers.BuildMemberAccessForEntityOrComplexType(typeBase, resolverPrm),
+                                                        EntityTypeFindPrimaryKeyMethod),
+                                                    nameof(IKey.Properties)),
+                                                resolverPrm),
+                                            typeBase.Name + "PrimaryKeyProperties",
+                                            typeof(IReadOnlyList<IProperty>))
+                                        : Constant(primaryKey.Properties),
                                         keyValuesVariable))));
                     }
                 }
@@ -491,18 +630,24 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             expressions.Add(
                 Assign(
                     shadowValuesVariable,
-                    Constant(Snapshot.Empty)));
+                    _supportsPrecompiledQuery
+                    ? _liftableConstantFactory.CreateLiftableConstant(
+                        Snapshot.Empty,
+                        static _ => Snapshot.Empty,
+                        "emptySnapshot",
+                        typeof(Snapshot))
+                    : Constant(Snapshot.Empty)));
 
             var returnType = typeBase.ClrType;
             var valueBufferExpression = Call(materializationContextVariable, MaterializationContext.GetValueBufferMethod);
+
+            var materializationConditionBody = ReplacingExpressionVisitor.Replace(
+                shaper.MaterializationCondition.Parameters[0],
+                valueBufferExpression,
+                shaper.MaterializationCondition.Body);
+
             var expressionContext = (returnType, materializationContextVariable, concreteEntityTypeVariable, shadowValuesVariable);
-            expressions.Add(
-                Assign(
-                    concreteEntityTypeVariable,
-                    ReplacingExpressionVisitor.Replace(
-                        shaper.MaterializationCondition.Parameters[0],
-                        valueBufferExpression,
-                        shaper.MaterializationCondition.Body)));
+            expressions.Add(Assign(concreteEntityTypeVariable, materializationConditionBody));
 
             var (primaryKey, concreteEntityTypes) = typeBase is IEntityType entityType
                 ? (entityType.FindPrimaryKey(), entityType.GetConcreteDerivedTypesInclusive().Cast<ITypeBase>().ToArray())
@@ -511,9 +656,16 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             var switchCases = new SwitchCase[concreteEntityTypes.Length];
             for (var i = 0; i < concreteEntityTypes.Length; i++)
             {
+                var concreteEntityType = concreteEntityTypes[i];
                 switchCases[i] = SwitchCase(
                     CreateFullMaterializeExpression(concreteEntityTypes[i], expressionContext),
-                    Constant(concreteEntityTypes[i], typeBase is IEntityType ? typeof(IEntityType) : typeof(IComplexType)));
+                    _supportsPrecompiledQuery
+                    ? _liftableConstantFactory.CreateLiftableConstant(
+                        concreteEntityTypes[i],
+                        LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForEntityOrComplexType(concreteEntityType),
+                        concreteEntityType.Name + (typeBase is IEntityType ? "EntityType" : "ComplexType"),
+                        typeBase is IEntityType ? typeof(IEntityType) : typeof(IComplexType))
+                    : Constant(concreteEntityTypes[i], typeBase is IEntityType ? typeof(IEntityType) : typeof(IComplexType)));
             }
 
             var materializationExpression = Switch(
@@ -604,28 +756,6 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             blockExpressions.Add(materializer);
 
             return Block(blockExpressions);
-        }
-
-        [UsedImplicitly]
-        private static Exception CreateNullKeyValueInNoTrackingQuery(
-            IEntityType entityType,
-            IReadOnlyList<IProperty> properties,
-            object?[] keyValues)
-        {
-            var index = -1;
-            for (var i = 0; i < keyValues.Length; i++)
-            {
-                if (keyValues[i] == null)
-                {
-                    index = i;
-                    break;
-                }
-            }
-
-            var property = properties[index];
-
-            throw new InvalidOperationException(
-                CoreStrings.InvalidKeyValue(entityType.DisplayName(), property.Name));
         }
     }
 }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -51,12 +52,22 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
         IEntityMaterializerSource entityMaterializerSource,
         ITypeMappingSource typeMappingSource,
         IMemoryCache memoryCache,
-        ICoreSingletonOptions coreSingletonOptions)
+        ICoreSingletonOptions coreSingletonOptions,
+        IModel model,
+        ILiftableConstantFactory liftableConstantFactory,
+        IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger,
+        IEnumerable<ISingletonInterceptor> singletonInterceptors,
+        IDbContextServices contextServices)
     {
         EntityMaterializerSource = entityMaterializerSource;
         TypeMappingSource = typeMappingSource;
         MemoryCache = memoryCache;
         CoreSingletonOptions = coreSingletonOptions;
+        Model = model;
+        LiftableConstantFactory = liftableConstantFactory;
+        QueryLogger = queryLogger;
+        SingletonInterceptors = singletonInterceptors;
+        ContextServices = contextServices;
     }
 
     /// <summary>
@@ -78,4 +89,29 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
     ///     Core singleton options.
     /// </summary>
     public ICoreSingletonOptions CoreSingletonOptions { get; init; }
+
+    /// <summary>
+    ///     The model.
+    /// </summary>
+    public IModel Model { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public ILiftableConstantFactory LiftableConstantFactory { get; init; }
+
+    /// <summary>
+    ///     The query logger.
+    /// </summary>
+    public IDiagnosticsLogger<DbLoggerCategory.Query> QueryLogger { get; init; }
+
+    /// <summary>
+    ///     Registered singleton interceptors.
+    /// </summary>
+    public IEnumerable<ISingletonInterceptor> SingletonInterceptors { get; init; }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public IDbContextServices ContextServices { get; init; }
 }

--- a/src/EFCore/Storage/Json/JsonBoolReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonBoolReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -10,14 +11,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 /// </summary>
 public sealed class JsonBoolReaderWriter : JsonValueReaderWriter<bool>
 {
+    private JsonBoolReaderWriter()
+    {
+    }
+
     /// <summary>
     ///     The singleton instance of this stateless reader/writer.
     /// </summary>
     public static JsonBoolReaderWriter Instance { get; } = new();
-
-    private JsonBoolReaderWriter()
-    {
-    }
 
     /// <inheritdoc />
     public override bool FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
@@ -26,4 +27,10 @@ public sealed class JsonBoolReaderWriter : JsonValueReaderWriter<bool>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, bool value)
         => writer.WriteBooleanValue(value);
+
+    private readonly Expression<Func<JsonBoolReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonByteArrayReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonByteArrayReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonByteArrayReaderWriter : JsonValueReaderWriter<byte[]>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, byte[] value)
         => writer.WriteBase64StringValue(value);
+
+    private readonly Expression<Func<JsonByteArrayReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonByteReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonByteReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonByteReaderWriter : JsonValueReaderWriter<byte>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, byte value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonByteReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonCastValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCastValueReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
@@ -34,4 +35,11 @@ public class JsonCastValueReaderWriter<TConverted> :
 
     JsonValueReaderWriter ICompositeJsonValueReaderWriter.InnerReaderWriter
         => _providerReaderWriter;
+
+    private readonly ConstructorInfo _constructorInfo = typeof(JsonCastValueReaderWriter<TConverted>).GetConstructor([typeof(JsonValueReaderWriter)])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(_constructorInfo, ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression);
 }

--- a/src/EFCore/Storage/Json/JsonCharReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCharReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonCharReaderWriter : JsonValueReaderWriter<char>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, char value)
         => writer.WriteStringValue(value.ToString());
+
+    private readonly Expression<Func<JsonCharReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonCollectionOfNullableStructsReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionOfNullableStructsReaderWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
@@ -122,4 +123,12 @@ public class JsonCollectionOfNullableStructsReaderWriter<TConcreteCollection, TE
 
     JsonValueReaderWriter ICompositeJsonValueReaderWriter.InnerReaderWriter
         => _elementReaderWriter;
+
+    private readonly ConstructorInfo _constructorInfo =
+        typeof(JsonCollectionOfNullableStructsReaderWriter<TConcreteCollection, TElement>).GetConstructor([typeof(JsonValueReaderWriter<TElement>)])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(_constructorInfo, ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression);
 }

--- a/src/EFCore/Storage/Json/JsonCollectionOfReferencesReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionOfReferencesReaderWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
@@ -120,4 +121,11 @@ public class JsonCollectionOfReferencesReaderWriter<TConcreteCollection, TElemen
 
     JsonValueReaderWriter ICompositeJsonValueReaderWriter.InnerReaderWriter
         => _elementReaderWriter;
+
+    private readonly ConstructorInfo _constructorInfo = typeof(JsonCollectionOfReferencesReaderWriter<TConcreteCollection, TElement>).GetConstructor([typeof(JsonValueReaderWriter)])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(_constructorInfo, ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression);
 }

--- a/src/EFCore/Storage/Json/JsonCollectionOfStructsReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionOfStructsReaderWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
@@ -111,4 +112,11 @@ public class JsonCollectionOfStructsReaderWriter<TConcreteCollection, TElement> 
 
     JsonValueReaderWriter ICompositeJsonValueReaderWriter.InnerReaderWriter
         => _elementReaderWriter;
+
+    private readonly ConstructorInfo _constructorInfo = typeof(JsonCollectionOfStructsReaderWriter<TConcreteCollection, TElement>).GetConstructor([typeof(JsonValueReaderWriter<TElement>)])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(_constructorInfo, ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression);
 }

--- a/src/EFCore/Storage/Json/JsonConvertedValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonConvertedValueReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
@@ -45,4 +46,14 @@ public class JsonConvertedValueReaderWriter<TModel, TProvider> :
 
     ValueConverter IJsonConvertedValueReaderWriter.Converter
         => _converter;
+
+    private readonly ConstructorInfo _constructorInfo = typeof(JsonConvertedValueReaderWriter<TModel, TProvider>).GetConstructor([typeof(JsonValueReaderWriter<TProvider>), typeof(ValueConverter)])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(
+            _constructorInfo,
+            ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression,
+            ((IJsonConvertedValueReaderWriter)this).Converter.ConstructorExpression);
 }

--- a/src/EFCore/Storage/Json/JsonDateOnlyReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonDateOnlyReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 
@@ -27,4 +28,10 @@ public sealed class JsonDateOnlyReaderWriter : JsonValueReaderWriter<DateOnly>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, DateOnly value)
         => writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+
+    private readonly Expression<Func<JsonDateOnlyReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonDateTimeOffsetReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonDateTimeOffsetReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonDateTimeOffsetReaderWriter : JsonValueReaderWriter<DateT
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, DateTimeOffset value)
         => writer.WriteStringValue(value);
+
+    private readonly Expression<Func<JsonDateTimeOffsetReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonDateTimeReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonDateTimeReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonDateTimeReaderWriter : JsonValueReaderWriter<DateTime>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, DateTime value)
         => writer.WriteStringValue(value);
+
+    private readonly Expression<Func<JsonDateTimeReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonDecimalReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonDecimalReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonDecimalReaderWriter : JsonValueReaderWriter<decimal>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, decimal value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonDecimalReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonDoubleReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonDoubleReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonDoubleReaderWriter : JsonValueReaderWriter<double>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, double value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonDoubleReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonFloatReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonFloatReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonFloatReaderWriter : JsonValueReaderWriter<float>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, float value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonFloatReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonGuidReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonGuidReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonGuidReaderWriter : JsonValueReaderWriter<Guid>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, Guid value)
         => writer.WriteStringValue(value);
+
+    private readonly Expression<Func<JsonGuidReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonInt16ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonInt16ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonInt16ReaderWriter : JsonValueReaderWriter<short>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, short value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonInt16ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonInt32ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonInt32ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonInt32ReaderWriter : JsonValueReaderWriter<int>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, int value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonInt32ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonInt64ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonInt64ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonInt64ReaderWriter : JsonValueReaderWriter<long>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, long value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonInt64ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonNullReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonNullReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonNullReaderWriter : JsonValueReaderWriter<object?>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, object? value)
         => writer.WriteNullValue();
+
+    private readonly Expression<Func<JsonNullReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonSByteReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonSByteReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonSByteReaderWriter : JsonValueReaderWriter<sbyte>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, sbyte value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonSByteReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonSignedEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonSignedEnumReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -27,4 +28,10 @@ public sealed class JsonSignedEnumReaderWriter<TEnum> : JsonValueReaderWriter<TE
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, TEnum value)
         => writer.WriteNumberValue((long)Convert.ChangeType(value, typeof(long))!);
+
+    private readonly Expression<Func<JsonSignedEnumReaderWriter<TEnum>>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonStringReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonStringReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonStringReaderWriter : JsonValueReaderWriter<string>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, string value)
         => writer.WriteStringValue(value);
+
+    private readonly Expression<Func<JsonStringReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonTimeOnlyReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonTimeOnlyReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 
@@ -27,4 +28,10 @@ public sealed class JsonTimeOnlyReaderWriter : JsonValueReaderWriter<TimeOnly>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, TimeOnly value)
         => writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+
+    private readonly Expression<Func<JsonTimeOnlyReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonTimeSpanReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonTimeSpanReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 
@@ -27,4 +28,10 @@ public sealed class JsonTimeSpanReaderWriter : JsonValueReaderWriter<TimeSpan>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, TimeSpan value)
         => writer.WriteStringValue(value.ToString("g", CultureInfo.InvariantCulture));
+
+    private readonly Expression<Func<JsonTimeSpanReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonUInt16ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonUInt16ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonUInt16ReaderWriter : JsonValueReaderWriter<ushort>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, ushort value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonUInt16ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonUInt32ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonUInt32ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonUInt32ReaderWriter : JsonValueReaderWriter<uint>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, uint value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonUInt32ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonUInt64ReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonUInt64ReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -26,4 +27,10 @@ public sealed class JsonUInt64ReaderWriter : JsonValueReaderWriter<ulong>
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, ulong value)
         => writer.WriteNumberValue(value);
+
+    private readonly Expression<Func<JsonUInt64ReaderWriter>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonUnsignedEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonUnsignedEnumReaderWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -27,4 +28,10 @@ public sealed class JsonUnsignedEnumReaderWriter<TEnum> : JsonValueReaderWriter<
     /// <inheritdoc />
     public override void ToJsonTyped(Utf8JsonWriter writer, TEnum value)
         => writer.WriteNumberValue((ulong)Convert.ChangeType(value, typeof(ulong))!);
+
+    private readonly Expression<Func<JsonUnsignedEnumReaderWriter<TEnum>>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonValueReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 
@@ -125,4 +126,10 @@ public abstract class JsonValueReaderWriter
 
         return null;
     }
+
+    /// <summary>
+    ///     The expression representing construction of this object.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public abstract Expression ConstructorExpression { get; }
 }

--- a/src/EFCore/Storage/Json/JsonWarningEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonWarningEnumReaderWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
@@ -72,4 +73,10 @@ public sealed class JsonWarningEnumReaderWriter<TEnum> : JsonValueReaderWriter<T
             writer.WriteNumberValue((ulong)Convert.ChangeType(value, typeof(ulong)));
         }
     }
+
+    private readonly Expression<Func<JsonWarningEnumReaderWriter<TEnum>>> _instanceLambda = () => Instance;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression => _instanceLambda.Body;
 }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -13,6 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 /// </summary>
 public class StringNumberConverter<TModel, TProvider, TNumber> : ValueConverter<TModel, TProvider>
 {
+    private static readonly Expression<Func<CultureInfo>> _cultureInfoInvariantCultureLambda =
+        () => CultureInfo.InvariantCulture;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -63,7 +66,7 @@ public class StringNumberConverter<TModel, TProvider, TNumber> : ValueConverter<
             parseMethod,
             param,
             Expression.Constant(NumberStyles.Any),
-            Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)));
+            _cultureInfoInvariantCultureLambda.Body);
 
         if (typeof(TNumber).IsNullableType())
         {
@@ -101,7 +104,7 @@ public class StringNumberConverter<TModel, TProvider, TNumber> : ValueConverter<
 
         Expression expression = Expression.Call(
             formatMethod,
-            Expression.Constant(CultureInfo.InvariantCulture),
+            _cultureInfoInvariantCultureLambda.Body,
             Expression.Constant(type == typeof(float) || type == typeof(double) ? "{0:R}" : "{0}"),
             Expression.Convert(param, typeof(object)));
 

--- a/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
@@ -13,6 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 /// </remarks>
 public class StringToBytesConverter : ValueConverter<string?, byte[]?>
 {
+    private static readonly MethodInfo EncodingGetBytesMethodInfo = typeof(Encoding).GetMethod(nameof(Encoding.GetBytes), [typeof(string)])!;
+    private static readonly MethodInfo EncodingGetStringMethodInfo = typeof(Encoding).GetMethod(nameof(Encoding.GetString), [typeof(byte[])])!;
+    private static readonly MethodInfo EncodingGetEncodingMethodInfo = typeof(Encoding).GetMethod(nameof(Encoding.GetEncoding), [typeof(int)])!;
+
     /// <summary>
     ///     Creates a new instance of this converter.
     /// </summary>
@@ -28,8 +32,8 @@ public class StringToBytesConverter : ValueConverter<string?, byte[]?>
         Encoding encoding,
         ConverterMappingHints? mappingHints = null)
         : base(
-            v => encoding.GetBytes(v!),
-            v => encoding.GetString(v!),
+            FromProvider(encoding),
+            ToProvider(encoding),
             mappingHints)
     {
     }
@@ -39,4 +43,34 @@ public class StringToBytesConverter : ValueConverter<string?, byte[]?>
     /// </summary>
     public static ValueConverterInfo DefaultInfo { get; }
         = new(typeof(string), typeof(byte[]), i => new StringToBytesConverter(Encoding.UTF8, i.MappingHints));
+
+    private static Expression<Func<string?, byte[]?>> FromProvider(Encoding encoding)
+    {
+        // v => encoding.GetBytes(v!),
+        var prm = Expression.Parameter(typeof(string), "v");
+        var result = Expression.Lambda<Func<string?, byte[]?>>(
+            Expression.Call(
+                Expression.Call(
+                    EncodingGetEncodingMethodInfo,
+                    Expression.Constant(encoding.CodePage)),
+                EncodingGetBytesMethodInfo, prm),
+            prm);
+
+        return result;
+    }
+
+    private static Expression<Func<byte[]?, string?>> ToProvider(Encoding encoding)
+    {
+        // v => encoding.GetString(v!)
+        var prm = Expression.Parameter(typeof(byte[]), "v");
+        var result = Expression.Lambda<Func<byte[]?, string?>>(
+            Expression.Call(
+                Expression.Call(
+                    EncodingGetEncodingMethodInfo,
+                    Expression.Constant(encoding.CodePage)),
+                EncodingGetStringMethodInfo, prm),
+            prm);
+
+        return result;
+    }
 }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
@@ -251,4 +252,10 @@ public abstract class ValueConverter
                 ? firstConverter.MappingHints
                 : secondConverter.MappingHints.With(firstConverter.MappingHints))!;
     }
+
+    /// <summary>
+    ///     The expression representing construction of this object.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public abstract Expression ConstructorExpression { get; }
 }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -18,6 +19,8 @@ public class ValueConverter<TModel, TProvider> : ValueConverter
     private Func<object?, object?>? _convertFromProvider;
     private Func<TModel, TProvider>? _convertToProviderTyped;
     private Func<TProvider, TModel>? _convertFromProviderTyped;
+    private static readonly ConstructorInfo MappingHintsCtor
+        = typeof(ConverterMappingHints).GetConstructor([typeof(int?), typeof(int?), typeof(int?), typeof(bool?), typeof(Func<IProperty, IEntityType, ValueGenerator>)])!;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class.
@@ -172,4 +175,29 @@ public class ValueConverter<TModel, TProvider> : ValueConverter
     /// </remarks>
     public override Type ProviderClrType
         => typeof(TProvider);
+
+    private readonly ConstructorInfo _constructorInfo = typeof(ValueConverter<TModel, TProvider>).GetConstructor(
+        [
+            typeof(Expression<Func<TModel, TProvider>>),
+            typeof(Expression<Func<TProvider, TModel>>),
+            typeof(ConverterMappingHints)
+        ])!;
+
+    /// <inheritdoc />
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public override Expression ConstructorExpression =>
+        Expression.New(
+            _constructorInfo,
+            ConvertToProviderExpression,
+            ConvertFromProviderExpression,
+            MappingHints != null
+                ? Expression.New(
+                    MappingHintsCtor,
+                    Expression.Constant(MappingHints.Size, typeof(int?)),
+                    Expression.Constant(MappingHints.Precision, typeof(int?)),
+                    Expression.Constant(MappingHints.Scale, typeof(int?)),
+                    Expression.Constant(MappingHints.IsUnicode, typeof(bool?)),
+                    // valueGeneratorFactory is difficult to build using Expression trees and is obsolete
+                    Expression.Default(typeof(Func<IProperty, IEntityType, ValueGenerator>)))
+            : Expression.Default(typeof(ConverterMappingHints)));
 }

--- a/src/Shared/ExpressionExtensions.cs
+++ b/src/Shared/ExpressionExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Query;
 
 // ReSharper disable once CheckNamespace
 namespace System.Linq.Expressions;
@@ -45,7 +46,30 @@ internal static class ExpressionExtensions
             : expression;
 
     public static T GetConstantValue<T>(this Expression expression)
-        => expression is ConstantExpression constantExpression
-            ? (T)constantExpression.Value!
-            : throw new InvalidOperationException();
+        => expression switch
+        {
+            ConstantExpression constantExpression => (T)constantExpression.Value!,
+#pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            LiftableConstantExpression liftableConstantExpression => (T)liftableConstantExpression.OriginalExpression.Value!,
+#pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            _ => throw new InvalidOperationException()
+        };
+
+    public static bool TryGetNonNullConstantValue<T>(this Expression expression, [NotNullWhen(true)][MaybeNullWhen(false)]out T value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression constant when constant.Value is T typedValue:
+                value = typedValue;
+                return true;
+#pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            case LiftableConstantExpression liftableConstant when liftableConstant.OriginalExpression.Value is T typedValue:
+#pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                value = typedValue;
+                return true;
+            default:
+                value = default;
+                return false;
+        }
+    }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
@@ -71,7 +71,8 @@ public abstract class AdHocAdvancedMappingsQueryRelationalTestBase : AdHocAdvanc
             .Select(
                 x => new
                 {
-                    x.B.A.Id, x.B.Info.Created,
+                    x.B.A.Id,
+                    x.B.Info.Created,
                 }).ToList();
 
         Assert.Equal(new DateTime(2000, 1, 1), query[0].Created);

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
@@ -275,7 +275,8 @@ public abstract class AdHocJsonQueryTestBase : NonSharedModelTestBase
     {
         var entity = new Context32939.Entity32939
         {
-            Empty = new Context32939.JsonEmpty32939(), FieldOnly = new Context32939.JsonFieldOnly32939()
+            Empty = new Context32939.JsonEmpty32939(),
+            FieldOnly = new Context32939.JsonFieldOnly32939()
         };
 
         ctx.Entities.Add(entity);

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
@@ -249,7 +249,8 @@ public abstract class AdHocQuerySplittingQueryTestBase : NonSharedModelTestBase
                         .Select(
                             c => new Context25225.CollectionViewModel
                             {
-                                Id = c.Id, ParentId = c.ParentId,
+                                Id = c.Id,
+                                ParentId = c.ParentId,
                             })
                         .ToArray()
                 });

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
@@ -518,13 +518,15 @@ public abstract class OwnedEntityQueryRelationalTestBase : OwnedEntityQueryTestB
             Add(
                 new Monarch
                 {
-                    Name = "His August Majesty Guslav the Fifth", RulerOf = "The Union",
+                    Name = "His August Majesty Guslav the Fifth",
+                    RulerOf = "The Union",
                 });
 
             Add(
                 new Monarch
                 {
-                    Name = "Emperor Uthman-ul-Dosht", RulerOf = "The Gurkish Empire",
+                    Name = "Emperor Uthman-ul-Dosht",
+                    RulerOf = "The Gurkish Empire",
                 });
 
             Add(

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -1158,7 +1158,8 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
                     where c.Id == customerId
                     select new
                     {
-                        c.LastName, OrderCount = context.StarValueInstance(starCount, context.CustomerOrderCountInstance(customerId))
+                        c.LastName,
+                        OrderCount = context.StarValueInstance(starCount, context.CustomerOrderCountInstance(customerId))
                     }).Single();
 
         Assert.Equal("Three", cust.LastName);
@@ -1592,7 +1593,8 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
                 () => (from c in context.Customers
                        select new
                        {
-                           c.Id, Prods = context.GetTopTwoSellingProducts().ToList(),
+                           c.Id,
+                           Prods = context.GetTopTwoSellingProducts().ToList(),
                        }).ToList()).Message;
 
             Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
@@ -1607,7 +1609,8 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
             var query = (from c in context.Customers
                          select new
                          {
-                             c.Id, Prods = context.GetTopTwoSellingProducts().Distinct().ToList(),
+                             c.Id,
+                             Prods = context.GetTopTwoSellingProducts().Distinct().ToList(),
                          }).ToList();
         }
     }
@@ -1734,7 +1737,8 @@ public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
                 () => (from c in context.Customers
                        select new
                        {
-                           c.Id, Prods = context.GetTopTwoSellingProducts().Select(p => p.ProductId).ToList(),
+                           c.Id,
+                           Prods = context.GetTopTwoSellingProducts().Select(p => p.ProductId).ToList(),
                        }).ToList()).Message;
 
             Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);

--- a/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
@@ -177,9 +177,16 @@ public class BufferedDataReaderTest
             columnType = typeof(object);
         }
 
+        var getFieldValueMethod = typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetFieldValue)).MakeGenericMethod(columnType);
+        var prm = Expression.Parameter(typeof(DbDataReader), "r");
+        var getFieldValueLambda = Expression.Lambda(
+            Expression.Call(prm, getFieldValueMethod, Expression.Constant(0)),
+            prm,
+            Expression.Parameter(typeof(int[]), "_"));
+
         var columns = new[]
         {
-            ReaderColumn.Create(columnType, true, null, null, (Func<DbDataReader, int[], T>)((r, _) => r.GetFieldValue<T>(0)))
+            ReaderColumn.Create(columnType, true, null, null, getFieldValueLambda)
         };
 
         var bufferedReader = new BufferedDataReader(reader, false);

--- a/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using static Microsoft.EntityFrameworkCore.Query.RelationalShapedQueryCompilingExpressionVisitor;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -552,13 +553,30 @@ public class RelationalApiConsistencyTest(RelationalApiConsistencyTest.Relationa
             typeof(RelationalConnectionDiagnosticsLogger).GetMethod(
                 nameof(IRelationalConnectionDiagnosticsLogger.ConnectionDisposingAsync)),
             typeof(RelationalConnectionDiagnosticsLogger).GetMethod(
-                nameof(IRelationalConnectionDiagnosticsLogger.ConnectionDisposedAsync))
+                nameof(IRelationalConnectionDiagnosticsLogger.ConnectionDisposedAsync)),
+
+            // internal methods made public for AOT
+            typeof(ShaperProcessingExpressionVisitor).GetMethod(nameof(ShaperProcessingExpressionVisitor.PopulateSplitIncludeCollectionAsync)),
+            typeof(ShaperProcessingExpressionVisitor).GetMethod(nameof(ShaperProcessingExpressionVisitor.PopulateSplitCollectionAsync)),
+            typeof(ShaperProcessingExpressionVisitor).GetMethod(nameof(ShaperProcessingExpressionVisitor.TaskAwaiter)),
+            typeof(RelationalShapedQueryCompilingExpressionVisitor).GetMethod(nameof(RelationalShapedQueryCompilingExpressionVisitor.NonQueryResultAsync)),
         ];
 
         public override HashSet<MethodInfo> MetadataMethodExceptions { get; } =
         [
             typeof(IMutableStoredProcedure).GetMethod(nameof(IMutableStoredProcedure.AddParameter)),
             typeof(IMutableStoredProcedure).GetMethod(nameof(IMutableStoredProcedure.AddResultColumn))
+        ];
+
+        public override HashSet<MethodInfo> VirtualMethodExceptions { get; } =
+        [
+            // non-sealed record
+#pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("get_RelationalDependencies"),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("set_RelationalDependencies"),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("Deconstruct", [typeof(ShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType()]),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("Deconstruct", [typeof(ShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType(), typeof(RelationalShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType()]),
+#pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         ];
 
         public List<IReadOnlyList<MethodInfo>> RelationalMetadataMethods { get; } = [];

--- a/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
@@ -1064,6 +1064,7 @@ public abstract class ApiConsistencyTestBase<TFixture> : IClassFixture<TFixture>
                from method in type.GetMethods(AnyInstance)
                where method.DeclaringType == type
                    && !Fixture.NonVirtualMethods.Contains(method)
+                   && !Fixture.VirtualMethodExceptions.Contains(method)
                    && !method.IsVirtual
                    && !method.Name.StartsWith("add_", StringComparison.Ordinal)
                    && !method.Name.StartsWith("remove_", StringComparison.Ordinal)
@@ -1275,6 +1276,15 @@ public abstract class ApiConsistencyTestBase<TFixture> : IClassFixture<TFixture>
         public virtual Dictionary<Type, HashSet<MethodInfo>> UnmatchedMirrorMethods { get; } = new();
         public virtual Dictionary<MethodInfo, string> MetadataMethodNameTransformers { get; } = new();
         public virtual HashSet<MethodInfo> MetadataMethodExceptions { get; } = [];
+        public virtual HashSet<MethodInfo> VirtualMethodExceptions { get; } =
+            [
+            // un-sealed record
+#pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            typeof(MaterializerLiftableConstantContext).GetMethod("get_Dependencies"),
+            typeof(MaterializerLiftableConstantContext).GetMethod("set_Dependencies"),
+            typeof(MaterializerLiftableConstantContext).GetMethod("Deconstruct"),
+#pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            ];
 
         public virtual HashSet<PropertyInfo> ComputedDependencyProperties { get; } =
             [

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -4242,6 +4243,12 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
             serializer.Serialize(jsonWriter, value);
             writer.WriteRawValue(stringWriter.ToString());
         }
+
+        private readonly Expression<Func<JsonGeoJsonReaderWriter>> _instanceLambda = () => Instance;
+
+        /// <inheritdoc />
+        [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private readonly NullabilityInfoContext _nullabilityInfoContext = new();

--- a/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
@@ -238,15 +238,18 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
             Contacts.AddRange(
                 new ServiceOperatorContact
                 {
-                    UserName = "service.operator@esoterix.co.uk", ServiceOperator = ServiceOperators.OrderBy(o => o.Id).First()
+                    UserName = "service.operator@esoterix.co.uk",
+                    ServiceOperator = ServiceOperators.OrderBy(o => o.Id).First()
                 },
                 new EmployerContact
                 {
-                    UserName = "uwe@esoterix.co.uk", Employer = Employers.OrderBy(e => e.Id).First(e => e.Name == "UWE")
+                    UserName = "uwe@esoterix.co.uk",
+                    Employer = Employers.OrderBy(e => e.Id).First(e => e.Name == "UWE")
                 },
                 new EmployerContact
                 {
-                    UserName = "hp@esoterix.co.uk", Employer = Employers.OrderBy(e => e.Id).First(e => e.Name == "Hewlett Packard")
+                    UserName = "hp@esoterix.co.uk",
+                    Employer = Employers.OrderBy(e => e.Id).First(e => e.Name == "Hewlett Packard")
                 },
                 new Contact { UserName = "noroles@esoterix.co.uk" });
 
@@ -1637,7 +1640,8 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
                 o => o.OrderId,
                 (o, g) => new
                 {
-                    Key = o, IsPending = g.Max(y => y.ShippingDate == null && y.CancellationDate == null ? o : (o - 10000000))
+                    Key = o,
+                    IsPending = g.Max(y => y.ShippingDate == null && y.CancellationDate == null ? o : (o - 10000000))
                 })
             .OrderBy(e => e.Key);
 
@@ -1896,7 +1900,8 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
                     into tg
                     select new
                     {
-                        A = tg.Key, B = context.Tables.Where(t => t.Value == tg.Max() * 6).Max(t => (int?)t.Id),
+                        A = tg.Key,
+                        B = context.Tables.Where(t => t.Value == tg.Max() * 6).Max(t => (int?)t.Id),
                     };
 
         var orders = async
@@ -2162,7 +2167,8 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
                             CountryId = m.Company.CountryId,
                             Country = new Context31961.CountryDto()
                             {
-                                Id = m.Company.Country.Id, CountryName = m.Company.Country.CountryName,
+                                Id = m.Company.Country.Id,
+                                CountryName = m.Company.Country.CountryName,
                             },
                         }
                         : null,

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2242,7 +2242,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
                     }
                     equals new
                     {
-                        A = EF.Property<int?>(l2, "Level1_Optional_Id"), B = EF.Property<int?>(l2, "OneToMany_Optional_Self_Inverse2Id")
+                        A = EF.Property<int?>(l2, "Level1_Optional_Id"),
+                        B = EF.Property<int?>(l2, "OneToMany_Optional_Self_Inverse2Id")
                     }
                 select l1);
 
@@ -3300,7 +3301,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
                             ? null
                             : new Level2Dto
                             {
-                                Id = l1.OneToOne_Optional_FK1.Id, Name = l1.OneToOne_Optional_FK1.Name,
+                                Id = l1.OneToOne_Optional_FK1.Id,
+                                Name = l1.OneToOne_Optional_FK1.Name,
                             }
                     })
                 .OrderBy(e => e.Level2.Name)
@@ -3458,7 +3460,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
                     o => new { o.Id, Condition = true },
                     i => new
                     {
-                        Id = i.Key, Condition = i.Sum > 10,
+                        Id = i.Key,
+                        Condition = i.Sum > 10,
                     },
                     (o, i) => i.Key));
 
@@ -3763,7 +3766,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
             ss => from x in ss.Set<InheritanceBase2>()
                   select new
                   {
-                      x.Id, InheritanceLeaf2Id = EF.Property<int?>(x, "InheritanceLeaf2Id"),
+                      x.Id,
+                      InheritanceLeaf2Id = EF.Property<int?>(x, "InheritanceLeaf2Id"),
                   },
             elementSorter: e => e.Id);
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -653,7 +653,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
                 .Select(
                     b => new
                     {
-                        hasFlagTrue = b.Rank.HasFlag(MilitaryRank.Corporal), hasFlagFalse = b.Rank.HasFlag(MilitaryRank.Sergeant)
+                        hasFlagTrue = b.Rank.HasFlag(MilitaryRank.Corporal),
+                        hasFlagFalse = b.Rank.HasFlag(MilitaryRank.Sergeant)
                     }));
 
     [ConditionalTheory]
@@ -1097,11 +1098,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
             ss => from g in ss.Set<Gear>()
                   from o in ss.Set<Gear>().OfType<Officer>()
                   where new
-                      {
-                          Name = g.LeaderNickname,
-                          Squad = g.LeaderSquadId,
-                          Five = 5
-                      }
+                  {
+                      Name = g.LeaderNickname,
+                      Squad = g.LeaderSquadId,
+                      Five = 5
+                  }
                       == new
                       {
                           Name = o.Nickname,
@@ -2807,7 +2808,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
             async,
             ss => from g1 in ss.Set<Gear>()
                   from g2 in ss.Set<Gear>()
-                  // ReSharper disable once PossibleUnintendedReferenceComparison
+                      // ReSharper disable once PossibleUnintendedReferenceComparison
                   where g1.Weapons == g2.Weapons
                   orderby g1.Nickname
                   select new { Nickname1 = g1.Nickname, Nickname2 = g2.Nickname },
@@ -6223,7 +6224,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Byte_array_filter_by_length_parameter(bool async)
     {
-        var someByteArr = new[] { (byte)42, (byte)24};
+        var someByteArr = new[] { (byte)42, (byte)24 };
         return AssertQuery(
             async,
             ss => ss.Set<Squad>().Where(w => w.Banner.Length == someByteArr.Length),

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2548,7 +2548,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
                     g =>
                         new
                         {
-                            g.Key, Max = g.Distinct().Select(e => e.OrderDate).Distinct().Max(),
+                            g.Key,
+                            Max = g.Distinct().Select(e => e.OrderDate).Distinct().Max(),
                         }),
             elementSorter: e => e.Key);
 
@@ -2563,7 +2564,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
                     g =>
                         new
                         {
-                            g.Key, Max = g.Where(e => e.OrderDate.HasValue).Select(e => e.OrderDate).Distinct().Max(),
+                            g.Key,
+                            Max = g.Where(e => e.OrderDate.HasValue).Select(e => e.OrderDate).Distinct().Max(),
                         }),
             elementSorter: e => e.Key);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -723,7 +723,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
                 o => new
                 {
                     // ReSharper disable SimplifyConditionalTernaryExpression
-                    Data1 = param != null ? o.OrderDate == param.Value : true, Data2 = param == null ? true : o.OrderDate == param.Value
+                    Data1 = param != null ? o.OrderDate == param.Value : true,
+                    Data2 = param == null ? true : o.OrderDate == param.Value
                     // ReSharper restore SimplifyConditionalTernaryExpression
                 }));
     }

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -363,7 +363,8 @@ public abstract class OwnedEntityQueryTestBase : NonSharedModelTestBase
         var query = context.Warehouses.Select(
             x => new Context18582.WarehouseModel
             {
-                WarehouseCode = x.WarehouseCode, DestinationCountryCodes = x.DestinationCountries.Select(c => c.CountryCode).ToArray()
+                WarehouseCode = x.WarehouseCode,
+                DestinationCountryCodes = x.DestinationCountries.Select(c => c.CountryCode).ToArray()
             }).AsNoTracking();
 
         var result = async
@@ -750,7 +751,8 @@ public abstract class OwnedEntityQueryTestBase : NonSharedModelTestBase
         var results = await context.Contacts.Select(
                 contact => new Context22089.ContactDto
                 {
-                    Id = contact.Id, Names = contact.Names.Select(name => new Context22089.NameDto()).ToArray()
+                    Id = contact.Id,
+                    Names = contact.Names.Select(name => new Context22089.NameDto()).ToArray()
                 })
             .ToListAsync();
     }

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -25,7 +25,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             await context.AddAsync(
                 new HeliumBalloon
                 {
-                    Id = Guid.NewGuid().ToString(), Gas = new Helium(),
+                    Id = Guid.NewGuid().ToString(),
+                    Gas = new Helium(),
                 });
 
             await context.AddAsync(new HydrogenBalloon { Id = Guid.NewGuid().ToString(), Gas = new Hydrogen() });

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -834,6 +834,11 @@ namespace TestNamespace
 
         public override void ToJsonTyped(Utf8JsonWriter writer, Guid value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<MyJsonGuidReaderWriter>> _ctorLambda = () => new();
+
+        /// <inheritdoc />
+        public override Expression ConstructorExpression => _ctorLambda.Body;
     }
 
     public class ManyTypes

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -695,9 +695,19 @@ WHERE (
 
     #endregion
 
-    [ConditionalFact]
-    public override Task Column_with_custom_converter()
-        => base.Column_with_custom_converter();
+    public override async Task Column_with_custom_converter()
+    {
+        await base.Column_with_custom_converter();
+
+        AssertSql(
+"""
+@__ints_0='1,2,3' (Size = 4000)
+
+SELECT TOP(2) [t].[Id], [t].[Ints]
+FROM [TestEntity] AS [t]
+WHERE [t].[Ints] = @__ints_0
+""");
+    }
 
     public override async Task Parameter_with_inferred_value_converter()
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -34,7 +34,7 @@ public class QueryLoggingSqlServerTest : IClassFixture<NorthwindQuerySqlServerFi
             "Compiling query expression: ",
             Fixture.TestSqlLoggerFactory.Log[0].Message);
         Assert.StartsWith(
-            "Generated query execution expression: " + Environment.NewLine + "'queryContext => new SingleQueryingEnumerable<Customer>(",
+            "Generated query execution expression: " + Environment.NewLine + "'queryContext => SingleQueryingEnumerable.Create<Customer>(",
             Fixture.TestSqlLoggerFactory.Log[1].Message);
     }
 
@@ -48,7 +48,7 @@ public class QueryLoggingSqlServerTest : IClassFixture<NorthwindQuerySqlServerFi
 
         Assert.NotNull(customers);
         Assert.StartsWith(
-            "Generated query execution expression: " + Environment.NewLine + "'queryContext => new SplitQueryingEnumerable<Customer>(",
+            "Generated query execution expression: " + Environment.NewLine + "'queryContext => SplitQueryingEnumerable.Create<Customer>(",
             Fixture.TestSqlLoggerFactory.Log[1].Message);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RawSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RawSqlServerTest.cs
@@ -13,53 +13,50 @@ public class RawSqlServerTest : NonSharedModelTestBase
     [ConditionalFact]
     public virtual async Task ToQuery_can_use_FromSqlRaw()
     {
-        var contextFactory = await InitializeAsync<MyContext13346>(seed: c => c.SeedAsync());
+        var contextFactory = await InitializeAsync<Context13346>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateContext();
+        var query = context.Set<Context13346.OrderSummary>().ToList();
 
-        using (var context = contextFactory.CreateContext())
-        {
-            var query = context.Set<MyContext13346.OrderSummary13346>().ToList();
+        Assert.Equal(4, query.Count);
 
-            Assert.Equal(4, query.Count);
-
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT o.Amount From Orders AS o -- RAW
 """);
-        }
     }
 
-    protected class MyContext13346(DbContextOptions options) : DbContext(options)
+    public class Context13346(DbContextOptions options) : DbContext(options)
     {
-        public virtual DbSet<Order13346> Orders { get; set; }
+        public virtual DbSet<Order> Orders { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            modelBuilder.Entity<OrderSummary13346>()
+            modelBuilder.Entity<OrderSummary>()
                 .HasNoKey()
-                .ToQuery(() => Set<OrderSummary13346>().FromSqlRaw("SELECT o.Amount From Orders AS o -- RAW"));
+                .ToQuery(() => Set<OrderSummary>().FromSqlRaw("SELECT o.Amount From Orders AS o -- RAW"));
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public Task SeedAsync()
         {
             AddRange(
-                new Order13346 { Amount = 1 },
-                new Order13346 { Amount = 2 },
-                new Order13346 { Amount = 3 },
-                new Order13346 { Amount = 4 }
+                new Order { Amount = 1 },
+                new Order { Amount = 2 },
+                new Order { Amount = 3 },
+                new Order { Amount = 4 }
             );
 
             return SaveChangesAsync();
         }
 
-        public class Order13346
+        public class Order
         {
             public int Id { get; set; }
             public int Amount { get; set; }
         }
 
-        public class OrderSummary13346
+        public class OrderSummary
         {
             public int Amount { get; set; }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
@@ -333,12 +333,12 @@ namespace TestNamespace
                     dbType: System.Data.DbType.String),
                 converter: new ValueConverter<bool, string>(
                     (bool v) => (string)(v ? "B" : "A"),
-                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B'),
+                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0]),
                 jsonValueReaderWriter: new JsonConvertedValueReaderWriter<bool, string>(
                     JsonStringReaderWriter.Instance,
                     new ValueConverter<bool, string>(
                         (bool v) => (string)(v ? "B" : "A"),
-                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B')));
+                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0])));
             boolToStringConverterProperty.SetSentinelFromProviderValue("A");
             boolToStringConverterProperty.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
             boolToStringConverterProperty.AddRuntimeAnnotation("UnsafeAccessors", new[] { ("ManyTypesEntityType.UnsafeAccessor_Microsoft_EntityFrameworkCore_Scaffolding_ManyTypes_BoolToStringConverterProperty", "TestNamespace") });

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/ManyTypesEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/ManyTypesEntityType.cs
@@ -333,12 +333,12 @@ namespace TestNamespace
                     dbType: System.Data.DbType.String),
                 converter: new ValueConverter<bool, string>(
                     (bool v) => (string)(v ? "B" : "A"),
-                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B'),
+                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0]),
                 jsonValueReaderWriter: new JsonConvertedValueReaderWriter<bool, string>(
                     JsonStringReaderWriter.Instance,
                     new ValueConverter<bool, string>(
                         (bool v) => (string)(v ? "B" : "A"),
-                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B')));
+                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0])));
             boolToStringConverterProperty.SetSentinelFromProviderValue("A");
             boolToStringConverterProperty.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
             boolToStringConverterProperty.AddRuntimeAnnotation("UnsafeAccessors", new[] { ("ManyTypesEntityType.UnsafeAccessor_Microsoft_EntityFrameworkCore_Scaffolding_ManyTypes_BoolToStringConverterProperty", "TestNamespace") });

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
@@ -242,12 +242,12 @@ namespace TestNamespace
                     size: 1),
                 converter: new ValueConverter<bool, string>(
                     (bool v) => (string)(v ? "B" : "A"),
-                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B'),
+                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0]),
                 jsonValueReaderWriter: new JsonConvertedValueReaderWriter<bool, string>(
                     JsonStringReaderWriter.Instance,
                     new ValueConverter<bool, string>(
                         (bool v) => (string)(v ? "B" : "A"),
-                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B')));
+                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0])));
             boolToStringConverterProperty.SetSentinelFromProviderValue("A");
             boolToStringConverterProperty.AddRuntimeAnnotation("UnsafeAccessors", new[] { ("ManyTypesEntityType.UnsafeAccessor_Microsoft_EntityFrameworkCore_Scaffolding_ManyTypes_BoolToStringConverterProperty", "TestNamespace") });
 

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/ManyTypesEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/ManyTypesEntityType.cs
@@ -242,12 +242,12 @@ namespace TestNamespace
                     size: 1),
                 converter: new ValueConverter<bool, string>(
                     (bool v) => (string)(v ? "B" : "A"),
-                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B'),
+                    (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0]),
                 jsonValueReaderWriter: new JsonConvertedValueReaderWriter<bool, string>(
                     JsonStringReaderWriter.Instance,
                     new ValueConverter<bool, string>(
                         (bool v) => (string)(v ? "B" : "A"),
-                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)'B')));
+                        (string v) => !string.IsNullOrEmpty(v) && (int)v.ToUpperInvariant()[0] == (int)"B".ToUpperInvariant()[0])));
             boolToStringConverterProperty.SetSentinelFromProviderValue("A");
             boolToStringConverterProperty.AddRuntimeAnnotation("UnsafeAccessors", new[] { ("ManyTypesEntityType.UnsafeAccessor_Microsoft_EntityFrameworkCore_Scaffolding_ManyTypes_BoolToStringConverterProperty", "TestNamespace") });
 

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -554,6 +554,10 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<SimpleJasonValueReaderWriter>> _instanceLambda = () => new();
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private class JasonValueReaderWriterWithPrivateInstance : JsonValueReaderWriter<string>
@@ -565,6 +569,10 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<JasonValueReaderWriterWithPrivateInstance>> _instanceLambda = () => Instance;
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private class JasonValueReaderWriterWithBadInstance : JsonValueReaderWriter<string>
@@ -576,6 +584,8 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        public override Expression ConstructorExpression => Expression.Default(typeof(JasonValueReaderWriterWithBadInstance));
     }
 
     private class SimpleJasonValueReaderWriterWithInstance : JsonValueReaderWriter<string>
@@ -587,6 +597,10 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<SimpleJasonValueReaderWriterWithInstance>> _instanceLambda = () => Instance;
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private class SimpleJasonValueReaderWriterWithInstanceAndPrivateConstructor : JsonValueReaderWriter<string>
@@ -602,6 +616,10 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<SimpleJasonValueReaderWriterWithInstanceAndPrivateConstructor>> _instanceLambda = () => Instance;
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private class NonDerivedJsonValueReaderWriter;
@@ -616,6 +634,10 @@ public class PropertyTest
 
         public override Type ValueType
             => typeof(string);
+
+        private readonly Expression<Func<NonGenericJsonValueReaderWriter>> _instanceLambda = () => new();
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
     private abstract class AbstractJasonValueReaderWriter : JsonValueReaderWriter<string>;
@@ -631,17 +653,24 @@ public class PropertyTest
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly Expression<Func<PrivateJasonValueReaderWriter>> _instanceLambda = () => new();
+
+        public override Expression ConstructorExpression => _instanceLambda.Body;
     }
 
-#pragma warning disable CS9113 // Parameter '_' is unread
     private class NonParameterlessJsonValueReaderWriter(bool _) : JsonValueReaderWriter<string>
-#pragma warning restore CS9113
     {
         public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
             => writer.WriteStringValue(value);
+
+        private readonly ConstructorInfo _constructorInfo = typeof(NonParameterlessJsonValueReaderWriter).GetConstructor([typeof(bool)])!;
+
+        public override Expression ConstructorExpression =>
+            Expression.New(_constructorInfo, Expression.Constant(_));
     }
 
     private static IMutableModel CreateModel()

--- a/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Proxies.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 // ReSharper disable UnusedMember.Local
@@ -178,7 +179,7 @@ public class EntityMaterializerSourceTest
                 et.ConstructorBinding
                     = new FactoryMethodBinding(
                         TestProxyFactory.Instance,
-                        typeof(TestProxyFactory).GetTypeInfo().GetDeclaredMethod(nameof(TestProxyFactory.Create))!,
+                        typeof(TestProxyFactory).GetMethod(nameof(TestProxyFactory.Create), [typeof(IEntityType)])!,
                         new List<ParameterBinding> { new EntityTypeParameterBinding() },
                         et.ClrType);
             });

--- a/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
+++ b/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
@@ -27,6 +27,8 @@ public class NavigationExpandingExpressionVisitorTests
                         null,
                         null,
                         null,
+                        null,
+                        null,
                         new ExecutionStrategyTest.TestExecutionStrategy(new MyDemoContext()),
                         new CurrentDbContext(new MyDemoContext()),
                         null,


### PR DESCRIPTION
Hey @ajcvickers @roji, @cincuranet 
I could use a second pair of eyes on this.
Basically trying to get rid of captured ValueComparer variable in the ListOf(...)Comparers. Generated ctor expression like we do for JsonReaderWriter and Converter and hand-crafted lambdas passed to the ctors, so that they use ctor expression to build ValueComparer, in place of previously captured variable. All tests pass except one - Edit_single_property_collection_of_collection_of_nullable_enum_with_int_converter.  I simplified it into adhoc test case for easier debugging.

Scenario: AdHocMiscellaneousQuerySqlServerTest -> MyRepro

When ctors of ListOfReferenceTypesComparer, ListOfNullableValueTypesComparer and ListOfValueTypesComparer get reverted to compiler generated lambdas, test works fine. With manually crafted lambdas things don't update.

With current code (that's bugged), when putting breakpoint at second SaveChanges (line 2427), and then placing breakpoints in the `Compare` methods for those 3 comparers, the inputs (a and b) are the same object.
When lambdas are compiled generated, a and b are different (one is the original and the second one is what we try to set the value to). Most likely my brain is just fried atm and I'm not seeing the obvious thing here.

