### PR TITLE
Fix comparison of nullable values

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringMethodTranslator.cs
@@ -207,20 +207,15 @@ public class SqliteStringMethodTranslator : IMethodCallTranslator
                 instance = _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping);
                 pattern = _sqlExpressionFactory.ApplyTypeMapping(pattern, stringTypeMapping);
 
-                // Note: we add IS NOT NULL checks here since we don't do null semantics/compensation for comparison (greater-than)
                 return
-                    _sqlExpressionFactory.AndAlso(
-                        _sqlExpressionFactory.IsNotNull(instance),
-                        _sqlExpressionFactory.AndAlso(
-                            _sqlExpressionFactory.IsNotNull(pattern),
-                            _sqlExpressionFactory.GreaterThan(
-                                _sqlExpressionFactory.Function(
-                                    "instr",
-                                    new[] { instance, pattern },
-                                    nullable: true,
-                                    argumentsPropagateNullability: new[] { true, true },
-                                    typeof(int)),
-                                _sqlExpressionFactory.Constant(0))));
+                    _sqlExpressionFactory.GreaterThan(
+                        _sqlExpressionFactory.Function(
+                            "instr",
+                            new[] { instance, pattern },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(int)),
+                        _sqlExpressionFactory.Constant(0));
             }
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1890,6 +1890,44 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 """);
             });
 
+    public override Task String_Contains_negated_in_predicate(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_Contains_negated_in_predicate(a);
+
+                AssertSql(
+"""
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND NOT(CONTAINS(c["CompanyName"], c["ContactName"])))
+""");
+            });
+
+    public override Task String_Contains_negated_in_projection(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_Contains_negated_in_projection(a);
+
+                AssertSql(
+"""
+SELECT VALUE {"Id" : c["CustomerID"], "Value" : NOT(CONTAINS(c["CompanyName"], c["ContactName"]))}
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+            });
+
+    [ConditionalTheory(Skip = "issue #33858")]
+    public override Task String_Contains_in_projection(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_Contains_in_projection(a);
+
+                AssertSql("");
+            });
+
     public override Task String_Join_over_non_nullable_column(bool async)
         => AssertTranslationFailed(() => base.String_Join_over_non_nullable_column(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1561,7 +1561,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
         await AssertQueryScalar(async, ss => ss.Set<NullSemanticsEntity1>().Where(e => !(e.IntA <= i)).Select(e => e.Id));
     }
 
-    [ConditionalTheory(Skip = "issue #9544")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Negated_order_comparison_on_nullable_arguments_doesnt_get_optimized(bool async)
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1066,6 +1066,9 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
                 e => (e.BoolA ? e.NullableBoolA != e.NullableBoolB : e.BoolC) != e.BoolB
                     ? e.BoolA
                     : e.NullableBoolB == e.NullableBoolC).Select(e => e.Id));
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(e => (e.BoolA ? e.NullableIntA : e.IntB) > e.IntC));
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -135,6 +135,29 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_in_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => new { Id = c.CustomerID, Value = c.CompanyName.Contains(c.ContactName) }),
+            elementSorter: e => e.Id);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_negated_in_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => !c.CompanyName.Contains(c.ContactName)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_negated_in_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => new { Id = c.CustomerID, Value = !c.CompanyName.Contains(c.ContactName) }),
+            elementSorter: e => e.Id);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task String_FirstOrDefault_MethodCall(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4126,10 +4126,10 @@ INNER JOIN (
         FROM [LevelTwo] AS [l0]
     ) AS [l1]
     GROUP BY [l1].[Key]
-) AS [l2] ON [l].[Id] = [l2].[Key] AND CAST(0 AS bit) = CASE
+) AS [l2] ON [l].[Id] = [l2].[Key] AND CASE
     WHEN [l2].[Sum] <= 10 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END
+END = CAST(0 AS bit)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -974,10 +974,10 @@ INNER JOIN (
         WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL
     ) AS [s]
     GROUP BY [s].[Key]
-) AS [s1] ON [l].[Id] = [s1].[Key] AND CAST(0 AS bit) = CASE
+) AS [s1] ON [l].[Id] = [s1].[Key] AND CASE
     WHEN [s1].[Sum] <= 10 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END
