### PR TITLE
[release/8.0] Fix parameter names for nested types in complex type equality (#33527)

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -9,6 +9,7 @@ public class InMemoryComplianceTest : ComplianceTestBase
     {
         // No in-memory tests
         typeof(ComplexTypeQueryTestBase<>),
+        typeof(AdHocComplexTypeQueryTestBase),
         typeof(PrimitiveCollectionsQueryTestBase<>),
         typeof(NonSharedPrimitiveCollectionsQueryTestBase),
         typeof(FunkyDataQueryTestBase<>),

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+// ReSharper disable ClassNeverInstantiated.Local
+
+public abstract class AdHocComplexTypeQueryTestBase : NonSharedModelTestBase
+{
+    #region 33449
+
+    [ConditionalFact]
+    public virtual Task Complex_type_equals_parameter_with_nested_types_with_property_of_same_name()
+    {
+        throw new NotImplementedException();
+    }
+
+    private class Context33449(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<EntityType>().ComplexProperty(b => b.ComplexContainer, x =>
+            {
+                x.ComplexProperty(c => c.Containee1);
+                x.ComplexProperty(c => c.Containee2);
+            });
+
+        public class EntityType
+        {
+            public int Id { get; set; }
+            public ComplexContainer ComplexContainer { get; set; } = null!;
+        }
+
+        public class ComplexContainer
+        {
+            public int Id { get; set; }
+
+            public ComplexContainee1 Containee1 { get; set; } = null!;
+            public ComplexContainee2 Containee2 { get; set; } = null!;
+        }
+
+        public class ComplexContainee1
+        {
+            public int Id { get; set; }
+        }
+
+        public class ComplexContainee2
+        {
+            public int Id { get; set; }
+        }
+    }
+
+    #endregion 33449
+
+    protected override string StoreName
+        => "AdHocComplexTypeQueryTest";
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class AdHocComplexTypeQuerySqlServerTest : AdHocComplexTypeQueryTestBase
+{
+    public override async Task Complex_type_equals_parameter_with_nested_types_with_property_of_same_name()
+    {
+        await base.Complex_type_equals_parameter_with_nested_types_with_property_of_same_name();
+
+        AssertSql(
+            """
+@__entity_equality_container_0_Id='1' (Nullable = true)
+@__entity_equality_container_0_Containee1_Id='2' (Nullable = true)
+@__entity_equality_container_0_Containee2_Id='3' (Nullable = true)
+
+SELECT TOP(2) [e].[Id], [e].[ComplexContainer_Id], [e].[ComplexContainer_Containee1_Id], [e].[ComplexContainer_Containee2_Id]
+FROM [EntityType] AS [e]
+WHERE [e].[ComplexContainer_Id] = @__entity_equality_container_0_Id AND [e].[ComplexContainer_Containee1_Id] = @__entity_equality_container_0_Containee1_Id AND [e].[ComplexContainer_Containee2_Id] = @__entity_equality_container_0_Containee2_Id
+""");
+    }
+
+    protected TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected void AssertSql(params string[] expected)
+        => TestSqlLoggerFactory.AssertBaseline(expected);
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -233,12 +233,12 @@ WHERE [c].[ShippingAddress_AddressLine1] = N'804 S. Lakeshore Road' AND [c].[Shi
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 4000)
-@__entity_equality_address_0_FullName='United States' (Size = 4000)
+@__entity_equality_address_0_Country_Code='US' (Size = 4000)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
 
 SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
 FROM [Customer] AS [c]
-WHERE [c].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c].[ShippingAddress_AddressLine2] IS NULL AND [c].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [c].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName
+WHERE [c].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c].[ShippingAddress_AddressLine2] IS NULL AND [c].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [c].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName
 """);
     }
 
@@ -264,15 +264,15 @@ WHERE [c].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressL
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 4000)
-@__entity_equality_address_0_FullName='United States' (Size = 4000)
+@__entity_equality_address_0_Country_Code='US' (Size = 4000)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
 
 SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
 FROM [Customer] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Customer] AS [c0]
-    WHERE [c0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c0].[ShippingAddress_AddressLine2] IS NULL AND [c0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [c0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName)
+    WHERE [c0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c0].[ShippingAddress_AddressLine2] IS NULL AND [c0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [c0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName)
 """);
     }
 
