### PR TITLE
Remove temporary properties created by ForeignKeyPropertyDiscoveryConvention if they aren't used.

### DIFF
--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
@@ -1369,6 +1369,19 @@ public abstract partial class ModelBuilding101TestBase
                     .WithOne(e => e.Blog)
                     .HasPrincipalKey(e => e.AlternateId);
         }
+
+        public class ContextAnnotated1 : ContextAnnotated0
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Post>().HasIndex(p => p.BlogId);
+            }
+
+            protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+                => configurationBuilder.Conventions.Remove<ForeignKeyIndexConvention>();
+        }
     }
 
     [ConditionalFact]

--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToOneNrtTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToOneNrtTestBase.cs
@@ -1272,7 +1272,7 @@ public abstract partial class ModelBuilding101TestBase
 
     [ConditionalFact]
     public virtual void OneToOneRequiredWithAlternateKeyNrtTest()
-        => Assert.Throws<EqualException>(() => Model101Test()); // Issue #30346
+        => Model101Test();
 
     protected class OneToOneRequiredWithAlternateKeyNrt
     {

--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToOneTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToOneTestBase.cs
@@ -1279,7 +1279,7 @@ public abstract partial class ModelBuilding101TestBase
 
     [ConditionalFact]
     public virtual void OneToOneRequiredWithAlternateKeyTest()
-        => Assert.Throws<EqualException>(() => Model101Test()); // Issue #30346
+        => Model101Test();
 
     protected class OneToOneRequiredWithAlternateKey
     {


### PR DESCRIPTION
Fixes #33531