### PR TITLE
Refactor compiled models MSBuild integration.

### DIFF
--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -208,11 +208,13 @@ public class DbContextOperations
     /// </summary>
     public virtual DbContext CreateContext(string? contextType)
     {
-        var factory = FindContextType(contextType).Value;
+        var contextPair = FindContextType(contextType);
+        var factory = contextPair.Value;
         try
         {
             var context = factory();
-            _reporter.WriteVerbose(DesignStrings.UseContext(context.GetType().ShortDisplayName()));
+            contextType = context.GetType().ShortDisplayName();
+            _reporter.WriteVerbose(DesignStrings.UseContext(contextType));
 
             var loggerFactory = context.GetService<ILoggerFactory>();
             loggerFactory.AddProvider(new OperationLoggerProvider(_reporter));
@@ -226,7 +228,8 @@ public class DbContextOperations
                 ex = ex.InnerException!;
             }
 
-            throw new OperationException(DesignStrings.CannotCreateContextInstance(contextType, ex.Message), ex);
+            throw new OperationException(DesignStrings.CannotCreateContextInstance(
+                contextType ?? contextPair.Key.GetType().ShortDisplayName(), ex.Message), ex);
         }
     }
 

--- a/src/EFCore.Tasks/EFCore.Tasks.csproj
+++ b/src/EFCore.Tasks/EFCore.Tasks.csproj
@@ -9,6 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateDependencyFile>true</GenerateDependencyFile>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <NoWarn>NU5100;NU5128</NoWarn>
     <ImplicitUsings>true</ImplicitUsings>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>

