### PR TITLE
Add precompiled query generation to the dbcontext optimize command

### DIFF
--- a/src/EFCore.Design/Design/DbContextActivator.cs
+++ b/src/EFCore.Design/Design/DbContextActivator.cs
@@ -43,12 +43,11 @@ public static class DbContextActivator
     {
         Check.NotNull(contextType, nameof(contextType));
 
-        EF.IsDesignTime = true;
-
         return new DbContextOperations(
                 new OperationReporter(reportHandler),
                 contextType.Assembly,
                 startupAssembly ?? contextType.Assembly,
+                project: "",
                 projectDir: "",
                 rootNamespace: null,
                 language: "C#",

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Query.Design;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 
@@ -54,6 +55,8 @@ public static class DesignTimeServiceCollectionExtensions
                     .TryAddSingleton<ICompiledModelCodeGenerator, CSharpRuntimeModelCodeGenerator>()
                     .TryAddSingleton<ICompiledModelCodeGeneratorSelector, CompiledModelCodeGeneratorSelector>()
                     .TryAddSingleton<ICompiledModelScaffolder, CompiledModelScaffolder>()
+                    .TryAddSingleton<IPrecompiledQueryCodeGenerator, PrecompiledQueryCodeGenerator>()
+                    .TryAddSingleton<IPrecompiledQueryCodeGeneratorSelector, PrecompiledQueryCodeGeneratorSelector>()
                     .TryAddSingleton<IDesignTimeConnectionStringResolver>(
                         new DesignTimeConnectionStringResolver(applicationServiceProviderAccessor))
                     .TryAddSingleton<IPluralizer, HumanizerPluralizer>()

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -265,7 +265,7 @@ public class DbContextOperations
         return scaffoldedFiles;
     }
 
-    private IReadOnlyList<string> PrecompileQueries(string? outputDir, DbContext context, string? suffix, IServiceProvider services, IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements, ISet<string> generatedFileNames)
+    private IReadOnlyList<string> PrecompileQueries(string? outputDir, DbContext context, string? suffix, IServiceProvider services, IReadOnlyDictionary<MemberInfo, QualifiedName> memberAccessReplacements, ISet<string> generatedFileNames)
     {
         outputDir = Path.GetFullPath(Path.Combine(_projectDir, outputDir ?? "Generated"));
 
@@ -332,8 +332,8 @@ public class DbContextOperations
             var document = project.AddDocument("_EfGeneratedInterceptors.cs", generatedFile.Code);
 
             // Run the simplifier to e.g. get rid of unneeded parentheses
-            var syntaxRootFoo = (await document.GetSyntaxRootAsync().ConfigureAwait(false))!;
-            var annotatedDocument = document.WithSyntaxRoot(syntaxRootFoo.WithAdditionalAnnotations(Simplifier.Annotation));
+            var syntaxRoot = (await document.GetSyntaxRootAsync().ConfigureAwait(false))!;
+            var annotatedDocument = document.WithSyntaxRoot(syntaxRoot.WithAdditionalAnnotations(Simplifier.Annotation));
             document = await Simplifier.ReduceAsync(annotatedDocument, optionSet: null).ConfigureAwait(false);
             document = await Formatter.FormatAsync(document, options: null).ConfigureAwait(false);
 

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -47,6 +47,7 @@ public class MigrationsOperations
             reporter,
             assembly,
             startupAssembly,
+            project: "",
             projectDir,
             rootNamespace,
             language,

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -102,6 +102,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("CircularBaseClassDependency");
 
         /// <summary>
+        ///     Compilation failed with errors:
+        /// </summary>
+        public static string CompilationErrors
+            => GetString("CompilationErrors");
+
+        /// <summary>
         ///     A compilation must be loaded.
         /// </summary>
         public static string CompilationMustBeLoaded
@@ -168,6 +174,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static string ConnectionDescription
             => GetString("ConnectionDescription");
+
+        /// <summary>
+        ///     Your target project '{assembly}' doesn't match the assembly containing '{contextType}' - '{contextAssembly}'. This is not recommended as it will cause the compiled model to not be discovered automatically.
+        ///     Consider changing your target project to the DbContext project by using the Package Manager Console's Default project drop-down list, by executing "dotnet ef" from the directory containing the DbContext project or by supplying it with the '--project' option.
+        /// </summary>
+        public static string ContextAssemblyMismatch(object? assembly, object? contextType, object? contextAssembly)
+            => string.Format(
+                GetString("ContextAssemblyMismatch", nameof(assembly), nameof(contextType), nameof(contextAssembly)),
+                assembly, contextType, contextAssembly);
 
         /// <summary>
         ///     The context class name '{contextClassName}' is not a valid C# identifier.
@@ -462,6 +477,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 name);
 
         /// <summary>
+        ///     Could not find symbol for anonymous object creation initializer:
+        /// </summary>
+        public static string NoAnonymousSymbol
+            => GetString("NoAnonymousSymbol");
+
+        /// <summary>
         ///     Don't colorize output.
         /// </summary>
         public static string NoColorDescription
@@ -628,6 +649,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("QueryComprehensionSyntaxNotSupportedInPrecompiledQueries");
 
         /// <summary>
+        ///     Query precompilation failed with errors:
+        /// </summary>
+        public static string QueryPrecompilationErrors
+            => GetString("QueryPrecompilationErrors");
+
+        /// <summary>
         ///     No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist(s) and must be made writeable to continue: {readOnlyFiles}.
         /// </summary>
         public static string ReadOnlyFiles(object? outputDirectoryName, object? readOnlyFiles)
@@ -714,6 +741,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("UnableToScaffoldIndexMissingProperty", nameof(indexName), nameof(columnNames)),
                 indexName, columnNames);
+
+        /// <summary>
+        ///     The project '{project}' does not support compilation.
+        /// </summary>
+        public static string UncompilableProject(object? project)
+            => string.Format(
+                GetString("UncompilableProject", nameof(project)),
+                project);
 
         /// <summary>
         ///     Unhandled enum value '{enumValue}'.

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -150,6 +150,9 @@
   <data name="CircularBaseClassDependency" xml:space="preserve">
     <value>You cannot add a migration with the name 'Migration'.</value>
   </data>
+  <data name="CompilationErrors" xml:space="preserve">
+    <value>Compilation failed with errors:</value>
+  </data>
   <data name="CompilationMustBeLoaded" xml:space="preserve">
     <value>A compilation must be loaded.</value>
   </data>
@@ -176,6 +179,10 @@
   </data>
   <data name="ConnectionDescription" xml:space="preserve">
     <value>The connection string to the database. Defaults to the one specified in AddDbContext or OnConfiguring.</value>
+  </data>
+  <data name="ContextAssemblyMismatch" xml:space="preserve">
+    <value>Your target project '{assembly}' doesn't match the assembly containing '{contextType}' - '{contextAssembly}'. This is not recommended as it will cause the compiled model to not be discovered automatically.
+Consider changing your target project to the DbContext project by using the Package Manager Console's Default project drop-down list, by executing "dotnet ef" from the directory containing the DbContext project or by supplying it with the '--project' option.</value>
   </data>
   <data name="ContextClassNotValidCSharpIdentifier" xml:space="preserve">
     <value>The context class name '{contextClassName}' is not a valid C# identifier.</value>
@@ -296,6 +303,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="MultipleContextsWithQualifiedName" xml:space="preserve">
     <value>More than one DbContext named '{name}' was found. Specify which one to use by providing its fully qualified name using its exact case.</value>
   </data>
+  <data name="NoAnonymousSymbol" xml:space="preserve">
+    <value>Could not find symbol for anonymous object creation initializer:</value>
+  </data>
   <data name="NoColorDescription" xml:space="preserve">
     <value>Don't colorize output.</value>
   </data>
@@ -368,6 +378,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="QueryComprehensionSyntaxNotSupportedInPrecompiledQueries" xml:space="preserve">
     <value>LINQ query comprehension syntax is currently not supported in precompiled queries.</value>
   </data>
+  <data name="QueryPrecompilationErrors" xml:space="preserve">
+    <value>Query precompilation failed with errors:</value>
+  </data>
   <data name="ReadOnlyFiles" xml:space="preserve">
     <value>No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist(s) and must be made writeable to continue: {readOnlyFiles}.</value>
   </data>
@@ -404,6 +417,9 @@ Change your target project to the migrations project by using the Package Manage
   </data>
   <data name="UnableToScaffoldIndexMissingProperty" xml:space="preserve">
     <value>Unable to scaffold the index '{indexName}'. The following columns could not be scaffolded: {columnNames}.</value>
+  </data>
+  <data name="UncompilableProject" xml:space="preserve">
+    <value>The project '{project}' does not support compilation.</value>
   </data>
   <data name="UnhandledEnumValue" xml:space="preserve">
     <value>Unhandled enum value '{enumValue}'.</value>

