### PR TITLE
Small fix to IInjectableService and lazy loading that removes constants of ParameterBindingInfo objects

### DIFF
--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -43,10 +43,10 @@ public class LazyLoader : ILazyLoader, IInjectableService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Injected(DbContext context, object entity, ParameterBindingInfo bindingInfo)
+    public virtual void Injected(DbContext context, object entity, QueryTrackingBehavior? queryTrackingBehavior, ITypeBase structuralType)
     {
-        _queryTrackingBehavior = bindingInfo.QueryTrackingBehavior;
-        _nonLazyNavigations ??= InitNavigationsMetadata(bindingInfo.StructuralType as IEntityType
+        _queryTrackingBehavior = queryTrackingBehavior;
+        _nonLazyNavigations ??= InitNavigationsMetadata(structuralType as IEntityType
             ?? throw new NotImplementedException("Navigations on complex types are not supported"));
     }
 

--- a/src/EFCore/Internal/IInjectableService.cs
+++ b/src/EFCore/Internal/IInjectableService.cs
@@ -22,7 +22,7 @@ public interface IInjectableService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void Injected(DbContext context, object entity, ParameterBindingInfo bindingInfo);
+    void Injected(DbContext context, object entity, QueryTrackingBehavior? queryTrackingBehavior, ITypeBase structuralType);
 
     /// <summary>
     ///     <para>

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -246,7 +246,8 @@ public class EntityMaterializerSource : IEntityMaterializerSource
                         InjectableServiceInjectedMethod,
                         getContext,
                         instanceVariable,
-                        Expression.Constant(bindingInfo, typeof(ParameterBindingInfo)))));
+                        Expression.Constant(bindingInfo.QueryTrackingBehavior, typeof(QueryTrackingBehavior?)),
+                        Expression.Constant(bindingInfo.StructuralType))));
         }
     }
 


### PR DESCRIPTION
This is needed for precompiled query work.