--- a/src/EFCore.Tasks/PACKAGE.md
+++ b/src/EFCore.Tasks/PACKAGE.md
@@ -8,6 +8,8 @@ Install the package into your project, set `<EFOptimizeContext Condition="'$(Con
 
 If the startup project is different from the current project it needs to be specified: `<EFStartupProject>..\Startup\Startup.csproj</EFStartupProject>`
 
+The startup project must also reference the `Microsoft.EntityFrameworkCore.Tasks` package.
+
 ## Getting started with EF Core
 
 See [Getting started with EF Core](https://learn.microsoft.com/ef/core/get-started/overview/install) for more information about EF NuGet packages, including which to install when getting started.

--- a/src/EFCore.Tasks/Properties/Resources.resx
+++ b/src/EFCore.Tasks/Properties/Resources.resx
@@ -121,10 +121,10 @@
     <value>Startup project '{startupProject}' targets framework '.NETCoreApp' version '{targetFrameworkVersion}'. This version of the Entity Framework Core Tools only supports version 2.0 or higher. For information on using older versions of the tools, see https://go.microsoft.com/fwlink/?linkid=871254</value>
   </data>
   <data name="NETStandardStartupProject" xml:space="preserve">
-    <value>Startup project '{startupProject}' targets framework '.NETStandard'. There is no runtime associated with this framework, and projects targeting it cannot be executed directly. To use the Entity Framework Core Tools with this project, add an executable project targeting .NET Core that references this project, and set it as the startup project using --startup-project; or, update this project to cross-target .NET Core. For more information on using the Entity Framework Tools with .NET Standard projects, see https://go.microsoft.com/fwlink/?linkid=2034781</value>
+    <value>Startup project '{startupProject}' targets framework '.NETStandard'. There is no runtime associated with this framework, and projects targeting it cannot be executed directly. To use the Entity Framework Core Tools with this project, add an executable project targeting .NET Core that references this project, and set it as the startup project using &lt;EFStartupProject&gt; property; or, update this project to cross-target .NET Core. For more information on using the Entity Framework Tools with .NET Standard projects, see https://go.microsoft.com/fwlink/?linkid=2034781</value>
   </data>
   <data name="NotExecutableStartupProject" xml:space="preserve">
-    <value>Startup project '{startupProject}' cannot be executed directly. To use the Entity Framework Core Tools with this project, add an executable project targeting .NET Core that references this project, and set it as the startup project using --startup-project.</value>
+    <value>Startup project '{startupProject}' cannot be executed directly. To use the Entity Framework Core Tools with this project, add an executable project targeting .NET Core that references this project, and set it as the startup project using &lt;EFStartupProject&gt; property.</value>
   </data>
   <data name="UnsupportedFramework" xml:space="preserve">
     <value>Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core Tools don't support this framework. See https://aka.ms/efcore-docs-cli-tfms for more information.</value>

--- a/src/EFCore.Tasks/Tasks/Internal/OperationTaskBase.cs
+++ b/src/EFCore.Tasks/Tasks/Internal/OperationTaskBase.cs
@@ -92,7 +92,7 @@ public abstract class OperationTaskBase : Build.Utilities.ToolTask
         var targetFramework = new FrameworkName(TargetFrameworkMoniker);
         if (targetFramework.Identifier == ".NETStandard")
         {
-            Log.LogError(Resources.NETStandardStartupProject(startupAssemblyName));            
+            Log.LogError(Resources.NETStandardStartupProject(startupAssemblyName));
             return false;
         }
 

--- a/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
+++ b/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Tasks;
 /// <summary>
 ///     Generates files that contain tailored code for some runtime services.
 /// </summary>
-public class OptimizeContext : OperationTaskBase
+public class OptimizeDbContext : OperationTaskBase
 {
     /// <summary>
     ///     The name of the target DbContext.

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -4,17 +4,9 @@
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">net8.0</_TaskTargetFramework>
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_TaskTargetFramework>
     <_EFCustomTasksAssembly>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory), '..\tasks\$(_TaskTargetFramework)\$(MSBuildThisFileName).dll'))</_EFCustomTasksAssembly>
+    <EFOptimizeContext Condition="'$(EFOptimizeContext)'==''">false</EFOptimizeContext>
+    <EFStartupProject Condition="'$(EFStartupProject)'==''">$(MSBuildProjectFullPath)</EFStartupProject>
   </PropertyGroup>
 
-  <UsingTask TaskName="$(MSBuildThisFileName).OptimizeContext" AssemblyFile="$(_EFCustomTasksAssembly)"/>
-
-  <PropertyGroup>
-    <EFOptimizeContext Condition="'$(EFOptimizeContext)' == ''">false</EFOptimizeContext>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(EFTargetLanguage)' == ''">
-    <EFTargetLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj'">C#</EFTargetLanguage>
-    <EFTargetLanguage Condition="'$(MSBuildProjectExtension)' == '.vbproj'">VB</EFTargetLanguage>
-    <EFTargetLanguage Condition="'$(MSBuildProjectExtension)' == '.fsproj'">F#</EFTargetLanguage>
-  </PropertyGroup>
+  <UsingTask TaskName="$(MSBuildThisFileName).OptimizeDbContext" AssemblyFile="$(_EFCustomTasksAssembly)"/>
 </Project>

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -2,20 +2,65 @@
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <EFGeneratedFilesList Condition="'$(EFGeneratedFilesList)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(IntermediateOutputPath)$(AssemblyName).EFGeneratedFiles.txt'))</EFGeneratedFilesList>
+    <_FullOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(OutputPath)'))</_FullOutputPath>
+    <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
+    <EFGeneratedSourcesFile Condition="'$(EFGeneratedSourcesFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.txt</EFGeneratedSourcesFile>
+    <EFProjectsToOptimizePath Condition="'$(EFProjectsToOptimizePath)' == ''">$(_FullIntermediateOutputPath)EFProjectsToOptimize\</EFProjectsToOptimizePath>
+    <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).dll</_AssemblyFullName>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);_EFPrepareForCompile</CoreCompileDependsOn>
   </PropertyGroup>
 
-  <!-- Invokes OptimizeContext on the startup project to generate files if needed -->
-  <Target Name="_GenerateFiles"
-          BeforeTargets="_ReadGeneratedFilesList"
-          Condition="'$(EFOptimizeContext)'=='true'">
+  <PropertyGroup Condition="'$(OutputType)'=='Exe' Or '$(OutputType)'=='WinExe'">
+    <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_AssemblyFullName>
+  </PropertyGroup>
+
+  <!-- Invokes OptimizeDbContext on projects that had changes since the last time they were optimized -->
+  <Target Name="_EFGenerateFiles"
+          AfterTargets="Build"
+          Condition="Exists($(EFProjectsToOptimizePath))">
+    <ItemGroup>
+      <_EFProjectsToOptimizeFiles Include="$(EFProjectsToOptimizePath)*.*" />
+    </ItemGroup>
+
+    <ReadLinesFromFile File="%(_EFProjectsToOptimizeFiles.Identity)">
+      <Output TaskParameter="Lines" ItemName="_EFProjectsToOptimize"/>
+    </ReadLinesFromFile>
+
+    <RemoveDir Directories="$(EFProjectsToOptimizePath)" />
+
+    <!-- The startup assembly used for file generation should be compiled without using AOT mode -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Build"
+             BuildInParallel="true"
+             Condition="'$(PublishAot)'=='true'"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false;PublishAot=false" />
+
+    <MSBuild Projects="@(_EFProjectsToOptimize)"
+             Targets="OptimizeDbContext"
+             BuildInParallel="true"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false;EFStartupAssembly=$(_AssemblyFullName)" />
+
+    <ItemGroup>
+      <_EFProjectsToOptimize Remove="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+
+    <!-- This assumes that the optimized projects are dependencies, so the current project needs to be recompiled too -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Build"
+             BuildInParallel="true"
+             Condition="@(_EFProjectsToOptimize->Count()) &gt; 0"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false" />
+  </Target>
+
+  <Target Name="OptimizeDbContext"
+          Inputs="$(_AssemblyFullName)"
+          Outputs="$(EFGeneratedSourcesFile)"
+          Returns="$(_EFGeneratedFiles)">
     <PropertyGroup>
-      <EFStartupProject Condition="'$(EFStartupProject)'==''">$(MSBuildProjectFullPath)</EFStartupProject>
       <EFRootNamespace Condition="'$(EFRootNamespace)'==''">$(RootNamespace)</EFRootNamespace>
       <EFRootNamespace Condition="'$(EFRootNamespace)'==''">$(AssemblyName)</EFRootNamespace>
       <EFTargetNamespace Condition="'$(EFTargetNamespace)'==''">$(EFRootNamespace)</EFTargetNamespace>
-      <_FullOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(OutputPath)'))</_FullOutputPath>
-      <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
+      <EFOutputDir Condition="'$(EFOutputDir)'==''">$(_FullIntermediateOutputPath)</EFOutputDir>
       <EFNullable>false</EFNullable>
     </PropertyGroup>
 
@@ -23,100 +68,99 @@
       <EFNullable>true</EFNullable>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(OutputType)'=='Library'">
-      <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).dll</_AssemblyFullName>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(OutputType)'=='Exe'">
-      <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_AssemblyFullName>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(OutputType)'=='WinExe'">
-      <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_AssemblyFullName>
-    </PropertyGroup>
+    <OptimizeDbContext Assembly="$(_AssemblyFullName)"
+                       StartupAssembly="$(EFStartupAssembly)"
+                       ProjectAssetsFile="$(ProjectAssetsFile)"
+                       RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
+                       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+                       DbContextName="$(DbContextName)"
+                       RootNamespace="$(EFRootNamespace)"
+                       TargetNamespace="$(EFTargetNamespace)"
+                       Language="$(Language)"
+                       Nullable="$(EFNullable)"
+                       OutputDir="$(EFOutputDir)"
+                       ProjectDir="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="GeneratedFiles" PropertyName="_EFGeneratedFiles" />
+    </OptimizeDbContext>
 
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="Build"
-             BuildInParallel="true"
-             Condition="'$(EFStartupProject)'!='$(MSBuildProjectFullPath)'"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);PublishAot=false;EFOptimizeContext=false" />
+    <Delete Files="$(EFGeneratedSourcesFile)" />
 
-    <MSBuild Projects="$(EFStartupProject)"
-             Targets="OptimizeContext"
-             BuildInParallel="true"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);PublishAot=false;EFOptimizeContext=false;EFGeneratedFilesListToWrite=$(EFGeneratedFilesList);DbContextAssembly=$(_AssemblyFullName);DbContextName=$(DbContextName);EFRootNamespace=$(EFRootNamespace);EFTargetNamespace=$(EFTargetNamespace);EFTargetLanguage=$(EFTargetLanguage);EFNullable=$(EFNullable);EFOutputDir=$(_FullIntermediateOutputPath);EFProjectDir=$(MSBuildProjectDirectory)">
-      <Output TaskParameter="TargetOutputs" ItemName="_GeneratedFiles" />
-    </MSBuild>
+    <CallTarget Targets="Build"/>
 
-    <Message Text="Generated files: @(_GeneratedFiles)" Importance="low" />
-  </Target>
-
-  <Target Name="OptimizeContext"
-          DependsOnTargets="Build"
-          Inputs="$(DbContextAssembly)"
-          Outputs="$(EFGeneratedFilesListToWrite)"
-          Returns="$(_GeneratedFiles)">
-    <PropertyGroup>
-      <_FullOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(OutputPath)'))</_FullOutputPath>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(OutputType)'=='Library'">
-      <_StartupAssemblyFullName>$(_FullOutputPath)$(AssemblyName).dll</_StartupAssemblyFullName>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(OutputType)'=='Exe'">
-      <_StartupAssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_StartupAssemblyFullName>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(OutputType)'=='WinExe'">
-      <_StartupAssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_StartupAssemblyFullName>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <MyItemGroup Remove="@(_GeneratedFiles)"/>
-    </ItemGroup>
-
-    <OptimizeContext Assembly="$(DbContextAssembly)"
-                     StartupAssembly="$(_StartupAssemblyFullName)"
-                     ProjectAssetsFile="$(ProjectAssetsFile)"
-                     RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
-                     TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                     DbContextName="$(DbContextName)"
-                     RootNamespace="$(EFRootNamespace)"
-                     TargetNamespace="$(EFTargetNamespace)"
-                     Language="$(EFTargetLanguage)"
-                     Nullable="$(EFNullable)"
-                     OutputDir="$(EFOutputDir)"
-                     ProjectDir="$(EFProjectDir)">
-      <Output TaskParameter="GeneratedFiles" PropertyName="_GeneratedFiles" />
-    </OptimizeContext>
+    <WriteLinesToFile File="$(EFGeneratedSourcesFile)" Lines="$(_EFGeneratedFiles)"/>
   </Target>
 
   <!-- Read the previously generated files if the files weren't regenerated -->
-  <Target Name="_ReadGeneratedFilesList"
-          BeforeTargets="_CompileGeneratedFiles"
-          Condition="Exists($(EFGeneratedFilesList))">
-    <ReadLinesFromFile File="$(EFGeneratedFilesList)" Condition="@(_GeneratedFiles->Count()) == 0">
+  <Target Name="_EFReadGeneratedFilesList"
+          BeforeTargets="_EFProcessGeneratedFiles;_EFCleanupGeneratedFiles"
+          Condition="'$(EFOptimizeContext)'=='true' And Exists($(EFGeneratedSourcesFile))">
+    <ReadLinesFromFile File="$(EFGeneratedSourcesFile)">
       <Output TaskParameter="Lines" ItemName="_ReadGeneratedFiles"/>
     </ReadLinesFromFile>
-    <Message Text="Found previously generated files: @(_ReadGeneratedFiles)" Importance="low" Condition="@(_GeneratedFiles->Count()) == 0" />
 
     <ItemGroup>
-      <_GeneratedFiles Include="@(_ReadGeneratedFiles)" />
+      <_EFGeneratedFiles Include="@(_ReadGeneratedFiles)" />
     </ItemGroup>
   </Target>
 
   <!-- Adds the generated files to compilation -->
-  <Target Name="_CompileGeneratedFiles"
+  <Target Name="_EFProcessGeneratedFiles"
           BeforeTargets="CoreCompile">
     <ItemGroup>
-      <Compile Include="@(_GeneratedFiles)" />
+      <Compile Include="@(_EFGeneratedFiles)" />
     </ItemGroup>
   </Target>
 
-  <!-- Writes the list of generated files with a newer timestamp than the assembly compiled with them -->
-  <Target Name="_WriteGeneratedFilesList"
-          AfterTargets="Build"
-          Condition="'$(EFOptimizeContext)'=='true' And @(_GeneratedFiles->Count()) &gt; 0">
-    <Message Text="Writing generated files list to: $(EFGeneratedFilesList)" Importance="low" />
+  <!-- Removes the outdated generated files from compilation and registers this project for optimization
+       This target has the same Inputs and Outputs as CoreCompile to run only if CoreCompile isn't going to be skipped -->
+  <Target Name="_EFPrepareForCompile"
+          DependsOnTargets="_EFProcessGeneratedFiles"
+          Condition="'$(EFOptimizeContext)'=='true'"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile);
+                  @(_CoreCompileResourceInputs);
+                  $(ApplicationIcon);
+                  $(KeyOriginatorFile);
+                  @(ReferencePathWithRefAssemblies);
+                  @(CompiledLicenseFile);
+                  @(LinkResource);
+                  @(EmbeddedDocumentation);
+                  $(Win32Resource);
+                  $(Win32Manifest);
+                  @(CustomAdditionalCompileInputs);
+                  $(ResolvedCodeAnalysisRuleSet);
+                  @(AdditionalFiles);
+                  @(EmbeddedFiles);
+                  @(Analyzer);
+                  @(EditorConfigFiles);
+                  $(SourceLink)"
+          Outputs="@(DocFileItem);
+                   @(IntermediateAssembly);
+                   @(IntermediateRefAssembly);
+                   @(_DebugSymbolsIntermediatePath);
+                   $(NonExistentFile);
+                   @(CustomAdditionalCompileOutputs)">
+    <ItemGroup>
+      <Compile Remove="@(_EFGeneratedFiles)" />
+    </ItemGroup>
 
-    <WriteLinesToFile File="$(EFGeneratedFilesList)" Lines="@(_GeneratedFiles)" Overwrite="true"/>
+    <MSBuild Projects="$(EFStartupProject)"
+             Targets="_EFRegisterProjectToOptimize"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_EFProjectToOptimize=$(MSBuildProjectFullPath)" />
+  </Target>
+
+  <Target Name="_EFRegisterProjectToOptimize">
+    <PropertyGroup>
+      <_ProjectName>$([System.IO.Path]::GetFileName('$(_EFProjectToOptimize)'))</_ProjectName>
+    </PropertyGroup>
+    <MakeDir Directories="$(EFProjectsToOptimizePath)" />
+    <WriteLinesToFile File="$(EFProjectsToOptimizePath)$(_ProjectName).txt" Lines="$(_EFProjectToOptimize)" Overwrite="true"/>
+  </Target>
+
+  <Target Name="_EFCleanGeneratedFiles" AfterTargets="Clean">
+    <Delete Files="@(_EFGeneratedFiles)" />
+    <Delete Files="$(EFGeneratedSourcesFile)" />
+    <RemoveDir Directories="$(EFProjectsToOptimizePath)" />
   </Target>
 
 </Project>

--- a/src/EFCore/Internal/DbContextServices.cs
+++ b/src/EFCore/Internal/DbContextServices.cs
@@ -88,7 +88,9 @@ public class DbContextServices : IDbContextServices
                 || (designTime && modelFromOptions is not Metadata.Internal.Model)
                     ? RuntimeFeature.IsDynamicCodeSupported
                         ? dependencies.ModelSource.GetModel(_currentContext!.Context, dependencies, designTime)
-                        : throw new InvalidOperationException(CoreStrings.NativeAotDesignTimeModel)
+                        : designTime
+                            ? throw new InvalidOperationException(CoreStrings.NativeAotDesignTimeModel)
+                            : throw new InvalidOperationException(CoreStrings.NativeAotNoCompiledModel)
                     : dependencies.ModelRuntimeInitializer.Initialize(modelFromOptions, designTime, dependencies.ValidationLogger);
         }
         finally

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -62,6 +62,16 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             {
                 throw new CommandException(Resources.MissingOption(Assembly.LongName));
             }
+
+            if (!File.Exists(Assembly.Value()))
+            {
+                throw new CommandException(Resources.FileNotFound(Assembly.Value()));
+            }
+
+            if (StartupAssembly!.HasValue() && !File.Exists(StartupAssembly.Value()))
+            {
+                throw new CommandException(Resources.FileNotFound(StartupAssembly.Value()));
+            }
         }
 
         protected IOperationExecutor CreateExecutor(string[] remainingArguments)

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -240,6 +240,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 path);
 
         /// <summary>
+        ///     File '{filename}' not found.
+        /// </summary>
+        public static string FileNotFound(object? filename)
+            => string.Format(
+                GetString("FileNotFound", nameof(filename)),
+                filename);
+
+        /// <summary>
         ///     The target framework.
         /// </summary>
         public static string FrameworkDescription

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -219,6 +219,9 @@
   <data name="FileExists" xml:space="preserve">
     <value>The file already exists: {path}. Use --force flag to overwrite it.</value>
   </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>File '{filename}' not found.</value>
+  </data>
   <data name="FrameworkDescription" xml:space="preserve">
     <value>The target framework.</value>
   </data>


### PR DESCRIPTION
Run build normally first and if the DbContext assembly was (re)built then generate the compiled model and compile again.
Don't use the previously generated compiled model during normal compilation.
Make the .Tasks NuGet package a development dependency Improve exception messages for common negative cases.
Rename OptimizeContext task to OptimizeDbContext.

Fixes #33487