### PR TITLE
Pregenerate SQL for precompiled queries

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -328,6 +328,9 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=precompilation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=precompiling/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pregenerate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pregenerated/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pregeneration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=prunable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=precompilation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pubternal/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -851,7 +851,10 @@ namespace System.Runtime.CompilerServices
             .IncrementIndent()
             .AppendLine("var relationalModel = dbContext.Model.GetRelationalModel();")
             .AppendLine("var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();")
-            .AppendLine("var materializerLiftableConstantContext = new RelationalMaterializerLiftableConstantContext(dbContext.GetService<ShapedQueryCompilingExpressionVisitorDependencies>(), dbContext.GetService<RelationalShapedQueryCompilingExpressionVisitorDependencies>());");
+            .AppendLine("var materializerLiftableConstantContext = new RelationalMaterializerLiftableConstantContext(")
+            .AppendLine("    dbContext.GetService<ShapedQueryCompilingExpressionVisitorDependencies>(),")
+            .AppendLine("    dbContext.GetService<RelationalShapedQueryCompilingExpressionVisitorDependencies>(),")
+            .AppendLine("    dbContext.GetService<RelationalCommandBuilderDependencies>());");
 
         HashSet<string> variableNames = ["relationalModel", "relationalTypeMappingSource", "materializerLiftableConstantContext"];
 

--- a/src/EFCore.Relational/Extensions/Internal/RelationalCommandResolverExtensions.cs
+++ b/src/EFCore.Relational/Extensions/Internal/RelationalCommandResolverExtensions.cs
@@ -1,9 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Query.Internal;
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Internal;
 
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -11,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public interface IParameterValues
+public static class RelationalCommandResolverExtensions
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,13 +20,13 @@ public interface IParameterValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IReadOnlyDictionary<string, object?> ParameterValues { get; }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    void AddParameter(string name, object? value);
+    public static IRelationalCommand RentAndPopulateRelationalCommand(
+        this RelationalCommandResolver relationalCommandResolver,
+        RelationalQueryContext queryContext)
+    {
+        var relationalCommandTemplate = relationalCommandResolver(queryContext.ParameterValues);
+        var relationalCommand = queryContext.Connection.RentCommand();
+        relationalCommand.PopulateFrom(relationalCommandTemplate);
+        return relationalCommand;
+    }
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandResolver.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandResolver.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public delegate IRelationalCommandTemplate RelationalCommandResolver(IReadOnlyDictionary<string, object?> parameters);

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryCompilationContextFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryCompilationContextFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
@@ -41,8 +43,8 @@ public class RelationalQueryCompilationContextFactory : IQueryCompilationContext
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async, bool precompiling)
-        => new RelationalQueryCompilationContext(Dependencies, RelationalDependencies, async, precompiling);
+    public virtual QueryCompilationContext Create(bool async)
+        => new RelationalQueryCompilationContext(Dependencies, RelationalDependencies, async);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -50,6 +52,7 @@ public class RelationalQueryCompilationContextFactory : IQueryCompilationContext
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async)
-        => throw new UnreachableException("The overload with `precompiling` should be called");
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public virtual QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+        => new RelationalQueryCompilationContext(Dependencies, RelationalDependencies, async, precompiling: true, nonNullableReferenceTypeParameters);
 }

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -24,9 +24,10 @@ public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
     /// </summary>
     public RelationalLiftableConstantProcessor(
         ShapedQueryCompilingExpressionVisitorDependencies dependencies,
-        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies,
+        RelationalCommandBuilderDependencies commandBuilderDependencies)
         : base(dependencies)
-        => _relationalMaterializerLiftableConstantContext = new(dependencies, relationalDependencies);
+        => _relationalMaterializerLiftableConstantContext = new(dependencies, relationalDependencies, commandBuilderDependencies);
 
     /// <inheritdoc/>
     protected override ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)

--- a/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
+++ b/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
@@ -14,5 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
 public record RelationalMaterializerLiftableConstantContext(
         ShapedQueryCompilingExpressionVisitorDependencies Dependencies,
-        RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies)
+        RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies,
+        RelationalCommandBuilderDependencies CommandBuilderDependencies)
     : MaterializerLiftableConstantContext(Dependencies);

--- a/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Query.Internal;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -22,13 +22,30 @@ public class RelationalQueryCompilationContext : QueryCompilationContext
     /// <param name="dependencies">Parameter object containing dependencies for this class.</param>
     /// <param name="relationalDependencies">Parameter object containing relational dependencies for this class.</param>
     /// <param name="async">A bool value indicating whether it is for async query.</param>
+    public RelationalQueryCompilationContext(
+        QueryCompilationContextDependencies dependencies,
+        RelationalQueryCompilationContextDependencies relationalDependencies,
+        bool async)
+        : this(dependencies, relationalDependencies, async, precompiling: false, nonNullableReferenceTypeParameters: null)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="RelationalQueryCompilationContext" /> class.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this class.</param>
+    /// <param name="relationalDependencies">Parameter object containing relational dependencies for this class.</param>
+    /// <param name="async">A bool value indicating whether it is for async query.</param>
     /// <param name="precompiling">Indicates whether the query is being precompiled.</param>
