### PR TITLE
Fix to #33443 - JSON path is not properly formatted

### DIFF
--- a/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
@@ -119,6 +119,13 @@ public interface ISqlGenerationHelper
     void DelimitIdentifier(StringBuilder builder, string name, string? schema);
 
     /// <summary>
+    ///     Writes the delimited SQL representation of an element in a JSON path.
+    /// </summary>
+    /// <param name="pathElement">The JSON path element to delimit.</param>
+    /// <returns>The generated string.</returns>
+    public string DelimitJsonPathElement(string pathElement);
+
+    /// <summary>
     ///     Generates a SQL comment.
     /// </summary>
     /// <param name="text">The comment text.</param>

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Text.Json;
 
 namespace Microsoft.EntityFrameworkCore.Storage;
 
@@ -178,6 +179,32 @@ public class RelationalSqlGenerationHelper : ISqlGenerationHelper
         }
 
         DelimitIdentifier(builder, name);
+    }
+
+    /// <summary>
+    ///     Generates the escaped SQL representation of an identifier (column name, table name, etc.).
+    /// </summary>
+    /// <param name="identifier">The identifier to be escaped.</param>
+    /// <returns>The generated string.</returns>
+    public virtual string EscapeJsonPathElement(string identifier)
+        => JsonEncodedText.Encode(identifier).Value;
+
+    /// <summary>
+    ///     Writes the delimited SQL representation of an element in a JSON path.
+    /// </summary>
+    /// <param name="pathElement">The JSON path element to delimit.</param>
+    /// <returns>The generated string.</returns>
+    public virtual string DelimitJsonPathElement(string pathElement)
+    {
+        for (var i = 0; i < pathElement.Length; i++)
+        {
+            if (!char.IsAsciiLetterOrDigit(pathElement[i]))
+            {
+                return $"\"{EscapeJsonPathElement(pathElement)}\"";
+            }
+        }
+
+        return pathElement;
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -506,7 +506,7 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
             switch (pathSegment)
             {
                 case { PropertyName: string propertyName }:
-                    Sql.Append(".").Append(propertyName);
+                    Sql.Append(".").Append(Dependencies.SqlGenerationHelper.DelimitJsonPathElement(propertyName));
                     break;
 
                 case { ArrayIndex: SqlExpression arrayIndex }:

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -225,7 +225,7 @@ public class SqliteQuerySqlGenerator : QuerySqlGenerator
                 case { PropertyName: string propertyName }:
                     if (inJsonpathString)
                     {
-                        Sql.Append(".").Append(propertyName);
+                        Sql.Append(".").Append(Dependencies.SqlGenerationHelper.DelimitJsonPathElement(propertyName));
                         continue;
                     }
 
@@ -234,11 +234,11 @@ public class SqliteQuerySqlGenerator : QuerySqlGenerator
                     // No need to start a $. JSONPATH string if we're the last segment or the next segment isn't a constant
                     if (isLast || path[i + 1] is { ArrayIndex: not null and not SqlConstantExpression })
                     {
-                        Sql.Append("'").Append(propertyName).Append("'");
+                        Sql.Append("'").Append(Dependencies.SqlGenerationHelper.DelimitJsonPathElement(propertyName)).Append("'");
                         continue;
                     }
 
-                    Sql.Append("'$.").Append(propertyName);
+                    Sql.Append("'$.").Append(Dependencies.SqlGenerationHelper.DelimitJsonPathElement(propertyName));
                     inJsonpathString = true;
                     continue;
 

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameBranch.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameBranch.cs
@@ -12,6 +12,6 @@ public class JsonOwnedCustomNameBranch
     [JsonPropertyName("CustomDate")]
     public DateTime Date { get; set; }
 
-    [JsonPropertyName("CustomFraction")]
+    [JsonPropertyName("ユニコーンFraction一角獣")]
     public double Fraction { get; set; }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
@@ -12,13 +12,12 @@ public class JsonOwnedCustomNameRoot
     [JsonPropertyName("CustomName")]
     public string Name { get; set; }
 
-    [JsonPropertyName("CustomNumber")]
     public int Number { get; set; }
 
     [JsonPropertyName("CustomEnum")]
     public JsonEnum Enum { get; set; }
 
-    [JsonPropertyName("CustomOwnedReferenceBranch")]
+    [JsonPropertyName("Custom#OwnedReferenceBranch`-=[]\\;',./~!@#$%^&*()_+{}|:\"<>?独角兽π獨角獸")]
     public JsonOwnedCustomNameBranch OwnedReferenceBranch { get; set; }
 
     [JsonPropertyName("CustomOwnedCollectionBranch")]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -429,8 +429,8 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Custom_naming_projection_owned_reference(async);
 
         AssertSql(
-            """
-SELECT JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch'), [j].[Id]
+"""
+SELECT JSON_QUERY([j].[json_reference_custom_naming], '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"'), [j].[Id]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -452,8 +452,8 @@ ORDER BY [j].[Id]
         await base.Custom_naming_projection_owned_scalar(async);
 
         AssertSql(
-            """
-SELECT CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
+"""
+SELECT CAST(JSON_VALUE([j].[json_reference_custom_naming], '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"."\u30E6\u30CB\u30B3\u30FC\u30F3Fraction\u4E00\u89D2\u7363"') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -463,8 +463,8 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Custom_naming_projection_everything(async);
 
         AssertSql(
-            """
-SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming], [j].[json_reference_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch'), [j].[json_collection_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedCollectionBranch'), JSON_VALUE([j].[json_reference_custom_naming], '$.CustomName'), CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
+"""
+SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming], [j].[json_reference_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"'), [j].[json_collection_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedCollectionBranch'), JSON_VALUE([j].[json_reference_custom_naming], '$.CustomName'), CAST(JSON_VALUE([j].[json_reference_custom_naming], '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"."\u30E6\u30CB\u30B3\u30FC\u30F3Fraction\u4E00\u89D2\u7363"') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -413,6 +413,39 @@ WHERE "j"."Reference" ->> 'BoolConvertedToStringYN' = 'Y'
             message);
     }
 
+    public override async Task Custom_naming_projection_everything(bool async)
+    {
+        await base.Custom_naming_projection_everything(async);
+
+        AssertSql(
+            """
+SELECT "j"."Id", "j"."Title", "j"."json_collection_custom_naming", "j"."json_reference_custom_naming", "j"."json_reference_custom_naming", "j"."json_reference_custom_naming" ->> '"Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"', "j"."json_collection_custom_naming", "j"."json_reference_custom_naming" ->> 'CustomOwnedCollectionBranch', "j"."json_reference_custom_naming" ->> 'CustomName', "j"."json_reference_custom_naming" ->> '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"."\u30E6\u30CB\u30B3\u30FC\u30F3Fraction\u4E00\u89D2\u7363"'
+FROM "JsonEntitiesCustomNaming" AS "j"
+""");
+    }
+
+    public override async Task Custom_naming_projection_owned_scalar(bool async)
+    {
+        await base.Custom_naming_projection_owned_scalar(async);
+
+        AssertSql(
+            """
+SELECT "j"."json_reference_custom_naming" ->> '$."Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"."\u30E6\u30CB\u30B3\u30FC\u30F3Fraction\u4E00\u89D2\u7363"'
+FROM "JsonEntitiesCustomNaming" AS "j"
+""");
+    }
+
+    public override async Task Custom_naming_projection_owned_reference(bool async)
+    {
+        await base.Custom_naming_projection_owned_reference(async);
+
+        AssertSql(
+            """
+SELECT "j"."json_reference_custom_naming" ->> '"Custom#OwnedReferenceBranch\u0060-=[]\\;\u0027,./~!@#$%^\u0026*()_\u002B{}|:\u0022\u003C\u003E?\u72EC\u89D2\u517D\u03C0\u7368\u89D2\u7378"', "j"."Id"
+FROM "JsonEntitiesCustomNaming" AS "j"
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
Queries extracting data from JSON properties containing special characters must escape references to those properties in JSON path. Moreover, the values we use in JSON paths must correspond to how we store those properties in database. When we serialize JSON-mapped entity into JSON string, many special (unicode) characters are stored in the \uxxxx form. Lastly in the shaper, when reading json data from the stream we need to make sure to correctly match the property names using Utf8JsonReader. ValueTextEquals un-escapes the property names before comparison, the Span representing the property name must also be un-escaped.

Fixes #33443