### PR TITLE
[release/8.0] Fix to #33547 - Breaking Change in 8.0.4: System.InvalidOperationException: The data is NULL at ordinal 0. This method can't be called on NULL values. Check using IsDBNull before calling.

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
@@ -792,6 +792,36 @@ public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixtur
                 AssertEqual(e.Complex?.Two, a.Complex?.Two);
             });
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Projecting_property_of_complex_type_using_left_join_with_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => from cg in ss.Set<CustomerGroup>()
+                  join c in ss.Set<Customer>().Where(x => x.Id > 5) on cg.Id equals c.Id into grouping
+                  from c in grouping.DefaultIfEmpty()
+                  select c == null ? null : (int?)c.BillingAddress.ZipCode);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Projecting_complex_from_optional_navigation_using_conditional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<CustomerGroup>().Select(x => x.OptionalCustomer == null ? null : x.OptionalCustomer.ShippingAddress)
+                .OrderBy(x => x!.ZipCode).Take(20).Distinct().Select(x => (int?)x!.ZipCode),
+            ss => ss.Set<CustomerGroup>().Select(x => x.OptionalCustomer == null ? null : x.OptionalCustomer.ShippingAddress)
+                .OrderBy(x => x.MaybeScalar(xx => xx!.ZipCode)).Take(20).Distinct().Select(x => x.MaybeScalar(xx => xx!.ZipCode)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_entity_with_complex_type_pushdown_and_then_left_join(bool async)
+        => AssertQuery(
+            async,
+            ss => from c1 in ss.Set<Customer>().OrderBy(x => x.Id).Take(20).Distinct()
+                  join c2 in ss.Set<Customer>().OrderByDescending(x => x.Id).Take(30).Distinct() on c1.Id equals c2.Id into grouping
+                  from c2 in grouping.DefaultIfEmpty()
+                  select new { Zip1 = c1.BillingAddress.ZipCode, Zip2 = c2.ShippingAddress.ZipCode });
+
     protected DbContext CreateContext()
         => Fixture.CreateContext();
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -1128,6 +1128,72 @@ OUTER APPLY (
         AssertSql("");
     }
 
+    public override async Task Projecting_property_of_complex_type_using_left_join_with_pushdown(bool async)
+    {
+        await base.Projecting_property_of_complex_type_using_left_join_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [t].[BillingAddress_ZipCode]
+FROM [CustomerGroup] AS [c]
+LEFT JOIN (
+    SELECT [c0].[Id], [c0].[BillingAddress_ZipCode]
+    FROM [Customer] AS [c0]
+    WHERE [c0].[Id] > 5
+) AS [t] ON [c].[Id] = [t].[Id]
+""");
+    }
+
+    public override async Task Projecting_complex_from_optional_navigation_using_conditional(bool async)
+    {
+        await base.Projecting_complex_from_optional_navigation_using_conditional(async);
+
+        AssertSql(
+"""
+@__p_0='20'
+
+SELECT [t0].[ShippingAddress_ZipCode]
+FROM (
+    SELECT DISTINCT [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+    FROM (
+        SELECT TOP(@__p_0) [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
+        FROM [CustomerGroup] AS [c]
+        LEFT JOIN [Customer] AS [c0] ON [c].[OptionalCustomerId] = [c0].[Id]
+        ORDER BY [c0].[ShippingAddress_ZipCode]
+    ) AS [t]
+) AS [t0]
+""");
+    }
+
+    public override async Task Project_entity_with_complex_type_pushdown_and_then_left_join(bool async)
+    {
+        await base.Project_entity_with_complex_type_pushdown_and_then_left_join(async);
+
+        AssertSql(
+"""
+@__p_0='20'
+@__p_1='30'
+
+SELECT [t0].[BillingAddress_ZipCode] AS [Zip1], [t1].[ShippingAddress_ZipCode] AS [Zip2]
+FROM (
+    SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+    FROM (
+        SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+        FROM [Customer] AS [c]
+        ORDER BY [c].[Id]
+    ) AS [t]
+) AS [t0]
+LEFT JOIN (
+    SELECT DISTINCT [t2].[Id], [t2].[Name], [t2].[BillingAddress_AddressLine1], [t2].[BillingAddress_AddressLine2], [t2].[BillingAddress_ZipCode], [t2].[BillingAddress_Country_Code], [t2].[BillingAddress_Country_FullName], [t2].[ShippingAddress_AddressLine1], [t2].[ShippingAddress_AddressLine2], [t2].[ShippingAddress_ZipCode], [t2].[ShippingAddress_Country_Code], [t2].[ShippingAddress_Country_FullName]
+    FROM (
+        SELECT TOP(@__p_1) [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
+        FROM [Customer] AS [c0]
+        ORDER BY [c0].[Id] DESC
+    ) AS [t2]
+) AS [t1] ON [t0].[Id] = [t1].[Id]
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -1010,6 +1010,75 @@ LIMIT @__p_0
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Same_complex_type_projected_twice_with_pushdown_as_part_of_another_projection(async))).Message);
 
+    public override async Task Projecting_property_of_complex_type_using_left_join_with_pushdown(bool async)
+    {
+        await base.Projecting_property_of_complex_type_using_left_join_with_pushdown(async);
+
+        AssertSql(
+"""
+SELECT "t"."BillingAddress_ZipCode"
+FROM "CustomerGroup" AS "c"
+LEFT JOIN (
+    SELECT "c0"."Id", "c0"."BillingAddress_ZipCode"
+    FROM "Customer" AS "c0"
+    WHERE "c0"."Id" > 5
+) AS "t" ON "c"."Id" = "t"."Id"
+""");
+    }
+
+    public override async Task Projecting_complex_from_optional_navigation_using_conditional(bool async)
+    {
+        await base.Projecting_complex_from_optional_navigation_using_conditional(async);
+
+        AssertSql(
+"""
+@__p_0='20'
+
+SELECT "t0"."ShippingAddress_ZipCode"
+FROM (
+    SELECT DISTINCT "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName"
+    FROM (
+        SELECT "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName"
+        FROM "CustomerGroup" AS "c"
+        LEFT JOIN "Customer" AS "c0" ON "c"."OptionalCustomerId" = "c0"."Id"
+        ORDER BY "c0"."ShippingAddress_ZipCode"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+""");
+    }
+
+    public override async Task Project_entity_with_complex_type_pushdown_and_then_left_join(bool async)
+    {
+        await base.Project_entity_with_complex_type_pushdown_and_then_left_join(async);
+
+        AssertSql(
+"""
+@__p_0='20'
+@__p_1='30'
+
+SELECT "t0"."BillingAddress_ZipCode" AS "Zip1", "t1"."ShippingAddress_ZipCode" AS "Zip2"
+FROM (
+    SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName"
+    FROM (
+        SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
+        FROM "Customer" AS "c"
+        ORDER BY "c"."Id"
+        LIMIT @__p_0
+    ) AS "t"
+) AS "t0"
+LEFT JOIN (
+    SELECT DISTINCT "t2"."Id", "t2"."Name", "t2"."BillingAddress_AddressLine1", "t2"."BillingAddress_AddressLine2", "t2"."BillingAddress_ZipCode", "t2"."BillingAddress_Country_Code", "t2"."BillingAddress_Country_FullName", "t2"."ShippingAddress_AddressLine1", "t2"."ShippingAddress_AddressLine2", "t2"."ShippingAddress_ZipCode", "t2"."ShippingAddress_Country_Code", "t2"."ShippingAddress_Country_FullName"
+    FROM (
+        SELECT "c0"."Id", "c0"."Name", "c0"."BillingAddress_AddressLine1", "c0"."BillingAddress_AddressLine2", "c0"."BillingAddress_ZipCode", "c0"."BillingAddress_Country_Code", "c0"."BillingAddress_Country_FullName", "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName"
+        FROM "Customer" AS "c0"
+        ORDER BY "c0"."Id" DESC
+        LIMIT @__p_1
+    ) AS "t2"
+) AS "t1" ON "t0"."Id" = "t1"."Id"
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/33559
Fixes https://github.com/dotnet/efcore/issues/33547

**Description**
Problem was that we changed the way that we store complex type information in the StructuralTypeProjectionExpression, specifically after performing pushdown. We used to extract all the properties from complex types into a flat list, along with regular properties, but that was wrong - we need to uphold the nested structure. If that STPE with flattened structure would be made nullable, we go through all the properties and mark the column expressions as nullable (which included properties of a complex type). However, in the new regime, we were not making those changes to columns representing complex type in the nested structure. As a result, if those columns were later projected (after pushdown), they would seem to be non-nullable, and could cause errors.
Fix is, during MakeNullable() operation for a complex type StructuralTypeProjectionExpression, to peek inside it's ValueBufferExpression and mark all the columns found there as nullable.

**Customer impact**

Queries projecting a non-optional property from an optional complex type via pushdown will fail. Workaround is to manually cast the property to nullable (which seems redundant) and is not always easy/possible without significant query rewrite.

**How found**
Customer reported on 8.

**Regression**
Yes, moreover, regression has been introduced in a patch 8.0.4 patch release. (by a high impact, medium risk fix - https://github.com/dotnet/efcore/pull/33212)

**Testing**
Multiple tests added.

**Risk**
Low. Change is straightforward invoking an existing functionality of a StructuralTypeProjectionExpression to make it's subcomponents nullable (like we should have done already). We apply similar logic in other places of the code. Added quirk just to be safe.