--- a/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using static Microsoft.EntityFrameworkCore.Query.Internal.PrecompiledQueryCodeGenerator;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Design;
+
+/// <summary>
+///     Used to generate code for precompiled queries.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-compiled-models">EF Core compiled models</see>, and
+///     <see href="https://aka.ms/efcore-docs-design-time-services">EF Core design-time services</see> for more information and examples.
+/// </remarks>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public interface IPrecompiledQueryCodeGenerator : ILanguageBasedService
+{
+    /// <summary>
+    ///     Generates the precompiled queries code.
+    /// </summary>
+    /// <param name="compilation">The compilation.</param>
+    /// <param name="syntaxGenerator">The syntax generator.</param>
+    /// <param name="dbContext">The context.</param>
+    /// <param name="memberAccessReplacements">The member access replacements.</param>
+    /// <param name="precompilationErrors">A list that will contain precompilation errors.</param>
+    /// <param name="assembly">The assembly corresponding to the provided compilation.</param>
+    /// <param name="suffix">The suffix to attach to the name of all the generated files.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The files containing precompiled queries code.</returns>
+    IReadOnlyList<GeneratedInterceptorFile> GeneratePrecompiledQueries(
+        Compilation compilation,
+        SyntaxGenerator syntaxGenerator,
+        DbContext dbContext,
+        IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements,
+        List<QueryPrecompilationError> precompilationErrors,
+        Assembly? assembly = null,
+        string? suffix = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
@@ -36,7 +36,7 @@ public interface IPrecompiledQueryCodeGenerator : ILanguageBasedService
         Compilation compilation,
         SyntaxGenerator syntaxGenerator,
         DbContext dbContext,
-        IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements,
+        IReadOnlyDictionary<MemberInfo, QualifiedName> memberAccessReplacements,
         List<QueryPrecompilationError> precompilationErrors,
         ISet<string> generatedFileNames,
         Assembly? assembly = null,

--- a/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGenerator.cs
@@ -27,16 +27,18 @@ public interface IPrecompiledQueryCodeGenerator : ILanguageBasedService
     /// <param name="dbContext">The context.</param>
     /// <param name="memberAccessReplacements">The member access replacements.</param>
     /// <param name="precompilationErrors">A list that will contain precompilation errors.</param>
+    /// <param name="generatedFileNames">The set of file names generated so far.</param>
     /// <param name="assembly">The assembly corresponding to the provided compilation.</param>
     /// <param name="suffix">The suffix to attach to the name of all the generated files.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The files containing precompiled queries code.</returns>
-    IReadOnlyList<GeneratedInterceptorFile> GeneratePrecompiledQueries(
+    IReadOnlyList<ScaffoldedFile> GeneratePrecompiledQueries(
         Compilation compilation,
         SyntaxGenerator syntaxGenerator,
         DbContext dbContext,
         IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements,
         List<QueryPrecompilationError> precompilationErrors,
+        ISet<string> generatedFileNames,
         Assembly? assembly = null,
         string? suffix = null,
         CancellationToken cancellationToken = default);

--- a/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGeneratorSelector.cs
+++ b/src/EFCore.Design/Query/Design/IPrecompiledQueryCodeGeneratorSelector.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query.Design;
+
+/// <summary>
+///     Selects an <see cref="IPrecompiledQueryCodeGenerator" /> service for a given programming language.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-compiled-models">EF Core compiled models</see>, and
+///     <see href="https://aka.ms/efcore-docs-design-time-services">EF Core design-time services</see> for more information and examples.
+/// </remarks>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public interface IPrecompiledQueryCodeGeneratorSelector
+{
+    /// <summary>
+    ///     Selects an <see cref="IPrecompiledQueryCodeGenerator" /> service for a given programming language.
+    /// </summary>
+    /// <param name="language">The programming language.</param>
+    /// <returns>The <see cref="IPrecompiledQueryCodeGenerator" />.</returns>
+    IPrecompiledQueryCodeGenerator Select(string? language);
+}

--- a/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
@@ -135,8 +135,7 @@ public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>
         // At least for EF's purposes, it doesn't matter, so we build a placeholder.
         if (_semanticModel.GetSymbolInfo(anonymousObjectCreation).Symbol is not IMethodSymbol constructorSymbol)
         {
-            throw new InvalidOperationException(
-                "Could not find symbol for anonymous object creation initializer: " + anonymousObjectCreation);
+            throw new InvalidOperationException(DesignStrings.NoAnonymousSymbol + " " + anonymousObjectCreation);
         }
 
         var anonymousType = ResolveType(constructorSymbol.ContainingType);

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -31,9 +31,9 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
 
     private Symbols _symbols;
 
-    private readonly HashSet<string> _namespaces = new();
-    private IReadOnlyDictionary<MemberInfo, QualifiedName>? _memberAccessReplacements;
-    private readonly HashSet<MethodDeclarationSyntax> _unsafeAccessors = new();
+    private readonly HashSet<string> _namespaces = [];
+    private IReadOnlyDictionary<MemberInfo, QualifiedName> _memberAccessReplacements = new Dictionary<MemberInfo, QualifiedName>();
+    private readonly HashSet<MethodDeclarationSyntax> _unsafeAccessors = [];
     private readonly IndentedStringBuilder _code = new();
 
     private const string InterceptorsNamespace = "Microsoft.EntityFrameworkCore.GeneratedInterceptors";
@@ -63,7 +63,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
         Compilation compilation,
         SyntaxGenerator syntaxGenerator,
         DbContext dbContext,
-        IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements,
+        IReadOnlyDictionary<MemberInfo, QualifiedName> memberAccessReplacements,
         List<QueryPrecompilationError> precompilationErrors,
         ISet<string> generatedFileNames,
         Assembly? additionalAssembly = null,

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -16,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class PrecompiledQueryCodeGenerator
+public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
 {
     private readonly QueryLocator _queryLocator;
     private readonly CSharpToLinqTranslator _csharpToLinqTranslator;
@@ -24,16 +25,20 @@ public class PrecompiledQueryCodeGenerator
     private SyntaxGenerator _g = null!;
     private IQueryCompiler _queryCompiler = null!;
     private ExpressionTreeFuncletizer _funcletizer = null!;
-    private LinqToCSharpSyntaxTranslator _linqToCSharpTranslator = null!;
+    private RuntimeModelLinqToCSharpSyntaxTranslator _linqToCSharpTranslator = null!;
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
 
     private Symbols _symbols;
 
     private readonly HashSet<string> _namespaces = new();
+    private IReadOnlyDictionary<MemberInfo, QualifiedName>? _memberAccessReplacements;
     private readonly HashSet<MethodDeclarationSyntax> _unsafeAccessors = new();
     private readonly IndentedStringBuilder _code = new();
 
     private const string InterceptorsNamespace = "Microsoft.EntityFrameworkCore.GeneratedInterceptors";
+
+    /// <inheritdoc/>
+    public string? Language => "C#";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -57,14 +62,17 @@ public class PrecompiledQueryCodeGenerator
         Compilation compilation,
         SyntaxGenerator syntaxGenerator,
         DbContext dbContext,
+        IReadOnlyDictionary<MemberInfo, QualifiedName>? memberAccessReplacements,
         List<QueryPrecompilationError> precompilationErrors,
         Assembly? additionalAssembly = null,
+        string? suffix = null,
         CancellationToken cancellationToken = default)
     {
         _queryLocator.Initialize(compilation);
         _symbols = Symbols.Load(compilation);
         _g = syntaxGenerator;
-        _linqToCSharpTranslator = new LinqToCSharpSyntaxTranslator(_g);
+        _linqToCSharpTranslator = new RuntimeModelLinqToCSharpSyntaxTranslator(_g);
+        _memberAccessReplacements = memberAccessReplacements;
         _liftableConstantProcessor = new LiftableConstantProcessor(null!);
         _queryCompiler = dbContext.GetService<IQueryCompiler>();
         _unsafeAccessors.Clear();
@@ -79,7 +87,7 @@ public class PrecompiledQueryCodeGenerator
         _csharpToLinqTranslator.Load(compilation, dbContext, additionalAssembly);
 
         // TODO: Ignore our auto-generated code! Also compiled model, generated code (comment, filename...?).
-        var generatedSyntaxTrees = new List<GeneratedInterceptorFile>();
+        var generatedFiles = new List<GeneratedInterceptorFile>();
         foreach (var syntaxTree in compilation.SyntaxTrees)
         {
             if (_queryLocator.LocateQueries(syntaxTree, precompilationErrors, cancellationToken) is not { Count: > 0 } locatedQueries)
@@ -88,15 +96,15 @@ public class PrecompiledQueryCodeGenerator
             }
 
             var semanticModel = compilation.GetSemanticModel(syntaxTree);
-            var generatedSyntaxTree = ProcessSyntaxTreeAsync(
-                syntaxTree, semanticModel, locatedQueries, precompilationErrors, cancellationToken);
-            if (generatedSyntaxTree is not null)
+            var generatedFile = ProcessSyntaxTree(
+                syntaxTree, semanticModel, locatedQueries, precompilationErrors, suffix ?? ".g", cancellationToken);
+            if (generatedFile is not null)
             {
-                generatedSyntaxTrees.Add(generatedSyntaxTree);
+                generatedFiles.Add(generatedFile);
             }
         }
 
-        return generatedSyntaxTrees;
+        return generatedFiles;
     }
 
     /// <summary>
@@ -105,11 +113,12 @@ public class PrecompiledQueryCodeGenerator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected virtual GeneratedInterceptorFile? ProcessSyntaxTreeAsync(
+    protected virtual GeneratedInterceptorFile? ProcessSyntaxTree(
         SyntaxTree syntaxTree,
         SemanticModel semanticModel,
         IReadOnlyList<InvocationExpressionSyntax> locatedQueries,
         List<QueryPrecompilationError> precompilationErrors,
+        string suffix,
         CancellationToken cancellationToken)
     {
         var queriesPrecompiledInFile = 0;
@@ -290,7 +299,7 @@ namespace System.Runtime.CompilerServices
 """);
 
         return new(
-            $"{Path.GetFileNameWithoutExtension(syntaxTree.FilePath)}.EFInterceptors.g{Path.GetExtension(syntaxTree.FilePath)}",
+            $"{Path.GetFileNameWithoutExtension(syntaxTree.FilePath)}.EFInterceptors{suffix}{Path.GetExtension(syntaxTree.FilePath)}",
             _code.ToString());
     }
 
@@ -473,7 +482,7 @@ namespace System.Runtime.CompilerServices
         // Output the interceptor method signature preceded by the [InterceptsLocation] attribute.
         var startPosition = operatorSyntax.SyntaxTree.GetLineSpan(memberAccessSyntax.Name.Span, cancellationToken).StartLinePosition;
         var interceptorName = $"Query{queryNum}_{memberAccessSyntax.Name}{operatorNum}";
-        code.AppendLine($"""[InterceptsLocation("{operatorSyntax.SyntaxTree.FilePath}", {startPosition.Line + 1}, {startPosition.Character + 1})]""");
+        code.AppendLine($"""[InterceptsLocation(@"{operatorSyntax.SyntaxTree.FilePath.Replace("\"","\"\"")}", {startPosition.Line + 1}, {startPosition.Character + 1})]""");
         GenerateInterceptorMethodSignature();
         code.AppendLine("{").IncrementIndent();
 
@@ -749,7 +758,7 @@ namespace System.Runtime.CompilerServices
                                 var collectedNamespaces = new HashSet<string>();
                                 var unsafeAccessors = new HashSet<MethodDeclarationSyntax>();
                                 var roslynPathSegment = _linqToCSharpTranslator.TranslateExpression(
-                                    linqPathSegment, constantReplacements: null, collectedNamespaces, unsafeAccessors);
+                                    linqPathSegment, constantReplacements: null, _memberAccessReplacements, collectedNamespaces, unsafeAccessors);
 
                                 var variableName = capturedVariablesPathTree.ExpressionType.Name;
                                 variableName = char.ToLower(variableName[0]) + variableName[1..^"Expression".Length] + ++variableCounter;
@@ -869,7 +878,7 @@ namespace System.Runtime.CompilerServices
         foreach (var liftedConstant in _liftableConstantProcessor.LiftedConstants)
         {
             var variableValueSyntax = _linqToCSharpTranslator.TranslateExpression(
-                liftedConstant.Expression, constantReplacements: null, namespaces, unsafeAccessors);
+                liftedConstant.Expression, constantReplacements: null, _memberAccessReplacements, namespaces, unsafeAccessors);
             // code.AppendLine($"{liftedConstant.Parameter.Type.Name} {liftedConstant.Parameter.Name} = {variableValueSyntax.NormalizeWhitespace().ToFullString()};");
             code.AppendLine($"var {liftedConstant.Parameter.Name} = {variableValueSyntax.NormalizeWhitespace().ToFullString()};");
         }
@@ -878,6 +887,7 @@ namespace System.Runtime.CompilerServices
             (AnonymousFunctionExpressionSyntax)_linqToCSharpTranslator.TranslateExpression(
                 queryExecutorAfterLiftingExpression,
                 constantReplacements: null,
+                _memberAccessReplacements,
                 namespaces,
                 unsafeAccessors);
 

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGeneratorSelector.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGeneratorSelector.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Query.Design;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class PrecompiledQueryCodeGeneratorSelector :
+    LanguageBasedSelector<IPrecompiledQueryCodeGenerator>,
+    IPrecompiledQueryCodeGeneratorSelector
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public PrecompiledQueryCodeGeneratorSelector(IEnumerable<IPrecompiledQueryCodeGenerator> services)
+        : base(services)
+    {
+    }
+}