+END = CAST(0 AS bit)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -2750,6 +2750,46 @@ END = -1
 """);
     }
 
+    public override async Task String_Contains_in_projection(bool async)
+    {
+        await base.String_Contains_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID] AS [Id], CASE
+    WHEN [c].[ContactName] IS NOT NULL AND (CHARINDEX([c].[ContactName], [c].[CompanyName]) > 0 OR [c].[ContactName] LIKE N'') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Value]
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task String_Contains_negated_in_predicate(bool async)
+    {
+        await base.String_Contains_negated_in_predicate(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] IS NULL OR (CHARINDEX([c].[ContactName], [c].[CompanyName]) <= 0 AND [c].[ContactName] NOT LIKE N'')
+""");
+    }
+
+    public override async Task String_Contains_negated_in_projection(bool async)
+    {
+        await base.String_Contains_negated_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID] AS [Id], CASE
+    WHEN [c].[ContactName] IS NULL OR (CHARINDEX([c].[ContactName], [c].[CompanyName]) <= 0 AND [c].[ContactName] NOT LIKE N'') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Value]
+FROM [Customers] AS [c]
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task StandardDeviation(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2529,7 +2529,49 @@ WHERE [e].[IntA] > @__i_0
         await base.Negated_order_comparison_on_nullable_arguments_doesnt_get_optimized(async);
 
         AssertSql(
-            @"");
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableIntA] > @__i_0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(0 AS bit)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableIntA] >= @__i_0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(0 AS bit)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableIntA] < @__i_0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(0 AS bit)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableIntA] <= @__i_0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(0 AS bit)
+""");
     }
 
     public override async Task Nullable_column_info_propagates_inside_binary_AndAlso(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1757,6 +1757,17 @@ WHERE CASE
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
+""",
+            //
+            """
+SELECT CASE
+    WHEN CASE
+        WHEN [e].[BoolA] = CAST(1 AS bit) THEN [e].[NullableIntA]
+        ELSE [e].[IntB]
+    END > [e].[IntC] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Entities1] AS [e]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -25,7 +25,7 @@ SELECT "m"."CustomerID", "m"."Address", "m"."City", "m"."CompanyName", "m"."Cont
 FROM (
     SELECT * FROM "Customers"
 ) AS "m"
-WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
+WHERE instr("m"."ContactName", 'z') > 0
 """);
     }
 
@@ -75,7 +75,7 @@ FROM (
     )
     SELECT * FROM "Customers2"
 ) AS "m"
-WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
+WHERE instr("m"."ContactName", 'z') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
@@ -25,7 +25,7 @@ public class FunkyDataQuerySqliteTest : FunkyDataQueryTestBase<FunkyDataQuerySql
 
 SELECT "f"."Id", "f"."FirstName", "f"."LastName", "f"."NullableBool"
 FROM "FunkyCustomers" AS "f"
-WHERE ("f"."FirstName" IS NOT NULL AND instr("f"."FirstName", @__s_0) > 0) OR "f"."LastName" LIKE @__s_0_startswith ESCAPE '\'
+WHERE instr("f"."FirstName", @__s_0) > 0 OR "f"."LastName" LIKE @__s_0_startswith ESCAPE '\'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -1178,7 +1178,7 @@ SELECT COALESCE((
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     ) AS "w0"
     LIMIT 1), 0)
 FROM "Gears" AS "g"
@@ -2342,7 +2342,7 @@ FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch" AND COALESCE((
     SELECT DISTINCT "w"."IsAutomatic"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     LIMIT 1), 0)
 ORDER BY "g"."Nickname"
 """);
@@ -3049,7 +3049,7 @@ WHERE "g"."HasSoulPatch" AND (
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     ) AS "w0"
     LIMIT 1)
 ORDER BY "g"."Nickname"
@@ -3252,7 +3252,7 @@ WHERE "g"."HasSoulPatch" AND COALESCE((
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     ) AS "w0"
     LIMIT 1), 0)
 ORDER BY "g"."Nickname"
@@ -3906,7 +3906,7 @@ INNER JOIN "Cities" AS "c" ON "g0"."CityOfBirthName" = "c"."Name"
             """
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE "c"."Location" IS NOT NULL AND instr("c"."Location", 'Jacinto') > 0
+WHERE instr("c"."Location", 'Jacinto') > 0
 """);
     }
 
@@ -4821,7 +4821,7 @@ END IS NOT NULL
 SELECT COALESCE((
     SELECT DISTINCT "w"."IsAutomatic"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     LIMIT 1), 0)
 FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch"
@@ -5047,7 +5047,10 @@ WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
 
         AssertSql(
             """
-SELECT "g"."HasSoulPatch" AND "t"."Note" IS NOT NULL AND instr("t"."Note", 'Cole') > 0
+SELECT "g"."HasSoulPatch" AND CASE
+    WHEN instr("t"."Note", 'Cole') > 0 THEN 1
+    ELSE 0
+END
 FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSquadId" = "g"."SquadId"
 """);
@@ -7235,7 +7238,7 @@ WHERE "g"."Discriminator" = 'Officer'
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSquadId" = "g"."SquadId"
-WHERE "g"."HasSoulPatch" OR ("t"."Note" IS NOT NULL AND instr("t"."Note", 'Cole') > 0)
+WHERE "g"."HasSoulPatch" OR instr("t"."Note", 'Cole') > 0
 """);
     }
 
@@ -7331,7 +7334,7 @@ SELECT (
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Lancer') > 0
     ) AS "w0"
     LIMIT 1)
 FROM "Gears" AS "g"
