### PR TITLE
Update DotNetBuild.props

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,10 +1,7 @@
-<!-- Whenever altering this or other DotNetBuild files, please include @dotnet/source-build-internal as a reviewer. -->
-
 <Project>
 
-    <PropertyGroup>
-      <GitHubRepositoryName>efcore</GitHubRepositoryName>
-      <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    </PropertyGroup>
+  <PropertyGroup>
+    <GitHubRepositoryName>efcore</GitHubRepositoryName>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
efcore isn't part of the source-build graph so we don't need that property and the comment.