+    /// <param name="nonNullableReferenceTypeParameters">Names of parameters which have non-nullable reference types.</param>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
     public RelationalQueryCompilationContext(
         QueryCompilationContextDependencies dependencies,
         RelationalQueryCompilationContextDependencies relationalDependencies,
         bool async,
-        bool precompiling)
-        : base(dependencies, async, precompiling)
+        bool precompiling,
+        IReadOnlySet<string>? nonNullableReferenceTypeParameters)
+        : base(dependencies, async, precompiling, nonNullableReferenceTypeParameters)
     {
         RelationalDependencies = relationalDependencies;
         QuerySplittingBehavior = RelationalOptionsExtension.Extract(ContextOptions).QuerySplittingBehavior;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -412,7 +412,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
-            RelationalCommandCache relationalCommandCache,
+            RelationalCommandResolver relationalCommandResolver,
             IReadOnlyList<ReaderColumn?>? readerColumns,
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
@@ -431,18 +431,18 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 // Execute and fetch data reader
                 var dataReader = executionStrategy.Execute(
-                    (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
-                    ((RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup)
+                    (queryContext, relationalCommandResolver, readerColumns, detailedErrorsEnabled),
+                    ((RelationalQueryContext, RelationalCommandResolver, IReadOnlyList<ReaderColumn?>?, bool) tup)
                         => InitializeReader(tup.Item1, tup.Item2, tup.Item3, tup.Item4),
                     verifySucceeded: null);
 
                 static RelationalDataReader InitializeReader(
                     RelationalQueryContext queryContext,
-                    RelationalCommandCache relationalCommandCache,
+                    RelationalCommandResolver relationalCommandResolver,
                     IReadOnlyList<ReaderColumn?>? readerColumns,
                     bool detailedErrorsEnabled)
                 {
-                    var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
+                    var relationalCommand = relationalCommandResolver.RentAndPopulateRelationalCommand(queryContext);
 
                     return relationalCommand.ExecuteReader(
                         new RelationalCommandParameterObject(
@@ -503,7 +503,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
-            RelationalCommandCache relationalCommandCache,
+            RelationalCommandResolver relationalCommandResolver,
             IReadOnlyList<ReaderColumn?>? readerColumns,
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
@@ -522,9 +522,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 // Execute and fetch data reader
                 var dataReader = await executionStrategy.ExecuteAsync(
-                        (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
+                        (queryContext, relationalCommandResolver, readerColumns, detailedErrorsEnabled),
                         (
-                                (RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup,
+                                (RelationalQueryContext, RelationalCommandResolver, IReadOnlyList<ReaderColumn?>?, bool) tup,
                                 CancellationToken cancellationToken)
                             => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, tup.Item4, cancellationToken),
                         verifySucceeded: null,
@@ -533,12 +533,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                 static async Task<RelationalDataReader> InitializeReaderAsync(
                     RelationalQueryContext queryContext,
-                    RelationalCommandCache relationalCommandCache,
+                    RelationalCommandResolver relationalCommandResolver,
                     IReadOnlyList<ReaderColumn?>? readerColumns,
                     bool detailedErrorsEnabled,
                     CancellationToken cancellationToken)
                 {
-                    var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
+                    var relationalCommand = relationalCommandResolver.RentAndPopulateRelationalCommand(queryContext);
 
                     return await relationalCommand.ExecuteReaderAsync(
                             new RelationalCommandParameterObject(
@@ -780,7 +780,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
-            RelationalCommandCache relationalCommandCache,
+            RelationalCommandResolver relationalCommandResolver,
             IReadOnlyList<ReaderColumn?>? readerColumns,
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
@@ -796,18 +796,18 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 // Execute and fetch data reader
                 var dataReader = executionStrategy.Execute(
-                    (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
-                    ((RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup)
+                    (queryContext, relationalCommandResolver, readerColumns, detailedErrorsEnabled),
+                    ((RelationalQueryContext, RelationalCommandResolver, IReadOnlyList<ReaderColumn?>?, bool) tup)
                         => InitializeReader(tup.Item1, tup.Item2, tup.Item3, tup.Item4),
                     verifySucceeded: null);
 
                 static RelationalDataReader InitializeReader(
                     RelationalQueryContext queryContext,
-                    RelationalCommandCache relationalCommandCache,
+                    RelationalCommandResolver relationalCommandResolver,
                     IReadOnlyList<ReaderColumn?>? readerColumns,
                     bool detailedErrorsEnabled)
                 {
-                    var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
+                    var relationalCommand = relationalCommandResolver.RentAndPopulateRelationalCommand(queryContext);
 
                     return relationalCommand.ExecuteReader(
                         new RelationalCommandParameterObject(
@@ -866,7 +866,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
-            RelationalCommandCache relationalCommandCache,
+            RelationalCommandResolver relationalCommandResolver,
             IReadOnlyList<ReaderColumn?>? readerColumns,
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
@@ -882,9 +882,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 // Execute and fetch data reader
                 var dataReader = await executionStrategy.ExecuteAsync(
-                        (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
+                        (queryContext, relationalCommandResolver, readerColumns, detailedErrorsEnabled),
                         (
-                                (RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup,
+                                (RelationalQueryContext, RelationalCommandResolver, IReadOnlyList<ReaderColumn?>?, bool) tup,
                                 CancellationToken cancellationToken)
                             => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, tup.Item4, cancellationToken),
                         verifySucceeded: null,
@@ -893,12 +893,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                 static async Task<RelationalDataReader> InitializeReaderAsync(
                     RelationalQueryContext queryContext,
-                    RelationalCommandCache relationalCommandCache,
+                    RelationalCommandResolver relationalCommandResolver,
                     IReadOnlyList<ReaderColumn?>? readerColumns,
                     bool detailedErrorsEnabled,
                     CancellationToken cancellationToken)
                 {
-                    var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
+                    var relationalCommand = relationalCommandResolver.RentAndPopulateRelationalCommand(queryContext);
 
                     return await relationalCommand.ExecuteReaderAsync(
                             new RelationalCommandParameterObject(

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -21,8 +21,15 @@ public sealed class SqlParameterExpression : SqlExpression
     {
     }
 
-    private SqlParameterExpression(string name, Type type, bool nullable, RelationalTypeMapping? typeMapping)
-        : base(type, typeMapping)
+    /// <summary>
+    ///     Creates a new instance of the <see cref="SqlParameterExpression" /> class.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="type">The <see cref="Type" /> of the expression.</param>
+    /// <param name="nullable">Whether this parameter can have null values.</param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
+    public SqlParameterExpression(string name, Type type, bool nullable, RelationalTypeMapping? typeMapping)
+        : base(type.UnwrapNullableType(), typeMapping)
     {
         Name = name;
         IsNullable = nullable;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -25,9 +25,29 @@ public class SqlServerQueryCompilationContext : RelationalQueryCompilationContex
         QueryCompilationContextDependencies dependencies,
         RelationalQueryCompilationContextDependencies relationalDependencies,
         bool async,
-        bool precompiling,
         bool multipleActiveResultSetsEnabled)
-        : base(dependencies, relationalDependencies, async, precompiling)
+        : this(
+            dependencies, relationalDependencies, async, multipleActiveResultSetsEnabled, precompiling: false,
+            nonNullableReferenceTypeParameters: null)
+    {
+        _multipleActiveResultSetsEnabled = multipleActiveResultSetsEnabled;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public SqlServerQueryCompilationContext(
+        QueryCompilationContextDependencies dependencies,
+        RelationalQueryCompilationContextDependencies relationalDependencies,
+        bool async,
+        bool multipleActiveResultSetsEnabled,
+        bool precompiling,
+        IReadOnlySet<string>? nonNullableReferenceTypeParameters)
+        : base(dependencies, relationalDependencies, async, precompiling, nonNullableReferenceTypeParameters)
     {
         _multipleActiveResultSetsEnabled = multipleActiveResultSetsEnabled;
     }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
@@ -47,9 +48,9 @@ public class SqlServerQueryCompilationContextFactory : IQueryCompilationContextF
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async, bool precompiling)
+    public virtual QueryCompilationContext Create(bool async)
         => new SqlServerQueryCompilationContext(
-            Dependencies, RelationalDependencies, async, precompiling, _sqlServerConnection.IsMultipleActiveResultSetsEnabled);
+            Dependencies, RelationalDependencies, async, _sqlServerConnection.IsMultipleActiveResultSetsEnabled);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -57,6 +58,9 @@ public class SqlServerQueryCompilationContextFactory : IQueryCompilationContextF
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async)
-        => throw new UnreachableException("The overload with `precompiling` should be called");
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public virtual QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+        => new SqlServerQueryCompilationContext(
+            Dependencies, RelationalDependencies, async, _sqlServerConnection.IsMultipleActiveResultSetsEnabled, precompiling: true,
+            nonNullableReferenceTypeParameters);
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContext.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContext.cs
@@ -22,9 +22,25 @@ public class SqliteQueryCompilationContext : RelationalQueryCompilationContext
     public SqliteQueryCompilationContext(
         QueryCompilationContextDependencies dependencies,
         RelationalQueryCompilationContextDependencies relationalDependencies,
+        bool async)
+        : this(dependencies, relationalDependencies, async, precompiling: false, nonNullableReferenceTypeParameters: null)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public SqliteQueryCompilationContext(
+        QueryCompilationContextDependencies dependencies,
+        RelationalQueryCompilationContextDependencies relationalDependencies,
         bool async,
-        bool precompiling)
-        : base(dependencies, relationalDependencies, async, precompiling)
+        bool precompiling,
+        IReadOnlySet<string>? nonNullableReferenceTypeParameters)
+        : base(dependencies, relationalDependencies, async, precompiling, nonNullableReferenceTypeParameters)
     {
     }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContextFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryCompilationContextFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 
 /// <summary>
@@ -39,10 +41,9 @@ public class SqliteQueryCompilationContextFactory : IQueryCompilationContextFact
     ///     Creates a new <see cref="QueryCompilationContext" />.
     /// </summary>
     /// <param name="async">Specifies whether the query is async.</param>
-    /// <param name="precompiling">Indicates whether the query is being precompiled.</param>
     /// <returns>The created query compilation context.</returns>
-    public QueryCompilationContext Create(bool async, bool precompiling)
-        => new SqliteQueryCompilationContext(Dependencies, RelationalDependencies, async, precompiling);
+    public QueryCompilationContext Create(bool async)
+        => new SqliteQueryCompilationContext(Dependencies, RelationalDependencies, async);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -50,6 +51,8 @@ public class SqliteQueryCompilationContextFactory : IQueryCompilationContextFact
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async)
-        => throw new UnreachableException("The overload with `precompiling` should be called");
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public virtual QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+        => new SqliteQueryCompilationContext(
+            Dependencies, RelationalDependencies, async, precompiling: true, nonNullableReferenceTypeParameters);
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -575,14 +575,9 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
             _ => expression
         };
 
-    private sealed class FakeMemberInfo : MemberInfo
+    private sealed class FakeMemberInfo(string name) : MemberInfo
     {
-        public FakeMemberInfo(string name)
-        {
-            Name = name;
-        }
-
-        public override string Name { get; }
+        public override string Name { get; } = name;
 
         public override object[] GetCustomAttributes(bool inherit)
             => throw new NotSupportedException();

--- a/src/EFCore/Query/IQueryCompilationContextFactory.cs
+++ b/src/EFCore/Query/IQueryCompilationContextFactory.cs
@@ -33,11 +33,9 @@ public interface IQueryCompilationContextFactory
     ///     Creates a new <see cref="QueryCompilationContext" />.
     /// </summary>
     /// <param name="async">Specifies whether the query is async.</param>
-    /// <param name="precompiling">Indicates whether the query is being precompiled.</param>
+    /// <param name="nonNullableReferenceTypeParameters">Names of parameters which have non-nullable reference types.</param>
     /// <returns>The created query compilation context.</returns>
     [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
-    QueryCompilationContext Create(bool async, bool precompiling)
-        => precompiling
-            ? throw new InvalidOperationException(CoreStrings.PrecompiledQueryNotSupported)
-            : Create(async);
+    QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+        => throw new InvalidOperationException(CoreStrings.PrecompiledQueryNotSupported);
 }

--- a/src/EFCore/Query/Internal/IParameterNullabilityInfo.cs
+++ b/src/EFCore/Query/Internal/IParameterNullabilityInfo.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Query.Internal;
-
-// ReSharper disable once CheckNamespace
-namespace Microsoft.EntityFrameworkCore.Internal;
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -12,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public static class RelationCommandCacheExtensions
+public interface IParameterNullabilityInfo
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,13 +17,5 @@ public static class RelationCommandCacheExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static IRelationalCommand RentAndPopulateRelationalCommand(
-        this RelationalCommandCache relationalCommandCache,
-        RelationalQueryContext queryContext)
-    {
-        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommandTemplate(queryContext.ParameterValues);
-        var relationalCommand = queryContext.Connection.RentCommand();
-        relationalCommand.PopulateFrom(relationalCommandTemplate);
-        return relationalCommand;
-    }
+    public bool IsNonNullableReferenceType { get; }
 }

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -208,9 +208,11 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
                     // Apply defining query only when it is not custom query root
                     && entityQueryRootExpression.GetType() == typeof(EntityQueryRootExpression))
                 {
+                    // TODO: #33509: merge NRT information (nonNullableReferenceTypeParameters) for parameters introduced by the query
+                    // TODO: filter into the QueryCompilationContext.NonNullableReferenceTypeParameters
                     var processedDefiningQueryBody = _funcletizer.ExtractParameters(
-                        definingQuery.Body, _parameters, _queryCompilationContext.IsPrecompiling, parameterize: false,
-                        clearParameterizedValues: false);
+                        definingQuery.Body, _parameters, parameterize: false, clearParameterizedValues: false,
+                        _queryCompilationContext.IsPrecompiling, out var nonNullableReferenceTypeParameters);
                     processedDefiningQueryBody = _queryTranslationPreprocessor.NormalizeQueryableMethod(processedDefiningQueryBody);
                     processedDefiningQueryBody = _nullCheckRemovingExpressionVisitor.Visit(processedDefiningQueryBody);
                     processedDefiningQueryBody =
@@ -1753,9 +1755,11 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
                 if (!_parameterizedQueryFilterPredicateCache.TryGetValue(rootEntityType, out var filterPredicate))
                 {
                     filterPredicate = queryFilter;
+                    // TODO: #33509: merge NRT information (nonNullableReferenceTypeParameters) for parameters introduced by the query
+                    // TODO: filter into the QueryCompilationContext.NonNullableReferenceTypeParameters
                     filterPredicate = (LambdaExpression)_funcletizer.ExtractParameters(
-                        filterPredicate, _parameters, _queryCompilationContext.IsPrecompiling, parameterize: false,
-                        clearParameterizedValues: false);
+                        filterPredicate, _parameters, parameterize: false, clearParameterizedValues: false,
+                        _queryCompilationContext.IsPrecompiling, out var nonNullableReferenceTypeParameters);
                     filterPredicate = (LambdaExpression)_queryTranslationPreprocessor.NormalizeQueryableMethod(filterPredicate);
 
                     // We need to do entity equality, but that requires a full method call on a query root to properly flow the

--- a/src/EFCore/Query/Internal/QueryCompilationContextFactory.cs
+++ b/src/EFCore/Query/Internal/QueryCompilationContextFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
@@ -33,8 +35,8 @@ public class QueryCompilationContextFactory : IQueryCompilationContextFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async, bool precompiling)
-        => new(Dependencies, async, precompiling);
+    public virtual QueryCompilationContext Create(bool async)
+        => new(Dependencies, async);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -42,6 +44,7 @@ public class QueryCompilationContextFactory : IQueryCompilationContextFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QueryCompilationContext Create(bool async)
-        => throw new UnreachableException("The overload with `precompiling` should be called");
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public virtual QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+        => new(Dependencies, async, precompiling: true, nonNullableReferenceTypeParameters);
 }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -53,6 +53,8 @@ public class QueryCompilationContext
     /// </summary>
     public static readonly Expression NotTranslatedExpression = new NotTranslatedExpressionType();
 
+    private static readonly IReadOnlySet<string> EmptySet = new HashSet<string>();
+
     private readonly IQueryTranslationPreprocessorFactory _queryTranslationPreprocessorFactory;
     private readonly IQueryableMethodTranslatingExpressionVisitorFactory _queryableMethodTranslatingExpressionVisitorFactory;
     private readonly IQueryTranslationPostprocessorFactory _queryTranslationPostprocessorFactory;
@@ -71,7 +73,7 @@ public class QueryCompilationContext
     public QueryCompilationContext(
         QueryCompilationContextDependencies dependencies,
         bool async)
-        : this(dependencies, async, precompiling: false)
+        : this(dependencies, async, precompiling: false, nonNullableReferenceTypeParameters: null)
     {
     }
 
@@ -81,11 +83,13 @@ public class QueryCompilationContext
     /// <param name="dependencies">Parameter object containing dependencies for this class.</param>
     /// <param name="async">A bool value indicating whether it is for async query.</param>
     /// <param name="precompiling">Indicates whether the query is being precompiled.</param>
+    /// <param name="nonNullableReferenceTypeParameters">Names of parameters which have non-nullable reference types.</param>
     [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
     public QueryCompilationContext(
         QueryCompilationContextDependencies dependencies,
         bool async,
-        bool precompiling)
+        bool precompiling,
+        IReadOnlySet<string>? nonNullableReferenceTypeParameters)
     {
         Dependencies = dependencies;
         IsAsync = async;
@@ -96,6 +100,7 @@ public class QueryCompilationContext
         ContextOptions = dependencies.ContextOptions;
         ContextType = dependencies.ContextType;
         Logger = dependencies.Logger;
+        NonNullableReferenceTypeParameters = nonNullableReferenceTypeParameters ?? EmptySet;
 
         _queryTranslationPreprocessorFactory = dependencies.QueryTranslationPreprocessorFactory;
         _queryableMethodTranslatingExpressionVisitorFactory = dependencies.QueryableMethodTranslatingExpressionVisitorFactory;
@@ -163,6 +168,12 @@ public class QueryCompilationContext
     ///     The CLR type of derived DbContext to use during query compilation.
     /// </summary>
     public virtual Type ContextType { get; }
+
+    /// <summary>
+    ///     Names of parameters which have non-nullable reference types.
+    /// </summary>
+    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+    public virtual IReadOnlySet<string> NonNullableReferenceTypeParameters { get; }
 
     /// <summary>
     ///     Adds a tag to <see cref="Tags" />.

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -66,13 +66,16 @@ public abstract class Database : IDatabase
     /// <inheritdoc />
     public virtual Func<QueryContext, TResult> CompileQuery<TResult>(Expression query, bool async)
         => Dependencies.QueryCompilationContextFactory
-            .Create(async, precompiling: false)
+            .Create(async)
             .CreateQueryExecutor<TResult>(query);
 
     /// <inheritdoc />
     [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
-    public virtual Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(Expression query, bool async)
+    public virtual Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(
+        Expression query,
+        bool async,
+        IReadOnlySet<string> nonNullableReferenceTypeParameters)
         => Dependencies.QueryCompilationContextFactory
-            .Create(async, precompiling: true)
+            .CreatePrecompiled(async, nonNullableReferenceTypeParameters)
             .CreateQueryExecutorExpression<TResult>(query);
 }

--- a/src/EFCore/Storage/IDatabase.cs
+++ b/src/EFCore/Storage/IDatabase.cs
@@ -63,8 +63,12 @@ public interface IDatabase
     /// </summary>
     /// <typeparam name="TResult">The type of query result.</typeparam>
     /// <param name="query">The query to compile.</param>
+    /// <param name="nonNullableReferenceTypeParameters">Names of parameters which have non-nullable reference types..</param>
     /// <param name="async">A value indicating whether this is an async query.</param>
     /// <returns>An expression tree which can be used to execute the query.</returns>
     [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
-    Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(Expression query, bool async);
+    Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(
+        Expression query,
+        bool async,
+        IReadOnlySet<string> nonNullableReferenceTypeParameters);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
@@ -17,7 +17,10 @@ public abstract class PrecompiledQueryRelationalFixture
 
     protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
         => base.AddServices(serviceCollection)
-            .AddScoped<IQueryCompiler, NonCompilingQueryCompiler>();
+            // Bomb if any query is executed that wasn't precompiled
+            .AddScoped<IQueryCompiler, NonCompilingQueryCompiler>()
+            // Don't pregenerate SQLs to make sure we're testing quotability of SQL expressions
+            .AddScoped<IShapedQueryCompilingExpressionVisitorFactory, NonSqlGeneratingShapedQueryCompilingExpressionVisitorFactory>();
 
     public new RelationalTestStore TestStore
         => (RelationalTestStore)base.TestStore;
@@ -31,4 +34,31 @@ public abstract class PrecompiledQueryRelationalFixture
     }
 
     public abstract PrecompiledQueryTestHelpers PrecompiledQueryTestHelpers { get; }
+
+    public class NonSqlGeneratingShapedQueryCompilingExpressionVisitorFactory(
+        ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
+        : IShapedQueryCompilingExpressionVisitorFactory
+    {
+        public ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
+            => new NonSqlGeneratingShapedQueryCompilingExpressionVisitor(
+                dependencies,
+                relationalDependencies,
+                queryCompilationContext);
+    }
+
+    /// <summary>
+    ///     A replacement for <see cref="RelationalShapedQueryCompilingExpressionVisitor" /> which does not pregenerate
+    ///     any SQL, ever. This means that we always generate the SQL as an expression tree in the interceptor, which allows us
+    ///     to check that all SQL expressions are properly quotable.
+    /// </summary>
+    public class NonSqlGeneratingShapedQueryCompilingExpressionVisitor(
+        ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies,
+        QueryCompilationContext queryCompilationContext)
+        : RelationalShapedQueryCompilingExpressionVisitor(dependencies, relationalDependencies, queryCompilationContext)
+    {
+        protected override int MaxNullableParametersForPregeneratedSql
+            => int.MinValue;
+    }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -13,6 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 // ReSharper disable InconsistentNaming
 
+/// <summary>
+///     General tests for precompiled queries.
+///     See also <see cref="PrecompiledSqlPregenerationQueryRelationalTestBase" /> for tests specifically related to SQL pregeneration.
+/// </summary>
 public class PrecompiledQueryRelationalTestBase
 {
     public PrecompiledQueryRelationalTestBase(PrecompiledQueryRelationalFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalFixture.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Blog = Microsoft.EntityFrameworkCore.Query.PrecompiledSqlPregenerationQueryRelationalTestBase.Blog;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class PrecompiledSqlPregenerationQueryRelationalFixture
+    : SharedStoreFixtureBase<PrecompiledSqlPregenerationQueryRelationalTestBase.PrecompiledQueryContext>, ITestSqlLoggerFactory
+{
+    protected override string StoreName
+        => "PrecompiledSqlPregenerationQueryTest";
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+        => base.AddServices(serviceCollection)
+            // Bomb if any query is executed that wasn't precompiled
+            .AddScoped<IQueryCompiler, PrecompiledQueryTestHelpers.NonCompilingQueryCompiler>();
+
+    protected override async Task SeedAsync(PrecompiledSqlPregenerationQueryRelationalTestBase.PrecompiledQueryContext context)
+    {
+        context.Blogs.AddRange(
+            new Blog { Id = 8, Name = "Blog1" },
+            new Blog { Id = 9, Name = "Blog2" });
+        await context.SaveChangesAsync();
+    }
+
+    public abstract PrecompiledQueryTestHelpers PrecompiledQueryTestHelpers { get; }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
@@ -1,0 +1,316 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Test suite for SQL pregeneration scenarios with precompiled queries.
+///     See <see cref="PrecompiledQueryRelationalTestBase" /> for general precompiled query tests not related to
+///     SQL pregeneration.
+/// </summary>
+public class PrecompiledSqlPregenerationQueryRelationalTestBase
+{
+    public PrecompiledSqlPregenerationQueryRelationalTestBase(PrecompiledSqlPregenerationQueryRelationalFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        Fixture = fixture;
+        TestOutputHelper = testOutputHelper;
+
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    protected virtual bool AlwaysPrintGeneratedSources
+        => false;
+
+    [ConditionalFact]
+    public virtual Task No_parameters()
+        => Test("""var blogs = await context.Blogs.Where(b => b.Name == "foo").ToListAsync();""");
+
+    [ConditionalFact]
+    public virtual Task Non_nullable_value_type()
+        => Test(
+            """
+int id = 8;
+var blogs = await context.Blogs.Where(b => b.Id == id).ToListAsync();
+""");
+
+    [ConditionalFact]
+    public virtual Task Nullable_value_type()
+        => Test(
+            """
+int? id = 8;
+var blogs = await context.Blogs.Where(b => b.Id == id).ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+                AssertContains(
+                    """
+if (parameters["__id_0"] == null)
+{
+    result = relationalCommandTemplate;
+}
+else
+{
+    result = relationalCommandTemplate0;
+}
+""", code);
+            });
+
+    [ConditionalFact]
+    public virtual Task Nullable_reference_type()
+        => Test(
+            """
+string? name = "bar";
+var blogs = await context.Blogs.Where(b => b.Name == name).ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+                AssertContains(
+                    """
+if (parameters["__name_0"] == null)
+{
+    result = relationalCommandTemplate;
+}
+else
+{
+    result = relationalCommandTemplate0;
+}
+""", code);
+            });
+
+    [ConditionalFact]
+    public virtual Task Non_nullable_reference_type()
+        => Test(
+            """
+string name = "bar";
+var blogs = await context.Blogs.Where(b => b.Name == name).ToListAsync();
+""");
+
+    [ConditionalFact]
+    public virtual Task Nullable_and_non_nullable_value_types()
+        => Test(
+            """
+int? id1 = 8;
+int id2 = 9;
+var blogs = await context.Blogs.Where(b => b.Id == id1 || b.Id == id2).ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+                AssertContains(
+                    """
+if (parameters["__id1_0"] == null)
+{
+    result = relationalCommandTemplate;
+}
+else
+{
+    result = relationalCommandTemplate0;
+}
+""", code);
+            });
+
+    [ConditionalFact]
+    public virtual Task Two_nullable_reference_types()
+        => Test(
+            """
+string? name1 = "foo";
+string? name2 = "bar";
+var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2).ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+                AssertContains(
+                    """
+if (parameters["__name1_0"] == null)
+{
+    if (parameters["__name2_1"] == null)
+    {
+        result = relationalCommandTemplate;
+    }
+    else
+    {
+        result = relationalCommandTemplate0;
+    }
+}
+else
+{
+    if (parameters["__name2_1"] == null)
+    {
+        result = relationalCommandTemplate1;
+    }
+    else
+    {
+        result = relationalCommandTemplate2;
+    }
+}
+""", code);
+            });
+
+    [ConditionalFact]
+    public virtual Task Two_non_nullable_reference_types()
+        => Test(
+            """
+string name1 = "foo";
+string name2 = "bar";
+var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2).ToListAsync();
+""");
+
+    [ConditionalFact]
+    public virtual Task Nullable_and_non_nullable_reference_types()
+        => Test(
+            """
+string? name1 = "foo";
+string name2 = "bar";
+var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2).ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+                AssertContains(
+                    """
+if (parameters["__name1_0"] == null)
+{
+    result = relationalCommandTemplate;
+}
+else
+{
+    result = relationalCommandTemplate0;
+}
+""", code);
+            });
+
+    [ConditionalFact]
+    public virtual Task Too_many_nullable_parameters_prevent_pregeneration()
+        => Test(
+            """
+string? name1 = "foo";
+string? name2 = "bar";
+string? name3 = "baz";
+string? name4 = "baq";
+var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2 || b.Name == name3 || b.Name == name4).ToListAsync();
+""",
+            interceptorCodeAsserter: code => Assert.Contains(nameof(RelationalCommandCache), code));
+
+    [ConditionalFact]
+    public virtual Task Many_non_nullable_parameters_do_not_prevent_pregeneration()
+        => Test(
+            """
+string name1 = "foo";
+string name2 = "bar";
+string name3 = "baz";
+string name4 = "baq";
+var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2 || b.Name == name3 || b.Name == name4).ToListAsync();
+""");
+
+    #region Tests for the different querying enumerables
+
+    [ConditionalFact]
+    public virtual Task Include_single_query()
+        => Test(
+            """
+var blogs = await context.Blogs
+    .Include(b => b.Posts)
+    .ToListAsync();
+""");
+
+    [ConditionalFact]
+    public virtual Task Include_split_query()
+        => Test(
+            """
+var blogs = await context.Blogs
+    .Include(b => b.Posts)
+    .AsSplitQuery()
+    .ToListAsync();
+""");
+
+    [ConditionalFact]
+    public virtual Task Final_GroupBy()
+        => Test("var blogs = await context.Blogs.GroupBy(b => b.Name).ToListAsync();");
+
+    #endregion Tests for the different querying enumerables
+
+    public class PrecompiledQueryContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Blog> Blogs { get; set; } = null!;
+    }
+
+    protected PrecompiledSqlPregenerationQueryRelationalFixture Fixture { get; }
+    protected ITestOutputHelper TestOutputHelper { get; }
+
+    protected void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    /// <summary>
+    ///     Normalizes line endings and strips all leading whitespace before checking substring containment.
+    /// </summary>
+    private void AssertContains(string expected, string actual)
+        => Assert.Contains(
+            Regex.Replace(expected.ReplaceLineEndings(), @"^\s*", "", RegexOptions.Multiline),
+            Regex.Replace(actual.ReplaceLineEndings(), @"^\s*", "", RegexOptions.Multiline));
+
+    protected virtual async Task Test(
+        string sourceCode,
+        Action<string>? interceptorCodeAsserter = null,
+        Action<List<PrecompiledQueryCodeGenerator.QueryPrecompilationError>>? errorAsserter = null,
+        [CallerMemberName] string callerName = "")
+    {
+        // By default, make sure there's no mention of RelationalCommandCache in the generated interceptor code.
+        // That means that SQL was pregenerated.
+        interceptorCodeAsserter ??= code => Assert.DoesNotContain(nameof(RelationalCommandCache), code);
+
+        await Fixture.PrecompiledQueryTestHelpers.Test(
+            """
+await using var context = new Microsoft.EntityFrameworkCore.Query.PrecompiledSqlPregenerationQueryRelationalTestBase.PrecompiledQueryContext(dbContextOptions);
+
+"""
+            + sourceCode,
+            Fixture.ServiceProvider.GetRequiredService<DbContextOptions>(),
+            typeof(PrecompiledQueryContext),
+            interceptorCodeAsserter,
+            errorAsserter,
+            TestOutputHelper,
+            AlwaysPrintGeneratedSources,
+            callerName);
+    }
+
+    public class Blog
+    {
+        public Blog()
+        {
+        }
+
+        public Blog(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public int Id { get; set; }
+        public string? Name { get; set; }
+
+        public List<Post> Posts { get; set; } = new();
+    }
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+
+        public Blog? Blog { get; set; }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
@@ -93,7 +93,7 @@ using static Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
             "TestCompilation",
             syntaxTrees: [syntaxTree],
             _metadataReferences,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
 
         IReadOnlyList<PrecompiledQueryCodeGenerator.GeneratedInterceptorFile>? generatedFiles = null;
 

--- a/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
@@ -574,8 +574,11 @@ public class RelationalApiConsistencyTest(RelationalApiConsistencyTest.Relationa
 #pragma warning disable EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             typeof(RelationalMaterializerLiftableConstantContext).GetMethod("get_RelationalDependencies"),
             typeof(RelationalMaterializerLiftableConstantContext).GetMethod("set_RelationalDependencies"),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("get_CommandBuilderDependencies"),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("set_CommandBuilderDependencies"),
             typeof(RelationalMaterializerLiftableConstantContext).GetMethod("Deconstruct", [typeof(ShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType()]),
             typeof(RelationalMaterializerLiftableConstantContext).GetMethod("Deconstruct", [typeof(ShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType(), typeof(RelationalShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType()]),
+            typeof(RelationalMaterializerLiftableConstantContext).GetMethod("Deconstruct", [typeof(ShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType(), typeof(RelationalShapedQueryCompilingExpressionVisitorDependencies).MakeByRefType(), typeof(RelationalCommandBuilderDependencies).MakeByRefType()]),
 #pragma warning restore EF9100 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         ];
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+// ReSharper disable InconsistentNaming
+
+public class PrecompiledSqlPregenerationQuerySqlServerTest(
+    PrecompiledSqlPregenerationQuerySqlServerTest.PrecompiledSqlPregenerationQuerySqlServerFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : PrecompiledSqlPregenerationQueryRelationalTestBase(fixture, testOutputHelper),
+        IClassFixture<PrecompiledSqlPregenerationQuerySqlServerTest.PrecompiledSqlPregenerationQuerySqlServerFixture>
+{
+    protected override bool AlwaysPrintGeneratedSources
+        => false;
+
+    public override async Task No_parameters()
+    {
+        await base.No_parameters();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = N'foo'
+""");
+    }
+
+    public override async Task Non_nullable_value_type()
+    {
+        await base.Non_nullable_value_type();
+
+        AssertSql(
+            """
+@__id_0='8'
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Id] = @__id_0
+""");
+    }
+
+    public override async Task Nullable_value_type()
+    {
+        await base.Nullable_value_type();
+
+        AssertSql(
+            """
+@__id_0='8' (Nullable = true)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Id] = @__id_0
+""");
+    }
+
+    public override async Task Nullable_reference_type()
+    {
+        await base.Nullable_reference_type();
+
+        AssertSql(
+            """
+@__name_0='bar' (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name_0
+""");
+    }
+
+    public override async Task Non_nullable_reference_type()
+    {
+        await base.Non_nullable_reference_type();
+
+        AssertSql(
+            """
+@__name_0='bar' (Nullable = false) (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name_0
+""");
+    }
+
+    public override async Task Nullable_and_non_nullable_value_types()
+    {
+        await base.Nullable_and_non_nullable_value_types();
+
+        AssertSql(
+            """
+@__id1_0='8' (Nullable = true)
+@__id2_1='9'
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
+""");
+    }
+
+    public override async Task Two_nullable_reference_types()
+    {
+        await base.Two_nullable_reference_types();
+
+        AssertSql(
+            """
+@__name1_0='foo' (Size = 4000)
+@__name2_1='bar' (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+""");
+    }
+
+    public override async Task Two_non_nullable_reference_types()
+    {
+        await base.Two_non_nullable_reference_types();
+
+        AssertSql(
+            """
+@__name1_0='foo' (Nullable = false) (Size = 4000)
+@__name2_1='bar' (Nullable = false) (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+""");
+    }
+
+    public override async Task Nullable_and_non_nullable_reference_types()
+    {
+        await base.Nullable_and_non_nullable_reference_types();
+
+        AssertSql(
+            """
+@__name1_0='foo' (Size = 4000)
+@__name2_1='bar' (Nullable = false) (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+""");
+    }
+
+    public override async Task Too_many_nullable_parameters_prevent_pregeneration()
+    {
+        await base.Too_many_nullable_parameters_prevent_pregeneration();
+
+        AssertSql(
+            """
+@__name1_0='foo' (Size = 4000)
+@__name2_1='bar' (Size = 4000)
+@__name3_2='baz' (Size = 4000)
+@__name4_3='baq' (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1 OR [b].[Name] = @__name3_2 OR [b].[Name] = @__name4_3
+""");
+    }
+
+    public override async Task Many_non_nullable_parameters_do_not_prevent_pregeneration()
+    {
+        await base.Many_non_nullable_parameters_do_not_prevent_pregeneration();
+
+        AssertSql(
+            """
+@__name1_0='foo' (Nullable = false) (Size = 4000)
+@__name2_1='bar' (Nullable = false) (Size = 4000)
+@__name3_2='baz' (Nullable = false) (Size = 4000)
+@__name4_3='baq' (Nullable = false) (Size = 4000)
+
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1 OR [b].[Name] = @__name3_2 OR [b].[Name] = @__name4_3
+""");
+    }
+
+    #region Tests for the different querying enumerables
+
+    public override async Task Include_single_query()
+    {
+        await base.Include_single_query();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name], [p].[Id], [p].[BlogId], [p].[Title]
+FROM [Blogs] AS [b]
+LEFT JOIN [Post] AS [p] ON [b].[Id] = [p].[BlogId]
+ORDER BY [b].[Id]
+""");
+    }
+
+    public override async Task Include_split_query()
+    {
+        await base.Include_split_query();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+ORDER BY [b].[Id]
+""",
+            //
+            """
+SELECT [p].[Id], [p].[BlogId], [p].[Title], [b].[Id]
+FROM [Blogs] AS [b]
+INNER JOIN [Post] AS [p] ON [b].[Id] = [p].[BlogId]
+ORDER BY [b].[Id]
+""");
+    }
+
+    public override async Task Final_GroupBy()
+    {
+        await base.Final_GroupBy();
+
+        AssertSql(
+            """
+SELECT [b].[Name], [b].[Id]
+FROM [Blogs] AS [b]
+ORDER BY [b].[Name]
+""");
+    }
+
+    #endregion Tests for the different querying enumerables
+
+    [ConditionalFact]
+    public virtual async Task Do_not_cache_is_respected()
+    {
+        // The "do not cache" flag in the 2nd part of the query pipeline is turned on in provider-specific situations, so we test it
+        // here in SQL Server; note that SQL Server compatibility mode is set low to trigger this.
+        await Test(
+            """
+string[] names = ["foo", "bar"];
+var blogs = await context.Blogs.Where(b => names.Contains(b.Name)).ToListAsync();
+""",
+            interceptorCodeAsserter: code => Assert.Contains(nameof(RelationalCommandCache), code));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name]
+FROM [Blogs] AS [b]
+WHERE [b].[Name] IN (N'foo', N'bar')
+""");
+    }
+
+    public class PrecompiledSqlPregenerationQuerySqlServerFixture : PrecompiledSqlPregenerationQueryRelationalFixture
+    {
+        protected override ITestStoreFactory TestStoreFactory
+            => SqlServerTestStoreFactory.Instance;
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            builder = base.AddOptions(builder);
+
+            // TODO: Figure out if there's a nice way to continue using the retrying strategy
+            var sqlServerOptionsBuilder = new SqlServerDbContextOptionsBuilder(builder);
+            sqlServerOptionsBuilder
+                .UseCompatibilityLevel(120)
+                .ExecutionStrategy(d => new NonRetryingExecutionStrategy(d));
+            return builder;
+        }
+
+        public override PrecompiledQueryTestHelpers PrecompiledQueryTestHelpers => SqlServerPrecompiledQueryTestHelpers.Instance;
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqliteTest.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class PrecompiledSqlPregenerationQuerySqlServerTest(
+    PrecompiledSqlPregenerationQuerySqlServerTest.PrecompiledSqlPregenerationQuerySqliteFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : PrecompiledSqlPregenerationQueryRelationalTestBase(fixture, testOutputHelper),
+        IClassFixture<PrecompiledSqlPregenerationQuerySqlServerTest.PrecompiledSqlPregenerationQuerySqliteFixture>
+{
+    protected override bool AlwaysPrintGeneratedSources
+        => false;
+
+    public class PrecompiledSqlPregenerationQuerySqliteFixture : PrecompiledSqlPregenerationQueryRelationalFixture
+    {
+        protected override ITestStoreFactory TestStoreFactory
+            => SqliteTestStoreFactory.Instance;
+
+        public override PrecompiledQueryTestHelpers PrecompiledQueryTestHelpers => SqlitePrecompiledQueryTestHelpers.Instance;
+    }
+}

--- a/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
+++ b/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
@@ -34,7 +34,7 @@ public class NavigationExpandingExpressionVisitorTests
                         contextOptions: null,
                         logger: null,
                         new TestInterceptors()
-                    ), async: false, precompiling: false),
+                    ), async: false),
                 null,
                 null)
         {


### PR DESCRIPTION
When generating the shaper for a precompiled query, we now check the number of nullable parameters it has, and if that number is low (currently 3), we pregenerate SQLs (or rather, RelationCommands) for it. This PR is stacked on top of #33297 (review only the last commits).

Implementation overview:

* Instead of accepting a RelationalCommandCache (which wraps the 2nd part of the query pipeline), querying enumerables now accept a RelationalCommandResolver, which is a lambda reponsible for producing the relational command.
    * In normal mode, the resolver references the RelationalCommandCache, so things work as before.
    * For precompiled queries with 3 nullable parameters or less, the resolver lambda directly contains code which switches over the nullness of the nullable parameters, and returns captured, fully-built relational commands containing the final SQL string. Example:

```c#
var relationalCommandTemplate = ((IRelationalCommandTemplate)(new RelationalCommand(commandBuilderDependencies, "SELECT [b].[Id], [b].[Name]\nFROM [Blogs] AS [b]\nWHERE 0 = 1", new IRelationalParameter[] { })));
var relationalCommandTemplate0 = ((IRelationalCommandTemplate)(new RelationalCommand(commandBuilderDependencies, "SELECT [b].[Id], [b].[Name]\nFROM [Blogs] AS [b]\nWHERE [b].[Id] = @__id_0", new IRelationalParameter[] { new TypeMappedRelationalParameter("__id_0", "@__id_0", relationalTypeMappingSource.FindMapping(typeof(int), "int", false, false, null, false, false, null, null), true, ParameterDirection.Input) })));

SingleQueryingEnumerable.Create(((RelationalQueryContext)(queryContext)), (IReadOnlyDictionary<string, object> parameters) =>
{
    IRelationalCommandTemplate result = default(IRelationalCommandTemplate);
    if (parameters["__id_0"] == null)
    {
        result = relationalCommandTemplate;
    }
    else
    {
        result = relationalCommandTemplate0;
    }

    return result;
}, ...
```

* This PR also implements awareness of NRT captured variables, so that e.g. a non-nullable string parameter causes only one SQL to get generated (with that SQL being optimized for the non-nullable case), just like for value types:
    * When translating the user's LINQ query from C# to LINQ, the captured variable is represented via an internal fake FieldInfo which contains the NRT information.
    * The funcletizer checks for this information and reports it out, and we store the list of all non-nullable NRT parameters on QueryCompilationContext.
    * When translating ParameterExpression to SqlParameterExpression in RelationalSqlTranslatingExpressionVisitor, we consult this list, and create a non-nullable SqlParameterExpression accordingly.

Closes #29753