### PR TITLE
re-enabling sqlite tests on macos now that ci was updated

### DIFF
--- a/test/EFCore.Sqlite.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
-
-[assembly: PlatformSkipCondition(TestPlatform.Mac, SkipReason = "#33785")]


### PR DESCRIPTION
Fixes #33785