@@ -600,12 +600,12 @@ WHERE [v].[ShippingAddress_AddressLine1] = N'804 S. Lakeshore Road' AND [v].[Shi
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 4000)
-@__entity_equality_address_0_FullName='United States' (Size = 4000)
+@__entity_equality_address_0_Country_Code='US' (Size = 4000)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
 
 SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
 FROM [ValuedCustomer] AS [v]
-WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [v].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName
+WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [v].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName
 """);
     }
 
@@ -624,15 +624,15 @@ WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressL
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 4000)
-@__entity_equality_address_0_FullName='United States' (Size = 4000)
+@__entity_equality_address_0_Country_Code='US' (Size = 4000)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
 
 SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
 FROM [ValuedCustomer] AS [v]
 WHERE EXISTS (
     SELECT 1
     FROM [ValuedCustomer] AS [v0]
-    WHERE [v0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v0].[ShippingAddress_AddressLine2] IS NULL AND [v0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [v0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName)
+    WHERE [v0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v0].[ShippingAddress_AddressLine2] IS NULL AND [v0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [v0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class AdHocComplexTypeQuerySqliteTest : AdHocComplexTypeQueryTestBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -231,12 +231,12 @@ WHERE "c"."ShippingAddress_AddressLine1" = '804 S. Lakeshore Road' AND "c"."Ship
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 2)
-@__entity_equality_address_0_FullName='United States' (Size = 13)
+@__entity_equality_address_0_Country_Code='US' (Size = 2)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
 
 SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
 FROM "Customer" AS "c"
-WHERE "c"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c"."ShippingAddress_AddressLine2" IS NULL AND "c"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "c"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName
+WHERE "c"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c"."ShippingAddress_AddressLine2" IS NULL AND "c"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "c"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName
 """);
     }
 
@@ -262,15 +262,15 @@ WHERE "c"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressL
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 2)
-@__entity_equality_address_0_FullName='United States' (Size = 13)
+@__entity_equality_address_0_Country_Code='US' (Size = 2)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
 
 SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
 FROM "Customer" AS "c"
 WHERE EXISTS (
     SELECT 1
     FROM "Customer" AS "c0"
-    WHERE "c0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c0"."ShippingAddress_AddressLine2" IS NULL AND "c0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "c0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName)
+    WHERE "c0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c0"."ShippingAddress_AddressLine2" IS NULL AND "c0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "c0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName)
 """);
     }
 
@@ -598,12 +598,12 @@ WHERE "v"."ShippingAddress_AddressLine1" = '804 S. Lakeshore Road' AND "v"."Ship
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 2)
-@__entity_equality_address_0_FullName='United States' (Size = 13)
+@__entity_equality_address_0_Country_Code='US' (Size = 2)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
 
 SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
 FROM "ValuedCustomer" AS "v"
-WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "v"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName
+WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "v"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName
 """);
     }
 
@@ -622,15 +622,15 @@ WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressL
             """
 @__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
 @__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Code='US' (Size = 2)
-@__entity_equality_address_0_FullName='United States' (Size = 13)
+@__entity_equality_address_0_Country_Code='US' (Size = 2)
+@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
 
 SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
 FROM "ValuedCustomer" AS "v"
 WHERE EXISTS (
     SELECT 1
     FROM "ValuedCustomer" AS "v0"
-    WHERE "v0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v0"."ShippingAddress_AddressLine2" IS NULL AND "v0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "v0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName)
+    WHERE "v0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v0"."ShippingAddress_AddressLine2" IS NULL AND "v0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "v0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName)
 """);
     }
 


### PR DESCRIPTION
Fixes #33449
Backport of #33527

**Description**
When translating the equality comparison of two complex types, EF generates SQL to compare every property of the complex type to each other; when one of these complex type is a client-side parameter, EF constructs a new, synthetic parameter for each such property - recursively. However, the synthetic parameter names contained the name of the parameter and the name of the final (non-complex property), but did not contain the names of intermediate nested complex types containing the property. As a result, if a complex type contains two properties with the same name within different nested complex types, the same parameter name is generated and the old parameter is overridden.

**Customer impact**
When doing complex type comparison against a parameter, where multiple nested properties have the same name, an incorrect query is generated, leading either to an error or two data corruption (incorrect results being returned).

**How found**
Customer reported on 8.

**Regression**
No, complex type support is a new feature in EF8.

**Testing**
Test added.

**Risk**
Very Low. The fix is very localized and straightforward - we simply add nested property names when constructing the parameter name. A quirk was added just in case.