--- a/src/EFCore.Design/Query/Internal/QueryLocator.cs
+++ b/src/EFCore.Design/Query/Internal/QueryLocator.cs
@@ -294,7 +294,7 @@ public class QueryLocator : CSharpSyntaxWalker
             {
                 while (true)
                 {
-                    // TODO: Check for the user's specific DbContext type
+                    // TODO: Check for the user's specific DbContext type #33866
                     if (typeSymbol.Equals(_symbols.DbContext, SymbolEqualityComparer.Default))
                     {
                         return true;

--- a/src/EFCore.Design/Query/Internal/RuntimeModelLinqToCSharpSyntaxTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/RuntimeModelLinqToCSharpSyntaxTranslator.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Design.Internal;
-using Microsoft.EntityFrameworkCore.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;

--- a/src/EFCore.Design/Scaffolding/CompiledModelCodeGenerationOptions.cs
+++ b/src/EFCore.Design/Scaffolding/CompiledModelCodeGenerationOptions.cs
@@ -37,4 +37,10 @@ public class CompiledModelCodeGenerationOptions
     /// </summary>
     /// <value> The suffix to attach to the name of all the generated files. </value>
     public virtual string? Suffix { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the set of file names generated so far.
+    /// </summary>
+    /// <value> The file names generated so far. </value>
+    public virtual ISet<string> GeneratedFileNames { get; set; } = new HashSet<string>();
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -80,9 +80,9 @@ public class CSharpModelGenerator : ModelCodeGenerator
         var resultingFiles = new ScaffoldedModel
         {
             ContextFile = new ScaffoldedFile
-            (options.ContextDir != null
-                ? Path.Combine(options.ContextDir, dbContextFileName)
-                : dbContextFileName,
+                (options.ContextDir != null
+                    ? Path.Combine(options.ContextDir, dbContextFileName)
+                    : dbContextFileName,
              generatedCode)
         };
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -80,12 +80,10 @@ public class CSharpModelGenerator : ModelCodeGenerator
         var resultingFiles = new ScaffoldedModel
         {
             ContextFile = new ScaffoldedFile
-            {
-                Path = options.ContextDir != null
-                    ? Path.Combine(options.ContextDir, dbContextFileName)
-                    : dbContextFileName,
-                Code = generatedCode
-            }
+            (options.ContextDir != null
+                ? Path.Combine(options.ContextDir, dbContextFileName)
+                : dbContextFileName,
+             generatedCode)
         };
 
         foreach (var entityType in model.GetEntityTypes())
@@ -106,8 +104,7 @@ public class CSharpModelGenerator : ModelCodeGenerator
 
             // output EntityType poco .cs file
             var entityTypeFileName = entityType.Name + host.Extension;
-            resultingFiles.AdditionalFiles.Add(
-                new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
+            resultingFiles.AdditionalFiles.Add(new ScaffoldedFile(entityTypeFileName, generatedCode));
         }
 
         return resultingFiles;

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -2267,7 +2267,6 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
 
             var runtimeType = (IRuntimeEntityType)entityType;
 
-            // TODO
             var unsafeAccessors = new HashSet<string>();
 
             var originalValuesFactory = OriginalValuesFactoryFactory.Instance.CreateExpression(runtimeType);
@@ -2333,6 +2332,9 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
                 .DecrementIndent();
 
             CreateAnnotations(entityType, _annotationCodeGenerator.Generate, parameters);
+
+            // TODO: Output any additional unsafe accessors
+            Check.DebugAssert(unsafeAccessors.Count == 0, "Generated unsafe accessors not handled");
 
             mainBuilder
                 .AppendLine()

--- a/src/EFCore.Design/Scaffolding/Internal/CompiledModelScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CompiledModelScaffolder.cs
@@ -21,6 +21,14 @@ public class CompiledModelScaffolder : ICompiledModelScaffolder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public static readonly int MaxFileNameLength = 255;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public CompiledModelScaffolder(ICompiledModelCodeGeneratorSelector modelCodeGeneratorSelector)
     {
         ModelCodeGeneratorSelector = modelCodeGeneratorSelector;
@@ -45,62 +53,46 @@ public class CompiledModelScaffolder : ICompiledModelScaffolder
         string outputDir,
         CompiledModelCodeGenerationOptions options)
     {
-        var codeGenerator = ModelCodeGeneratorSelector.Select(options);
-
-        var scaffoldedModel = codeGenerator.GenerateModel(model, options);
-
-        if (options.Suffix != null)
-        {
-            foreach (var file in scaffoldedModel)
-            {
-                file.Path = file.Path.Insert(file.Path.LastIndexOf('.'), options.Suffix);
-            }
-        }
-
-        CheckOutputFiles(scaffoldedModel, outputDir);
-
-        Directory.CreateDirectory(outputDir);
-
-        var savedFiles = new List<string>();
-        foreach (var file in scaffoldedModel)
-        {
-            var filePath = Path.Combine(outputDir, file.Path);
-            File.WriteAllText(filePath, file.Code, Encoding.UTF8);
-            savedFiles.Add(filePath);
-        }
-
-        return savedFiles;
+        var scaffoldedModel = ModelCodeGeneratorSelector.Select(options).GenerateModel(model, options);
+        return WriteFiles(scaffoldedModel, outputDir);
     }
 
-    private static void CheckOutputFiles(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static IReadOnlyList<string> WriteFiles(
         IReadOnlyCollection<ScaffoldedFile> scaffoldedModel,
         string outputDir)
     {
+        Directory.CreateDirectory(outputDir);
         var paths = scaffoldedModel.Select(f => f.Path).ToList();
 
-        var existingFiles = new List<string>();
         var readOnlyFiles = new List<string>();
-        foreach (var path in paths)
+        var savedFiles = new List<string>();
+        foreach (var file in scaffoldedModel)
         {
-            var fullPath = Path.Combine(outputDir, path);
+            var fullPath = Path.Combine(outputDir, file.Path);
 
-            if (File.Exists(fullPath))
+            if (File.Exists(fullPath)
+                && File.GetAttributes(fullPath).HasFlag(FileAttributes.ReadOnly))
             {
-                existingFiles.Add(path);
-
-                if (File.GetAttributes(fullPath).HasFlag(FileAttributes.ReadOnly))
-                {
-                    readOnlyFiles.Add(path);
-                }
+                readOnlyFiles.Add(file.Path);
+            }
+            else
+            {
+                File.WriteAllText(fullPath, file.Code, Encoding.UTF8);
+                savedFiles.Add(fullPath);
             }
         }
 
-        if (readOnlyFiles.Count != 0)
-        {
-            throw new OperationException(
+        return readOnlyFiles.Count != 0
+            ? throw new OperationException(
                 DesignStrings.ReadOnlyFiles(
                     outputDir,
-                    string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, readOnlyFiles)));
-        }
+                    string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, readOnlyFiles)))
+            : (IReadOnlyList<string>)savedFiles;
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/TextTemplatingModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/TextTemplatingModelGenerator.cs
@@ -137,13 +137,11 @@ public class TextTemplatingModelGenerator : TemplatedModelGenerator
         var dbContextFileName = options.ContextName + host.Extension;
         var resultingFiles = new ScaffoldedModel
         {
-            ContextFile = new ScaffoldedFile
-            {
-                Path = options.ContextDir != null
+            ContextFile = new ScaffoldedFile(
+                options.ContextDir != null
                     ? Path.Combine(options.ContextDir, dbContextFileName)
                     : dbContextFileName,
-                Code = generatedCode
-            }
+                generatedCode)
         };
 
         var entityTypeTemplate = Path.Combine(options.ProjectDir!, TemplatesDirectory, EntityTypeTemplate);
@@ -181,7 +179,7 @@ public class TextTemplatingModelGenerator : TemplatedModelGenerator
 
                     var entityTypeFileName = entityType.Name + entityTypeExtension;
                     resultingFiles.AdditionalFiles.Add(
-                        new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
+                        new ScaffoldedFile(entityTypeFileName,  generatedCode));
                 }
             }
             finally
@@ -225,13 +223,11 @@ public class TextTemplatingModelGenerator : TemplatedModelGenerator
 
                     var configurationFileName = entityType.Name + "Configuration" + configurationExtension;
                     resultingFiles.AdditionalFiles.Add(
-                        new ScaffoldedFile
-                        {
-                            Path = options.ContextDir != null
+                        new ScaffoldedFile(
+                            options.ContextDir != null
                                 ? Path.Combine(options.ContextDir, configurationFileName)
                                 : configurationFileName,
-                            Code = generatedCode
-                        });
+                            generatedCode));
                 }
             }
             finally

--- a/src/EFCore.Design/Scaffolding/ScaffoldedFile.cs
+++ b/src/EFCore.Design/Scaffolding/ScaffoldedFile.cs
@@ -9,6 +9,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding;
 public class ScaffoldedFile
 {
     /// <summary>
+    ///     Constructs a new instance of <see cref="ScaffoldedFile" />.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <param name="code">The scaffolded code</param>
+    public ScaffoldedFile(string path, string code)
+    {
+        Path = path;
+        Code = code;
+    }
+
+    /// <summary>
     ///     Gets or sets the path.
     /// </summary>
     /// <value> The path. </value>

--- a/src/EFCore.Design/Scaffolding/ScaffoldedFile.cs
+++ b/src/EFCore.Design/Scaffolding/ScaffoldedFile.cs
@@ -6,28 +6,22 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding;
 /// <summary>
 ///     Represents a scaffolded file.
 /// </summary>
-public class ScaffoldedFile
+/// <remarks>
+///     Constructs a new instance of <see cref="ScaffoldedFile" />.
+/// </remarks>
+/// <param name="path">The path.</param>
+/// <param name="code">The scaffolded code</param>
+public class ScaffoldedFile(string path, string code)
 {
-    /// <summary>
-    ///     Constructs a new instance of <see cref="ScaffoldedFile" />.
-    /// </summary>
-    /// <param name="path">The path.</param>
-    /// <param name="code">The scaffolded code</param>
-    public ScaffoldedFile(string path, string code)
-    {
-        Path = path;
-        Code = code;
-    }
-
     /// <summary>
     ///     Gets or sets the path.
     /// </summary>
     /// <value> The path. </value>
-    public virtual string Path { get; set; } = null!;
+    public virtual string Path { get; set; } = path;
 
     /// <summary>
     ///     Gets or sets the scaffolded code.
     /// </summary>
     /// <value> The scaffolded code. </value>
-    public virtual string Code { get; set; } = null!;
+    public virtual string Code { get; set; } = code;
 }

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection.Emit;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/src/EFCore.Tasks/Tasks/Internal/OperationTaskBase.cs
+++ b/src/EFCore.Tasks/Tasks/Internal/OperationTaskBase.cs
@@ -52,6 +52,11 @@ public abstract class OperationTaskBase : Build.Utilities.ToolTask
     public ITaskItem? DataDir { get; set; }
 
     /// <summary>
+    ///    The target project.
+    /// </summary>
+    public ITaskItem? Project { get; set; }
+
+    /// <summary>
     ///    The project directory.
     /// </summary>
     public ITaskItem? ProjectDir { get; set; }
@@ -195,6 +200,12 @@ public abstract class OperationTaskBase : Build.Utilities.ToolTask
         {
             args.Add("--startup-assembly");
             args.Add(Path.ChangeExtension(StartupAssembly.ItemSpec, ".dll"));
+        }
+
+        if (Project != null)
+        {
+            args.Add("--project");
+            args.Add(Project.ItemSpec);
         }
 
         if (ProjectDir != null)

--- a/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
+++ b/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
@@ -28,6 +28,16 @@ public class OptimizeDbContext : OperationTaskBase
     public ITaskItem? OutputDir { get; set; }
 
     /// <summary>
+    ///     Don't generate a compiled model.
+    /// </summary>
+    public bool NoScaffold { get; set; }
+
+    /// <summary>
+    ///     Generate precompiled queries.
+    /// </summary>
+    public bool PrecompileQueries { get; set; }
+
+    /// <summary>
     ///     Generated files that should be include in the build.
     /// </summary>
     [Output]
@@ -56,10 +66,20 @@ public class OptimizeDbContext : OperationTaskBase
             }
 
             var dbContextName = MsBuildUtilities.TrimAndGetNullForEmpty(DbContextName);
