### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,6 +118,7 @@ extends:
                   arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
                 env:
                   Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - task: NuGetAuthenticate@1
               - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs) $(_InternalRuntimeDownloadArgs) $(_AdditionalBuildArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
@@ -157,6 +158,7 @@ extends:
                   arguments: $(Build.SourcesDirectory)/NuGet.config $Token
                 env:
                   Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - task: NuGetAuthenticate@1
               - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
@@ -200,6 +202,7 @@ extends:
                   arguments: $(Build.SourcesDirectory)/NuGet.config $Token
                 env:
                   Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - task: NuGetAuthenticate@1
               - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
@@ -242,6 +245,7 @@ extends:
                   arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
                 env:
                     Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - task: NuGetAuthenticate@1
               - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
                 displayName: Restore packages
               - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

