### PR TITLE
Make sure table name inferred from DbSet name is has proper length based on maximum length for identifiers.

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -85,7 +85,7 @@ public class TableNameFromDbSetConvention :
                  && !entityType.HasSharedClrType
                  && _sets.TryGetValue(entityType.ClrType, out var setName))
         {
-            entityTypeBuilder.ToTable(setName);
+            entityTypeBuilder.ToTable(Uniquifier.Truncate(setName, entityType.Model.GetMaxIdentifierLength()));
         }
     }
 
@@ -101,7 +101,7 @@ public class TableNameFromDbSetConvention :
                 != RelationalAnnotationNames.TphMappingStrategy)
             && _sets.TryGetValue(entityType.ClrType, out var setName))
         {
-            entityTypeBuilder.ToTable(setName);
+            entityTypeBuilder.ToTable(Uniquifier.Truncate(setName, entityType.Model.GetMaxIdentifierLength()));
         }
     }
 
@@ -123,7 +123,7 @@ public class TableNameFromDbSetConvention :
                 if (!derivedEntityType.HasSharedClrType
                     && _sets.TryGetValue(derivedEntityType.ClrType, out var setName))
                 {
-                    derivedEntityType.Builder.ToTable(setName);
+                    derivedEntityType.Builder.ToTable(Uniquifier.Truncate(setName, derivedEntityType.Model.GetMaxIdentifierLength()));
                 }
             }
         }

--- a/test/EFCore.Relational.Tests/DbSetAsTableNameTest.cs
+++ b/test/EFCore.Relational.Tests/DbSetAsTableNameTest.cs
@@ -107,6 +107,15 @@ public abstract class DbSetAsTableNameTest
         Assert.Equal("YummyMarmite", GetTableName<Marmite>(context));
     }
 
+    [ConditionalFact]
+    public virtual void DbSet_long_name_properly_truncated()
+    {
+        using var context = CreateContext();
+        var maxLength = context.Model.GetMaxIdentifierLength();
+        var realLength = GetTableName<ReallyLongName>(context).Length;
+        Assert.True(realLength <= maxLength);
+    }
+
     protected abstract string GetTableName<TEntity>(DbContext context);
 
     protected abstract string GetTableName<TEntity>(DbContext context, string entityTypeName);
@@ -124,6 +133,7 @@ public abstract class DbSetAsTableNameTest
         public DbSet<WheatThin> WheatThins { get; set; }
         public DbSet<Marmite> Food { get; set; }
         public DbSet<Marmite> Beverage { get; set; }
+        public DbSet<ReallyLongName> ReallyLongNames12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 { get; set; }
 
         public DbSet<BothEntity> Bovrils
             => Set<BothEntity>("Bovril");
@@ -211,6 +221,11 @@ public abstract class DbSetAsTableNameTest
     }
 
     protected class VeggieEntity
+    {
+        public int Id { get; set; }
+    }
+
+    protected class ReallyLongName
     {
         public int Id { get; set; }
     }

--- a/test/EFCore.Relational.Tests/DbSetAsTableNameTest.cs
+++ b/test/EFCore.Relational.Tests/DbSetAsTableNameTest.cs
@@ -112,8 +112,17 @@ public abstract class DbSetAsTableNameTest
     {
         using var context = CreateContext();
         var maxLength = context.Model.GetMaxIdentifierLength();
-        var realLength = GetTableName<ReallyLongName>(context).Length;
+        var realLength = GetTableName<ReallyLongNameA>(context).Length;
         Assert.True(realLength <= maxLength);
+    }
+
+    [ConditionalFact]
+    public virtual void DbSet_long_name_uniquely_truncated()
+    {
+        using var context = CreateContext();
+        var nameA = GetTableName<ReallyLongNameA>(context);
+        var nameB = GetTableName<ReallyLongNameB>(context);
+        Assert.NotEqual(nameA, nameB);
     }
 
     protected abstract string GetTableName<TEntity>(DbContext context);
@@ -133,7 +142,8 @@ public abstract class DbSetAsTableNameTest
         public DbSet<WheatThin> WheatThins { get; set; }
         public DbSet<Marmite> Food { get; set; }
         public DbSet<Marmite> Beverage { get; set; }
-        public DbSet<ReallyLongName> ReallyLongNames12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 { get; set; }
+        public DbSet<ReallyLongNameA> ReallyLongNames12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890A { get; set; }
+        public DbSet<ReallyLongNameB> ReallyLongNames12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890B { get; set; }
 
         public DbSet<BothEntity> Bovrils
             => Set<BothEntity>("Bovril");
@@ -225,7 +235,12 @@ public abstract class DbSetAsTableNameTest
         public int Id { get; set; }
     }
 
-    protected class ReallyLongName
+    protected class ReallyLongNameA
+    {
+        public int Id { get; set; }
+    }
+
+    protected class ReallyLongNameB
     {
         public int Id { get; set; }
     }


### PR DESCRIPTION
Fixes #30196