-            if(dbContextName != null)
+            if (dbContextName != null)
             {
                 AdditionalArguments.Add("--context");
                 AdditionalArguments.Add(dbContextName);
+            }
+
+            if (NoScaffold)
+            {
+                AdditionalArguments.Add("--no-scaffold");
+            }
+
+            if (PrecompileQueries)
+            {
+                AdditionalArguments.Add("--precompile-queries");
             }
 
             AdditionalArguments.Add("--suffix");

--- a/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
+++ b/src/EFCore.Tasks/Tasks/OptimizeDbContext.cs
@@ -13,9 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Tasks;
 public class OptimizeDbContext : OperationTaskBase
 {
     /// <summary>
-    ///     The name of the target DbContext.
+    ///     The type of the target DbContext.
     /// </summary>
-    public string? DbContextName { get; set; }
+    public string? DbContextType { get; set; }
 
     /// <summary>
     ///     The namespace to use for the generated classes.
@@ -65,11 +65,11 @@ public class OptimizeDbContext : OperationTaskBase
                 AdditionalArguments.Add(targetNamespace);
             }
 
-            var dbContextName = MsBuildUtilities.TrimAndGetNullForEmpty(DbContextName);
-            if (dbContextName != null)
+            var dbContextType = MsBuildUtilities.TrimAndGetNullForEmpty(DbContextType);
+            if (dbContextType != null)
             {
                 AdditionalArguments.Add("--context");
-                AdditionalArguments.Add(dbContextName);
+                AdditionalArguments.Add(dbContextType);
             }
 
             if (NoScaffold)

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -7,7 +7,7 @@
     <EFScaffoldModelStage Condition="'$(EFScaffoldModelStage)'==''">publish</EFScaffoldModelStage>
     <EFPrecompileQueriesStage Condition="'$(EFPrecompileQueriesStage)'==''">publish</EFPrecompileQueriesStage>
     <EFStartupProject Condition="'$(EFStartupProject)'==''">$(MSBuildProjectFullPath)</EFStartupProject>
-    <DbContextName Condition="'$(DbContextName)'==''">*</DbContextName>
+    <DbContextType Condition="'$(DbContextType)'==''">*</DbContextType>
   </PropertyGroup>
 
   <UsingTask TaskName="$(MSBuildThisFileName).OptimizeDbContext" AssemblyFile="$(_EFCustomTasksAssembly)"/>

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -7,6 +7,7 @@
     <EFScaffoldModelStage Condition="'$(EFScaffoldModelStage)'==''">publish</EFScaffoldModelStage>
     <EFPrecompileQueriesStage Condition="'$(EFPrecompileQueriesStage)'==''">publish</EFPrecompileQueriesStage>
     <EFStartupProject Condition="'$(EFStartupProject)'==''">$(MSBuildProjectFullPath)</EFStartupProject>
+    <DbContextName Condition="'$(DbContextName)'==''">*</DbContextName>
   </PropertyGroup>
 
   <UsingTask TaskName="$(MSBuildThisFileName).OptimizeDbContext" AssemblyFile="$(_EFCustomTasksAssembly)"/>

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -4,7 +4,8 @@
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">net8.0</_TaskTargetFramework>
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_TaskTargetFramework>
     <_EFCustomTasksAssembly>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory), '..\tasks\$(_TaskTargetFramework)\$(MSBuildThisFileName).dll'))</_EFCustomTasksAssembly>
-    <EFOptimizeContext Condition="'$(EFOptimizeContext)'==''">false</EFOptimizeContext>
+    <EFScaffoldModelStage Condition="'$(EFScaffoldModelStage)'==''">publish</EFScaffoldModelStage>
+    <EFPrecompileQueriesStage Condition="'$(EFPrecompileQueriesStage)'==''">publish</EFPrecompileQueriesStage>
     <EFStartupProject Condition="'$(EFStartupProject)'==''">$(MSBuildProjectFullPath)</EFStartupProject>
   </PropertyGroup>
 

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <_FullOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(OutputPath)'))</_FullOutputPath>
     <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
-    <EFGeneratedSourcesFile Condition="'$(EFGeneratedSourcesFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.txt</EFGeneratedSourcesFile>
+    <EFGeneratedSourcesBuildFile Condition="'$(EFGeneratedSourcesBuildFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Build.txt</EFGeneratedSourcesBuildFile>
+    <EFGeneratedSourcesPublishFile Condition="'$(EFGeneratedSourcesPublishFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Publish.txt</EFGeneratedSourcesPublishFile>
     <EFProjectsToOptimizePath Condition="'$(EFProjectsToOptimizePath)' == ''">$(_FullIntermediateOutputPath)EFProjectsToOptimize\</EFProjectsToOptimizePath>
     <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).dll</_AssemblyFullName>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);_EFPrepareForCompile</CoreCompileDependsOn>
@@ -14,10 +15,29 @@
     <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_AssemblyFullName>
   </PropertyGroup>
 
+  <Target Name="_EFGenerateFilesAfterBuild"
+        AfterTargets="Build"
+        Condition="Exists($(EFProjectsToOptimizePath)) And '$(_EFGenerationStage)'==''">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_EFGenerateFiles"
+             BuildInParallel="$(BuildInParallel)"
+             ContinueOnError="$(ContinueOnError)"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_EFGenerationStage=build" />
+  </Target>
+
+  <Target Name="_EFGenerateFilesBeforePublish"
+        AfterTargets="GetCopyToPublishDirectoryItems"
+        BeforeTargets="GeneratePublishDependencyFile"
+        Condition="Exists($(EFProjectsToOptimizePath)) And '$(_EFGenerationStage)'==''">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_EFGenerateFiles"
+             BuildInParallel="$(BuildInParallel)"
+             ContinueOnError="$(ContinueOnError)"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_EFGenerationStage=publish" />
+  </Target>
+
   <!-- Invokes OptimizeDbContext on projects that had changes since the last time they were optimized -->
-  <Target Name="_EFGenerateFiles"
-          AfterTargets="Build"
-          Condition="Exists($(EFProjectsToOptimizePath)) And '$(_InEFGenerateFiles)'!='true'">
+  <Target Name="_EFGenerateFiles">
     <ItemGroup>
       <_EFProjectsToOptimizeFiles Include="$(EFProjectsToOptimizePath)*.*" />
     </ItemGroup>
@@ -31,14 +51,16 @@
     <!-- The startup assembly used for file generation should be compiled without using AOT mode -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="Build"
-             BuildInParallel="true"
+             BuildInParallel="$(BuildInParallel)"
+             ContinueOnError="$(ContinueOnError)"
              Condition="'$(PublishAot)'=='true'"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false;PublishAot=false" />
+             Properties="Configuration=$(Configuration);Platform=$(Platform);PublishAot=false;_EFGenerationStage=$(_EFGenerationStage)" />
 
     <MSBuild Projects="@(_EFProjectsToOptimize)"
              Targets="OptimizeDbContext"
-             BuildInParallel="true"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);EFStartupAssembly=$(_AssemblyFullName)" />
+             BuildInParallel="$(BuildInParallel)"
+             ContinueOnError="$(ContinueOnError)"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);EFStartupAssembly=$(_AssemblyFullName);_EFGenerationStage=$(_EFGenerationStage)" />
 
     <ItemGroup>
       <_EFProjectsToOptimize Remove="$(MSBuildProjectFullPath)" />
@@ -47,25 +69,24 @@
     <!-- This assumes that the optimized projects are dependencies, so the current project needs to be recompiled too -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="Build"
-             BuildInParallel="true"
+             BuildInParallel="$(BuildInParallel)"
+             ContinueOnError="$(ContinueOnError)"
              Condition="@(_EFProjectsToOptimize->Count()) &gt; 0"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);_InEFGenerateFiles=true" />
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_EFGenerationStage=$(_EFGenerationStage)" />
   </Target>
 
-  <Target Name="OptimizeDbContext"
-          Inputs="$(_AssemblyFullName)"
-          Outputs="$(EFGeneratedSourcesFile)"
-          Returns="$(_EFGeneratedFiles)">
+  <Target Name="OptimizeDbContext">
     <PropertyGroup>
       <EFRootNamespace Condition="'$(EFRootNamespace)'==''">$(RootNamespace)</EFRootNamespace>
       <EFRootNamespace Condition="'$(EFRootNamespace)'==''">$(AssemblyName)</EFRootNamespace>
       <EFTargetNamespace Condition="'$(EFTargetNamespace)'==''">$(EFRootNamespace)</EFTargetNamespace>
       <EFOutputDir Condition="'$(EFOutputDir)'==''">$(_FullIntermediateOutputPath)</EFOutputDir>
-      <EFNullable>false</EFNullable>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Nullable)'=='enable' Or '$(Nullable)'=='annotations'">
-      <EFNullable>true</EFNullable>
+      <_EFNoScaffold>true</_EFNoScaffold>
+      <_EFNoScaffold Condition="'$(_EFGenerationStage)'=='$(EFScaffoldModelStage)'">false</_EFNoScaffold>
+      <_EFPrecompileQueries>false</_EFPrecompileQueries>
+      <_EFPrecompileQueries Condition="'$(_EFGenerationStage)'=='$(EFPrecompileQueriesStage)'">true</_EFPrecompileQueries>
+      <EFNullable Condition="'$(Nullable)'=='enable' Or '$(Nullable)'=='annotations'">true</EFNullable>
+      <EFNullable Condition="'$(EFNullable)'==''">false</EFNullable>
     </PropertyGroup>
 
     <OptimizeDbContext Assembly="$(_AssemblyFullName)"
@@ -79,22 +100,43 @@
                        Language="$(Language)"
                        Nullable="$(EFNullable)"
                        OutputDir="$(EFOutputDir)"
-                       ProjectDir="$(MSBuildProjectDirectory)">
+                       Project="$(MSBuildProjectFullPath)"
+                       ProjectDir="$(MSBuildProjectDirectory)"
+                       NoScaffold="$(_EFNoScaffold)"
+                       PrecompileQueries="$(_EFPrecompileQueries)">
       <Output TaskParameter="GeneratedFiles" PropertyName="_EFGeneratedFiles" />
     </OptimizeDbContext>
 
-    <Delete Files="$(EFGeneratedSourcesFile)" />
+    <Delete Files="$(EFGeneratedSourcesBuildFile)"
+            Condition="'$(_EFGenerationStage)'=='build'"/>
+    <Delete Files="$(EFGeneratedSourcesPublishFile)"
+            Condition="'$(_EFGenerationStage)'=='publish'"/>
 
     <CallTarget Targets="Build"/>
 
