### PR TITLE
Only build the model once and cache the (non)runtime one in the same pass.

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -152,7 +152,6 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IRelationalCommandBuilderFactory, RelationalCommandBuilderFactory>();
         TryAdd<IRawSqlCommandBuilder, RawSqlCommandBuilder>();
         TryAdd<ICommandBatchPreparer, CommandBatchPreparer>();
-        TryAdd<IResettableService, ICommandBatchPreparer>(p => p.GetRequiredService<ICommandBatchPreparer>());
         TryAdd<IModificationCommandFactory, ModificationCommandFactory>();
         TryAdd<IMigrationsModelDiffer, MigrationsModelDiffer>();
         TryAdd<IMigrationsSqlGenerator, MigrationsSqlGenerator>();

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -143,9 +143,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
             annotations[RelationalAnnotationNames.SqlQuery] = entityType.GetSqlQuery();
             annotations[RelationalAnnotationNames.FunctionName] = entityType.GetFunctionName();
 
-            if (annotations.TryGetValue(RelationalAnnotationNames.MappingFragments, out var mappingFragments))
+            if (annotations.TryGetValue(RelationalAnnotationNames.MappingFragments, out var mappingFragments)
+                && mappingFragments != null)
             {
-                var entityTypeMappingFragment = (IReadOnlyStoreObjectDictionary<IEntityTypeMappingFragment>)mappingFragments!;
+                var entityTypeMappingFragment = (IReadOnlyStoreObjectDictionary<IEntityTypeMappingFragment>)mappingFragments;
                 var runtimeEntityTypeMappingFragment = new StoreObjectDictionary<RuntimeEntityTypeMappingFragment>();
                 foreach (var fragment in entityTypeMappingFragment.GetValues())
                 {
@@ -161,9 +162,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
                 annotations[RelationalAnnotationNames.MappingFragments] = runtimeEntityTypeMappingFragment;
             }
 
-            if (annotations.TryGetValue(RelationalAnnotationNames.InsertStoredProcedure, out var insertStoredProcedure))
+            if (annotations.TryGetValue(RelationalAnnotationNames.InsertStoredProcedure, out var insertStoredProcedure)
+                && insertStoredProcedure != null)
             {
-                var runtimeSproc = Create((IStoredProcedure)insertStoredProcedure!, runtimeEntityType);
+                var runtimeSproc = Create((IStoredProcedure)insertStoredProcedure, runtimeEntityType);
 
                 CreateAnnotations(
                     (IStoredProcedure)insertStoredProcedure!, runtimeSproc,
@@ -173,9 +175,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
                 annotations[RelationalAnnotationNames.InsertStoredProcedure] = runtimeSproc;
             }
 
-            if (annotations.TryGetValue(RelationalAnnotationNames.DeleteStoredProcedure, out var deleteStoredProcedure))
+            if (annotations.TryGetValue(RelationalAnnotationNames.DeleteStoredProcedure, out var deleteStoredProcedure)
+                && deleteStoredProcedure != null)
             {
-                var runtimeSproc = Create((IStoredProcedure)deleteStoredProcedure!, runtimeEntityType);
+                var runtimeSproc = Create((IStoredProcedure)deleteStoredProcedure, runtimeEntityType);
 
                 CreateAnnotations(
                     (IStoredProcedure)deleteStoredProcedure!, runtimeSproc,
@@ -185,9 +188,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
                 annotations[RelationalAnnotationNames.DeleteStoredProcedure] = runtimeSproc;
             }
 
-            if (annotations.TryGetValue(RelationalAnnotationNames.UpdateStoredProcedure, out var updateStoredProcedure))
+            if (annotations.TryGetValue(RelationalAnnotationNames.UpdateStoredProcedure, out var updateStoredProcedure)
+                && updateStoredProcedure != null)
             {
-                var runtimeSproc = Create((IStoredProcedure)updateStoredProcedure!, runtimeEntityType);
+                var runtimeSproc = Create((IStoredProcedure)updateStoredProcedure, runtimeEntityType);
 
                 CreateAnnotations(
                     (IStoredProcedure)updateStoredProcedure!, runtimeSproc,
@@ -384,9 +388,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
             annotations.Remove(RelationalAnnotationNames.Comment);
             annotations.Remove(RelationalAnnotationNames.Collation);
 
-            if (annotations.TryGetValue(RelationalAnnotationNames.RelationalOverrides, out var relationalOverrides))
+            if (annotations.TryGetValue(RelationalAnnotationNames.RelationalOverrides, out var relationalOverrides)
+                && relationalOverrides != null)
             {
-                var tableOverrides = (IReadOnlyStoreObjectDictionary<IRelationalPropertyOverrides>)relationalOverrides!;
+                var tableOverrides = (IReadOnlyStoreObjectDictionary<IRelationalPropertyOverrides>)relationalOverrides;
                 var runtimeTableOverrides = new StoreObjectDictionary<RuntimeRelationalPropertyOverrides>();
                 foreach (var overrides in tableOverrides.GetValues())
                 {

--- a/src/EFCore/Infrastructure/ModelRuntimeInitializer.cs
+++ b/src/EFCore/Infrastructure/ModelRuntimeInitializer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
@@ -88,12 +89,7 @@ public class ModelRuntimeInitializer : IModelRuntimeInitializer
             }
         }
 
-        if (designTime)
-        {
-            return model;
-        }
-
-        model = model.GetOrAddRuntimeAnnotationValue(
+        var finalizedModel = model.GetOrAddRuntimeAnnotationValue(
             CoreAnnotationNames.ReadOnlyModel,
             static model =>
             {
@@ -107,7 +103,7 @@ public class ModelRuntimeInitializer : IModelRuntimeInitializer
             },
             model);
 
-        return model;
+        return designTime ? model : finalizedModel;
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -1113,12 +1113,15 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     public virtual IModel OnModelFinalized()
     {
         IModel model = this;
-        foreach (var modelConvention in _modelFinalizedConventions!)
+        if (_modelFinalizedConventions != null)
         {
-            model = modelConvention.ProcessModelFinalized(model);
-        }
+            foreach (var modelConvention in _modelFinalizedConventions)
+            {
+                model = modelConvention.ProcessModelFinalized(model);
+            }
 
-        _modelFinalizedConventions = null;
+            _modelFinalizedConventions = null;
+        }
 
         return model;
     }

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
@@ -789,19 +789,20 @@ public abstract class MigrationsSqlGeneratorTestBase
         MigrationOperation[] operation,
         MigrationsSqlGenerationOptions options)
     {
+        var services = ContextOptions != null
+            ? TestHelpers.CreateContextServices(CustomServices, ContextOptions)
+            : TestHelpers.CreateContextServices(CustomServices);
+
         IModel model = null;
         if (buildAction != null)
         {
-            var modelBuilder = TestHelpers.CreateConventionBuilder();
+            var modelBuilder = TestHelpers.CreateConventionBuilder(services);
             modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
             buildAction(modelBuilder);
 
             model = modelBuilder.FinalizeModel(designTime: true, skipValidation: true);
         }
 
-        var services = ContextOptions != null
-            ? TestHelpers.CreateContextServices(CustomServices, ContextOptions)
-            : TestHelpers.CreateContextServices(CustomServices);
         var batch = services.GetRequiredService<IMigrationsSqlGenerator>().Generate(operation, model, options);
 
         Sql = string.Join(

--- a/test/EFCore.SqlServer.HierarchyId.Tests/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/CSharpDbContextGeneratorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer;

--- a/test/EFCore.SqlServer.HierarchyId.Tests/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/CSharpEntityTypeGeneratorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer;

--- a/test/EFCore.SqlServer.HierarchyId.Tests/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/ModelCodeGeneratorTestBase.cs
@@ -21,7 +21,7 @@ public abstract class ModelCodeGeneratorTestBase
         modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
         buildModel(modelBuilder);
 
-        var model = modelBuilder.FinalizeModel(designTime: true, skipValidation: true);
+        var model = modelBuilder.FinalizeModel(designTime: true);
 
         var services = AddScaffoldingServices(CreateServices());
         var generator = services.BuildServiceProvider(validateScopes: true)
@@ -47,7 +47,7 @@ public abstract class ModelCodeGeneratorTestBase
     }
 
     protected virtual IServiceCollection AddModelServices(IServiceCollection services)
-        => services;
+        => services.AddEntityFrameworkSqlServerHierarchyId();
 
     protected virtual IServiceCollection AddScaffoldingServices(IServiceCollection services)
         => services;


### PR DESCRIPTION
Clear the list of IModelFinalizedConventions for design-time model to allow the dependencies to be GC'd
Reset CommandBatchPreparer state immediatly after execution to release the memory faster

Fixes #26186