### PR TITLE
 When creating the "missing column" error message, use the same (case insensitive) column name comparer used in field value retrieval

### DIFF
--- a/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
+++ b/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
@@ -1232,7 +1232,9 @@ public class BufferedDataReader : DbDataReader
             if (FieldCount < _columns.Count)
             {
                 // Non-composed FromSql
-                var firstMissingColumn = _columns.Select(c => c?.Name).Where(c => c != null).Except(_columnNames).FirstOrDefault();
+                var readerColumns = _fieldNameLookup.Value;
+
+                var firstMissingColumn = _columns.Select(c => c?.Name).FirstOrDefault(c => c != null && !readerColumns.ContainsKey(c));
                 if (firstMissingColumn != null)
                 {
                     throw new InvalidOperationException(RelationalStrings.FromSqlMissingColumn(firstMissingColumn));

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -195,6 +195,23 @@ public abstract class FromSqlQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task FromSqlRaw_queryable_simple_different_cased_columns_and_not_enough_columns_throws(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            NormalizeDelimitersInRawString(
+                "SELECT [PostalCODE], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"));
+
+        Assert.Equal(
+            RelationalStrings.FromSqlMissingColumn("Region"),
+            (async
+                ? await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())
+                : Assert.Throws<InvalidOperationException>(() => query.ToList())).Message);
+    }
+
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task FromSqlRaw_queryable_composed(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Relational.Specification.Tests/Query/SqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SqlQueryTestBase.cs
@@ -206,6 +206,22 @@ public abstract class SqlQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task SqlQueryRaw_queryable_simple_different_cased_columns_and_not_enough_columns_throws(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Database.SqlQueryRaw<UnmappedCustomer>(
+            NormalizeDelimitersInRawString(
+                "SELECT [PostalCODE], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"));
+
+        Assert.Equal(
+            RelationalStrings.FromSqlMissingColumn("Region"),
+            (async
+                ? await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())
+                : Assert.Throws<InvalidOperationException>(() => query.ToList())).Message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task SqlQueryRaw_queryable_composed(bool async)
         => AssertQuery(
             async,


### PR DESCRIPTION
Issue #33748

This addresses an issue where a column with different casing to the entity's field would be selected as the "first missing column" when assembling the error message. The field name lookup's key comparer is case insensitive, and using it here ensures that all column name comparisons will use the same comparer.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