-    <WriteLinesToFile File="$(EFGeneratedSourcesFile)" Lines="$(_EFGeneratedFiles)"/>
+    <WriteLinesToFile File="$(EFGeneratedSourcesBuildFile)"
+                      Lines="$(_EFGeneratedFiles)"
+                      Condition="'$(_EFGenerationStage)'=='build'"/>
+    <WriteLinesToFile File="$(EFGeneratedSourcesPublishFile)"
+                      Lines="$(_EFGeneratedFiles)"
+                      Condition="'$(_EFGenerationStage)'=='publish'"/>
+  </Target>
+
+  <Target Name="_EFValidateProperties"
+          BeforeTargets="CoreCompile">
+    <Error Condition="'$(EFScaffoldModelStage)'=='publish' And '$(EFPrecompileQueriesStage)'=='build'"
+           Text="If %24(EFScaffoldModelStage) is set to 'publish' then %24(EFPrecompileQueriesStage) must also be set to 'publish'."/>
   </Target>
 
   <!-- Read the previously generated files -->
   <Target Name="_EFReadGeneratedFilesList"
-          BeforeTargets="_EFProcessGeneratedFiles;_EFCleanupGeneratedFiles"
-          Condition="'$(EFOptimizeContext)'=='true' And Exists($(EFGeneratedSourcesFile))">
-    <ReadLinesFromFile File="$(EFGeneratedSourcesFile)">
+          BeforeTargets="_EFProcessGeneratedFiles;_EFCleanGeneratedFiles">
+    <ReadLinesFromFile File="$(EFGeneratedSourcesBuildFile)"
+                       Condition="Exists($(EFGeneratedSourcesBuildFile))">
+      <Output TaskParameter="Lines" ItemName="_ReadGeneratedFiles"/>
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="$(EFGeneratedSourcesPublishFile)"
+                       Condition="Exists($(EFGeneratedSourcesPublishFile))">
       <Output TaskParameter="Lines" ItemName="_ReadGeneratedFiles"/>
     </ReadLinesFromFile>
 
@@ -111,11 +153,11 @@
     </ItemGroup>
   </Target>
 
-  <!-- Removes the outdated generated files from compilation and registers this project for optimization
+  <!-- Removes the outdated generated files from compilation and registers this project for after-compile optimization
        This target has the same Inputs and Outputs as CoreCompile to run only if CoreCompile isn't going to be skipped -->
   <Target Name="_EFPrepareForCompile"
           DependsOnTargets="_EFProcessGeneratedFiles"
-          Condition="'$(EFOptimizeContext)'=='true' And '$(_InEFGenerateFiles)'!='true'"
+          Condition="'$(_EFGenerationStage)'==''"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);
                   @(_CoreCompileResourceInputs);
@@ -144,9 +186,40 @@
       <Compile Remove="@(_EFGeneratedFiles)" />
     </ItemGroup>
 
+    <Delete Files="$(EFGeneratedSourcesBuildFile)" />
+    <Delete Files="$(EFGeneratedSourcesPublishFile)" />
+
+    <MSBuild Projects="$(EFStartupProject)"
+             Targets="_EFRegisterProjectToOptimize"
+             Condition="'$(EFOptimizeContext)'=='true' And ('$(EFScaffoldModelStage)'=='build' Or '$(EFPrecompileQueriesStage)'=='build')"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_EFProjectToOptimize=$(MSBuildProjectFullPath)" />
+  </Target>
+
+  <!-- Registers this project for before-publish optimization -->
+  <Target Name="_EFPrepareForPublish"
+          BeforeTargets="GetCopyToPublishDirectoryItems"
+          Condition="'$(_EFGenerationStage)'=='' And ('$(EFScaffoldModelStage)'=='publish' Or '$(EFPrecompileQueriesStage)'=='publish') And ('$(EFOptimizeContext)'=='true' Or ('$(EFOptimizeContext)'=='' And ('$(_EFPublishAOT)'=='true' Or '$(PublishAOT)'=='true')))">
     <MSBuild Projects="$(EFStartupProject)"
              Targets="_EFRegisterProjectToOptimize"
              Properties="Configuration=$(Configuration);Platform=$(Platform);_EFProjectToOptimize=$(MSBuildProjectFullPath)" />
+  </Target>
+
+  <!-- Go through the dependencies to check whether they need code generated for Native AOT -->
+  <Target Name="_EFPrepareDependenciesForPublishAOT"
+          BeforeTargets="GetCopyToPublishDirectoryItems"
+          Condition="'$(PublishAOT)'=='true' And '$(_EFGenerationStage)'=='' and '@(_MSBuildProjectReferenceExistent)' != ''">
+    <MSBuild
+      Projects="@(_MSBuildProjectReferenceExistent)"
+      Targets="_EFPrepareForPublish"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework); _EFPublishAOT=true"
+      Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' "
+      ContinueOnError="$(ContinueOnError)"
+      SkipNonexistentTargets="true"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
+
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProjectReferencePaths"/>
+    </MSBuild>
   </Target>
 
   <Target Name="_EFRegisterProjectToOptimize">
@@ -159,7 +232,8 @@
 
   <Target Name="_EFCleanGeneratedFiles" AfterTargets="Clean">
     <Delete Files="@(_EFGeneratedFiles)" />
-    <Delete Files="$(EFGeneratedSourcesFile)" />
+    <Delete Files="$(EFGeneratedSourcesBuildFile)" />
+    <Delete Files="$(EFGeneratedSourcesPublishFile)" />
     <RemoveDir Directories="$(EFProjectsToOptimizePath)" />
   </Target>
 

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -103,7 +103,8 @@
                        Project="$(MSBuildProjectFullPath)"
                        ProjectDir="$(MSBuildProjectDirectory)"
                        NoScaffold="$(_EFNoScaffold)"
-                       PrecompileQueries="$(_EFPrecompileQueries)">
+                       PrecompileQueries="$(_EFPrecompileQueries)"
+                       Condition="'$(_EFNoScaffold)'=='false' Or '$(_EFPrecompileQueries)'=='true'">
       <Output TaskParameter="GeneratedFiles" PropertyName="_EFGeneratedFiles" />
     </OptimizeDbContext>
 

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -2,8 +2,9 @@
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <_FullOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(OutputPath)'))</_FullOutputPath>
-    <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
+    <_FullOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(OutputPath)'))</_FullOutputPath>
+    <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
+    <_FullIntermediateOutputPath Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' And '$(RuntimeIdentifier)' != '' And '$(_UsingDefaultRuntimeIdentifier)' != 'true' And '$(UseArtifactsIntermediateOutput)' != 'true'">$([MSBuild]::NormalizePath('$(_FullIntermediateOutputPath)', '../'))</_FullIntermediateOutputPath>
     <EFGeneratedSourcesBuildFile Condition="'$(EFGeneratedSourcesBuildFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Build.txt</EFGeneratedSourcesBuildFile>
     <EFGeneratedSourcesPublishFile Condition="'$(EFGeneratedSourcesPublishFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Publish.txt</EFGeneratedSourcesPublishFile>
     <EFProjectsToOptimizePath Condition="'$(EFProjectsToOptimizePath)' == ''">$(_FullIntermediateOutputPath)EFProjectsToOptimize\</EFProjectsToOptimizePath>
@@ -14,6 +15,29 @@
   <PropertyGroup Condition="'$(OutputType)'=='Exe' Or '$(OutputType)'=='WinExe'">
     <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).exe</_AssemblyFullName>
   </PropertyGroup>
+
+  <!-- Usage:
+  For the compiled model and precompiled queries to be generated when publishing with $(PublishAOT) set to true the only action needed is to reference Microsoft.EntityFrameworkCore.Tasks from all projects containing a derived DbContext or a query.
+  For solutions where specifying the startup project is necessary, $(EFStartupProject) should be set.
+$(EFOptimizeContext) can be set to true to enable code generation outside of NativeAOT.
+$(EFScaffoldModelStage) and $(EFPrecompileQueriesStage) can be set to either publish or build to control at what stage will the code be generated. Any other value will disable the corresponding generation (in case the code is generated manually using dotnet ef dbcontext optimize)
+If there's more than one context and $(DbContextType) is not set, then the compiled model will be generated for all of them.
+$(EFTargetNamespace) and $(EFOutputDir) can be used to further fine-tune the generation.
+  -->
+
+  <!--Implementation details:
+  For Build:
+
+1. _EFReadGeneratedFilesList and _EFProcessGeneratedFiles add the files generated previously to @(Compile) to make incremental build work.
+2. If compilation needs to be performed again then _EFPrepareForCompile removes the previously generated files from @(Compile) as they are probably outdated. And if EFOptimizeContext is true it also calls _EFRegisterProjectToOptimize on the startup project to mark the current project for optimization. Startup project could also be the same as the project containing the derived DbContext, but if it's not the tooling needs the compiled startup assembly to be able to generate code for any other project.
+3. If any project was marked then _EFGenerateFilesAfterBuild in the startup project calls _EFGenerateFiles which in turn calls OptimizeDbContext on the marked projects.
+4. OptimizeDbContext generates NativeAOT-compatible code and writes the list of generated files for _EFReadGeneratedFilesList to read when recompiling.
+
+For Publish:
+
+1. If PublishAOT is true _EFPrepareDependenciesForPublishAOT in the startup project invokes _EFPrepareForPublish on all dependencies to mark them for optimization even if they don't set EFOptimizeContext to true. Otherwise _EFPrepareForPublish runs on the projects before Publish.
+2. If any project was marked then _EFGenerateFilesBeforePublish in the startup project calls _EFGenerateFiles and the rest is similar to the Build flow.
+  -->
 
   <Target Name="_EFGenerateFilesAfterBuild"
         AfterTargets="Build"
@@ -94,7 +118,7 @@
                        ProjectAssetsFile="$(ProjectAssetsFile)"
                        RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
                        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                       DbContextName="$(DbContextName)"
+                       DbContextType="$(DbContextType)"
                        RootNamespace="$(EFRootNamespace)"
                        TargetNamespace="$(EFTargetNamespace)"
                        Language="$(Language)"
@@ -213,14 +237,11 @@
       Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="_EFPrepareForPublish"
       BuildInParallel="$(BuildInParallel)"
-      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework); _EFPublishAOT=true"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);%(_MSBuildProjectReferenceExistent.SetPlatform);%(_MSBuildProjectReferenceExistent.SetTargetFramework);_EFPublishAOT=true"
       Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' "
       ContinueOnError="$(ContinueOnError)"
       SkipNonexistentTargets="true"
-      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
-
-      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProjectReferencePaths"/>
-    </MSBuild>
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)"/>
   </Target>
 
   <Target Name="_EFRegisterProjectToOptimize">

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -17,7 +17,7 @@
   <!-- Invokes OptimizeDbContext on projects that had changes since the last time they were optimized -->
   <Target Name="_EFGenerateFiles"
           AfterTargets="Build"
-          Condition="Exists($(EFProjectsToOptimizePath))">
+          Condition="Exists($(EFProjectsToOptimizePath)) And '$(_InEFGenerateFiles)'!='true'">
     <ItemGroup>
       <_EFProjectsToOptimizeFiles Include="$(EFProjectsToOptimizePath)*.*" />
     </ItemGroup>
@@ -38,7 +38,7 @@
     <MSBuild Projects="@(_EFProjectsToOptimize)"
              Targets="OptimizeDbContext"
              BuildInParallel="true"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false;EFStartupAssembly=$(_AssemblyFullName)" />
+             Properties="Configuration=$(Configuration);Platform=$(Platform);EFStartupAssembly=$(_AssemblyFullName)" />
 
     <ItemGroup>
       <_EFProjectsToOptimize Remove="$(MSBuildProjectFullPath)" />
