### PR TITLE
Minor improvement of `SqlServerParameterBasedSqlProcessor.Optimize`

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedSqlProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedSqlProcessor.cs
@@ -35,10 +35,10 @@ public class SqlServerParameterBasedSqlProcessor : RelationalParameterBasedSqlPr
         IReadOnlyDictionary<string, object?> parametersValues,
         out bool canCache)
     {
-        var optimizedQueryExpression = base.Optimize(queryExpression, parametersValues, out canCache);
+        var optimizedQueryExpression = new SkipTakeCollapsingExpressionVisitor(Dependencies.SqlExpressionFactory)
+            .Process(queryExpression, parametersValues, out var canCache2);
 
-        optimizedQueryExpression = new SkipTakeCollapsingExpressionVisitor(Dependencies.SqlExpressionFactory)
-            .Process(optimizedQueryExpression, parametersValues, out var canCache2);
+        optimizedQueryExpression = base.Optimize(optimizedQueryExpression, parametersValues, out canCache);
 
         canCache &= canCache2;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5985,13 +5985,7 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
 
         AssertSql(
             """
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o]
-        WHERE 0 = 1) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END
+SELECT CAST(0 AS bit)
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[CustomerID]
@@ -6004,13 +5998,7 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o]
-        WHERE 0 = 1) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END
+SELECT CAST(0 AS bit)
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[CustomerID]


### PR DESCRIPTION
Running the `SkipTakeCollapsingExpressionVisitor` before `RelationalParameterBasedSqlProcessor.Optimize` opens up some additional query optimization opportunities that can lead to a simpler query.