@@ -8695,7 +8698,7 @@ LEFT JOIN "Weapons" AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
 ORDER BY (
     SELECT "w"."Name"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Gnasher') > 0
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND instr("w"."Name", 'Gnasher') > 0
     LIMIT 1), "g"."Nickname", "g"."SquadId"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -856,6 +856,49 @@ WHERE instr("c"."ContactName", "c"."ContactName") > 0
 """);
     }
 
+    public override async Task String_Contains_in_projection(bool async)
+    {
+        await base.String_Contains_in_projection(async);
+
+        AssertSql(
+            """
+SELECT "c"."CustomerID" AS "Id", CASE
+    WHEN instr("c"."CompanyName", "c"."ContactName") > 0 THEN 1
+    ELSE 0
+END AS "Value"
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task String_Contains_negated_in_predicate(bool async)
+    {
+        await base.String_Contains_negated_in_predicate(async);
+
+        AssertSql(
+            """
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+FROM "Customers" AS "c"
+WHERE NOT (CASE
+    WHEN instr("c"."CompanyName", "c"."ContactName") > 0 THEN 1
+    ELSE 0
+END)
+""");
+    }
+
+    public override async Task String_Contains_negated_in_projection(bool async)
+    {
+        await base.String_Contains_negated_in_projection(async);
+
+        AssertSql(
+            """
+SELECT "c"."CustomerID" AS "Id", NOT (CASE
+    WHEN instr("c"."CompanyName", "c"."ContactName") > 0 THEN 1
+    ELSE 0
+END) AS "Value"
+FROM "Customers" AS "c"
+""");
+    }
+
     public override async Task String_FirstOrDefault_MethodCall(bool async)
     {
         await base.String_FirstOrDefault_MethodCall(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -828,7 +828,7 @@ WHERE "c"."ContactName" LIKE '%m'
             """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'M') > 0
+WHERE instr("c"."ContactName", 'M') > 0
 """);
     }
 
@@ -840,7 +840,7 @@ WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'M') > 0
             """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", "c"."ContactName") > 0
+WHERE instr("c"."ContactName", "c"."ContactName") > 0
 """);
     }
 
@@ -852,7 +852,7 @@ WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", "c"."ContactNam
             """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", "c"."ContactName") > 0
+WHERE instr("c"."ContactName", "c"."ContactName") > 0
 """);
     }
 
@@ -886,7 +886,7 @@ WHERE substr("c"."ContactName", length("c"."ContactName"), 1) = 's'
             """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'M') > 0
+WHERE instr("c"."ContactName", 'M') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -28,7 +28,7 @@ public class NorthwindMiscellaneousQuerySqliteTest : NorthwindMiscellaneousQuery
             """
 SELECT "o"."CustomerID"
 FROM "Orders" AS "o"
-WHERE "o"."OrderDate" IS NOT NULL AND "o"."EmployeeID" IS NOT NULL AND instr(CAST("o"."EmployeeID" AS TEXT), '7') > 0
+WHERE "o"."OrderDate" IS NOT NULL AND instr(CAST("o"."EmployeeID" AS TEXT), '7') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -397,6 +397,94 @@ WHERE "e"."BoolB" | ("e"."NullableBoolA" IS NOT NULL)
 """);
     }
 
+    public override async Task Negated_order_comparison_on_non_nullable_arguments_gets_optimized(bool async)
+    {
+        await base.Negated_order_comparison_on_non_nullable_arguments_gets_optimized(async);
+
+        AssertSql(
+            """
+@__i_0='1'
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE "e"."IntA" <= @__i_0
+""",
+            //
+            """
+@__i_0='1'
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE "e"."IntA" < @__i_0
+""",
+            //
+            """
+@__i_0='1'
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE "e"."IntA" >= @__i_0
+""",
+            //
+            """
+@__i_0='1'
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE "e"."IntA" > @__i_0
+""");
+    }
+
+    public override async Task Negated_order_comparison_on_nullable_arguments_doesnt_get_optimized(bool async)
+    {
+        await base.Negated_order_comparison_on_nullable_arguments_doesnt_get_optimized(async);
+
+        AssertSql(
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE NOT (CASE
+    WHEN "e"."NullableIntA" > @__i_0 THEN 1
+    ELSE 0
+END)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE NOT (CASE
+    WHEN "e"."NullableIntA" >= @__i_0 THEN 1
+    ELSE 0
+END)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE NOT (CASE
+    WHEN "e"."NullableIntA" < @__i_0 THEN 1
+    ELSE 0
+END)
+""",
+            //
+            """
+@__i_0='1' (Nullable = true)
+
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE NOT (CASE
+    WHEN "e"."NullableIntA" <= @__i_0 THEN 1
+    ELSE 0
+END)
+""");
+    }
+
     public override async Task Comparison_compared_to_null_check_on_bool(bool async)
     {
         await base.Comparison_compared_to_null_check_on_bool(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -692,7 +692,10 @@ FROM "PointEntity" AS "p"
             """
 @__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-SELECT "p"."Id", Distance("p"."Point", @__point_0) <= 1.0 AS "IsWithinDistance"
+SELECT "p"."Id", CASE
+    WHEN Distance("p"."Point", @__point_0) <= 1.0 THEN 1
+    ELSE 0
+END AS "IsWithinDistance"
 FROM "PointEntity" AS "p"
 """);
     }


### PR DESCRIPTION
Handle comparison of nullable values
 - add a test that reproduces the issue
 - extend `SqlNullabilityProcessor` to handle comparisons of nullable values
 - cleanup code that was needed because of missing handling of comparisons

Fixes #33752 