@@ -49,7 +49,7 @@
              Targets="Build"
              BuildInParallel="true"
              Condition="@(_EFProjectsToOptimize->Count()) &gt; 0"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);EFOptimizeContext=false" />
+             Properties="Configuration=$(Configuration);Platform=$(Platform);_InEFGenerateFiles=true" />
   </Target>
 
   <Target Name="OptimizeDbContext"
@@ -90,7 +90,7 @@
     <WriteLinesToFile File="$(EFGeneratedSourcesFile)" Lines="$(_EFGeneratedFiles)"/>
   </Target>
 
-  <!-- Read the previously generated files if the files weren't regenerated -->
+  <!-- Read the previously generated files -->
   <Target Name="_EFReadGeneratedFilesList"
           BeforeTargets="_EFProcessGeneratedFiles;_EFCleanupGeneratedFiles"
           Condition="'$(EFOptimizeContext)'=='true' And Exists($(EFGeneratedSourcesFile))">
@@ -115,7 +115,7 @@
        This target has the same Inputs and Outputs as CoreCompile to run only if CoreCompile isn't going to be skipped -->
   <Target Name="_EFPrepareForCompile"
           DependsOnTargets="_EFProcessGeneratedFiles"
-          Condition="'$(EFOptimizeContext)'=='true'"
+          Condition="'$(EFOptimizeContext)'=='true' And '$(_InEFGenerateFiles)'!='true'"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);
                   @(_CoreCompileResourceInputs);

--- a/src/EFCore/Infrastructure/DbContextModelAttribute.cs
+++ b/src/EFCore/Infrastructure/DbContextModelAttribute.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
@@ -22,7 +24,8 @@ public sealed class DbContextModelAttribute : Attribute
     /// </summary>
     /// <param name="contextType">The associated context.</param>
     /// <param name="modelType">The compiled model.</param>
-    public DbContextModelAttribute(Type contextType, Type modelType)
+    public DbContextModelAttribute(
+        Type contextType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type modelType)
     {
         Check.NotNull(contextType, nameof(contextType));
 

--- a/src/EFCore/Infrastructure/DbContextModelAttribute.cs
+++ b/src/EFCore/Infrastructure/DbContextModelAttribute.cs
@@ -25,7 +25,8 @@ public sealed class DbContextModelAttribute : Attribute
     /// <param name="contextType">The associated context.</param>
     /// <param name="modelType">The compiled model.</param>
     public DbContextModelAttribute(
-        Type contextType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type modelType)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type contextType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type modelType)
     {
         Check.NotNull(contextType, nameof(contextType));
 

--- a/src/EFCore/Infrastructure/Uniquifier.cs
+++ b/src/EFCore/Infrastructure/Uniquifier.cs
@@ -26,16 +26,7 @@ public static class Uniquifier
         string currentIdentifier,
         IReadOnlyDictionary<string, T> otherIdentifiers,
         int maxLength)
-    {
-        var finalIdentifier = Truncate(currentIdentifier, maxLength);
-        var suffix = 1;
-        while (otherIdentifiers.ContainsKey(finalIdentifier))
-        {
-            finalIdentifier = Truncate(currentIdentifier, maxLength, suffix++);
-        }
-
-        return finalIdentifier;
-    }
+        => Uniquify(currentIdentifier, otherIdentifiers, s => s, maxLength);
 
     /// <summary>
     ///     Creates a unique identifier by appending a number to the given string.
@@ -64,6 +55,30 @@ public static class Uniquifier
     }
 
     /// <summary>
+    ///     Creates a unique identifier by appending a number to the given string.
+    /// </summary>
+    /// <param name="currentIdentifier">The base identifier.</param>
+    /// <param name="otherIdentifiers">A dictionary where the identifier will be used as part of the key.</param>
+    /// <param name="suffix">An optional suffix to add after the uniquifier.</param>
+    /// <param name="maxLength">The maximum length of the identifier.</param>
+    /// <returns>A unique identifier.</returns>
+    public static string Uniquify(
+        string currentIdentifier,
+        ISet<string> otherIdentifiers,
+        string? suffix,
+        int maxLength)
+    {
+        var finalIdentifier = Truncate(currentIdentifier, maxLength, suffix);
+        var uniquifier = 1;
+        while (otherIdentifiers.Contains(finalIdentifier))
+        {
+            finalIdentifier = Truncate(currentIdentifier, maxLength, suffix, uniquifier++);
+        }
+
+        return finalIdentifier;
+    }
+
+    /// <summary>
     ///     Ensures the given identifier is shorter than the given length by removing the extra characters from the end.
     /// </summary>
     /// <param name="identifier">The identifier to shorten.</param>
@@ -71,9 +86,24 @@ public static class Uniquifier
     /// <param name="uniquifier">An optional number that will be appended to the identifier.</param>
     /// <returns>The shortened identifier.</returns>
     public static string Truncate(string identifier, int maxLength, int? uniquifier = null)
+        => Truncate(identifier, maxLength, null, uniquifier);
+
+    /// <summary>
+    ///     Ensures the given identifier is shorter than the given length by removing the extra characters from the end.
+    /// </summary>
+    /// <param name="identifier">The identifier to shorten.</param>
+    /// <param name="maxLength">The maximum length of the identifier.</param>
+    /// <param name="suffix">An optional suffix to add after the uniquifier.</param>
+    /// <param name="uniquifier">An optional number that will be appended to the identifier.</param>
+    /// <returns>The shortened identifier.</returns>
+    public static string Truncate(string identifier, int maxLength, string? suffix, int? uniquifier = null)
     {
-        var uniquifierLength = GetLength(uniquifier);
+        var uniquifierLength = GetLength(uniquifier) + (suffix?.Length ?? 0);
         var maxNameLength = maxLength - uniquifierLength;
+        if (maxNameLength <= 0)
+        {
+            throw new ArgumentException(nameof(maxLength));
+        }
 
         var builder = new StringBuilder();
         if (identifier.Length <= maxNameLength)
@@ -90,6 +120,8 @@ public static class Uniquifier
         {
             builder.Append(uniquifier.Value);
         }
+
+        builder.Append(suffix);
 
         return builder.ToString();
     }

--- a/src/EFCore/Metadata/Internal/IRuntimeModel.cs
+++ b/src/EFCore/Metadata/Internal/IRuntimeModel.cs
@@ -42,11 +42,11 @@ public interface IRuntimeModel : IModel
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IReadOnlyDictionary<MemberInfo, QualifiedName>? GetUnsafeAccessors()
+    IReadOnlyDictionary<MemberInfo, QualifiedName> GetUnsafeAccessors()
     {
         return GetOrAddRuntimeAnnotationValue(CoreAnnotationNames.UnsafeAccessors, m => GetAccessors(m!), this);
 
-        static IReadOnlyDictionary<MemberInfo, QualifiedName>? GetAccessors(IRuntimeModel model)
+        static IReadOnlyDictionary<MemberInfo, QualifiedName> GetAccessors(IRuntimeModel model)
         {
             var accessors = new Dictionary<MemberInfo, QualifiedName>();
             foreach (var entityType in model.GetEntityTypes())
@@ -69,7 +69,7 @@ public interface IRuntimeModel : IModel
                 }
             }
 
-            return accessors.Count > 0 ? accessors : null;
+            return accessors;
         }
 
         static void AddPropertyAccessors(ITypeBase structuralType, Dictionary<MemberInfo, QualifiedName> accessors)

--- a/src/dotnet-ef/Project.cs
+++ b/src/dotnet-ef/Project.cs
@@ -153,7 +153,7 @@ internal class Project
         };
     }
 
-    public void Build()
+    public void Build(IEnumerable<string>? additionalArgs)
     {
         var args = new List<string> { "build" };
 
@@ -184,6 +184,10 @@ internal class Project
         args.Add("/verbosity:quiet");
         args.Add("/nologo");
         args.Add("/p:PublishAot=false"); // Avoid NativeAOT warnings
+        if (additionalArgs != null)
+        {
+            args.AddRange(additionalArgs);
+        }
 
         var exitCode = Exe.Run("dotnet", args, handleOutput: Reporter.WriteVerbose);
         if (exitCode != 0)

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -290,6 +290,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("MigrationToDescription");
 
         /// <summary>
+        ///     Option '--{requiredOption}' must be specified if '--{conditionalOption}' is used.
+        /// </summary>
+        public static string MissingConditionalOption(object? requiredOption, object? conditionalOption)
+            => string.Format(
+                GetString("MissingConditionalOption", nameof(requiredOption), nameof(conditionalOption)),
+                requiredOption, conditionalOption);
+
+        /// <summary>
         ///     More than one project was found in the current working directory. Use the --project option.
         /// </summary>
         public static string MultipleProjects
@@ -370,6 +378,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 projectDir);
 
         /// <summary>
+        ///     Don't generate a compiled model.
+        /// </summary>
+        public static string NoScaffoldDescription
+            => GetString("NoScaffoldDescription");
+
+        /// <summary>
         ///     Don't generate SQL transaction statements.
         /// </summary>
         public static string NoTransactionsDescription
@@ -386,6 +400,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         /// </summary>
         public static string OutputDirDescription
             => GetString("OutputDirDescription");
+
+        /// <summary>
+        ///     Generate precompiled queries.
+        /// </summary>
+        public static string PrecompileQueriesDescription
+            => GetString("PrecompileQueriesDescription");
 
         /// <summary>
         ///     Prefix output with level.

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -408,6 +408,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("PrecompileQueriesDescription");
 
         /// <summary>
+        ///     Query precompilation is an experimental feature and should be used with caution.
+        /// </summary>
+        public static string PrecompileQueriesWarning
+            => GetString("PrecompileQueriesWarning");
+
+        /// <summary>
         ///     Prefix output with level.
         /// </summary>
         public static string PrefixDescription

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -252,6 +252,9 @@
   <data name="MigrationToDescription" xml:space="preserve">
     <value>The target migration. Defaults to the last migration.</value>
   </data>
+  <data name="MissingConditionalOption" xml:space="preserve">
+    <value>Option '--{requiredOption}' must be specified if '--{conditionalOption}' is used.</value>
+  </data>
   <data name="MultipleProjects" xml:space="preserve">
     <value>More than one project was found in the current working directory. Use the --project option.</value>
   </data>
@@ -288,6 +291,9 @@
   <data name="NoProjectInDirectory" xml:space="preserve">
     <value>No project was found in directory '{projectDir}'.</value>
   </data>
+  <data name="NoScaffoldDescription" xml:space="preserve">
+    <value>Don't generate a compiled model.</value>
+  </data>
   <data name="NoTransactionsDescription" xml:space="preserve">
     <value>Don't generate SQL transaction statements.</value>
   </data>
@@ -296,6 +302,9 @@
   </data>
   <data name="OutputDirDescription" xml:space="preserve">
     <value>The directory to put files in. Paths are relative to the project directory.</value>
+  </data>
+  <data name="PrecompileQueriesDescription" xml:space="preserve">
+    <value>Generate precompiled queries.</value>
   </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -306,6 +306,9 @@
   <data name="PrecompileQueriesDescription" xml:space="preserve">
     <value>Generate precompiled queries.</value>
   </data>
+  <data name="PrecompileQueriesWarning" xml:space="preserve">
+    <value>Query precompilation is an experimental feature and should be used with caution.</value>
+  </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>
   </data>

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Versioning;
 using System.Text.Json;
