### PR TITLE
[SMALL/TEST ONLY] Fix to #33590 - Test ordering issue

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
@@ -36,14 +36,6 @@ public class MaterializationInterceptionCosmosTest :
     public override Task Intercept_query_materialization_for_empty_constructor(bool inject, bool usePooling)
         => base.Intercept_query_materialization_for_empty_constructor(inject, usePooling);
 
-
-
-    
-
-
-
-
-
     protected override ITestStoreFactory TestStoreFactory
         => CosmosTestStoreFactory.Instance;
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3383,26 +3383,6 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Distinct_skip_without_orderby(bool async)
-        => AssertQuery(
-            async,
-            ss => from l1 in ss.Set<Level1>()
-                  where l1.Id < 3
-                  select (from l3 in ss.Set<Level3>()
-                          select l3).Distinct().Skip(1).OrderBy(e => e.Id).FirstOrDefault().Name);
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Distinct_take_without_orderby(bool async)
-        => AssertQuery(
-            async,
-            ss => from l1 in ss.Set<Level1>()
-                  where l1.Id < 3
-                  select (from l3 in ss.Set<Level3>()
-                          select l3).Distinct().Take(1).OrderBy(e => e.Id).FirstOrDefault().Name);
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Let_let_contains_from_outer_let(bool async)
         => AssertQuery(
             async,


### PR DESCRIPTION
Moving the problematic tests from base to SQL Server, where they happen to return results in default order, rather than removing the tests altogether.

Fixes #33590