### PR TITLE
InMemoryTable: Make IsConcurrencyConflict() method more readable

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
@@ -229,29 +229,32 @@ public class InMemoryTable<TKey> : IInMemoryTable
         object? rowValue,
         Dictionary<IProperty, object?> concurrencyConflicts)
     {
-        if (property.IsConcurrencyToken)
+        if (!property.IsConcurrencyToken)
         {
-            var comparer = property.GetKeyValueComparer();
-            var originalValue = entry.GetOriginalValue(property);
-
-            var converter = property.GetValueConverter()
-                ?? property.FindTypeMapping()?.Converter;
-
-            if (converter != null)
-            {
-                rowValue = converter.ConvertFromProvider(rowValue);
-            }
-
-            if ((comparer != null && !comparer.Equals(rowValue, originalValue))
-                || (comparer == null && !StructuralComparisons.StructuralEqualityComparer.Equals(rowValue, originalValue)))
-            {
-                concurrencyConflicts.Add(property, rowValue);
-
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        var comparer = property.GetKeyValueComparer()
+            ?? StructuralComparisons.StructuralEqualityComparer;
+
+        var originalValue = entry.GetOriginalValue(property);
+
+        var converter = property.GetValueConverter()
+            ?? property.FindTypeMapping()?.Converter;
+
+        if (converter != null)
+        {
+            rowValue = converter.ConvertFromProvider(rowValue);
+        }
+
+        if (comparer.Equals(rowValue, originalValue))
+        {
+            return false;
+        }
+
+        concurrencyConflicts.Add(property, rowValue);
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
These changes are not related to any issue.

**Changed:**
- Make [IsConcurrencyConflict()][link] method more readable

**Checklist:**
- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] ~~I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team~~
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] ~~Commit messages follow this format:~~
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] ~~New tests for the changes have been added (for bug fixes / features)~~
- [x] Code follows the same patterns and style as existing code in this repo

[link]: https://github.com/dotnet/efcore/blob/3163cb9a0677f94bd986dcdbe3d6026d4f743c73/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs#L226