@@ -79,7 +80,9 @@ internal class RootCommand : CommandBase
         if (!_noBuild!.HasValue())
         {
             Reporter.WriteInformation(Resources.BuildStarted);
-            startupProject.Build();
+            var skipOptimization = _args!.Count > 2
+                && _args[0] == "dbcontext" && _args[1] == "optimize" && !_args.Any(a => a == "--no-scaffold");
+            startupProject.Build(skipOptimization ? new[] { "/p:EFOptimizeContext=false" } : null);
             Reporter.WriteInformation(Resources.BuildSucceeded);
         }
 

--- a/src/ef/AppDomainOperationExecutor.cs
+++ b/src/ef/AppDomainOperationExecutor.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         public AppDomainOperationExecutor(
             string assembly,
             string? startupAssembly,
+            string? project,
             string? projectDir,
             string? dataDirectory,
             string? rootNamespace,
@@ -30,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             bool nullable,
             string[] remainingArguments,
             IOperationReportHandler reportHandler)
-            : base(assembly, startupAssembly, projectDir, rootNamespace, language, nullable, remainingArguments, reportHandler)
+            : base(assembly, startupAssembly, project, projectDir, rootNamespace, language, nullable, remainingArguments, reportHandler)
         {
             var info = new AppDomainSetup { ApplicationBase = AppBasePath };
 
@@ -77,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     {
                         { "targetName", AssemblyFileName },
                         { "startupTargetName", StartupAssemblyFileName },
+                        { "project", Project },
                         { "projectDir", ProjectDirectory },
                         { "rootNamespace", RootNamespace },
                         { "language", Language },

--- a/src/ef/Commands/DbContextOptimizeCommand.Configure.cs
+++ b/src/ef/Commands/DbContextOptimizeCommand.Configure.cs
@@ -11,6 +11,8 @@ internal partial class DbContextOptimizeCommand : ContextCommandBase
     private CommandOption? _outputDir;
     private CommandOption? _namespace;
     private CommandOption? _suffix;
+    private CommandOption? _noScaffold;
+    private CommandOption? _precompileQueries;
 
     public override void Configure(CommandLineApplication command)
     {
@@ -19,6 +21,8 @@ internal partial class DbContextOptimizeCommand : ContextCommandBase
         _outputDir = command.Option("-o|--output-dir <PATH>", Resources.OutputDirDescription);
         _namespace = command.Option("-n|--namespace <NAMESPACE>", Resources.NamespaceDescription);
         _suffix = command.Option("--suffix <SUFFIX>", Resources.SuffixDescription);
+        _noScaffold = command.Option("--no-scaffold", Resources.NoScaffoldDescription);
+        _precompileQueries = command.Option("--precompile-queries", Resources.PrecompileQueriesDescription);
 
         base.Configure(command);
     }

--- a/src/ef/Commands/DbContextOptimizeCommand.cs
+++ b/src/ef/Commands/DbContextOptimizeCommand.cs
@@ -18,6 +18,11 @@ internal partial class DbContextOptimizeCommand
         {
             throw new CommandException(Resources.MissingConditionalOption(_precompileQueries.LongName, _noScaffold.LongName));
         }
+
+        if (_precompileQueries!.HasValue())
+        {
+            Reporter.WriteWarning(Resources.PrecompileQueriesWarning);
+        }
     }
 
     protected override int Execute(string[] args)

--- a/src/ef/Commands/DbContextOptimizeCommand.cs
+++ b/src/ef/Commands/DbContextOptimizeCommand.cs
@@ -9,6 +9,17 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands;
 // ReSharper disable once ArrangeTypeModifiers
 internal partial class DbContextOptimizeCommand
 {
+    protected override void Validate()
+    {
+        base.Validate();
+
+        if (_noScaffold!.HasValue()
+            && !_precompileQueries!.HasValue())
+        {
+            throw new CommandException(Resources.MissingConditionalOption(_precompileQueries.LongName, _noScaffold.LongName));
+        }
+    }
+
     protected override int Execute(string[] args)
     {
         if (new SemanticVersionComparer().Compare(EFCoreVersion, "6.0.0") < 0)
@@ -21,7 +32,9 @@ internal partial class DbContextOptimizeCommand
             _outputDir!.Value(),
             _namespace!.Value(),
             Context!.Value(),
-            _suffix!.Value());
+            _suffix!.Value() ?? "",
+            !_noScaffold!.HasValue(),
+            _precompileQueries!.HasValue());
 
         ReportResults(result);
 

--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Tools.Generators;
 using Microsoft.EntityFrameworkCore.Tools.Properties;

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -89,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                     return new AppDomainOperationExecutor(
                         Assembly!.Value()!,
                         StartupAssembly!.Value(),
+                        Project!.Value(),
                         _projectDir!.Value(),
                         _dataDir!.Value(),
                         _rootNamespace!.Value(),
@@ -127,6 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 return new ReflectionOperationExecutor(
                     Assembly!.Value()!,
                     StartupAssembly!.Value(),
+                    Project!.Value(),
                     _projectDir!.Value(),
                     _dataDir!.Value(),
                     _rootNamespace!.Value(),

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -14,7 +14,8 @@ internal interface IOperationExecutor : IDisposable
     IDictionary GetContextInfo(string? name);
     void UpdateDatabase(string? migration, string? connectionString, string? contextType);
     IEnumerable<IDictionary> GetContextTypes();
-    IEnumerable<string> OptimizeContext(string? outputDir, string? modelNamespace, string? contextType, string? suffix);
+    IEnumerable<string> OptimizeContext(
+        string? outputDir, string? modelNamespace, string? contextType, string? suffix, bool scaffoldModel, bool precompileQueries);
 
     IDictionary ScaffoldContext(
         string provider,

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -19,6 +19,7 @@ internal abstract class OperationExecutorBase : IOperationExecutor
     protected string AssemblyFileName { get; set; }
     protected string StartupAssemblyFileName { get; set; }
     protected string ProjectDirectory { get; }
+    protected string Project { get; }
     protected string RootNamespace { get; }
     protected string? Language { get; }
     protected bool Nullable { get; }
@@ -27,6 +28,7 @@ internal abstract class OperationExecutorBase : IOperationExecutor
     protected OperationExecutorBase(
         string assembly,
         string? startupAssembly,
+        string? project,
         string? projectDir,
         string? rootNamespace,
         string? language,
@@ -43,6 +45,7 @@ internal abstract class OperationExecutorBase : IOperationExecutor
             Path.Combine(Directory.GetCurrentDirectory(), Path.GetDirectoryName(startupAssembly ?? assembly)!));
 
         RootNamespace = rootNamespace ?? AssemblyFileName;
+        Project = project ?? "";
         ProjectDirectory = projectDir ?? Directory.GetCurrentDirectory();
         Language = language;
         Nullable = nullable;
@@ -140,7 +143,8 @@ internal abstract class OperationExecutorBase : IOperationExecutor
     public IEnumerable<IDictionary> GetContextTypes()
         => InvokeOperation<IEnumerable<IDictionary>>("GetContextTypes");
 
-    public IEnumerable<string> OptimizeContext(string? outputDir, string? modelNamespace, string? contextType, string? suffix)
+    public IEnumerable<string> OptimizeContext(
+        string? outputDir, string? modelNamespace, string? contextType, string? suffix, bool scaffoldModel, bool precompileQueries)
         => InvokeOperation<IEnumerable<string>>(
             "OptimizeContext",
             new Dictionary<string, object?>
@@ -148,7 +152,9 @@ internal abstract class OperationExecutorBase : IOperationExecutor
                 ["outputDir"] = outputDir,
                 ["modelNamespace"] = modelNamespace,
                 ["contextType"] = contextType,
-                ["suffix"] = suffix
+                ["suffix"] = suffix,
+                ["scaffoldModel"] = scaffoldModel,
+                ["precompileQueries"] = precompileQueries
             });
 
     public IDictionary ScaffoldContext(

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -382,6 +382,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 arg);
 
         /// <summary>
+        ///     Option '--{requiredOption}' must be specified if '--{conditionalOption}' is used.
+        /// </summary>
+        public static string MissingConditionalOption(object? requiredOption, object? conditionalOption)
+            => string.Format(
+                GetString("MissingConditionalOption", nameof(requiredOption), nameof(conditionalOption)),
+                requiredOption, conditionalOption);
+
+        /// <summary>
         ///     Missing required option '--{option}'.
         /// </summary>
         public static string MissingOption(object? option)
@@ -426,6 +434,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("NoPluralizeDescription");
 
         /// <summary>
+        ///     Don't generate a compiled model.
+        /// </summary>
+        public static string NoScaffoldDescription
+            => GetString("NoScaffoldDescription");
+
+        /// <summary>
         ///     Don't generate SQL transaction statements.
         /// </summary>
         public static string NoTransactionsDescription
@@ -468,6 +482,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         /// </summary>
         public static string PendingUnknown
             => GetString("PendingUnknown");
+
+        /// <summary>
+        ///     Generate precompiled queries.
+        /// </summary>
+        public static string PrecompileQueriesDescription
+            => GetString("PrecompileQueriesDescription");
 
         /// <summary>
         ///     Prefix output with level.

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -490,6 +490,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("PrecompileQueriesDescription");
 
         /// <summary>
+        ///     Query precompilation is an experimental feature and should be used with caution.
+        /// </summary>
+        public static string PrecompileQueriesWarning
+            => GetString("PrecompileQueriesWarning");
+
+        /// <summary>
         ///     Prefix output with level.
         /// </summary>
         public static string PrefixDescription

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -288,6 +288,9 @@
   <data name="MissingArgument" xml:space="preserve">
     <value>Missing required argument '{arg}'.</value>
   </data>
+  <data name="MissingConditionalOption" xml:space="preserve">
+    <value>Option '--{requiredOption}' must be specified if '--{conditionalOption}' is used.</value>
+  </data>
   <data name="MissingOption" xml:space="preserve">
     <value>Missing required option '--{option}'.</value>
   </data>
@@ -309,6 +312,9 @@
   <data name="NoPluralizeDescription" xml:space="preserve">
     <value>Don't use the pluralizer.</value>
   </data>
+  <data name="NoScaffoldDescription" xml:space="preserve">
+    <value>Don't generate a compiled model.</value>
+  </data>
   <data name="NoTransactionsDescription" xml:space="preserve">
     <value>Don't generate SQL transaction statements.</value>
   </data>
@@ -329,6 +335,9 @@
   </data>
   <data name="PendingUnknown" xml:space="preserve">
     <value>Pending status not shown. Unable to determine which migrations have been applied. This can happen when your project uses a version of Entity Framework Core lower than 5.0.0 or when an error occurs while accessing the database.</value>
+  </data>
+  <data name="PrecompileQueriesDescription" xml:space="preserve">
+    <value>Generate precompiled queries.</value>
   </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -339,6 +339,9 @@
   <data name="PrecompileQueriesDescription" xml:space="preserve">
     <value>Generate precompiled queries.</value>
   </data>
+  <data name="PrecompileQueriesWarning" xml:space="preserve">
+    <value>Query precompilation is an experimental feature and should be used with caution.</value>
+  </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>
   </data>

--- a/src/ef/ReflectionOperationExecutor.cs
+++ b/src/ef/ReflectionOperationExecutor.cs
@@ -21,6 +21,7 @@ internal class ReflectionOperationExecutor : OperationExecutorBase
     public ReflectionOperationExecutor(
         string assembly,
         string? startupAssembly,
+        string? project,
         string? projectDir,
         string? dataDirectory,
         string? rootNamespace,
@@ -28,7 +29,7 @@ internal class ReflectionOperationExecutor : OperationExecutorBase
         bool nullable,
         string[] remainingArguments,
         IOperationReportHandler reportHandler)
-        : base(assembly, startupAssembly, projectDir, rootNamespace, language, nullable, remainingArguments, reportHandler)
+        : base(assembly, startupAssembly, project, projectDir, rootNamespace, language, nullable, remainingArguments, reportHandler)
     {
         var reporter = new OperationReporter(reportHandler);
         var configurationFile = (startupAssembly ?? assembly) + ".config";
@@ -63,6 +64,7 @@ internal class ReflectionOperationExecutor : OperationExecutorBase
             {
                 { "targetName", AssemblyFileName },
                 { "startupTargetName", StartupAssemblyFileName },
+                { "project", Project },
                 { "projectDir", ProjectDirectory },
                 { "rootNamespace", RootNamespace },
                 { "language", Language },

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -30,6 +30,7 @@ public class DbContextOperationsTest
             new TestOperationReporter(),
             assembly,
             assembly,
+            project: "",
             projectDir: "",
             rootNamespace: null,
             language: "C#",
@@ -46,6 +47,7 @@ public class DbContextOperationsTest
             new TestOperationReporter(),
             assembly,
             assembly,
+            project: "",
             projectDir: "",
             rootNamespace: null,
             language: "C#",
@@ -164,6 +166,7 @@ public class DbContextOperationsTest
             new TestOperationReporter(),
             assembly,
             assembly,
+            project: "",
             projectDir: "",
             rootNamespace: null,
             language: "C#",
@@ -176,8 +179,7 @@ public class DbContextOperationsTest
         => new(
             new ServiceCollection()
                 .AddDbContext<TestContext>(
-                    b =>
-                        configureProvider(b.EnableServiceProviderCaching(false)))
+                    b => configureProvider(b.EnableServiceProviderCaching(false)))
                 .BuildServiceProvider(validateScopes: true));
 
     private class TestContext : DbContext

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -63,6 +63,28 @@ public class DbContextOperationsTest
     }
 
     [ConditionalFact]
+    public void CreateAllContexts_creates_all_contexts()
+    {
+        var assembly = MockAssembly.Create(typeof(BaseContext), typeof(DerivedContext), typeof(HierarchyContextFactory));
+        var operations = new TestDbContextOperations(
+            new TestOperationReporter(),
+            assembly,
+            assembly,
+            project: "",
+            projectDir: "",
+            rootNamespace: null,
+            language: "C#",
+            nullable: false,
+            args: [],
+            new TestAppServiceProviderFactory(assembly));
+
+        var contexts = operations.CreateAllContexts().ToList();
+        Assert.Collection(contexts,
+            c => Assert.Equal(nameof(BaseContext), Assert.IsType<BaseContext>(c).FactoryUsed),
+            c => Assert.Equal(nameof(DerivedContext), Assert.IsType<DerivedContext>(c).FactoryUsed));
+    }
+
+    [ConditionalFact]
     public void GetContextInfo_returns_correct_info()
     {
         var info = CreateOperations(typeof(TestProgramRelational)).GetContextInfo(nameof(TestContext));

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
@@ -19,8 +19,8 @@ public class ReverseEngineerScaffolderTest
         var scaffolder = CreateScaffolder();
         var scaffoldedModel = new ScaffoldedModel
         {
-            ContextFile = new ScaffoldedFile { Path = Path.Combine("..", "Data", "TestContext.cs"), Code = "// TestContext" },
-            AdditionalFiles = { new ScaffoldedFile { Path = "TestEntity.cs", Code = "// TestEntity" } }
+            ContextFile = new ScaffoldedFile(Path.Combine("..", "Data", "TestContext.cs"), "// TestContext"),
+            AdditionalFiles = { new ScaffoldedFile("TestEntity.cs", "// TestEntity") }
         };
 
         var result = scaffolder.Save(
@@ -51,8 +51,8 @@ public class ReverseEngineerScaffolderTest
         var scaffolder = CreateScaffolder();
         var scaffoldedModel = new ScaffoldedModel
         {
-            ContextFile = new ScaffoldedFile { Path = "TestContext.cs", Code = "// TestContext" },
-            AdditionalFiles = { new ScaffoldedFile { Path = "TestEntity.cs", Code = "// TestEntity" } }
+            ContextFile = new ScaffoldedFile("TestContext.cs", "// TestContext"),
+            AdditionalFiles = { new ScaffoldedFile("TestEntity.cs", "// TestEntity") }
         };
 
         var ex = Assert.Throws<OperationException>(
@@ -73,7 +73,7 @@ public class ReverseEngineerScaffolderTest
         File.WriteAllText(path, "// Old");
 
         var scaffolder = CreateScaffolder();
-        var scaffoldedModel = new ScaffoldedModel { ContextFile = new ScaffoldedFile { Path = "Test.cs", Code = "// Test" } };
+        var scaffoldedModel = new ScaffoldedModel { ContextFile = new ScaffoldedFile("Test.cs", "// Test") };
 
         var result = scaffolder.Save(scaffoldedModel, directory.Path, overwriteFiles: true);
 
@@ -99,8 +99,8 @@ public class ReverseEngineerScaffolderTest
             var scaffolder = CreateScaffolder();
             var scaffoldedModel = new ScaffoldedModel
             {
-                ContextFile = new ScaffoldedFile { Path = "TestContext.cs", Code = "// TestContext" },
-                AdditionalFiles = { new ScaffoldedFile { Path = "TestEntity.cs", Code = "// TestEntity" } }
+                ContextFile = new ScaffoldedFile("TestContext.cs", "// TestContext"),
+                AdditionalFiles = { new ScaffoldedFile("TestEntity.cs", "// TestEntity") }
             };
 
             var ex = Assert.Throws<OperationException>(

--- a/test/EFCore.Design.Tests/TestUtilities/TestDbContextOperations.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestDbContextOperations.cs
@@ -9,9 +9,10 @@ public class TestDbContextOperations(
     IOperationReporter reporter,
     Assembly assembly,
     Assembly startupAssembly,
+    string project,
     string projectDir,
     string rootNamespace,
     string language,
     bool nullable,
     string[] args,
-    AppServiceProviderFactory appServicesFactory) : DbContextOperations(reporter, assembly, startupAssembly, projectDir, rootNamespace, language, nullable, args, appServicesFactory);
+    AppServiceProviderFactory appServicesFactory) : DbContextOperations(reporter, assembly, startupAssembly, project, projectDir, rootNamespace, language, nullable, args, appServicesFactory);

--- a/test/EFCore.Relational.Specification.Tests/Scaffolding/CompiledModelRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Scaffolding/CompiledModelRelationalTestBase.cs
@@ -1226,10 +1226,8 @@ public abstract class CompiledModelRelationalTestBase : CompiledModelTestBase
             },
             additionalSourceFiles:
             [
-                new()
-                {
-                    Path = "DbContextModelCustomizer.cs",
-                    Code = """
+                new("DbContextModelCustomizer.cs",
+                    """
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace TestNamespace;
@@ -1302,8 +1300,7 @@ public partial class DbContextModel
         }
     }
 }
-"""
-                }
+""")
             ]);
 
     public class SpatialTypes : AbstractBase;

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
@@ -114,7 +114,7 @@ using static Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
                 // Perform precompilation
                 var precompilationErrors = new List<PrecompiledQueryCodeGenerator.QueryPrecompilationError>();
                 generatedFiles = precompiledQueryCodeGenerator.GeneratePrecompiledQueries(
-                    compilation, syntaxGenerator, dbContext, precompilationErrors, additionalAssembly: assembly);
+                    compilation, syntaxGenerator, dbContext, memberAccessReplacements: null, precompilationErrors, additionalAssembly: assembly);
 
                 if (errorAsserter is null)
                 {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
@@ -95,7 +95,7 @@ using static Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
             _metadataReferences,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
 
-        IReadOnlyList<PrecompiledQueryCodeGenerator.GeneratedInterceptorFile>? generatedFiles = null;
+        IReadOnlyList<ScaffoldedFile>? generatedFiles = null;
 
         try
         {
@@ -114,7 +114,7 @@ using static Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
                 // Perform precompilation
                 var precompilationErrors = new List<PrecompiledQueryCodeGenerator.QueryPrecompilationError>();
                 generatedFiles = precompiledQueryCodeGenerator.GeneratePrecompiledQueries(
-                    compilation, syntaxGenerator, dbContext, memberAccessReplacements: null, precompilationErrors, additionalAssembly: assembly);
+                    compilation, syntaxGenerator, dbContext, memberAccessReplacements: null, precompilationErrors, new HashSet<string>(), additionalAssembly: assembly);
 
                 if (errorAsserter is null)
                 {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/PrecompiledQueryTestHelpers.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -114,7 +115,7 @@ using static Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
                 // Perform precompilation
                 var precompilationErrors = new List<PrecompiledQueryCodeGenerator.QueryPrecompilationError>();
                 generatedFiles = precompiledQueryCodeGenerator.GeneratePrecompiledQueries(
-                    compilation, syntaxGenerator, dbContext, memberAccessReplacements: null, precompilationErrors, new HashSet<string>(), additionalAssembly: assembly);
+                    compilation, syntaxGenerator, dbContext, memberAccessReplacements: new Dictionary<MemberInfo, QualifiedName>(), precompilationErrors, new HashSet<string>(), additionalAssembly: assembly);
 
                 if (errorAsserter is null)
                 {

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -47,10 +47,8 @@ public abstract class CompiledModelTestBase : NonSharedModelTestBase
             options: new CompiledModelCodeGenerationOptions { UseNullableReferenceTypes = true },
             additionalSourceFiles:
             [
-                new()
-                {
-                    Path = "DbContextModelStub.cs",
-                    Code = """
+                new("DbContextModelStub.cs",
+                    """
 using Microsoft.EntityFrameworkCore.Metadata;
 using static TestNamespace.DbContextModel.Dummy;
 
@@ -67,8 +65,7 @@ namespace TestNamespace
         }
     }
 }
-"""
-                }
+""")
             ],
             assertAssembly: assembly =>
             {
@@ -586,7 +583,7 @@ namespace TestNamespace
             AssertComplexTypes,
             c =>
             {
-                // #33828
+                // Blocked by https://github.com/dotnet/runtime/issues/102792
                 //c.Set<PrincipalDerived<DependentBase<byte?>>>().Add(
                 //    new PrincipalDerived<DependentBase<byte?>>
                 //    {


### PR DESCRIPTION
Also adds publish integration for precompiled queries and combines it with compiled model generation.

For the compiled model and precompiled queries to be generated when publishing with NativeAOT the only action needed is to reference `Microsoft.EntityFrameworkCore.Tasks` from all projects containing a `DbContext` or a query.

For solutions where specifying the startup project is necessary, `EFStartupProject` should be set.

`EFOptimizeContext` can be set to `true` to enable code generation outside of NativeAOT.

`EFScaffoldModelStage` and `EFPrecompileQueriesStage` can be set to either `publish` or `build` to control at what stage will the code be generated. Any other value will disable the corresponding generation (in case the code is generated manually using `dotnet ef dbcontext optimize`)

If there's more than one context and `DbContextName` is not set, then the compiled model will be generated for all of them.

`EFTargetNamespace` and `EFOutputDir` can be used to further fine-tune the generation.

Fixes #33103
Fixes #33558
