### PR TITLE
Skip sync tests in Cosmos

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/ConcurrencyDetectorDisabledCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ConcurrencyDetectorDisabledCosmosTest.cs
@@ -13,27 +13,6 @@ public class ConcurrencyDetectorDisabledCosmosTest(ConcurrencyDetectorDisabledCo
     public override Task Any(bool async)
         => base.Any(async);
 
-    public override Task SaveChanges(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.SaveChanges(a));
-
-    public override Task Count(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Count(a));
-
-    public override Task Find(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Find(a));
-
-    public override Task First(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.First(a));
-
-    public override Task Last(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Last(a));
-
-    public override Task Single(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Single(a));
-
-    public override Task ToList(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.ToList(a));
-
     public class ConcurrencyDetectorCosmosFixture : ConcurrencyDetectorFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -136,9 +136,6 @@ WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND NOT((c["IndexerVisible"] = 
     public override void Infer_type_mapping_from_in_subquery_to_item()
         => Assert.Throws<InvalidOperationException>(() => base.Infer_type_mapping_from_in_subquery_to_item());
 
-    public override Task Can_query_custom_type_not_mapped_by_default_equality(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Can_query_custom_type_not_mapped_by_default_equality(a));
-
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
@@ -28,49 +28,49 @@ public abstract class FindCosmosTest : FindTestBase<FindCosmosTest.FindCosmosFix
         => Task.CompletedTask;
 
     public override void Find_int_key_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_int_key_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_int_key_from_store());
 
     public override void Returns_null_for_int_key_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_int_key_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_int_key_not_in_store());
 
     public override void Find_nullable_int_key_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_nullable_int_key_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_nullable_int_key_from_store());
 
     public override void Returns_null_for_nullable_int_key_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_nullable_int_key_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_nullable_int_key_not_in_store());
 
     public override void Find_string_key_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_string_key_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_string_key_from_store());
 
     public override void Returns_null_for_string_key_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_string_key_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_string_key_not_in_store());
 
     public override void Find_composite_key_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_composite_key_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_composite_key_from_store());
 
     public override void Returns_null_for_composite_key_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_composite_key_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_composite_key_not_in_store());
 
     public override void Find_base_type_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_base_type_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_base_type_from_store());
 
     public override void Returns_null_for_base_type_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_base_type_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_base_type_not_in_store());
 
     public override void Find_derived_type_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_derived_type_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_derived_type_from_store());
 
     public override void Returns_null_for_derived_type_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_derived_type_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_derived_type_not_in_store());
 
     public override void Find_base_type_using_derived_set_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_base_type_using_derived_set_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_base_type_using_derived_set_from_store());
 
     public override void Find_shadow_key_from_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Find_shadow_key_from_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Find_shadow_key_from_store());
 
     public override void Returns_null_for_shadow_key_not_in_store()
-        => CosmosTestHelpers.Instance.NoSyncTest(() => base.Returns_null_for_shadow_key_not_in_store());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(() => base.Returns_null_for_shadow_key_not_in_store());
 
     public class FindCosmosTestSet(FindCosmosFixture fixture) : FindCosmosTest(fixture)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
@@ -11,9 +11,6 @@ public class MaterializationInterceptionCosmosTest :
     public override Task Intercept_query_materialization_with_owned_types_projecting_collection(bool async, bool usePooling)
         => Task.CompletedTask;
 
-    public override Task Intercept_query_materialization_with_owned_types(bool async, bool usePooling)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Intercept_query_materialization_with_owned_types(a, usePooling));
-
     public class CosmosLibraryContext(DbContextOptions options) : LibraryContext(options)
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.Cosmos.FunctionalTests/OptimisticConcurrencyCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/OptimisticConcurrencyCosmosTest.cs
@@ -45,53 +45,16 @@ public class OptimisticConcurrencyCosmosTest(F1CosmosFixture<byte[]> fixture)
 
     // Uses lazy-loader, which is always sync
     public override Task Two_concurrency_issues_in_one_to_one_related_entities_can_be_handled_by_dealing_with_dependent_first()
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            false,
-            _ => base.Two_concurrency_issues_in_one_to_one_related_entities_can_be_handled_by_dealing_with_dependent_first());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(
+            () => base.Two_concurrency_issues_in_one_to_one_related_entities_can_be_handled_by_dealing_with_dependent_first());
 
     // Uses lazy-loader, which is always sync
     public override Task Two_concurrency_issues_in_one_to_many_related_entities_can_be_handled_by_dealing_with_dependent_first()
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            false,
-            _ => base.Two_concurrency_issues_in_one_to_many_related_entities_can_be_handled_by_dealing_with_dependent_first());
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(
+            () => base.Two_concurrency_issues_in_one_to_many_related_entities_can_be_handled_by_dealing_with_dependent_first());
 
     protected override IDbContextTransaction BeginTransaction(DatabaseFacade facade)
         => new FakeDbContextTransaction();
-
-    public override Task Calling_Reload_on_an_Added_entity_that_is_not_in_database_is_no_op(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Calling_Reload_on_an_Added_entity_that_is_not_in_database_is_no_op(a));
-
-    public override Task Calling_Reload_on_an_Unchanged_entity_that_is_not_in_database_detaches_it(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, a => base.Calling_Reload_on_an_Unchanged_entity_that_is_not_in_database_detaches_it(a));
-
-    public override Task Calling_Reload_on_a_Modified_entity_that_is_not_in_database_detaches_it(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, a => base.Calling_Reload_on_a_Modified_entity_that_is_not_in_database_detaches_it(a));
-
-    public override Task Calling_Reload_on_a_Deleted_entity_that_is_not_in_database_detaches_it(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, a => base.Calling_Reload_on_a_Deleted_entity_that_is_not_in_database_detaches_it(a));
-
-    public override Task Calling_Reload_on_a_Detached_entity_that_is_not_in_database_detaches_it(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, a => base.Calling_Reload_on_a_Detached_entity_that_is_not_in_database_detaches_it(a));
-
-    public override Task Calling_Reload_on_an_Unchanged_entity_makes_the_entity_unchanged(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Calling_Reload_on_an_Unchanged_entity_makes_the_entity_unchanged(a));
-
-    public override Task Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged(a));
-
-    public override Task Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged(a));
-
-    public override Task Calling_Reload_on_an_Added_entity_that_was_saved_elsewhere_makes_the_entity_unchanged(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, a => base.Calling_Reload_on_an_Added_entity_that_was_saved_elsewhere_makes_the_entity_unchanged(a));
-
-    public override Task Calling_Reload_on_a_Detached_entity_makes_the_entity_unchanged(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Calling_Reload_on_a_Detached_entity_makes_the_entity_unchanged(a));
 
     private class FakeDbContextTransaction : IDbContextTransaction
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
@@ -3,7 +3,12 @@
 
 // Skip the entire assembly if cannot connect to CosmosDb
 
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+
 [assembly: CosmosDbConfiguredCondition]
 
 // Waiting on Task causes deadlocks when run in parallel
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+// Cosmos doesn't support sync I/O
+[assembly: SkipSyncTests]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -25,29 +25,25 @@ public class FromSqlQueryCosmosTest : QueryTestBase<NorthwindQueryCosmosFixture<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%'");
+    public async Task FromSqlRaw_queryable_simple(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%'");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(14, actual.Length);
-                Assert.Equal(14, context.ChangeTracker.Entries().Count());
+        Assert.Equal(14, actual.Length);
+        Assert.Equal(14, context.ChangeTracker.Entries().Count());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["ContactName"] LIKE '%z%'
 ) c
 """);
-            });
+    }
 
     [ConditionalFact]
     public async Task FromSqlRaw_queryable_incorrect_discriminator_throws()
@@ -64,229 +60,205 @@ FROM (
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_simple_columns_out_of_order(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
+    public async Task FromSqlRaw_queryable_simple_columns_out_of_order(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
+        Assert.Equal(91, actual.Length);
+        Assert.Equal(91, context.ChangeTracker.Entries().Count());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["Phone"], c["Fax"], c["CustomerID"], c["Country"], c["ContactTitle"], c["ContactName"], c["CompanyName"], c["City"], c["Address"] FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_simple_columns_out_of_order_and_extra_columns(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
+    public async Task FromSqlRaw_queryable_simple_columns_out_of_order_and_extra_columns(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
+        Assert.Equal(91, actual.Length);
+        Assert.Equal(91, context.ChangeTracker.Entries().Count());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["PostalCode"] AS Foo, c["Phone"], c["Fax"], c["CustomerID"], c["Country"], c["ContactTitle"], c["ContactName"], c["CompanyName"], c["City"], c["Address"] FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_composed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                    .Where(c => c.ContactName.Contains("z"));
+    public async Task FromSqlRaw_queryable_composed(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            .Where(c => c.ContactName.Contains("z"));
 
-                var sql = query.ToQueryString();
+        var sql = query.ToQueryString();
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(14, actual.Length);
-                Assert.Equal(14, context.ChangeTracker.Entries().Count());
+        Assert.Equal(14, actual.Length);
+        Assert.Equal(14, context.ChangeTracker.Entries().Count());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 WHERE CONTAINS(c["ContactName"], "z")
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_composed_after_removing_whitespaces(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                        _eol + "    " + _eol + _eol + _eol + "SELECT" + _eol + @"* FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                    .Where(c => c.ContactName.Contains("z"));
+    public virtual async Task FromSqlRaw_queryable_composed_after_removing_whitespaces(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+                _eol + "    " + _eol + _eol + _eol + "SELECT" + _eol + @"* FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            .Where(c => c.ContactName.Contains("z"));
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(14, actual.Length);
+        Assert.Equal(14, actual.Length);
 
-                AssertSql(
-                    @"SELECT c
+        AssertSql(
+            @"SELECT c
 FROM (
 
         "
-                    + @"
+            + @"
 
 
     SELECT
     * FROM root c WHERE c[""Discriminator""] = ""Customer""
 ) c
 WHERE CONTAINS(c[""ContactName""], ""z"")");
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_composed_compiled(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
+    public async Task FromSqlRaw_queryable_composed_compiled(bool async)
+    {
+        if (async)
+        {
+            var query = EF.CompileAsyncQuery(
+                (NorthwindContext context) => context.Set<Customer>()
+                    .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+                    .Where(c => c.ContactName.Contains("z")));
+
+            using (var context = CreateContext())
             {
-                if (a)
-                {
-                    var query = EF.CompileAsyncQuery(
-                        (NorthwindContext context) => context.Set<Customer>()
-                            .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                            .Where(c => c.ContactName.Contains("z")));
+                var actual = await query(context).ToListAsync();
 
-                    using (var context = CreateContext())
-                    {
-                        var actual = await query(context).ToListAsync();
+                Assert.Equal(14, actual.Count);
+            }
+        }
+        else
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context) => context.Set<Customer>()
+                    .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+                    .Where(c => c.ContactName.Contains("z")));
 
-                        Assert.Equal(14, actual.Count);
-                    }
-                }
-                else
-                {
-                    var query = EF.CompileQuery(
-                        (NorthwindContext context) => context.Set<Customer>()
-                            .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                            .Where(c => c.ContactName.Contains("z")));
+            using (var context = CreateContext())
+            {
+                var actual = query(context).ToArray();
 
-                    using (var context = CreateContext())
-                    {
-                        var actual = query(context).ToArray();
+                Assert.Equal(14, actual.Length);
+            }
+        }
 
-                        Assert.Equal(14, actual.Length);
-                    }
-                }
-
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 WHERE CONTAINS(c["ContactName"], "z")
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_composed_compiled_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
+    public virtual async Task FromSqlRaw_queryable_composed_compiled_with_parameter(bool async)
+    {
+        if (async)
+        {
+            var query = EF.CompileAsyncQuery(
+                (NorthwindContext context) => context.Set<Customer>().FromSqlRaw(
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
+                    .Where(c => c.ContactName.Contains("z")));
+
+            using (var context = CreateContext())
             {
-                if (a)
-                {
-                    var query = EF.CompileAsyncQuery(
-                        (NorthwindContext context) => context.Set<Customer>().FromSqlRaw(
-                                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
-                            .Where(c => c.ContactName.Contains("z")));
+                var actual = await query(context).ToListAsync();
 
-                    using (var context = CreateContext())
-                    {
-                        var actual = await query(context).ToListAsync();
+                Assert.Single(actual);
+            }
+        }
+        else
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context) => context.Set<Customer>().FromSqlRaw(
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
+                    .Where(c => c.ContactName.Contains("z")));
 
-                        Assert.Single(actual);
-                    }
-                }
-                else
-                {
-                    var query = EF.CompileQuery(
-                        (NorthwindContext context) => context.Set<Customer>().FromSqlRaw(
-                                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
-                            .Where(c => c.ContactName.Contains("z")));
+            using (var context = CreateContext())
+            {
+                var actual = query(context).ToArray();
 
-                    using (var context = CreateContext())
-                    {
-                        var actual = query(context).ToArray();
+                Assert.Single(actual);
+            }
+        }
 
-                        Assert.Single(actual);
-                    }
-                }
-
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["CustomerID"] = "CONSH"
 ) c
 WHERE CONTAINS(c["ContactName"], "z")
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_multiple_line_query(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    """
+    public virtual async Task FromSqlRaw_queryable_multiple_line_query(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            """
 SELECT *
 FROM root c
 WHERE c["Discriminator"] = "Customer" AND c["City"] = 'London'
 """);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
+        Assert.Equal(6, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT *
@@ -294,32 +266,28 @@ FROM (
     WHERE c["Discriminator"] = "Customer" AND c["City"] = 'London'
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_composed_multiple_line_query(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                        """
+    public virtual async Task FromSqlRaw_queryable_composed_multiple_line_query(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+                """
 SELECT *
 FROM root c
 WHERE c["Discriminator"] = "Customer"
 """)
-                    .Where(c => c.City == "London");
+            .Where(c => c.City == "London");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
+        Assert.Equal(6, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT *
@@ -328,33 +296,29 @@ FROM (
 ) c
 WHERE (c["City"] = "London")
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_with_parameters(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                var city = "London";
-                var contactTitle = "Sales Representative";
+    public async Task FromSqlRaw_queryable_with_parameters(bool async)
+    {
+        var city = "London";
+        var contactTitle = "Sales Representative";
 
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}",
-                    city,
-                    contactTitle);
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}",
+            city,
+            contactTitle);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+        Assert.Equal(3, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
+        Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @p0='London'
 @p1='Sales Representative'
 
@@ -363,30 +327,26 @@ FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_with_parameters_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                    @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}",
-                    "London",
-                    "Sales Representative");
+    public async Task FromSqlRaw_queryable_with_parameters_inline(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+            @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}",
+            "London",
+            "Sales Representative");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+        Assert.Equal(3, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
+        Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @p0='London'
 @p1='Sales Representative'
 
@@ -395,29 +355,25 @@ FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_with_null_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                uint? reportsTo = null;
+    public async Task FromSqlRaw_queryable_with_null_parameter(bool async)
+    {
+        uint? reportsTo = null;
 
-                using var context = CreateContext();
-                var query = context.Set<Employee>().FromSqlRaw(
-                    @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Employee"" AND c[""ReportsTo""] = {0} OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL({0}))",
-                    reportsTo);
+        using var context = CreateContext();
+        var query = context.Set<Employee>().FromSqlRaw(
+            @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Employee"" AND c[""ReportsTo""] = {0} OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL({0}))",
+            reportsTo);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Single(actual);
+        Assert.Single(actual);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @p0=null
 
 SELECT c
@@ -425,33 +381,29 @@ FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Employee" AND c["ReportsTo"] = @p0 OR (IS_NULL(c["ReportsTo"]) AND IS_NULL(@p0))
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public Task FromSqlRaw_queryable_with_parameters_and_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                var city = "London";
-                var contactTitle = "Sales Representative";
+    public async Task FromSqlRaw_queryable_with_parameters_and_closure(bool async)
+    {
+        var city = "London";
+        var contactTitle = "Sales Representative";
 
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(
-                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0}", city)
-                    .Where(c => c.ContactTitle == contactTitle);
-                var queryString = query.ToQueryString();
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0}", city)
+            .Where(c => c.ContactTitle == contactTitle);
+        var queryString = query.ToQueryString();
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+        Assert.Equal(3, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
+        Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @p0='London'
 @__contactTitle_1='Sales Representative'
 
@@ -461,88 +413,76 @@ FROM (
 ) c
 WHERE (c["ContactTitle"] = @__contactTitle_1)
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_simple_cache_key_includes_query_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>()
-                    .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'London'");
+    public virtual async Task FromSqlRaw_queryable_simple_cache_key_includes_query_string(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>()
+            .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'London'");
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
+        Assert.Equal(6, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
 
-                query = context.Set<Customer>()
-                    .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'Seattle'");
+        query = context.Set<Customer>()
+            .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'Seattle'");
 
-                actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        actual = await query.ToArrayAsync();
 
-                Assert.Single(actual);
-                Assert.True(actual.All(c => c.City == "Seattle"));
+        Assert.Single(actual);
+        Assert.True(actual.All(c => c.City == "Seattle"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = 'London'
 ) c
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = 'Seattle'
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                var city = "London";
-                var contactTitle = "Sales Representative";
-                var sql =
-                    @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}";
+    public virtual async Task FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters(bool async)
+    {
+        var city = "London";
+        var contactTitle = "Sales Representative";
+        var sql =
+            @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}";
 
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+        Assert.Equal(3, actual.Length);
+        Assert.True(actual.All(c => c.City == "London"));
+        Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
 
-                city = "Madrid";
-                contactTitle = "Accounting Manager";
+        city = "Madrid";
+        contactTitle = "Accounting Manager";
 
-                query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+        query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
 
-                actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        actual = await query.ToArrayAsync();
 
-                Assert.Equal(2, actual.Length);
-                Assert.True(actual.All(c => c.City == "Madrid"));
-                Assert.True(actual.All(c => c.ContactTitle == "Accounting Manager"));
+        Assert.Equal(2, actual.Length);
+        Assert.True(actual.All(c => c.City == "Madrid"));
+        Assert.True(actual.All(c => c.ContactTitle == "Accounting Manager"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @p0='London'
 @p1='Sales Representative'
 
@@ -551,8 +491,8 @@ FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) c
 """,
-                    //
-                    """
+            //
+            """
 @p0='Madrid'
 @p1='Accounting Manager'
 
@@ -561,55 +501,47 @@ FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_simple_as_no_tracking_not_composed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                    .AsNoTracking();
+    public virtual async Task FromSqlRaw_queryable_simple_as_no_tracking_not_composed(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            .AsNoTracking();
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(91, actual.Length);
-                Assert.Empty(context.ChangeTracker.Entries());
+        Assert.Equal(91, actual.Length);
+        Assert.Empty(context.ChangeTracker.Entries());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_simple_projection_composed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Product>().FromSqlRaw(
-                        @"SELECT *
+    public virtual async Task FromSqlRaw_queryable_simple_projection_composed(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Product>().FromSqlRaw(
+                @"SELECT *
 FROM root c
 WHERE c[""Discriminator""] = ""Product"" AND NOT c[""Discontinued""] AND ((c[""UnitsInStock""] + c[""UnitsOnOrder""]) < c[""ReorderLevel""])")
-                    .Select(p => p.ProductName);
+            .Select(p => p.ProductName);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(2, actual.Length);
+        Assert.Equal(2, actual.Length);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["ProductName"]
 FROM (
     SELECT *
@@ -617,96 +549,84 @@ FROM (
     WHERE c["Discriminator"] = "Product" AND NOT c["Discontinued"] AND ((c["UnitsInStock"] + c["UnitsOnOrder"]) < c["ReorderLevel"])
 ) c
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_composed_with_nullable_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                    .Where(c => c.ContactName == c.CompanyName);
+    public virtual async Task FromSqlRaw_composed_with_nullable_predicate(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            .Where(c => c.ContactName == c.CompanyName);
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Empty(actual);
+        Assert.Empty(actual);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 WHERE (c["ContactName"] = c["CompanyName"])
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_does_not_parameterize_interpolated_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var propertyName = "OrderID";
-                var max = 10250;
-                var query = context.Orders.FromSqlRaw(
-                    $@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order"" AND c[""{propertyName}""] < {{0}}", max);
+    public virtual async Task FromSqlRaw_does_not_parameterize_interpolated_string(bool async)
+    {
+        using var context = CreateContext();
+        var propertyName = "OrderID";
+        var max = 10250;
+        var query = context.Orders.FromSqlRaw(
+            $@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order"" AND c[""{propertyName}""] < {{0}}", max);
 
-                var actual = a
-                    ? await query.ToListAsync()
-                    : query.ToList();
+        var actual = await query.ToListAsync();
 
-                Assert.Equal(2, actual.Count);
-            });
+        Assert.Equal(2, actual.Count);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task FromSqlRaw_queryable_simple_projection_not_composed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                using var context = CreateContext();
-                var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
-                    .Select(
-                        c => new { c.CustomerID, c.City })
-                    .AsNoTracking();
+    public virtual async Task FromSqlRaw_queryable_simple_projection_not_composed(bool async)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            .Select(
+                c => new { c.CustomerID, c.City })
+            .AsNoTracking();
 
-                var actual = a
-                    ? await query.ToArrayAsync()
-                    : query.ToArray();
+        var actual = await query.ToArrayAsync();
 
-                Assert.Equal(91, actual.Length);
-                Assert.Empty(context.ChangeTracker.Entries());
+        Assert.Equal(91, actual.Length);
+        Assert.Empty(context.ChangeTracker.Entries());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], c["City"]
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) c
 """);
-            });
+    }
 
     [ConditionalFact]
     public async Task FromSqlRaw_queryable_simple_with_missing_key_and_non_tracking_throws()
     {
-            using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Category""")
-                .AsNoTracking();
+        using var context = CreateContext();
+        var query = context.Set<Customer>()
+            .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Category""")
+            .AsNoTracking();
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToArrayAsync());
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToArrayAsync());
 
-            Assert.Equal(
-                CoreStrings.InvalidKeyValue(
-                    context.Model.FindEntityType(typeof(Customer))!.DisplayName(),
-                    "CustomerID"),
-                exception.Message);
+        Assert.Equal(
+            CoreStrings.InvalidKeyValue(
+                context.Model.FindEntityType(typeof(Customer))!.DisplayName(),
+                "CustomerID"),
+            exception.Message);
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosFixture.cs
@@ -19,9 +19,6 @@ public class InheritanceQueryCosmosFixture : InheritanceQueryFixtureBase
     public override bool EnableComplexTypes
         => false;
 
-    public Task NoSyncTest(bool async, Func<bool, Task> testCode)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, testCode);
-
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder.ConfigureWarnings(
             w => w.Ignore(CoreEventId.MappedEntityTypeIgnoredWarning, CosmosEventId.NoPartitionKeyDefined)));

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
@@ -14,250 +14,218 @@ public class InheritanceQueryCosmosTest : InheritanceQueryTestBase<InheritanceQu
         //TestLoggerFactory.TestOutputHelper = testOutputHelper;
     }
 
-    public override Task Can_query_when_shared_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_when_shared_column(a);
+    public override async Task Can_query_when_shared_column(bool async)
+    {
+        await base.Can_query_when_shared_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = 1)
 OFFSET 0 LIMIT 2
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = 2)
 OFFSET 0 LIMIT 2
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = 3)
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
-    public override Task Can_query_all_types_when_shared_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_all_types_when_shared_column(a);
+    public override async Task Can_query_all_types_when_shared_column(bool async)
+    {
+        await base.Can_query_all_types_when_shared_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN (0, 1, 2, 3)
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_animal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_animal(a);
+    public override async Task Can_use_of_type_animal(bool async)
+    {
+        await base.Can_use_of_type_animal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_use_is_kiwi(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_is_kiwi(a);
+    public override async Task Can_use_is_kiwi(bool async)
+    {
+        await base.Can_use_is_kiwi(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
-            });
+    }
 
-    public override Task Can_use_is_kiwi_with_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_is_kiwi_with_cast(a);
+    public override async Task Can_use_is_kiwi_with_cast(bool async)
+    {
+        await base.Can_use_is_kiwi_with_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Value" : ((c["Discriminator"] = "Kiwi") ? c["FoundOn"] : 0)}
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
-            });
+    }
 
-    public override Task Can_use_backwards_is_animal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_backwards_is_animal(a);
+    public override async Task Can_use_backwards_is_animal(bool async)
+    {
+        await base.Can_use_backwards_is_animal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
-            });
+    }
 
-    public override Task Can_use_is_kiwi_with_other_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_is_kiwi_with_other_predicate(a);
+    public override async Task Can_use_is_kiwi_with_other_predicate(bool async)
+    {
+        await base.Can_use_is_kiwi_with_other_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ((c["Discriminator"] = "Kiwi") AND (c["CountryId"] = 1)))
 """);
-            });
+    }
 
-    public override Task Can_use_is_kiwi_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_is_kiwi_in_projection(a);
+    public override async Task Can_use_is_kiwi_in_projection(bool async)
+    {
+        await base.Can_use_is_kiwi_in_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : (c["Discriminator"] = "Kiwi")}
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_bird(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_bird(a);
+    public override async Task Can_use_of_type_bird(bool async)
+    {
+        await base.Can_use_of_type_bird(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND c["Discriminator"] IN ("Eagle", "Kiwi"))
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_bird_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_bird_predicate(a);
+    public override async Task Can_use_of_type_bird_predicate(bool async)
+    {
+        await base.Can_use_of_type_bird_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["CountryId"] = 1)) AND c["Discriminator"] IN ("Eagle", "Kiwi"))
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_bird_with_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_bird_with_projection(a);
+    public override async Task Can_use_of_type_bird_with_projection(bool async)
+    {
+        await base.Can_use_of_type_bird_with_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EagleId"]
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND c["Discriminator"] IN ("Eagle", "Kiwi"))
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_bird_first(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_bird_first(a);
+    public override async Task Can_use_of_type_bird_first(bool async)
+    {
+        await base.Can_use_of_type_bird_first(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND c["Discriminator"] IN ("Eagle", "Kiwi"))
 ORDER BY c["Species"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_kiwi(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_kiwi(a);
+    public override async Task Can_use_of_type_kiwi(bool async)
+    {
+        await base.Can_use_of_type_kiwi(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
-            });
+    }
 
-    public override Task Can_use_backwards_of_type_animal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_backwards_of_type_animal(a);
+    public override async Task Can_use_backwards_of_type_animal(bool async)
+    {
+        await base.Can_use_backwards_of_type_animal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_rose(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_rose(a);
+    public override async Task Can_use_of_type_rose(bool async)
+    {
+        await base.Can_use_of_type_rose(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Daisy", "Rose") AND (c["Discriminator"] = "Rose"))
 """);
-            });
+    }
 
-    public override Task Can_query_all_animals(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_all_animals(a);
+    public override async Task Can_query_all_animals(bool async)
+    {
+        await base.Can_query_all_animals(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Issue#17246 Views are not supported")]
     public override async Task Can_query_all_animal_views(bool async)
@@ -267,80 +235,70 @@ ORDER BY c["Species"]
         AssertSql(" ");
     }
 
-    public override Task Can_query_all_plants(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_all_plants(a);
+    public override async Task Can_query_all_plants(bool async)
+    {
+        await base.Can_query_all_plants(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Daisy", "Rose")
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_filter_all_animals(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_filter_all_animals(a);
+    public override async Task Can_filter_all_animals(bool async)
+    {
+        await base.Can_filter_all_animals(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Name"] = "Great spotted kiwi"))
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_query_all_birds(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_all_birds(a);
+    public override async Task Can_query_all_birds(bool async)
+    {
+        await base.Can_query_all_birds(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
 """);
-            });
+    }
 
-    public override Task Can_query_just_kiwis(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_just_kiwis(a);
+    public override async Task Can_query_just_kiwis(bool async)
+    {
+        await base.Can_query_just_kiwis(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
-    public override Task Can_query_just_roses(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_just_roses(a);
+    public override async Task Can_query_just_roses(bool async)
+    {
+        await base.Can_query_just_roses(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Rose")
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Issue#17246 Non-embedded Include")]
     public override async Task Can_include_animals(bool async)
@@ -358,89 +316,77 @@ OFFSET 0 LIMIT 2
         AssertSql(" ");
     }
 
-    public override Task Can_use_of_type_kiwi_where_south_on_derived_property(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_kiwi_where_south_on_derived_property(a);
+    public override async Task Can_use_of_type_kiwi_where_south_on_derived_property(bool async)
+    {
+        await base.Can_use_of_type_kiwi_where_south_on_derived_property(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["FoundOn"] = 1))
 """);
-            });
+    }
 
-    public override Task Can_use_of_type_kiwi_where_north_on_derived_property(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_use_of_type_kiwi_where_north_on_derived_property(a);
+    public override async Task Can_use_of_type_kiwi_where_north_on_derived_property(bool async)
+    {
+        await base.Can_use_of_type_kiwi_where_north_on_derived_property(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["FoundOn"] = 0))
 """);
-            });
+    }
 
-    public override Task Discriminator_used_when_projection_over_derived_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Discriminator_used_when_projection_over_derived_type(a);
+    public override async Task Discriminator_used_when_projection_over_derived_type(bool async)
+    {
+        await base.Discriminator_used_when_projection_over_derived_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["FoundOn"]
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
-            });
+    }
 
-    public override Task Discriminator_used_when_projection_over_derived_type2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Discriminator_used_when_projection_over_derived_type2(a);
+    public override async Task Discriminator_used_when_projection_over_derived_type2(bool async)
+    {
+        await base.Discriminator_used_when_projection_over_derived_type2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["IsFlightless"], c["Discriminator"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
-            });
+    }
 
-    public override Task Discriminator_with_cast_in_shadow_property(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Discriminator_with_cast_in_shadow_property(a);
+    public override async Task Discriminator_with_cast_in_shadow_property(bool async)
+    {
+        await base.Discriminator_with_cast_in_shadow_property(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Predator" : c["Name"]}
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ("Kiwi" = c["Discriminator"]))
 """);
-            });
+    }
 
-    public override Task Discriminator_used_when_projection_over_of_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Discriminator_used_when_projection_over_of_type(a);
+    public override async Task Discriminator_used_when_projection_over_of_type(bool async)
+    {
+        await base.Discriminator_used_when_projection_over_of_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["FoundOn"]
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
-            });
+    }
 
     [ConditionalFact(Skip = "Issue#17246 Transations not supported")]
     public override async Task Can_insert_update_delete()
@@ -471,14 +417,12 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
         AssertSql(" ");
     }
 
-    public override Task Subquery_OfType(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Subquery_OfType(a);
+    public override async Task Subquery_OfType(bool async)
+    {
+        await base.Subquery_OfType(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='5'
 
 SELECT DISTINCT c
@@ -487,7 +431,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 ORDER BY c["Species"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     public override async Task Union_entity_equality(bool async)
     {
@@ -509,19 +453,17 @@ OFFSET 0 LIMIT 2
 """);
     }
 
-    public override Task Byte_enum_value_constant_used_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Byte_enum_value_constant_used_in_projection(a);
+    public override async Task Byte_enum_value_constant_used_in_projection(bool async)
+    {
+        await base.Byte_enum_value_constant_used_in_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : (c["IsFlightless"] ? 0 : 1)}
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
-            });
+    }
 
     public override async Task Member_access_on_intermediate_type_works()
     {
@@ -544,145 +486,125 @@ ORDER BY c["Name"]
         AssertSql(" ");
     }
 
-    public override Task Selecting_only_base_properties_on_base_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Selecting_only_base_properties_on_base_type(a);
+    public override async Task Selecting_only_base_properties_on_base_type(bool async)
+    {
+        await base.Selecting_only_base_properties_on_base_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
-            });
+    }
 
-    public override Task Selecting_only_base_properties_on_derived_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Selecting_only_base_properties_on_derived_type(a);
+    public override async Task Selecting_only_base_properties_on_derived_type(bool async)
+    {
+        await base.Selecting_only_base_properties_on_derived_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_abstract_base_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_abstract_base_type(a);
+    public override async Task GetType_in_hierarchy_in_abstract_base_type(bool async)
+    {
+        await base.GetType_in_hierarchy_in_abstract_base_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND false)
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_intermediate_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_intermediate_type(a);
+    public override async Task GetType_in_hierarchy_in_intermediate_type(bool async)
+    {
+        await base.GetType_in_hierarchy_in_intermediate_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND false)
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_leaf_type_with_sibling(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_leaf_type_with_sibling(a);
+    public override async Task GetType_in_hierarchy_in_leaf_type_with_sibling(bool async)
+    {
+        await base.GetType_in_hierarchy_in_leaf_type_with_sibling(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Eagle"))
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_leaf_type_with_sibling2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_leaf_type_with_sibling2(a);
+    public override async Task GetType_in_hierarchy_in_leaf_type_with_sibling2(bool async)
+    {
+        await base.GetType_in_hierarchy_in_leaf_type_with_sibling2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_leaf_type_with_sibling2_reverse(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_leaf_type_with_sibling2_reverse(a);
+    public override async Task GetType_in_hierarchy_in_leaf_type_with_sibling2_reverse(bool async)
+    {
+        await base.GetType_in_hierarchy_in_leaf_type_with_sibling2_reverse(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
-            });
+    }
 
-    public override Task GetType_in_hierarchy_in_leaf_type_with_sibling2_not_equal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_in_hierarchy_in_leaf_type_with_sibling2_not_equal(a);
+    public override async Task GetType_in_hierarchy_in_leaf_type_with_sibling2_not_equal(bool async)
+    {
+        await base.GetType_in_hierarchy_in_leaf_type_with_sibling2_not_equal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] != "Kiwi"))
 """);
-            });
+    }
 
-    public override Task Using_is_operator_on_multiple_type_with_no_result(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Using_is_operator_on_multiple_type_with_no_result(a);
+    public override async Task Using_is_operator_on_multiple_type_with_no_result(bool async)
+    {
+        await base.Using_is_operator_on_multiple_type_with_no_result(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["Discriminator"] = "Eagle"))
 """);
-            });
+    }
 
-    public override Task Using_is_operator_with_of_type_on_multiple_type_with_no_result(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Using_is_operator_with_of_type_on_multiple_type_with_no_result(a);
+    public override async Task Using_is_operator_with_of_type_on_multiple_type_with_no_result(bool async)
+    {
+        await base.Using_is_operator_with_of_type_on_multiple_type_with_no_result(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["Discriminator"] = "Eagle"))
 """);
-            });
+    }
 
     protected override bool EnforcesFkConstraints
         => false;

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -26,440 +26,374 @@ public class NorthwindAggregateOperatorsQueryCosmosTest
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    public override Task Average_over_default_returns_default(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_over_default_returns_default(a);
+    public override async Task Average_over_default_returns_default(bool async)
+    {
+        await base.Average_over_default_returns_default(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG((c["OrderID"] - 10248)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
-            });
+    }
 
-    public override Task Contains_over_keyless_entity_throws(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                // The `First()` query is always executed synchronously. The outer query does not translate.
-                if (!a)
-                {
-                    // Aggregates. Issue #16146.
-                    await base.Contains_over_keyless_entity_throws(a);
+    public override async Task Contains_over_keyless_entity_throws(bool async)
+    {
+        // Aggregates. Issue #16146.
+        await base.Contains_over_keyless_entity_throws(async);
 
-                    AssertSql(
-                        """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT 1
 """);
-                }
-            });
+    }
 
-    public override Task Contains_with_local_non_primitive_list_closure_mix(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_non_primitive_list_closure_mix(a);
+    public override async Task Contains_with_local_non_primitive_list_closure_mix(bool async)
+    {
+        await base.Contains_with_local_non_primitive_list_closure_mix(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_non_primitive_list_inline_closure_mix(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_non_primitive_list_inline_closure_mix(a);
+    public override async Task Contains_with_local_non_primitive_list_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_non_primitive_list_inline_closure_mix(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Count_on_projection_with_client_eval(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Count_on_projection_with_client_eval(a);
+    public override async Task Count_on_projection_with_client_eval(bool async)
+    {
+        await base.Count_on_projection_with_client_eval(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """,
-                    //
-                    """
+            //
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """,
-                    //
-                    """
+            //
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task First(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.First(a);
+    public override async Task First(bool async)
+    {
+        await base.First(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Max_over_default_returns_default(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_over_default_returns_default(a);
+    public override async Task Max_over_default_returns_default(bool async)
+    {
+        await base.Max_over_default_returns_default(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX((c["OrderID"] - 10248)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
-            });
+    }
 
-    public override Task Min_over_default_returns_default(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_over_default_returns_default(a);
+    public override async Task Min_over_default_returns_default(bool async)
+    {
+        await base.Min_over_default_returns_default(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN((c["OrderID"] - 10248)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
-            });
+    }
 
-    public override Task Sum_over_empty_returns_zero(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_over_empty_returns_zero(a);
+    public override async Task Sum_over_empty_returns_zero(bool async)
+    {
+        await base.Sum_over_empty_returns_zero(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 """);
-            });
+    }
 
-    public override Task First_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.First_Predicate(a);
+    public override async Task First_Predicate(bool async)
+    {
+        await base.First_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
     public override async Task Single_Throws(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Single_Throws(async);
+        await base.Single_Throws(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT 2
 """);
-        }
     }
 
-    public override Task Where_First(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_First(a);
+    public override async Task Where_First(bool async)
+    {
+        await base.Where_First(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Where_Single(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Single(a);
+    public override async Task Where_Single(bool async)
+    {
+        await base.Where_Single(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
-    public override Task FirstOrDefault(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.FirstOrDefault(a);
+    public override async Task FirstOrDefault(bool async)
+    {
+        await base.FirstOrDefault(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Array_cast_to_IEnumerable_Contains_with_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Array_cast_to_IEnumerable_Contains_with_constant(a);
+    public override async Task Array_cast_to_IEnumerable_Contains_with_constant(bool async)
+    {
+        await base.Array_cast_to_IEnumerable_Contains_with_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "WRONG"))
 """);
-            });
+    }
 
-    public override Task FirstOrDefault_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.FirstOrDefault_Predicate(a);
+    public override async Task FirstOrDefault_Predicate(bool async)
+    {
+        await base.FirstOrDefault_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task SingleOrDefault_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.SingleOrDefault_Predicate(a);
+    public override async Task SingleOrDefault_Predicate(bool async)
+    {
+        await base.SingleOrDefault_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
     public override async Task SingleOrDefault_Throws(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.SingleOrDefault_Throws(async);
+        await base.SingleOrDefault_Throws(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT 2
 """);
-        }
     }
 
-    public override Task Where_FirstOrDefault(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_FirstOrDefault(a);
+    public override async Task Where_FirstOrDefault(bool async)
+    {
+        await base.Where_FirstOrDefault(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Where_SingleOrDefault(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_SingleOrDefault(a);
+    public override async Task Where_SingleOrDefault(bool async)
+    {
+        await base.Where_SingleOrDefault(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
     public override async Task Select_All(bool async)
     {
-        // Always throws sync-not-support for sync.
-        if (async)
-        {
-            // Contains over subquery. Issue #17246.
-            await AssertTranslationFailed(() => base.Select_All(async));
+        // Contains over subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_All(async));
 
-            AssertSql();
-        }
+        AssertSql();
     }
 
-    public override Task Sum_with_no_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_no_arg(a);
+    public override async Task Sum_with_no_arg(bool async)
+    {
+        await base.Sum_with_no_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Sum_with_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_no_data_cast_to_nullable(a);
+    public override async Task Sum_with_no_data_cast_to_nullable(bool async)
+    {
+        await base.Sum_with_no_data_cast_to_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 0))
 """);
-            });
+    }
 
-    public override Task Sum_with_binary_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_binary_expression(a);
+    public override async Task Sum_with_binary_expression(bool async)
+    {
+        await base.Sum_with_binary_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM((c["OrderID"] * 2)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Sum_with_no_arg_empty(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_no_arg_empty(a);
+    public override async Task Sum_with_no_arg_empty(bool async)
+    {
+        await base.Sum_with_no_arg_empty(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 """);
-            });
+    }
 
-    public override Task Sum_with_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_no_data_nullable(a);
+    public override async Task Sum_with_no_data_nullable(bool async)
+    {
+        await base.Sum_with_no_data_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["SupplierID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 """);
-            });
+    }
 
-    public override Task Sum_with_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_arg(a);
+    public override async Task Sum_with_arg(bool async)
+    {
+        await base.Sum_with_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Sum_with_arg_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_arg_expression(a);
+    public override async Task Sum_with_arg_expression(bool async)
+    {
+        await base.Sum_with_arg_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM((c["OrderID"] + c["OrderID"])) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Sum_with_division_on_decimal(bool async)
     {
@@ -478,19 +412,17 @@ WHERE (c["Discriminator"] = "Order")
         AssertSql();
     }
 
-    public override Task Sum_with_coalesce(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_with_coalesce(a);
+    public override async Task Sum_with_coalesce(bool async)
+    {
+        await base.Sum_with_coalesce(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
-            });
+    }
 
     public override async Task Sum_over_subquery_is_client_eval(bool async)
     {
@@ -516,19 +448,17 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
         AssertSql();
     }
 
-    public override Task Sum_on_float_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Sum_on_float_column(a);
+    public override async Task Sum_on_float_column(bool async)
+    {
+        await base.Sum_on_float_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(c["Discount"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 """);
-            });
+    }
 
     public override async Task Sum_on_float_column_in_subquery(bool async)
     {
@@ -540,78 +470,62 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 
     public override async Task Average_no_data(bool async)
     {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await base.Average_no_data(async);
+        await base.Average_no_data(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT AVG(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-        }
     }
 
-    public override Task Average_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_no_data_nullable(a);
+    public override async Task Average_no_data_nullable(bool async)
+    {
+        await base.Average_no_data_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG(c["SupplierID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+    }
 
-    public override Task Average_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_no_data_cast_to_nullable(a);
+    public override async Task Average_no_data_cast_to_nullable(bool async)
+    {
+        await base.Average_no_data_cast_to_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+    }
 
     public override async Task Min_no_data(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Min_no_data(async);
+        await base.Min_no_data(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT MIN(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-        }
     }
 
     public override async Task Max_no_data(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Max_no_data(async);
+        await base.Max_no_data(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT MAX(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-        }
     }
 
     public override async Task Average_no_data_subquery(bool async)
@@ -630,33 +544,29 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
         AssertSql();
     }
 
-    public override Task Max_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_no_data_nullable(a);
+    public override async Task Max_no_data_nullable(bool async)
+    {
+        await base.Max_no_data_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(c["SupplierID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+    }
 
-    public override Task Max_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_no_data_cast_to_nullable(a);
+    public override async Task Max_no_data_cast_to_nullable(bool async)
+    {
+        await base.Max_no_data_cast_to_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+    }
 
     public override async Task Min_no_data_subquery(bool async)
     {
@@ -668,65 +578,53 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 
     public override async Task Average_with_no_arg(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_no_arg(async));
+        // Average truncates. Issue #26378.
+        await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_no_arg(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT AVG(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-        }
     }
 
-    public override Task Average_with_binary_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_with_binary_expression(a);
+    public override async Task Average_with_binary_expression(bool async)
+    {
+        await base.Average_with_binary_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG((c["OrderID"] * 2)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Average_with_arg(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_arg(async));
+        // Average truncates. Issue #26378.
+        await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_arg(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT AVG(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-        }
     }
 
-    public override Task Average_with_arg_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_with_arg_expression(a);
+    public override async Task Average_with_arg_expression(bool async)
+    {
+        await base.Average_with_arg_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG((c["OrderID"] + c["OrderID"])) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Average_with_division_on_decimal(bool async)
     {
@@ -745,19 +643,17 @@ WHERE (c["Discriminator"] = "Order")
         AssertSql();
     }
 
-    public override Task Average_with_coalesce(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_with_coalesce(a);
+    public override async Task Average_with_coalesce(bool async)
+    {
+        await base.Average_with_coalesce(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
-            });
+    }
 
     public override async Task Average_over_subquery_is_client_eval(bool async)
     {
@@ -783,19 +679,17 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
         AssertSql();
     }
 
-    public override Task Average_on_float_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_on_float_column(a);
+    public override async Task Average_on_float_column(bool async)
+    {
+        await base.Average_on_float_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG(c["Discount"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 """);
-            });
+    }
 
     public override async Task Average_on_float_column_in_subquery(bool async)
     {
@@ -813,75 +707,65 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
         AssertSql();
     }
 
-    public override Task Min_with_no_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_with_no_arg(a);
+    public override async Task Min_with_no_arg(bool async)
+    {
+        await base.Min_with_no_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Min_with_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_with_arg(a);
+    public override async Task Min_with_arg(bool async)
+    {
+        await base.Min_with_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Min_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_no_data_nullable(a);
+    public override async Task Min_no_data_nullable(bool async)
+    {
+        await base.Min_no_data_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN(c["SupplierID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+    }
 
-    public override Task Min_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_no_data_cast_to_nullable(a);
+    public override async Task Min_no_data_cast_to_nullable(bool async)
+    {
+        await base.Min_no_data_cast_to_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+    }
 
-    public override Task Min_with_coalesce(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_with_coalesce(a);
+    public override async Task Min_with_coalesce(bool async)
+    {
+        await base.Min_with_coalesce(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
-            });
+    }
 
     public override async Task Min_over_subquery_is_client_eval(bool async)
     {
@@ -907,47 +791,41 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
         AssertSql();
     }
 
-    public override Task Max_with_no_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_with_no_arg(a);
+    public override async Task Max_with_no_arg(bool async)
+    {
+        await base.Max_with_no_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Max_with_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_with_arg(a);
+    public override async Task Max_with_arg(bool async)
+    {
+        await base.Max_with_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(c["OrderID"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Max_with_coalesce(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_with_coalesce(a);
+    public override async Task Max_with_coalesce(bool async)
+    {
+        await base.Max_with_coalesce(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
-            });
+    }
 
     public override async Task Max_over_subquery_is_client_eval(bool async)
     {
@@ -973,103 +851,89 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
         AssertSql();
     }
 
-    public override Task Count_with_no_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Count_with_no_predicate(a);
+    public override async Task Count_with_no_predicate(bool async)
+    {
+        await base.Count_with_no_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Count_with_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Count_with_predicate(a);
+    public override async Task Count_with_predicate(bool async)
+    {
+        await base.Count_with_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Count_with_order_by(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Count_with_order_by(a);
+    public override async Task Count_with_order_by(bool async)
+    {
+        await base.Count_with_order_by(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Where_OrderBy_Count(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_OrderBy_Count(a);
+    public override async Task Where_OrderBy_Count(bool async)
+    {
+        await base.Where_OrderBy_Count(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task OrderBy_Where_Count(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Where_Count(a);
+    public override async Task OrderBy_Where_Count(bool async)
+    {
+        await base.OrderBy_Where_Count(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task OrderBy_Count_with_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Count_with_predicate(a);
+    public override async Task OrderBy_Count_with_predicate(bool async)
+    {
+        await base.OrderBy_Count_with_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task OrderBy_Where_Count_with_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Where_Count_with_predicate(a);
+    public override async Task OrderBy_Where_Count_with_predicate(bool async)
+    {
+        await base.OrderBy_Where_Count_with_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (((c["Discriminator"] = "Order") AND (c["OrderID"] > 10)) AND (c["CustomerID"] != "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Where_OrderBy_Count_client_eval(bool async)
     {
@@ -1138,14 +1002,11 @@ WHERE (((c["Discriminator"] = "Order") AND (c["OrderID"] > 10)) AND (c["Customer
 
     public override async Task OrderBy_client_Take(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_client_Take(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_client_Take(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT c
@@ -1154,53 +1015,46 @@ WHERE (c["Discriminator"] = "Employee")
 ORDER BY 42
 OFFSET 0 LIMIT @__p_0
 """);
-        }
     }
 
-    public override Task Distinct(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Distinct(a);
+    public override async Task Distinct(bool async)
+    {
+        await base.Distinct(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Fails on CI #27688")]
-    public override Task Distinct_Scalar(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Distinct_Scalar(a);
+    public override async Task Distinct_Scalar(bool async)
+    {
+        await base.Distinct_Scalar(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT c[""City""]
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Fails on emulator https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4339")]
-    public override Task OrderBy_Distinct(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Distinct(a);
+    public override async Task OrderBy_Distinct(bool async)
+    {
+        await base.OrderBy_Distinct(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task Distinct_OrderBy(bool async)
         // Subquery pushdown. Issue #16156.
@@ -1240,20 +1094,18 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Single_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Single_Predicate(a);
+    public override async Task Single_Predicate(bool async)
+    {
+        await base.Single_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
     public override async Task FirstOrDefault_inside_subquery_gets_server_evaluated(bool async)
     {
@@ -1279,131 +1131,115 @@ OFFSET 0 LIMIT 2
         AssertSql();
     }
 
-    public override Task Last(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Last(a);
+    public override async Task Last(bool async)
+    {
+        await base.Last(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Last_when_no_order_by(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Last_when_no_order_by(a);
+    public override async Task Last_when_no_order_by(bool async)
+    {
+        await base.Last_when_no_order_by(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task LastOrDefault_when_no_order_by(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.LastOrDefault_when_no_order_by(a);
+    public override async Task LastOrDefault_when_no_order_by(bool async)
+    {
+        await base.LastOrDefault_when_no_order_by(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Last_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Last_Predicate(a);
+    public override async Task Last_Predicate(bool async)
+    {
+        await base.Last_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Where_Last(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Last(a);
+    public override async Task Where_Last(bool async)
+    {
+        await base.Where_Last(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task LastOrDefault(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.LastOrDefault(a);
+    public override async Task LastOrDefault(bool async)
+    {
+        await base.LastOrDefault(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task LastOrDefault_Predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.LastOrDefault_Predicate(a);
+    public override async Task LastOrDefault_Predicate(bool async)
+    {
+        await base.LastOrDefault_Predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
-    public override Task Where_LastOrDefault(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_LastOrDefault(a);
+    public override async Task Where_LastOrDefault(bool async)
+    {
+        await base.Where_LastOrDefault(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
     public override async Task Contains_with_subquery(bool async)
     {
@@ -1413,25 +1249,23 @@ OFFSET 0 LIMIT 1
         AssertSql();
     }
 
-    public override Task Contains_with_local_array_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_array_closure(a);
+    public override async Task Contains_with_local_array_closure(bool async)
+    {
+        await base.Contains_with_local_array_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
 """);
-            });
+    }
 
     public override async Task Contains_with_subquery_and_local_array_closure(bool async)
     {
@@ -1441,184 +1275,162 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
         AssertSql();
     }
 
-    public override Task Contains_with_local_uint_array_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_uint_array_closure(a);
+    public override async Task Contains_with_local_uint_array_closure(bool async)
+    {
+        await base.Contains_with_local_uint_array_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND c["EmployeeID"] IN (0, 1))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND c["EmployeeID"] IN (0))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_nullable_uint_array_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_nullable_uint_array_closure(a);
+    public override async Task Contains_with_local_nullable_uint_array_closure(bool async)
+    {
+        await base.Contains_with_local_nullable_uint_array_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND c["EmployeeID"] IN (0, 1))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND c["EmployeeID"] IN (0))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_array_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_array_inline(a);
+    public override async Task Contains_with_local_array_inline(bool async)
+    {
+        await base.Contains_with_local_array_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_list_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_list_closure(a);
+    public override async Task Contains_with_local_list_closure(bool async)
+    {
+        await base.Contains_with_local_list_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_object_list_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_object_list_closure(a);
+    public override async Task Contains_with_local_object_list_closure(bool async)
+    {
+        await base.Contains_with_local_object_list_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_list_closure_all_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_list_closure_all_null(a);
+    public override async Task Contains_with_local_list_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_list_closure_all_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_list_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_list_inline(a);
+    public override async Task Contains_with_local_list_inline(bool async)
+    {
+        await base.Contains_with_local_list_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_list_inline_closure_mix(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_list_inline_closure_mix(a);
+    public override async Task Contains_with_local_list_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_list_inline_closure_mix(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_enumerable_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_enumerable_closure(a);
-                AssertSql(
-                    """
+    public override async Task Contains_with_local_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure(async);
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_object_enumerable_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_object_enumerable_closure(a);
+    public override async Task Contains_with_local_object_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_enumerable_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_enumerable_closure_all_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_enumerable_closure_all_null(a);
+    public override async Task Contains_with_local_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure_all_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (true = false))
 """
-                );
-            });
+        );
+    }
 
     public override async Task Contains_with_local_enumerable_inline(bool async)
     {
@@ -1640,291 +1452,255 @@ WHERE ((c["Discriminator"] = "Customer") AND (true = false))
         AssertSql();
     }
 
-    public override Task Contains_with_local_ordered_enumerable_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_ordered_enumerable_closure(a);
+    public override async Task Contains_with_local_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
 //
-                    """
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_object_ordered_enumerable_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_object_ordered_enumerable_closure(a);
+    public override async Task Contains_with_local_object_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_ordered_enumerable_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_ordered_enumerable_closure_all_null(a);
+    public override async Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure_all_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_ordered_enumerable_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_ordered_enumerable_inline(a);
+    public override async Task Contains_with_local_ordered_enumerable_inline(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_ordered_enumerable_inline_closure_mix(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_ordered_enumerable_inline_closure_mix(a);
+    public override async Task Contains_with_local_ordered_enumerable_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline_closure_mix(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
 //
-                    """
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_read_only_collection_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_read_only_collection_closure(a);
+    public override async Task Contains_with_local_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
 //
-                    """
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_object_read_only_collection_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_object_read_only_collection_closure(a);
+    public override async Task Contains_with_local_object_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_object_read_only_collection_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_ordered_read_only_collection_all_null(a);
+    public override async Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_read_only_collection_all_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_read_only_collection_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_read_only_collection_inline(a);
+    public override async Task Contains_with_local_read_only_collection_inline(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_read_only_collection_inline_closure_mix(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_read_only_collection_inline_closure_mix(a);
+    public override async Task Contains_with_local_read_only_collection_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline_closure_mix(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """,
 //
-                    """
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
 """
-                );
-            });
+        );
+    }
 
-    public override Task Contains_with_local_collection_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_false(a);
+    public override async Task Contains_with_local_collection_false(bool async)
+    {
+        await base.Contains_with_local_collection_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_complex_predicate_and(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_complex_predicate_and(a);
+    public override async Task Contains_with_local_collection_complex_predicate_and(bool async)
+    {
+        await base.Contains_with_local_collection_complex_predicate_and(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE")) AND c["CustomerID"] IN ("ABCDE", "ALFKI")))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_complex_predicate_or(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_complex_predicate_or(a);
+    public override async Task Contains_with_local_collection_complex_predicate_or(bool async)
+    {
+        await base.Contains_with_local_collection_complex_predicate_or(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ABCDE", "ALFKI") OR ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE"))))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_complex_predicate_not_matching_ins1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_complex_predicate_not_matching_ins1(a);
+    public override async Task Contains_with_local_collection_complex_predicate_not_matching_ins1(bool async)
+    {
+        await base.Contains_with_local_collection_complex_predicate_not_matching_ins1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE")) OR c["CustomerID"] NOT IN ("ABCDE", "ALFKI")))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_complex_predicate_not_matching_ins2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_complex_predicate_not_matching_ins2(a);
+    public override async Task Contains_with_local_collection_complex_predicate_not_matching_ins2(bool async)
+    {
+        await base.Contains_with_local_collection_complex_predicate_not_matching_ins2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ABCDE", "ALFKI") AND ((c["CustomerID"] != "ALFKI") AND (c["CustomerID"] != "ABCDE"))))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_sql_injection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_sql_injection(a);
+    public override async Task Contains_with_local_collection_sql_injection(bool async)
+    {
+        await base.Contains_with_local_collection_sql_injection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ABC')); GO; DROP TABLE Orders; GO; --") OR ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE"))))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_empty_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_empty_closure(a);
+    public override async Task Contains_with_local_collection_empty_closure(bool async)
+    {
+        await base.Contains_with_local_collection_empty_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (true = false))
 """);
-            });
+    }
 
-    public override Task Contains_with_local_collection_empty_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_local_collection_empty_inline(a);
+    public override async Task Contains_with_local_collection_empty_inline(bool async)
+    {
+        await base.Contains_with_local_collection_empty_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
 """);
-            });
+    }
 
     public override async Task Contains_top_level(bool async)
     {
@@ -1977,15 +1753,11 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
 
     public override async Task Max_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Aggregate selecting non-mapped type. Issue #20677.
-            await Assert.ThrowsAsync<KeyNotFoundException>(
-                async () => await base.Max_with_non_matching_types_in_projection_introduces_explicit_cast(async));
+        // Aggregate selecting non-mapped type. Issue #20677.
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            async () => await base.Max_with_non_matching_types_in_projection_introduces_explicit_cast(async));
 
-            AssertSql();
-        }
+        AssertSql();
     }
 
     public override async Task Min_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
@@ -1999,16 +1771,12 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
 
     public override async Task OrderBy_Take_Last_gives_correct_result(bool async)
     {
-        // Always throws sync-not-support for sync.
-        if (async)
-        {
-            Assert.Equal(
-                CosmosStrings.ReverseAfterSkipTakeNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    async () => await base.OrderBy_Take_Last_gives_correct_result(async))).Message);
+        Assert.Equal(
+            CosmosStrings.ReverseAfterSkipTakeNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await base.OrderBy_Take_Last_gives_correct_result(async))).Message);
 
-            AssertSql();
-        }
+        AssertSql();
     }
 
     public override async Task OrderBy_Skip_Last_gives_correct_result(bool async)
@@ -2023,17 +1791,16 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
 
     public override async Task Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
     {
-        // Inner query is always sync.
-        if (!async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    // Contains over subquery. Issue #17246.
-                    await base.Contains_over_entityType_should_rewrite_to_identity_equality(a);
-                }
-            );
-        }
+        // Contains over subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Contains_over_entityType_should_rewrite_to_identity_equality(async));
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
+OFFSET 0 LIMIT 2
+""");
     }
 
     public override async Task List_Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
@@ -2044,117 +1811,101 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
         AssertSql();
     }
 
-    public override Task List_Contains_with_constant_list(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.List_Contains_with_constant_list(a);
+    public override async Task List_Contains_with_constant_list(bool async)
+    {
+        await base.List_Contains_with_constant_list(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task List_Contains_with_parameter_list(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.List_Contains_with_parameter_list(a);
+    public override async Task List_Contains_with_parameter_list(bool async)
+    {
+        await base.List_Contains_with_parameter_list(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Contains_with_parameter_list_value_type_id(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_parameter_list_value_type_id(a);
+    public override async Task Contains_with_parameter_list_value_type_id(bool async)
+    {
+        await base.Contains_with_parameter_list_value_type_id(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
-            });
+    }
 
-    public override Task Contains_with_constant_list_value_type_id(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_with_constant_list_value_type_id(a);
+    public override async Task Contains_with_constant_list_value_type_id(bool async)
+    {
+        await base.Contains_with_constant_list_value_type_id(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
-            });
+    }
 
-    public override Task IImmutableSet_Contains_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.IImmutableSet_Contains_with_parameter(a);
+    public override async Task IImmutableSet_Contains_with_parameter(bool async)
+    {
+        await base.IImmutableSet_Contains_with_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI"))
 """);
-            });
+    }
 
-    public override Task IReadOnlySet_Contains_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.IReadOnlySet_Contains_with_parameter(a);
+    public override async Task IReadOnlySet_Contains_with_parameter(bool async)
+    {
+        await base.IReadOnlySet_Contains_with_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI"))
 """);
-            });
+    }
 
-    public override Task HashSet_Contains_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.HashSet_Contains_with_parameter(a);
+    public override async Task HashSet_Contains_with_parameter(bool async)
+    {
+        await base.HashSet_Contains_with_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI"))
 """);
-            });
+    }
 
-    public override Task ImmutableHashSet_Contains_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.ImmutableHashSet_Contains_with_parameter(a);
+    public override async Task ImmutableHashSet_Contains_with_parameter(bool async)
+    {
+        await base.ImmutableHashSet_Contains_with_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI"))
 """);
-            });
+    }
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_false(bool async)
     {
@@ -2172,171 +1923,149 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI"))
         AssertSql();
     }
 
-    public override Task String_FirstOrDefault_in_projection_does_not_do_client_eval(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_FirstOrDefault_in_projection_does_not_do_client_eval(a);
+    public override async Task String_FirstOrDefault_in_projection_does_not_do_client_eval(bool async)
+    {
+        await base.String_FirstOrDefault_in_projection_does_not_do_client_eval(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT LEFT(c["CustomerID"], 1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Project_constant_Sum(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Project_constant_Sum(a);
+    public override async Task Project_constant_Sum(bool async)
+    {
+        await base.Project_constant_Sum(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
-            });
+    }
 
-    public override Task Where_subquery_any_equals_operator(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_any_equals_operator(a);
+    public override async Task Where_subquery_any_equals_operator(bool async)
+    {
+        await base.Where_subquery_any_equals_operator(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_any_equals(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_any_equals(a);
+    public override async Task Where_subquery_any_equals(bool async)
+    {
+        await base.Where_subquery_any_equals(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_any_equals_static(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_any_equals_static(a);
+    public override async Task Where_subquery_any_equals_static(bool async)
+    {
+        await base.Where_subquery_any_equals_static(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_where_any(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_where_any(a);
+    public override async Task Where_subquery_where_any(bool async)
+    {
+        await base.Where_subquery_where_any(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_all_not_equals_operator(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_all_not_equals_operator(a);
+    public override async Task Where_subquery_all_not_equals_operator(bool async)
+    {
+        await base.Where_subquery_all_not_equals_operator(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_all_not_equals(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_all_not_equals(a);
+    public override async Task Where_subquery_all_not_equals(bool async)
+    {
+        await base.Where_subquery_all_not_equals(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_all_not_equals_static(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_all_not_equals_static(a);
+    public override async Task Where_subquery_all_not_equals_static(bool async)
+    {
+        await base.Where_subquery_all_not_equals_static(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Where_subquery_where_all(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_subquery_where_all(a);
+    public override async Task Where_subquery_where_all(bool async)
+    {
+        await base.Where_subquery_where_all(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """);
-            });
+    }
 
-    public override Task Cast_to_same_Type_Count_works(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Cast_to_same_Type_Count_works(a);
+    public override async Task Cast_to_same_Type_Count_works(bool async)
+    {
+        await base.Cast_to_same_Type_Count_works(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     public override async Task Cast_before_aggregate_is_preserved(bool async)
     {
@@ -2532,141 +2261,127 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
-    public override Task Contains_inside_Average_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_Average_without_GroupBy(a);
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT AVG((c["City"] IN ("London", "Berlin") ? 1.0 : 0.0)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Contains_inside_Sum_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_Sum_without_GroupBy(a);
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUM((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Contains_inside_Count_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_Count_without_GroupBy(a);
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
 """);
-            });
+    }
 
-    public override Task Contains_inside_LongCount_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_LongCount_without_GroupBy(a);
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
 """);
-            });
+    }
 
-    public override Task Contains_inside_Max_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_Max_without_GroupBy(a);
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Contains_inside_Min_without_GroupBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_inside_Min_without_GroupBy(a);
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MIN((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Return_type_of_singular_operator_is_preserved(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Return_type_of_singular_operator_is_preserved(a);
+    public override async Task Return_type_of_singular_operator_is_preserved(bool async)
+    {
+        await base.Return_type_of_singular_operator_is_preserved(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 1
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 1
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 OFFSET 0 LIMIT 2
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"] DESC
 OFFSET 0 LIMIT 1
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["CustomerID"], c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"] DESC
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Issue #20677")]
     public override async Task Type_casting_inside_sum(bool async)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
@@ -54,33 +54,29 @@ public class NorthwindDbFunctionsQueryCosmosTest : NorthwindDbFunctionsQueryTest
         AssertSql();
     }
 
-    public override Task Random_return_less_than_1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Random_return_less_than_1(async);
+    public override async Task Random_return_less_than_1(bool async)
+    {
+        await base.Random_return_less_than_1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (RAND() < 1.0))
 """);
-            });
+    }
 
-    public override Task Random_return_greater_than_0(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Random_return_greater_than_0(async);
+    public override async Task Random_return_greater_than_0(bool async)
+    {
+        await base.Random_return_greater_than_0(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (RAND() >= 0.0))
 """);
-            });
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -24,232 +24,200 @@ public class NorthwindFunctionsQueryCosmosTest : NorthwindFunctionsQueryTestBase
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    public override Task String_StartsWith_Literal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_StartsWith_Literal(a);
+    public override async Task String_StartsWith_Literal(bool async)
+    {
+        await base.String_StartsWith_Literal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
-            });
+    }
 
-    public override Task String_StartsWith_Parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_StartsWith_Parameter(a);
+    public override async Task String_StartsWith_Parameter(bool async)
+    {
+        await base.String_StartsWith_Parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__pattern_0='M'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], @__pattern_0))
 """);
-            });
+    }
 
-    public override Task String_StartsWith_Identity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_StartsWith_Identity(a);
+    public override async Task String_StartsWith_Identity(bool async)
+    {
+        await base.String_StartsWith_Identity(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_StartsWith_Column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_StartsWith_Column(a);
+    public override async Task String_StartsWith_Column(bool async)
+    {
+        await base.String_StartsWith_Column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_StartsWith_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_StartsWith_MethodCall(a);
+    public override async Task String_StartsWith_MethodCall(bool async)
+    {
+        await base.String_StartsWith_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
-            });
+    }
 
-    public override Task String_EndsWith_Literal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_EndsWith_Literal(a);
+    public override async Task String_EndsWith_Literal(bool async)
+    {
+        await base.String_EndsWith_Literal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "b"))
 """);
-            });
+    }
 
-    public override Task String_EndsWith_Parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_EndsWith_Parameter(a);
+    public override async Task String_EndsWith_Parameter(bool async)
+    {
+        await base.String_EndsWith_Parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__pattern_0='b'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], @__pattern_0))
 """);
-            });
+    }
 
-    public override Task String_EndsWith_Identity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_EndsWith_Identity(a);
+    public override async Task String_EndsWith_Identity(bool async)
+    {
+        await base.String_EndsWith_Identity(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_EndsWith_Column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_EndsWith_Column(a);
+    public override async Task String_EndsWith_Column(bool async)
+    {
+        await base.String_EndsWith_Column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_EndsWith_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_EndsWith_MethodCall(a);
+    public override async Task String_EndsWith_MethodCall(bool async)
+    {
+        await base.String_EndsWith_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "m"))
 """);
-            });
+    }
 
-    public override Task String_Contains_Literal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_Literal(a);
+    public override async Task String_Contains_Literal(bool async)
+    {
+        await base.String_Contains_Literal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
 """);
-            });
+    }
 
-    public override Task String_Contains_Identity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_Identity(a);
-                AssertSql(
-                    """
+    public override async Task String_Contains_Identity(bool async)
+    {
+        await base.String_Contains_Identity(async);
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_Contains_Column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_Column(a);
+    public override async Task String_Contains_Column(bool async)
+    {
+        await base.String_Contains_Column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], c["ContactName"]))
 """);
-            });
+    }
 
-    public override Task String_FirstOrDefault_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_FirstOrDefault_MethodCall(a);
+    public override async Task String_FirstOrDefault_MethodCall(bool async)
+    {
+        await base.String_FirstOrDefault_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LEFT(c["ContactName"], 1) = "A"))
 """);
-            });
+    }
 
-    public override Task String_LastOrDefault_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_LastOrDefault_MethodCall(a);
+    public override async Task String_LastOrDefault_MethodCall(bool async)
+    {
+        await base.String_LastOrDefault_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (RIGHT(c["ContactName"], 1) = "s"))
 """);
-            });
+    }
 
-    public override Task String_Contains_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_MethodCall(a);
+    public override async Task String_Contains_MethodCall(bool async)
+    {
+        await base.String_Contains_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
 """);
-            });
+    }
 
     public override async Task String_Compare_simple_zero(bool async)
     {
@@ -347,61 +315,53 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
         AssertSql();
     }
 
-    public override Task Where_math_abs1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_abs1(a);
+    public override async Task Where_math_abs1(bool async)
+    {
+        await base.Where_math_abs1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (ABS(c["ProductID"]) > 10))
 """);
-            });
+    }
 
-    public override Task Where_math_abs2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_abs2(a);
+    public override async Task Where_math_abs2(bool async)
+    {
+        await base.Where_math_abs2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (ABS(c["Quantity"]) > 10))
 """);
-            });
+    }
 
-    public override Task Where_math_abs3(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_abs3(a);
+    public override async Task Where_math_abs3(bool async)
+    {
+        await base.Where_math_abs3(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ABS(c["UnitPrice"]) > 10.0))
 """);
-            });
+    }
 
-    public override Task Where_math_abs_uncorrelated(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_abs_uncorrelated(a);
+    public override async Task Where_math_abs_uncorrelated(bool async)
+    {
+        await base.Where_math_abs_uncorrelated(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (10 < c["ProductID"]))
 """);
-            });
+    }
 
     public override async Task Where_math_ceiling1(bool async)
     {
@@ -411,33 +371,29 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (10
         AssertSql();
     }
 
-    public override Task Where_math_ceiling2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_ceiling2(a);
+    public override async Task Where_math_ceiling2(bool async)
+    {
+        await base.Where_math_ceiling2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (CEILING(c["UnitPrice"]) > 10.0))
 """);
-            });
+    }
 
-    public override Task Where_math_floor(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_floor(a);
+    public override async Task Where_math_floor(bool async)
+    {
+        await base.Where_math_floor(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (FLOOR(c["UnitPrice"]) > 10.0))
 """);
-            });
+    }
 
     public override async Task Where_math_power(bool async)
     {
@@ -455,19 +411,17 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (FLOOR
         AssertSql();
     }
 
-    public override Task Where_math_round(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_round(async);
+    public override async Task Where_math_round(bool async)
+    {
+        await base.Where_math_round(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ROUND(c["UnitPrice"]) > 10.0))
 """);
-            });
+    }
 
     public override Task Sum_over_round_works_correctly_in_projection(bool async)
         => AssertTranslationFailed(() => base.Sum_over_round_works_correctly_in_projection(async));
@@ -481,33 +435,29 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ROUND
     public override Task Sum_over_truncate_works_correctly_in_projection_2(bool async)
         => AssertTranslationFailed(() => base.Sum_over_truncate_works_correctly_in_projection_2(async));
 
-    public override Task Select_math_round_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_math_round_int(a);
+    public override async Task Select_math_round_int(bool async)
+    {
+        await base.Select_math_round_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
-            });
+    }
 
-    public override Task Select_math_truncate_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_math_truncate_int(a);
+    public override async Task Select_math_truncate_int(bool async)
+    {
+        await base.Select_math_truncate_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
-            });
+    }
 
     public override async Task Where_math_round2(bool async)
     {
@@ -517,19 +467,17 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
         AssertSql();
     }
 
-    public override Task Where_math_truncate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_truncate(a);
+    public override async Task Where_math_truncate(bool async)
+    {
+        await base.Where_math_truncate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (TRUNC(c["UnitPrice"]) > 10.0))
 """);
-            });
+    }
 
     public override async Task Where_math_exp(bool async)
     {
@@ -627,19 +575,17 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (TRUNC
         AssertSql();
     }
 
-    public override Task Where_math_sign(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_math_sign(a);
+    public override async Task Where_math_sign(bool async)
+    {
+        await base.Where_math_sign(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIGN(c["Discount"]) > 0))
 """);
-            });
+    }
 
     public override async Task Where_math_min(bool async)
     {
@@ -713,19 +659,17 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SI
         AssertSql();
     }
 
-    public override Task Where_mathf_ceiling1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_ceiling1(a);
+    public override async Task Where_mathf_ceiling1(bool async)
+    {
+        await base.Where_mathf_ceiling1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (CEILING(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
     public override async Task Where_mathf_floor(bool async)
     {
@@ -735,33 +679,29 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (CE
         AssertSql();
     }
 
-    public override Task Where_mathf_power(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_power(a);
+    public override async Task Where_mathf_power(bool async)
+    {
+        await base.Where_mathf_power(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 3.0) > 0.005))
 """);
-            });
+    }
 
-    public override Task Where_mathf_square(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_square(a);
+    public override async Task Where_mathf_square(bool async)
+    {
+        await base.Where_mathf_square(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 2.0) > 0.05))
 """);
-            });
+    }
 
     public override async Task Where_mathf_round2(bool async)
     {
@@ -779,215 +719,185 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 2.0) > 0.0
         AssertSql();
     }
 
-    public override Task Where_mathf_exp(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_exp(a);
+    public override async Task Where_mathf_exp(bool async)
+    {
+        await base.Where_mathf_exp(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (EXP(c["Discount"]) > 1.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_log10(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_log10(a);
+    public override async Task Where_mathf_log10(bool async)
+    {
+        await base.Where_mathf_log10(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG10(c["Discount"]) < 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_log(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_log(a);
+    public override async Task Where_mathf_log(bool async)
+    {
+        await base.Where_mathf_log(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG(c["Discount"]) < 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_log_new_base(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_log_new_base(a);
+    public override async Task Where_mathf_log_new_base(bool async)
+    {
+        await base.Where_mathf_log_new_base(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG(c["Discount"], 7.0) < -1.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_sqrt(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_sqrt(a);
+    public override async Task Where_mathf_sqrt(bool async)
+    {
+        await base.Where_mathf_sqrt(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SQRT(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_acos(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_acos(a);
+    public override async Task Where_mathf_acos(bool async)
+    {
+        await base.Where_mathf_acos(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ACOS(c["Discount"]) > 1.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_asin(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_asin(a);
+    public override async Task Where_mathf_asin(bool async)
+    {
+        await base.Where_mathf_asin(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ASIN(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_atan(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_atan(a);
+    public override async Task Where_mathf_atan(bool async)
+    {
+        await base.Where_mathf_atan(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ATAN(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_atan2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_atan2(a);
+    public override async Task Where_mathf_atan2(bool async)
+    {
+        await base.Where_mathf_atan2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ATN2(c["Discount"], 1.0) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_cos(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_cos(a);
+    public override async Task Where_mathf_cos(bool async)
+    {
+        await base.Where_mathf_cos(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (COS(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_sin(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_sin(a);
+    public override async Task Where_mathf_sin(bool async)
+    {
+        await base.Where_mathf_sin(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIN(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_tan(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_tan(a);
+    public override async Task Where_mathf_tan(bool async)
+    {
+        await base.Where_mathf_tan(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (TAN(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_sign(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_sign(a);
+    public override async Task Where_mathf_sign(bool async)
+    {
+        await base.Where_mathf_sign(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIGN(c["Discount"]) > 0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_degrees(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_degrees(a);
+    public override async Task Where_mathf_degrees(bool async)
+    {
+        await base.Where_mathf_degrees(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (DEGREES(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
-    public override Task Where_mathf_radians(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_mathf_radians(a);
+    public override async Task Where_mathf_radians(bool async)
+    {
+        await base.Where_mathf_radians(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (RADIANS(c["Discount"]) > 0.0))
 """);
-            });
+    }
 
     public override async Task Where_guid_newguid(bool async)
     {
@@ -997,33 +907,29 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (RA
         AssertSql();
     }
 
-    public override Task Where_string_to_upper(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_to_upper(a);
+    public override async Task Where_string_to_upper(bool async)
+    {
+        await base.Where_string_to_upper(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (UPPER(c["CustomerID"]) = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Where_string_to_lower(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_to_lower(a);
+    public override async Task Where_string_to_lower(bool async)
+    {
+        await base.Where_string_to_lower(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LOWER(c["CustomerID"]) = "alfki"))
 """);
-            });
+    }
 
     public override async Task Where_functions_nested(bool async)
     {
@@ -1097,223 +1003,193 @@ WHERE ((c["Discriminator"] = "Customer") AND (LOWER(c["CustomerID"]) = "alfki"))
         AssertSql();
     }
 
-    public override Task Indexof_with_emptystring(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Indexof_with_emptystring(a);
+    public override async Task Indexof_with_emptystring(bool async)
+    {
+        await base.Indexof_with_emptystring(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "") = 0))
 """);
-            });
+    }
 
-    public override Task Indexof_with_one_constant_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Indexof_with_one_constant_arg(a);
+    public override async Task Indexof_with_one_constant_arg(bool async)
+    {
+        await base.Indexof_with_one_constant_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a") = 1))
 """);
-            });
+    }
 
-    public override Task Indexof_with_one_parameter_arg(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Indexof_with_one_parameter_arg(a);
+    public override async Task Indexof_with_one_parameter_arg(bool async)
+    {
+        await base.Indexof_with_one_parameter_arg(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__pattern_0='a'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], @__pattern_0) = 1))
 """);
-            });
+    }
 
-    public override Task Indexof_with_constant_starting_position(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Indexof_with_constant_starting_position(a);
+    public override async Task Indexof_with_constant_starting_position(bool async)
+    {
+        await base.Indexof_with_constant_starting_position(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", 2) = 4))
 """);
-            });
+    }
 
-    public override Task Indexof_with_parameter_starting_position(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Indexof_with_parameter_starting_position(a);
+    public override async Task Indexof_with_parameter_starting_position(bool async)
+    {
+        await base.Indexof_with_parameter_starting_position(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__start_0='2'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", @__start_0) = 4))
 """);
-            });
+    }
 
-    public override Task Replace_with_emptystring(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Replace_with_emptystring(a);
+    public override async Task Replace_with_emptystring(bool async)
+    {
+        await base.Replace_with_emptystring(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], "ia", "") = "Mar Anders"))
 """);
-            });
+    }
 
-    public override Task Replace_using_property_arguments(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Replace_using_property_arguments(a);
+    public override async Task Replace_using_property_arguments(bool async)
+    {
+        await base.Replace_using_property_arguments(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], c["ContactName"], c["CustomerID"]) = c["CustomerID"]))
 """);
-            });
+    }
 
-    public override Task Substring_with_one_arg_with_zero_startindex(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_one_arg_with_zero_startindex(a);
+    public override async Task Substring_with_one_arg_with_zero_startindex(bool async)
+    {
+        await base.Substring_with_one_arg_with_zero_startindex(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 0, LENGTH(c["CustomerID"])) = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_one_arg_with_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_one_arg_with_constant(a);
+    public override async Task Substring_with_one_arg_with_constant(bool async)
+    {
+        await base.Substring_with_one_arg_with_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 1, LENGTH(c["CustomerID"])) = "LFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_one_arg_with_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_one_arg_with_closure(a);
+    public override async Task Substring_with_one_arg_with_closure(bool async)
+    {
+        await base.Substring_with_one_arg_with_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__start_0='2'
 
 SELECT c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], @__start_0, LENGTH(c["CustomerID"])) = "FKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_two_args_with_zero_startindex(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_two_args_with_zero_startindex(a);
+    public override async Task Substring_with_two_args_with_zero_startindex(bool async)
+    {
+        await base.Substring_with_two_args_with_zero_startindex(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT LEFT(c["ContactName"], 3) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_two_args_with_zero_length(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_two_args_with_zero_length(a);
+    public override async Task Substring_with_two_args_with_zero_length(bool async)
+    {
+        await base.Substring_with_two_args_with_zero_length(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUBSTRING(c["ContactName"], 2, 0) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_two_args_with_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_two_args_with_constant(a);
+    public override async Task Substring_with_two_args_with_constant(bool async)
+    {
+        await base.Substring_with_two_args_with_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUBSTRING(c["ContactName"], 1, 3) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_two_args_with_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_two_args_with_closure(a);
+    public override async Task Substring_with_two_args_with_closure(bool async)
+    {
+        await base.Substring_with_two_args_with_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__start_0='2'
 
 SELECT SUBSTRING(c["ContactName"], @__start_0, 3) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Substring_with_two_args_with_Index_of(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Substring_with_two_args_with_Index_of(a);
+    public override async Task Substring_with_two_args_with_Index_of(bool async)
+    {
+        await base.Substring_with_two_args_with_Index_of(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT SUBSTRING(c["ContactName"], INDEX_OF(c["ContactName"], "a"), 3) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task IsNullOrEmpty_in_predicate(bool async)
     {
@@ -1339,33 +1215,29 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task IsNullOrEmpty_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.IsNullOrEmpty_in_projection(a);
+    public override async Task IsNullOrEmpty_in_projection(bool async)
+    {
+        await base.IsNullOrEmpty_in_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], c["Region"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task IsNullOrEmpty_negated_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.IsNullOrEmpty_negated_in_projection(a);
+    public override async Task IsNullOrEmpty_negated_in_projection(bool async)
+    {
+        await base.IsNullOrEmpty_negated_in_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], c["Region"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     public override async Task IsNullOrWhiteSpace_in_predicate(bool async)
     {
@@ -1375,19 +1247,17 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
-    public override Task TrimStart_without_arguments_in_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.TrimStart_without_arguments_in_predicate(a);
+    public override async Task TrimStart_without_arguments_in_predicate(bool async)
+    {
+        await base.TrimStart_without_arguments_in_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LTRIM(c["ContactTitle"]) = "Owner"))
 """);
-            });
+    }
 
     public override async Task TrimStart_with_char_argument_in_predicate(bool async)
     {
@@ -1405,19 +1275,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (LTRIM(c["ContactTitle"]) = "Owner"
         AssertSql();
     }
 
-    public override Task TrimEnd_without_arguments_in_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.TrimEnd_without_arguments_in_predicate(a);
+    public override async Task TrimEnd_without_arguments_in_predicate(bool async)
+    {
+        await base.TrimEnd_without_arguments_in_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (RTRIM(c["ContactTitle"]) = "Owner"))
 """);
-            });
+    }
 
     public override async Task TrimEnd_with_char_argument_in_predicate(bool async)
     {
@@ -1435,19 +1303,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (RTRIM(c["ContactTitle"]) = "Owner"
         AssertSql();
     }
 
-    public override Task Trim_without_argument_in_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Trim_without_argument_in_predicate(a);
+    public override async Task Trim_without_argument_in_predicate(bool async)
+    {
+        await base.Trim_without_argument_in_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (TRIM(c["ContactTitle"]) = "Owner"))
 """);
-            });
+    }
 
     public override async Task Trim_with_char_argument_in_predicate(bool async)
     {
@@ -1467,20 +1333,16 @@ WHERE ((c["Discriminator"] = "Customer") AND (TRIM(c["ContactTitle"]) = "Owner")
 
     public override async Task Order_by_length_twice(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Unsupported ORDER BY clause. Issue #27037.
-            await Assert.ThrowsAsync<CosmosException>(() => base.Order_by_length_twice(async));
+        // Unsupported ORDER BY clause. Issue #27037.
+        await Assert.ThrowsAsync<CosmosException>(() => base.Order_by_length_twice(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY LENGTH(c["CustomerID"]), c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool async)
@@ -1492,49 +1354,43 @@ ORDER BY LENGTH(c["CustomerID"]), c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Static_string_equals_in_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Static_string_equals_in_predicate(a);
+    public override async Task Static_string_equals_in_predicate(bool async)
+    {
+        await base.Static_string_equals_in_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ANATR"))
 """);
-            });
+    }
 
-    public override Task Static_equals_nullable_datetime_compared_to_non_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Static_equals_nullable_datetime_compared_to_non_nullable(a);
+    public override async Task Static_equals_nullable_datetime_compared_to_non_nullable(bool async)
+    {
+        await base.Static_equals_nullable_datetime_compared_to_non_nullable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__arg_0='1996-07-04T00:00:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] = @__arg_0))
 """);
-            });
+    }
 
-    public override Task Static_equals_int_compared_to_long(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Static_equals_int_compared_to_long(a);
+    public override async Task Static_equals_int_compared_to_long(bool async)
+    {
+        await base.Static_equals_int_compared_to_long(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND false)
 """);
-            });
+    }
 
     public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool async)
     {
@@ -1584,142 +1440,126 @@ WHERE ((c["Discriminator"] = "Order") AND false)
         AssertSql();
     }
 
-    public override Task Regex_IsMatch_MethodCall(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Regex_IsMatch_MethodCall(a);
+    public override async Task Regex_IsMatch_MethodCall(bool async)
+    {
+        await base.Regex_IsMatch_MethodCall(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 """);
-            });
+    }
 
-    public override Task Regex_IsMatch_MethodCall_constant_input(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Regex_IsMatch_MethodCall_constant_input(a);
+    public override async Task Regex_IsMatch_MethodCall_constant_input(bool async)
+    {
+        await base.Regex_IsMatch_MethodCall_constant_input(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch("ALFKI", c["CustomerID"]))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Option_None(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.None)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Option_None(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.None)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Option_IgnoreCase(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Option_IgnoreCase(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "i"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Option_Multiline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.Multiline)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Option_Multiline(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.Multiline)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "m"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Option_Singleline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.Singleline)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Option_Singleline(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.Singleline)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "s"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Option_IgnorePatternWhitespace(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnorePatternWhitespace)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Option_IgnorePatternWhitespace(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnorePatternWhitespace)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "x"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Regex_IsMatch_MethodCall_With_Options_IgnoreCase_And_IgnorePatternWhitespace(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(
-                        o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace)));
+    public virtual async Task Regex_IsMatch_MethodCall_With_Options_IgnoreCase_And_IgnorePatternWhitespace(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(
+                o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "ix"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1740,75 +1580,67 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Case_insensitive_string_comparison_instance(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("alFkI", StringComparison.OrdinalIgnoreCase)));
+    public virtual async Task Case_insensitive_string_comparison_instance(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("alFkI", StringComparison.OrdinalIgnoreCase)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFkI", true))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Case_insensitive_string_comparison_static(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "alFkI", StringComparison.OrdinalIgnoreCase)));
+    public virtual async Task Case_insensitive_string_comparison_static(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "alFkI", StringComparison.OrdinalIgnoreCase)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFkI", true))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Case_sensitive_string_comparison_instance(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.Ordinal)));
+    public virtual async Task Case_sensitive_string_comparison_instance(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.Ordinal)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFKI"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Case_sensitive_string_comparison_static(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.Ordinal)));
+    public virtual async Task Case_sensitive_string_comparison_static(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.Ordinal)));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Datetime_subtraction_TotalDays(bool async)
     {
@@ -1818,77 +1650,67 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFK
         AssertSql();
     }
 
-    public override Task String_Contains_constant_with_whitespace(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_constant_with_whitespace(a);
+    public override async Task String_Contains_constant_with_whitespace(bool async)
+    {
+        await base.String_Contains_constant_with_whitespace(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "     "))
 """);
-            });
+    }
 
-    public override Task String_Contains_parameter_with_whitespace(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.String_Contains_parameter_with_whitespace(a);
+    public override async Task String_Contains_parameter_with_whitespace(bool async)
+    {
+        await base.String_Contains_parameter_with_whitespace(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__pattern_0='     '
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], @__pattern_0))
 """);
-            });
+    }
 
-    public override Task Select_mathf_round(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_mathf_round(a);
+    public override async Task Select_mathf_round(bool async)
+    {
+        await base.Select_mathf_round(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
-            });
+    }
 
-    public override Task Select_mathf_round2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_mathf_round2(a);
+    public override async Task Select_mathf_round2(bool async)
+    {
+        await base.Select_mathf_round2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["UnitPrice"]
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 """);
-            });
+    }
 
-    public override Task Select_mathf_truncate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_mathf_truncate(a);
+    public override async Task Select_mathf_truncate(bool async)
+    {
+        await base.Select_mathf_truncate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["UnitPrice"]
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 """);
-            });
+    }
 
     public override Task String_Join_over_non_nullable_column(bool async)
         => AssertTranslationFailed(() => base.String_Join_over_non_nullable_column(async));

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
@@ -23,50 +23,42 @@ public class NorthwindKeylessEntitiesQueryCosmosTest : NorthwindKeylessEntitiesQ
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    public override Task KeylessEntity_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.KeylessEntity_simple(a);
+    public override async Task KeylessEntity_simple(bool async)
+    {
+        await base.KeylessEntity_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task KeylessEntity_where_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.KeylessEntity_where_simple(a);
+    public override async Task KeylessEntity_where_simple(bool async)
+    {
+        await base.KeylessEntity_where_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
     public override async Task KeylessEntity_by_database_view(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Views are not supported.
-            await Assert.ThrowsAsync<EqualException>(
-                () => base.KeylessEntity_by_database_view(async));
+        // Views are not supported.
+        await Assert.ThrowsAsync<EqualException>(
+            () => base.KeylessEntity_by_database_view(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "ProductView")
 """);
-        }
     }
 
     public override async Task Entity_mapped_to_view_on_right_side_of_join(bool async)
@@ -78,20 +70,16 @@ WHERE (c["Discriminator"] = "ProductView")
 
     public override async Task KeylessEntity_with_nav_defining_query(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Defining queries are not supported.
-            await Assert.ThrowsAsync<EqualException>(
-                () => base.KeylessEntity_with_nav_defining_query(async));
+        // Defining queries are not supported.
+        await Assert.ThrowsAsync<EqualException>(
+            () => base.KeylessEntity_with_nav_defining_query(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["OrderCount"] > 0))
 """);
-        }
     }
 
     public override async Task KeylessEntity_with_mixed_tracking(bool async)
@@ -110,19 +98,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["OrderCount"] > 0))
         AssertSql();
     }
 
-    public override Task KeylessEntity_with_defining_query(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.KeylessEntity_with_defining_query(a);
+    public override async Task KeylessEntity_with_defining_query(bool async)
+    {
+        await base.KeylessEntity_with_defining_query(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task KeylessEntity_with_defining_query_and_correlated_collection(bool async)
     {
@@ -172,33 +158,29 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Auto_initialized_view_set(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Auto_initialized_view_set(a);
+    public override async Task Auto_initialized_view_set(bool async)
+    {
+        await base.Auto_initialized_view_set(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Count_over_keyless_entity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Count_over_keyless_entity(a);
+    public override async Task Count_over_keyless_entity(bool async)
+    {
+        await base.Count_over_keyless_entity(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     public override Task Count_over_keyless_entity_with_pushdown(bool async)
         // Cosmos client evaluation. Issue #17246.

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Xunit.Sdk;
@@ -30,39 +31,35 @@ public class NorthwindMiscellaneousQueryCosmosTest : NorthwindMiscellaneousQuery
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Simple_IQueryable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(a, ss => ss.Set<Customer>());
+    public virtual async Task Simple_IQueryable(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<Customer>());
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Shaper_command_caching_when_parameter_names_different(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Shaper_command_caching_when_parameter_names_different(a);
+    public override async Task Shaper_command_caching_when_parameter_names_different(bool async)
+    {
+        await base.Shaper_command_caching_when_parameter_names_different(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Lifting_when_subquery_nested_order_by_anonymous(bool async)
     {
@@ -80,14 +77,12 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Local_dictionary(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Local_dictionary(a);
+    public override async Task Local_dictionary(bool async)
+    {
+        await base.Local_dictionary(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='ALFKI'
 
 SELECT c
@@ -95,46 +90,40 @@ FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 OFFSET 0 LIMIT 2
 """);
-            });
+    }
 
-    public override Task Entity_equality_self(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_self(a);
+    public override async Task Entity_equality_self(bool async)
+    {
+        await base.Entity_equality_self(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = c["CustomerID"]))
 """);
-            });
+    }
 
-    public override Task Entity_equality_local(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_local(a);
+    public override async Task Entity_equality_local(bool async)
+    {
+        await base.Entity_equality_local(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__entity_equality_local_0_CustomerID='ANATR'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_local_0_CustomerID))
 """);
-            });
+    }
 
-    public override Task Entity_equality_local_composite_key(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_local_composite_key(a);
+    public override async Task Entity_equality_local_composite_key(bool async)
+    {
+        await base.Entity_equality_local_composite_key(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__entity_equality_local_0_OrderID='10248'
 @__entity_equality_local_0_ProductID='11'
 
@@ -142,7 +131,7 @@ SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = @__entity_equality_local_0_OrderID) AND (c["ProductID"] = @__entity_equality_local_0_ProductID)))
 """);
-            });
+    }
 
     public override async Task Join_with_entity_equality_local_on_both_sources(bool async)
     {
@@ -152,61 +141,53 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = @__entity_equal
         AssertSql();
     }
 
-    public override Task Entity_equality_local_inline(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_local_inline(a);
+    public override async Task Entity_equality_local_inline(bool async)
+    {
+        await base.Entity_equality_local_inline(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ANATR"))
 """);
-            });
+    }
 
-    public override Task Entity_equality_local_inline_composite_key(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_local_inline_composite_key(a);
+    public override async Task Entity_equality_local_inline_composite_key(bool async)
+    {
+        await base.Entity_equality_local_inline_composite_key(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 10248) AND (c["ProductID"] = 11)))
 """);
-            });
+    }
 
-    public override Task Entity_equality_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_null(a);
+    public override async Task Entity_equality_null(bool async)
+    {
+        await base.Entity_equality_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
-            });
+    }
 
-    public override Task Entity_equality_not_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_not_null(a);
+    public override async Task Entity_equality_not_null(bool async)
+    {
+        await base.Entity_equality_not_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] != null))
 """);
-            });
+    }
 
     public override async Task Query_when_evaluatable_queryable_method_call_with_repository(bool async)
     {
@@ -487,59 +468,47 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] != null))
 
     public override async Task OrderBy_arithmetic(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_arithmetic(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_arithmetic(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY (c["EmployeeID"] - c["EmployeeID"])
 """);
-        }
     }
 
     public override async Task OrderBy_condition_comparison(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_condition_comparison(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_condition_comparison(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY (c["UnitsInStock"] > 0), c["ProductID"]
 """);
-        }
     }
 
     public override async Task OrderBy_ternary_conditions(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_ternary_conditions(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ternary_conditions(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitsInStock"] > 10) ? (c["ProductID"] > 40) : (c["ProductID"] <= 40)), c["ProductID"]
 """);
-        }
     }
 
     public override async Task OrderBy_any(bool async)
@@ -570,14 +539,12 @@ ORDER BY ((c["UnitsInStock"] > 10) ? (c["ProductID"] > 40) : (c["ProductID"] <= 
         AssertSql();
     }
 
-    public override Task Skip_Take(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Skip_Take(a);
+    public override async Task Skip_Take(bool async)
+    {
+        await base.Skip_Take(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='10'
 
@@ -587,7 +554,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-            });
+    }
 
     public override async Task Join_Customers_Orders_Skip_Take(bool async)
     {
@@ -667,56 +634,48 @@ OFFSET @__p_0 LIMIT @__p_1
         AssertSql();
     }
 
-    public override Task Queryable_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Queryable_simple(a);
+    public override async Task Queryable_simple(bool async)
+    {
+        await base.Queryable_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Queryable_simple_anonymous(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Queryable_simple_anonymous(a);
+    public override async Task Queryable_simple_anonymous(bool async)
+    {
+        await base.Queryable_simple_anonymous(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Queryable_nested_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Queryable_nested_simple(a);
+    public override async Task Queryable_nested_simple(bool async)
+    {
+        await base.Queryable_nested_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Queryable_simple_anonymous_projection_subquery(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Queryable_simple_anonymous_projection_subquery(a);
+    public override async Task Queryable_simple_anonymous_projection_subquery(bool async)
+    {
+        await base.Queryable_simple_anonymous_projection_subquery(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='91'
 
 SELECT c["City"]
@@ -724,16 +683,14 @@ FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Queryable_simple_anonymous_subquery(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Queryable_simple_anonymous_subquery(a);
+    public override async Task Queryable_simple_anonymous_subquery(bool async)
+    {
+        await base.Queryable_simple_anonymous_subquery(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='91'
 
 SELECT c
@@ -741,16 +698,14 @@ FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Take_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Take_simple(a);
+    public override async Task Take_simple(bool async)
+    {
+        await base.Take_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT c
@@ -759,16 +714,14 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Take_simple_parameterized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Take_simple_parameterized(a);
+    public override async Task Take_simple_parameterized(bool async)
+    {
+        await base.Take_simple_parameterized(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT c
@@ -777,16 +730,14 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Take_simple_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Take_simple_projection(a);
+    public override async Task Take_simple_projection(bool async)
+    {
+        await base.Take_simple_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT c["City"]
@@ -795,16 +746,14 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Take_subquery_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Take_subquery_projection(a);
+    public override async Task Take_subquery_projection(bool async)
+    {
+        await base.Take_subquery_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='2'
 
 SELECT c["City"]
@@ -813,7 +762,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     public override async Task OrderBy_Take_Count(bool async)
     {
@@ -1267,14 +1216,12 @@ OFFSET 0 LIMIT @__p_0
         AssertSql();
     }
 
-    public override Task Skip_Take_Distinct(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Skip_Take_Distinct(a);
+    public override async Task Skip_Take_Distinct(bool async)
+    {
+        await base.Skip_Take_Distinct(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='10'
 
@@ -1284,7 +1231,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-            });
+    }
 
     public override async Task Skip_Take_Any(bool async)
     {
@@ -1326,70 +1273,57 @@ OFFSET @__p_0 LIMIT @__p_1
         AssertSql();
     }
 
-    public override Task OrderBy(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy(a);
+    public override async Task OrderBy(bool async)
+    {
+        await base.OrderBy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task OrderBy_true(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_true(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_true(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY true
 """);
-        }
     }
 
     public override async Task OrderBy_integer(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_integer(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_integer(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY 3
 """);
-        }
     }
 
     public override async Task OrderBy_parameter(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_parameter(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_parameter(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__param_0='5'
 
 SELECT c
@@ -1397,38 +1331,33 @@ FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY @__param_0
 """);
-        }
     }
 
-    public override Task OrderBy_anon(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_anon(a);
+    public override async Task OrderBy_anon(bool async)
+    {
+        await base.OrderBy_anon(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task OrderBy_anon2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_anon2(a);
+    public override async Task OrderBy_anon2(bool async)
+    {
+        await base.OrderBy_anon2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task OrderBy_client_mixed(bool async)
     {
@@ -1444,14 +1373,12 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Take_Distinct(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Take_Distinct(a);
+    public override async Task Take_Distinct(bool async)
+    {
+        await base.Take_Distinct(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='5'
 
 SELECT DISTINCT c
@@ -1460,7 +1387,7 @@ WHERE (c["Discriminator"] = "Order")
 ORDER BY c["OrderID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     public override async Task Distinct_Take(bool async)
     {
@@ -1482,40 +1409,32 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task OrderBy_shadow(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_shadow(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_shadow(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["Title"], c["EmployeeID"]
 """);
-        }
     }
 
     public override async Task OrderBy_multiple(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_multiple(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_multiple(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["Country"], c["City"]
 """);
-        }
     }
 
     public override async Task OrderBy_ThenBy_Any(bool async)
@@ -1558,87 +1477,75 @@ ORDER BY c["Country"], c["City"]
     }
 
     [ConditionalTheory(Skip = "Always does sync evaluation.")]
-    public override Task Where_subquery_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                // Cosmos client evaluation. Issue #17246.
-                Assert.Equal(
-                    CoreStrings.ExpressionParameterizationExceptionSensitive(
-                        "value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).ss.Set().Where(value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).expr).Any()"),
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => base.Where_subquery_expression(async))).Message);
+    public override async Task Where_subquery_expression(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        Assert.Equal(
+            CoreStrings.ExpressionParameterizationExceptionSensitive(
+                "value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).ss.Set().Where(value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).expr).Any()"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Where_subquery_expression(async))).Message);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 OFFSET 0 LIMIT 1
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Always does sync evaluation.")]
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {
-        // Always throws
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await AssertTranslationFailed(() => base.Where_subquery_expression_same_parametername(async));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_expression_same_parametername(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 ORDER BY c["OrderID"]
 OFFSET 0 LIMIT 1
 """);
-        }
     }
 
-    public override Task Select_DTO_distinct_translated_to_server(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_DTO_distinct_translated_to_server(a);
+    public override async Task Select_DTO_distinct_translated_to_server(bool async)
+    {
+        await base.Select_DTO_distinct_translated_to_server(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT 1
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 """);
-            });
+    }
 
-    public override Task Select_DTO_constructor_distinct_translated_to_server(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_DTO_constructor_distinct_translated_to_server(a);
+    public override async Task Select_DTO_constructor_distinct_translated_to_server(bool async)
+    {
+        await base.Select_DTO_constructor_distinct_translated_to_server(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 """);
-            });
+    }
 
-    public override Task Select_DTO_with_member_init_distinct_translated_to_server(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_DTO_with_member_init_distinct_translated_to_server(a);
+    public override async Task Select_DTO_with_member_init_distinct_translated_to_server(bool async)
+    {
+        await base.Select_DTO_with_member_init_distinct_translated_to_server(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT VALUE {"Id" : c["CustomerID"], "Count" : c["OrderID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 """);
-            });
+    }
 
     public override async Task Select_nested_collection_count_using_DTO(bool async)
     {
@@ -1723,122 +1630,100 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 
     public override async Task OrderBy_null_coalesce_operator(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_null_coalesce_operator(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_null_coalesce_operator(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ"), c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Select_null_coalesce_operator(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.Select_null_coalesce_operator(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Select_null_coalesce_operator(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "CompanyName" : c["CompanyName"], "Region" : ((c["Region"] != null) ? c["Region"] : "ZZ")}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ"), c["CustomerID"]
 """);
-        }
     }
 
     public override async Task OrderBy_conditional_operator(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_conditional_operator(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_conditional_operator(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] = null) ? "ZZ" : c["Region"]), c["CustomerID"]
 """);
-        }
     }
 
-    public override Task OrderBy_conditional_operator_where_condition_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_conditional_operator_where_condition_false(a);
+    public override async Task OrderBy_conditional_operator_where_condition_false(bool async)
+    {
+        await base.OrderBy_conditional_operator_where_condition_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["City"]
 """);
-            });
+    }
 
     public override async Task OrderBy_comparison_operator(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_comparison_operator(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_comparison_operator(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["Region"] = "ASK")
 """);
-        }
     }
 
-    public override Task Projection_null_coalesce_operator(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_null_coalesce_operator(a);
+    public override async Task Projection_null_coalesce_operator(bool async)
+    {
+        await base.Projection_null_coalesce_operator(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "CompanyName" : c["CompanyName"], "Region" : ((c["Region"] != null) ? c["Region"] : "ZZ")}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Filter_coalesce_operator(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_coalesce_operator(a);
+    public override async Task Filter_coalesce_operator(bool async)
+    {
+        await base.Filter_coalesce_operator(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CompanyName"] != null) ? c["CompanyName"] : c["ContactName"]) = "The Big Cheese"))
 """);
-            });
+    }
 
     public override async Task Take_skip_null_coalesce_operator(bool async)
     {
@@ -1852,15 +1737,12 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CompanyName"] != null) ? c["C
 
     public override async Task Select_take_null_coalesce_operator(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Subquery pushdown. Issue #16156.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.Select_take_null_coalesce_operator(async));
+        // Subquery pushdown. Issue #16156.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Select_take_null_coalesce_operator(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='5'
 
 SELECT VALUE {"CustomerID" : c["CustomerID"], "CompanyName" : c["CompanyName"], "Region" : ((c["Region"] != null) ? c["Region"] : "ZZ")}
@@ -1869,7 +1751,6 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ")
 OFFSET 0 LIMIT @__p_0
 """);
-        }
     }
 
     public override async Task Select_take_skip_null_coalesce_operator(bool async)
@@ -1904,90 +1785,78 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task Selected_column_can_coalesce(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Unsupported ORDER BY clause.
-            await Assert.ThrowsAsync<CosmosException>(
-                () => base.Selected_column_can_coalesce(async));
+        // Unsupported ORDER BY clause.
+        await Assert.ThrowsAsync<CosmosException>(
+            () => base.Selected_column_can_coalesce(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ")
 """);
-        }
     }
 
-    public override Task DateTime_parse_is_inlined(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.DateTime_parse_is_inlined(a);
+    public override async Task DateTime_parse_is_inlined(bool async)
+    {
+        await base.DateTime_parse_is_inlined(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 """);
-            });
+    }
 
-    public override Task DateTime_parse_is_parameterized_when_from_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.DateTime_parse_is_parameterized_when_from_closure(a);
+    public override async Task DateTime_parse_is_parameterized_when_from_closure(bool async)
+    {
+        await base.DateTime_parse_is_parameterized_when_from_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__Parse_0='1998-01-01T12:00:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__Parse_0))
 """);
-            });
+    }
 
-    public override Task New_DateTime_is_inlined(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.New_DateTime_is_inlined(a);
+    public override async Task New_DateTime_is_inlined(bool async)
+    {
+        await base.New_DateTime_is_inlined(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 """);
-            });
+    }
 
-    public override Task New_DateTime_is_parameterized_when_from_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.New_DateTime_is_parameterized_when_from_closure(a);
+    public override async Task New_DateTime_is_parameterized_when_from_closure(bool async)
+    {
+        await base.New_DateTime_is_parameterized_when_from_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='1998-01-01T12:00:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
 """,
-                    //
-                    """
+            //
+            """
 @__p_0='1998-01-01T11:00:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
 """);
-            });
+    }
 
     public override async Task Random_next_is_not_funcletized_1(bool async)
     {
@@ -2037,24 +1906,22 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
         AssertSql();
     }
 
-    public override Task Environment_newline_is_funcletized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Environment_newline_is_funcletized(a);
+    public override async Task Environment_newline_is_funcletized(bool async)
+    {
+        await base.Environment_newline_is_funcletized(async);
 
-                var sql = Fixture.TestSqlLoggerFactory.SqlStatements[0];
-                Assert.StartsWith("@__NewLine_0='", sql);
-                Assert.EndsWith(
-                    """
+        var sql = Fixture.TestSqlLoggerFactory.SqlStatements[0];
+        Assert.StartsWith("@__NewLine_0='", sql);
+        Assert.EndsWith(
+            """
 '
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["CustomerID"], @__NewLine_0))
 """,
-                    sql);
-            });
+            sql);
+    }
 
     public override async Task String_concat_with_navigation1(bool async)
     {
@@ -2074,216 +1941,174 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["CustomerID"], @__NewLin
 
     public override async Task Select_bitwise_or(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : ((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Select_bitwise_or_multiple(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_multiple(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_multiple(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) | (c["CustomerID"] = "ANTON"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Select_bitwise_and(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : ((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Select_bitwise_and_or(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_or(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_or(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) | (c["CustomerID"] = "ANTON"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Where_bitwise_or_with_logical_or(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_or(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_or(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")))
 """);
-        }
     }
 
-    public override Task Where_bitwise_and_with_logical_and(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_and_with_logical_and(a);
+    public override async Task Where_bitwise_and_with_logical_and(bool async)
+    {
+        await base.Where_bitwise_and_with_logical_and(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) AND (c["CustomerID"] = "ANTON")))
 """);
-            });
+    }
 
     public override async Task Where_bitwise_or_with_logical_and(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_and(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_and(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) AND (c["Country"] = "Germany")))
 """);
-        }
     }
 
-    public override Task Where_bitwise_and_with_logical_or(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_and_with_logical_or(a);
+    public override async Task Where_bitwise_and_with_logical_or(bool async)
+    {
+        await base.Where_bitwise_and_with_logical_or(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")))
 """);
-            });
+    }
 
-    public override Task Where_bitwise_binary_not(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_binary_not(a);
+    public override async Task Where_bitwise_binary_not(bool async)
+    {
+        await base.Where_bitwise_binary_not(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__negatedId_0='-10249'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = @__negatedId_0))
 """);
-            });
+    }
 
-    public override Task Where_bitwise_binary_and(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_binary_and(a);
+    public override async Task Where_bitwise_binary_and(bool async)
+    {
+        await base.Where_bitwise_binary_and(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] & 10248) = 10248))
 """);
-            });
+    }
 
-    public override Task Where_bitwise_binary_or(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_binary_or(a);
+    public override async Task Where_bitwise_binary_or(bool async)
+    {
+        await base.Where_bitwise_binary_or(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] | 10248) = 10248))
 """);
-            });
+    }
 
     public override async Task Select_bitwise_or_with_logical_or(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_with_logical_or(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_with_logical_or(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Select_bitwise_and_with_logical_and(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Bitwise operators on booleans. Issue #13168.
-            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_with_logical_and(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_with_logical_and(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Value" : (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) AND (c["CustomerID"] = "ANTON"))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-        }
     }
 
     public override async Task Handle_materialization_properly_when_more_than_two_query_sources_are_involved(bool async)
@@ -2334,194 +2159,168 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Select_expression_long_to_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_long_to_string(a);
+    public override async Task Select_expression_long_to_string(bool async)
+    {
+        await base.Select_expression_long_to_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_int_to_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_int_to_string(a);
+    public override async Task Select_expression_int_to_string(bool async)
+    {
+        await base.Select_expression_int_to_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.ToString_with_formatter_is_evaluated_on_the_client(a);
+    public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
+    {
+        await base.ToString_with_formatter_is_evaluated_on_the_client(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_other_to_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_other_to_string(a);
+    public override async Task Select_expression_other_to_string(bool async)
+    {
+        await base.Select_expression_other_to_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_date_add_year(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_date_add_year(a);
+    public override async Task Select_expression_date_add_year(bool async)
+    {
+        await base.Select_expression_date_add_year(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_datetime_add_month(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_datetime_add_month(a);
+    public override async Task Select_expression_datetime_add_month(bool async)
+    {
+        await base.Select_expression_datetime_add_month(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_datetime_add_hour(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_datetime_add_hour(a);
+    public override async Task Select_expression_datetime_add_hour(bool async)
+    {
+        await base.Select_expression_datetime_add_hour(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_datetime_add_minute(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_datetime_add_minute(a);
+    public override async Task Select_expression_datetime_add_minute(bool async)
+    {
+        await base.Select_expression_datetime_add_minute(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_datetime_add_second(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_datetime_add_second(a);
+    public override async Task Select_expression_datetime_add_second(bool async)
+    {
+        await base.Select_expression_datetime_add_second(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_date_add_milliseconds_above_the_range(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_date_add_milliseconds_above_the_range(a);
+    public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
+    {
+        await base.Select_expression_date_add_milliseconds_above_the_range(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_date_add_milliseconds_below_the_range(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_date_add_milliseconds_below_the_range(a);
+    public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
+    {
+        await base.Select_expression_date_add_milliseconds_below_the_range(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_date_add_milliseconds_large_number_divided(a);
+    public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
+    {
+        await base.Select_expression_date_add_milliseconds_large_number_divided(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
-    public override Task Add_minutes_on_constant_value(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Add_minutes_on_constant_value(a);
+    public override async Task Add_minutes_on_constant_value(bool async)
+    {
+        await base.Add_minutes_on_constant_value(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : (c["OrderID"] % 25)}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10500))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
     public override async Task Select_expression_references_are_updated_correctly_with_subquery(bool async)
     {
@@ -2573,15 +2372,12 @@ ORDER BY c["OrderID"]
 
     public override async Task OrderBy_skip_take(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_skip_take(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_skip_take(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='8'
 
@@ -2591,7 +2387,6 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactTitle"], c["ContactName"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-        }
     }
 
     public override async Task OrderBy_skip_skip_take(bool async)
@@ -2636,15 +2431,12 @@ OFFSET @__p_0 LIMIT @__p_1
 
     public override async Task OrderBy_skip_take_distinct(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_skip_take_distinct(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_skip_take_distinct(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='15'
 
@@ -2654,20 +2446,16 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactTitle"], c["ContactName"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-        }
     }
 
     public override async Task OrderBy_coalesce_take_distinct(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_coalesce_take_distinct(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_coalesce_take_distinct(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='15'
 
 SELECT DISTINCT c
@@ -2676,20 +2464,16 @@ WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)
 OFFSET 0 LIMIT @__p_0
 """);
-        }
     }
 
     public override async Task OrderBy_coalesce_skip_take_distinct(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_coalesce_skip_take_distinct(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_coalesce_skip_take_distinct(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='15'
 
@@ -2699,7 +2483,6 @@ WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)
 OFFSET @__p_0 LIMIT @__p_1
 """);
-        }
     }
 
     public override async Task OrderBy_coalesce_skip_take_distinct_take(bool async)
@@ -2792,19 +2575,17 @@ OFFSET @__p_0 LIMIT @__p_1
         AssertSql();
     }
 
-    public override Task Anonymous_member_distinct_where(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Anonymous_member_distinct_where(a);
+    public override async Task Anonymous_member_distinct_where(bool async)
+    {
+        await base.Anonymous_member_distinct_where(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Anonymous_member_distinct_orderby(bool async)
     {
@@ -2824,19 +2605,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Anonymous_complex_distinct_where(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Anonymous_complex_distinct_where(a);
+    public override async Task Anonymous_complex_distinct_where(bool async)
+    {
+        await base.Anonymous_complex_distinct_where(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT VALUE {"A" : (c["CustomerID"] || c["City"])}
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "ALFKIBerlin"))
 """);
-            });
+    }
 
     public override async Task Anonymous_complex_distinct_orderby(bool async)
     {
@@ -2858,20 +2637,16 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "
 
     public override async Task Anonymous_complex_orderby(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.Anonymous_complex_orderby(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Anonymous_complex_orderby(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"A" : (c["CustomerID"] || c["City"])}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["CustomerID"] || c["City"])
 """);
-        }
     }
 
     public override async Task Anonymous_subquery_orderby(bool async)
@@ -2882,19 +2657,17 @@ ORDER BY (c["CustomerID"] || c["City"])
         AssertSql();
     }
 
-    public override Task DTO_member_distinct_where(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.DTO_member_distinct_where(a);
+    public override async Task DTO_member_distinct_where(bool async)
+    {
+        await base.DTO_member_distinct_where(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT VALUE {"Property" : c["CustomerID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task DTO_member_distinct_orderby(bool async)
     {
@@ -2914,19 +2687,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task DTO_complex_distinct_where(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.DTO_complex_distinct_where(a);
+    public override async Task DTO_complex_distinct_where(bool async)
+    {
+        await base.DTO_complex_distinct_where(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT DISTINCT VALUE {"Property" : (c["CustomerID"] || c["City"])}
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "ALFKIBerlin"))
 """);
-            });
+    }
 
     public override async Task DTO_complex_distinct_orderby(bool async)
     {
@@ -2948,21 +2719,17 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "
 
     public override async Task DTO_complex_orderby(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.DTO_complex_orderby(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.DTO_complex_orderby(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT VALUE {"Property" : (c["CustomerID"] || c["City"])}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["CustomerID"] || c["City"])
 """);
-        }
     }
 
     public override async Task DTO_subquery_orderby(bool async)
@@ -2986,19 +2753,17 @@ ORDER BY (c["CustomerID"] || c["City"])
         AssertSql();
     }
 
-    public override Task Int16_parameter_can_be_used_for_int_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Int16_parameter_can_be_used_for_int_column(a);
+    public override async Task Int16_parameter_can_be_used_for_int_column(bool async)
+    {
+        await base.Int16_parameter_can_be_used_for_int_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10300))
 """);
-            });
+    }
 
     public override async Task Subquery_is_null_translated_correctly(bool async)
     {
@@ -3192,21 +2957,19 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10300))
         AssertSql();
     }
 
-    public override Task Comparing_to_fixed_string_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Comparing_to_fixed_string_parameter(a);
+    public override async Task Comparing_to_fixed_string_parameter(bool async)
+    {
+        await base.Comparing_to_fixed_string_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prefix_0='A'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], @__prefix_0))
 """);
-            });
+    }
 
     public override async Task Comparing_entities_using_Equals(bool async)
     {
@@ -3224,20 +2987,18 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], @__pref
         AssertSql();
     }
 
-    public override Task Comparing_entity_to_null_using_Equals(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Comparing_entity_to_null_using_Equals(a);
+    public override async Task Comparing_entity_to_null_using_Equals(bool async)
+    {
+        await base.Comparing_entity_to_null_using_Equals(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND NOT((c["CustomerID"] = null)))
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task Comparing_navigations_using_Equals(bool async)
     {
@@ -3271,19 +3032,17 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Comparing_collection_navigation_to_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Comparing_collection_navigation_to_null(a);
+    public override async Task Comparing_collection_navigation_to_null(bool async)
+    {
+        await base.Comparing_collection_navigation_to_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
-            });
+    }
 
     public override async Task Comparing_collection_navigation_to_null_complex(bool async)
     {
@@ -3293,19 +3052,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
         AssertSql();
     }
 
-    public override Task Compare_collection_navigation_with_itself(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Compare_collection_navigation_with_itself(a);
+    public override async Task Compare_collection_navigation_with_itself(bool async)
+    {
+        await base.Compare_collection_navigation_with_itself(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND (c["CustomerID"] = c["CustomerID"]))
 """);
-            });
+    }
 
     public override async Task Compare_two_collection_navigations_with_different_query_sources(bool async)
     {
@@ -3331,35 +3088,31 @@ WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) 
         AssertSql();
     }
 
-    public override Task OrderBy_ThenBy_same_column_different_direction(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_ThenBy_same_column_different_direction(a);
+    public override async Task OrderBy_ThenBy_same_column_different_direction(bool async)
+    {
+        await base.OrderBy_ThenBy_same_column_different_direction(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task OrderBy_OrderBy_same_column_different_direction(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_OrderBy_same_column_different_direction(a);
+    public override async Task OrderBy_OrderBy_same_column_different_direction(bool async)
+    {
+        await base.OrderBy_OrderBy_same_column_different_direction(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"] DESC
 """);
-            });
+    }
 
     public override async Task Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(bool async)
     {
@@ -3379,14 +3132,12 @@ ORDER BY c["CustomerID"] DESC
         AssertSql();
     }
 
-    public override Task OrderBy_Dto_projection_skip_take(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Dto_projection_skip_take(a);
+    public override async Task OrderBy_Dto_projection_skip_take(bool async)
+    {
+        await base.OrderBy_Dto_projection_skip_take(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='5'
 @__p_1='10'
 
@@ -3396,7 +3147,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-            });
+    }
 
     public override async Task Join_take_count_works(bool async)
     {
@@ -3408,38 +3159,30 @@ OFFSET @__p_0 LIMIT @__p_1
 
     public override async Task OrderBy_empty_list_contains(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_empty_list_contains(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_empty_list_contains(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (true = false)
 """);
-        }
     }
 
     public override async Task OrderBy_empty_list_does_not_contains(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_empty_list_does_not_contains(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_empty_list_does_not_contains(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY NOT((true = false))
 """);
-        }
     }
 
     public override async Task Manual_expression_tree_typed_null_equality(bool async)
@@ -3528,43 +3271,37 @@ ORDER BY NOT((true = false))
         AssertSql();
     }
 
-    public override Task Can_convert_manually_build_expression_with_default(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_convert_manually_build_expression_with_default(a);
+    public override async Task Can_convert_manually_build_expression_with_default(bool async)
+    {
+        await base.Can_convert_manually_build_expression_with_default(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """,
-                    //
-                    """
+            //
+            """
 SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """);
-            });
+    }
 
     public override async Task Entity_equality_orderby_descending_composite_key(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.Entity_equality_orderby_descending_composite_key(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Entity_equality_orderby_descending_composite_key(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "OrderDetail")
 ORDER BY c["OrderID"] DESC, c["ProductID"] DESC
 """);
-        }
     }
 
     public override async Task Entity_equality_orderby_subquery(bool async)
@@ -3593,40 +3330,32 @@ ORDER BY c["OrderID"] DESC, c["ProductID"] DESC
 
     public override async Task OrderByDescending_ThenBy(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderByDescending_ThenBy(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderByDescending_ThenBy(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC, c["Country"]
 """);
-        }
     }
 
     public override async Task OrderByDescending_ThenByDescending(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderByDescending_ThenByDescending(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderByDescending_ThenByDescending(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC, c["Country"] DESC
 """);
-        }
     }
 
     public override async Task OrderBy_Join(bool async)
@@ -3639,40 +3368,32 @@ ORDER BY c["CustomerID"] DESC, c["Country"] DESC
 
     public override async Task OrderBy_ThenBy(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_ThenBy(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ThenBy(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"], c["Country"]
 """);
-        }
     }
 
     public override async Task OrderBy_ThenBy_predicate(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Cosmos client evaluation. Issue #17246.
-            await Assert.ThrowsAsync<CosmosException>(
-                async () => await base.OrderBy_ThenBy_predicate(async));
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ThenBy_predicate(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["City"], c["CustomerID"]
 """);
-        }
     }
 
     public override async Task SelectMany_correlated_simple(bool async)
@@ -3740,19 +3461,17 @@ ORDER BY c["City"], c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Select_Property_when_shadow_unconstrained_generic_method(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_Property_when_shadow_unconstrained_generic_method(a);
+    public override async Task Select_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Select_Property_when_shadow_unconstrained_generic_method(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Title"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
-            });
+    }
 
     public override async Task Skip_orderby_const(bool async)
     {
@@ -3764,21 +3483,19 @@ WHERE (c["Discriminator"] = "Employee")
         AssertSql();
     }
 
-    public override Task Where_Property_when_shadow_unconstrained_generic_method(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Property_when_shadow_unconstrained_generic_method(a);
+    public override async Task Where_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Where_Property_when_shadow_unconstrained_generic_method(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__value_0='Sales Representative'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
 """);
-            });
+    }
 
     public override async Task Inner_parameter_in_nested_lambdas_gets_preserved(bool async)
     {
@@ -3970,64 +3687,56 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
         AssertSql();
     }
 
-    public override Task Checked_context_with_arithmetic_does_not_fail(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Checked_context_with_arithmetic_does_not_fail(async);
+    public override async Task Checked_context_with_arithmetic_does_not_fail(bool async)
+    {
+        await base.Checked_context_with_arithmetic_does_not_fail(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((((c["Quantity"] + 1) = 5) AND ((c["Quantity"] - 1) = 3)) AND ((c["Quantity"] * 1) = c["Quantity"])))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Checked_context_with_case_to_same_nullable_type_does_not_fail(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Checked_context_with_case_to_same_nullable_type_does_not_fail(async);
+    public override async Task Checked_context_with_case_to_same_nullable_type_does_not_fail(bool async)
+    {
+        await base.Checked_context_with_case_to_same_nullable_type_does_not_fail(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT MAX(c["Quantity"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "OrderDetail")
 """);
-            });
+    }
 
-    public override Task Entity_equality_with_null_coalesce_client_side(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_with_null_coalesce_client_side(a);
+    public override async Task Entity_equality_with_null_coalesce_client_side(bool async)
+    {
+        await base.Entity_equality_with_null_coalesce_client_side(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__entity_equality_a_0_CustomerID='ALFKI'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_a_0_CustomerID))
 """);
-            });
+    }
 
-    public override Task Entity_equality_contains_with_list_of_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_contains_with_list_of_null(a);
+    public override async Task Entity_equality_contains_with_list_of_null(bool async)
+    {
+        await base.Entity_equality_contains_with_list_of_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI") OR (c["CustomerID"] = null)))
 """);
-            });
+    }
 
     public override async Task Perform_identity_resolution_reuses_same_instances(bool async, bool useAsTracking)
     {
@@ -4218,533 +3927,453 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI") OR (c
         AssertSql();
     }
 
-    public override Task AsEnumerable_over_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.AsEnumerable_over_string(a);
+    public override async Task AsEnumerable_over_string(bool async)
+    {
+        await base.AsEnumerable_over_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task Select_Property_when_non_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_Property_when_non_shadow(a);
+    public override async Task Select_Property_when_non_shadow(bool async)
+    {
+        await base.Select_Property_when_non_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Cast_results_to_object(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Cast_results_to_object(a);
+    public override async Task Cast_results_to_object(bool async)
+    {
+        await base.Cast_results_to_object(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Null_Coalesce_Short_Circuit_with_server_correlated_leftover(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Null_Coalesce_Short_Circuit_with_server_correlated_leftover(a);
+    public override async Task Null_Coalesce_Short_Circuit_with_server_correlated_leftover(bool async)
+    {
+        await base.Null_Coalesce_Short_Circuit_with_server_correlated_leftover(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Result" : false}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Concat_int_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Concat_int_string(a);
+    public override async Task Concat_int_string(bool async)
+    {
+        await base.Concat_int_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_expression_datetime_add_ticks(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_expression_datetime_add_ticks(a);
+    public override async Task Select_expression_datetime_add_ticks(bool async)
+    {
+        await base.Select_expression_datetime_add_ticks(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
-            });
+    }
 
     public override async Task Throws_on_concurrent_query_first(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Throws_on_concurrent_query_first(async);
+        await base.Throws_on_concurrent_query_first(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-        }
     }
 
-    public override Task Entity_equality_through_include(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_through_include(a);
+    public override async Task Entity_equality_through_include(bool async)
+    {
+        await base.Entity_equality_through_include(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
-            });
+    }
 
-    public override Task Concat_constant_string_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Concat_constant_string_int(a);
+    public override async Task Concat_constant_string_int(bool async)
+    {
+        await base.Concat_constant_string_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task OrderBy_scalar_primitive(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_scalar_primitive(a);
+    public override async Task OrderBy_scalar_primitive(bool async)
+    {
+        await base.OrderBy_scalar_primitive(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
 """);
-            });
+    }
 
-    public override Task Where_Property_when_non_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Property_when_non_shadow(a);
+    public override async Task Where_Property_when_non_shadow(bool async)
+    {
+        await base.Where_Property_when_non_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
-            });
+    }
 
-    public override Task OrderBy_Select(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderBy_Select(a);
+    public override async Task OrderBy_Select(bool async)
+    {
+        await base.OrderBy_Select(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["ContactName"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task Concat_string_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Concat_string_int(a);
+    public override async Task Concat_string_int(bool async)
+    {
+        await base.Concat_string_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"], c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Non_nullable_property_through_optional_navigation(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Non_nullable_property_through_optional_navigation(async);
+        await base.Non_nullable_property_through_optional_navigation(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT LENGTH(c["Region"]) AS Length
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-        }
     }
 
-    public override Task ToList_over_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.ToList_over_string(a);
+    public override async Task ToList_over_string(bool async)
+    {
+        await base.ToList_over_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task Entity_equality_not_null_composite_key(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_not_null_composite_key(a);
+    public override async Task Entity_equality_not_null_composite_key(bool async)
+    {
+        await base.Entity_equality_not_null_composite_key(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] != null) AND (c["ProductID"] != null)))
 """);
-            });
+    }
 
     public override void Query_composition_against_ienumerable_set()
-        => Fixture.NoSyncTest(
-            () =>
-            {
-                base.Query_composition_against_ienumerable_set();
-            });
+        => base.Query_composition_against_ienumerable_set();
 
-    public override Task ToListAsync_with_canceled_token()
-        => Fixture.NoSyncTest(
-            true, async _ =>
-            {
-                await base.ToListAsync_with_canceled_token();
+    public override async Task ToListAsync_with_canceled_token()
+    {
+        await base.ToListAsync_with_canceled_token();
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
-            });
+    }
 
-    public override Task Ternary_should_not_evaluate_both_sides(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Ternary_should_not_evaluate_both_sides(a);
+    public override async Task Ternary_should_not_evaluate_both_sides(bool async)
+    {
+        await base.Ternary_should_not_evaluate_both_sides(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Data1" : "none"}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Entity_equality_orderby(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_orderby(a);
+    public override async Task Entity_equality_orderby(bool async)
+    {
+        await base.Entity_equality_orderby(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task Load_should_track_results(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Load_should_track_results(a);
+    public override async Task Load_should_track_results(bool async)
+    {
+        await base.Load_should_track_results(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Null_parameter_name_works(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Null_parameter_name_works(a);
+    public override async Task Null_parameter_name_works(bool async)
+    {
+        await base.Null_parameter_name_works(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
-            });
+    }
 
-    public override Task Where_Property_shadow_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Property_shadow_closure(a);
+    public override async Task Where_Property_shadow_closure(bool async)
+    {
+        await base.Where_Property_shadow_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__value_0='Sales Representative'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
 """,
-                    //
-                    """
+            //
+            """
 @__value_0='Steven'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["FirstName"] = @__value_0))
 """);
-            });
+    }
 
-    public override Task Entity_equality_local_double_check(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_local_double_check(a);
+    public override async Task Entity_equality_local_double_check(bool async)
+    {
+        await base.Entity_equality_local_double_check(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__entity_equality_local_0_CustomerID='ANATR'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__entity_equality_local_0_CustomerID) AND (@__entity_equality_local_0_CustomerID = c["CustomerID"])))
 """);
-            });
+    }
 
-    public override Task ToArray_over_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.ToArray_over_string(a);
+    public override async Task ToArray_over_string(bool async)
+    {
+        await base.ToArray_over_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(a);
+    public override async Task MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(bool async)
+    {
+        await base.MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
-            });
+    }
 
-    public override Task Entity_equality_null_composite_key(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_equality_null_composite_key(a);
+    public override async Task Entity_equality_null_composite_key(bool async)
+    {
+        await base.Entity_equality_null_composite_key(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = null) OR (c["ProductID"] = null)))
 """);
-            });
+    }
 
-    public override Task Concat_parameter_string_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Concat_parameter_string_int(a);
+    public override async Task Concat_parameter_string_int(bool async)
+    {
+        await base.Concat_parameter_string_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     // ReSharper disable once RedundantOverriddenMember
     public override Task ToListAsync_can_be_canceled()
         // May or may not generate SQL depending on when cancellation happens.
         => base.ToListAsync_can_be_canceled();
 
-    public override Task Where_Property_when_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Property_when_shadow(a);
+    public override async Task Where_Property_when_shadow(bool async)
+    {
+        await base.Where_Property_when_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
-            });
+    }
 
     public override async Task Throws_on_concurrent_query_list(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.Throws_on_concurrent_query_list(async);
+        await base.Throws_on_concurrent_query_list(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-        }
     }
 
-    public override Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Convert_to_nullable_on_nullable_value_is_ignored(a);
+    public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
+    {
+        await base.Convert_to_nullable_on_nullable_value_is_ignored(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Ternary_should_not_evaluate_both_sides_with_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Ternary_should_not_evaluate_both_sides_with_parameter(a);
+    public override async Task Ternary_should_not_evaluate_both_sides_with_parameter(bool async)
+    {
+        await base.Ternary_should_not_evaluate_both_sides_with_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Data1" : true}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Context_based_client_method(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Context_based_client_method(a);
+    public override async Task Context_based_client_method(bool async)
+    {
+        await base.Context_based_client_method(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task OrderByDescending(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.OrderByDescending(a);
+    public override async Task OrderByDescending(bool async)
+    {
+        await base.OrderByDescending(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC
 """);
-            });
+    }
 
-    public override Task Select_Property_when_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_Property_when_shadow(a);
+    public override async Task Select_Property_when_shadow(bool async)
+    {
+        await base.Select_Property_when_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Title"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
-            });
+    }
 
-    public override Task Skip_0_Take_0_works_when_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Skip_0_Take_0_works_when_parameter(a);
+    public override async Task Skip_0_Take_0_works_when_parameter(bool async)
+    {
+        await base.Skip_0_Take_0_works_when_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='0'
 
 SELECT c
@@ -4753,8 +4382,8 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET @__p_0 LIMIT @__p_0
 """,
-                    //
-                    """
+            //
+            """
 @__p_0='1'
 
 SELECT c
@@ -4763,7 +4392,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET @__p_0 LIMIT @__p_0
 """);
-            });
+    }
 
     public override Task Mixed_sync_async_in_query_cache()
         => Task.CompletedTask; // No sync on Cosmos
@@ -4991,33 +4620,29 @@ OFFSET @__p_0 LIMIT @__p_0
         AssertSql();
     }
 
-    public override Task Contains_over_concatenated_columns_with_different_sizes(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_over_concatenated_columns_with_different_sizes(a);
+    public override async Task Contains_over_concatenated_columns_with_different_sizes(bool async)
+    {
+        await base.Contains_over_concatenated_columns_with_different_sizes(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] || c["CompanyName"]) IN ("ALFKIAlfreds Futterkiste", "ANATRAna Trujillo Emparedados y helados"))
 """);
-            });
+    }
 
-    public override Task Contains_over_concatenated_column_and_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_over_concatenated_column_and_constant(a);
+    public override async Task Contains_over_concatenated_column_and_constant(bool async)
+    {
+        await base.Contains_over_concatenated_column_and_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] || "SomeConstant") IN ("ALFKISomeConstant", "ANATRSomeConstant", "ALFKIX"))
 """);
-            });
+    }
 
     public override async Task Contains_over_concatenated_columns_both_fixed_length(bool async)
     {
@@ -5027,46 +4652,40 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] || "SomeConstant")
         AssertSql();
     }
 
-    public override Task Contains_over_concatenated_column_and_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_over_concatenated_column_and_parameter(a);
+    public override async Task Contains_over_concatenated_column_and_parameter(bool async)
+    {
+        await base.Contains_over_concatenated_column_and_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__someVariable_0='SomeVariable'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] || @__someVariable_0) IN ("ALFKISomeVariable", "ANATRSomeVariable", "ALFKIX"))
 """);
-            });
+    }
 
-    public override Task Contains_over_concatenated_parameter_and_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Contains_over_concatenated_parameter_and_constant(a);
+    public override async Task Contains_over_concatenated_parameter_and_constant(bool async)
+    {
+        await base.Contains_over_concatenated_parameter_and_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__Contains_0='true'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND @__Contains_0)
 """);
-            });
+    }
 
-    public override Task Compiler_generated_local_closure_produces_valid_parameter_name(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Compiler_generated_local_closure_produces_valid_parameter_name(a);
+    public override async Task Compiler_generated_local_closure_produces_valid_parameter_name(bool async)
+    {
+        await base.Compiler_generated_local_closure_produces_valid_parameter_name(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__customerId_0='ALFKI'
 @__details_City_1='Berlin'
 
@@ -5074,23 +4693,28 @@ SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__customerId_0) AND (c["City"] = @__details_City_1)))
 """);
-            });
+    }
 
-    public override Task Static_member_access_gets_parameterized_within_larger_evaluatable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Static_member_access_gets_parameterized_within_larger_evaluatable(a);
+    public override async Task Static_member_access_gets_parameterized_within_larger_evaluatable(bool async)
+    {
+        await base.Static_member_access_gets_parameterized_within_larger_evaluatable(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='ALFKI'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 """);
-            });
+    }
+
+    [ConditionalFact]
+    public virtual Task Sync_querying_is_not_supported_on_cosmos()
+        => CosmosTestHelpers.Instance.AssertSyncNotSupported(
+            () => AssertQuery(
+                async: false,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")));
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
@@ -22,12 +22,6 @@ public class NorthwindQueryCosmosFixture<TModelCustomizer> : NorthwindQueryFixtu
     protected override bool ShouldLogCategory(string logCategory)
         => logCategory == DbLoggerCategory.Query.Name;
 
-    public Task NoSyncTest(bool async, Func<bool, Task> testCode)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, testCode);
-
-    public void NoSyncTest(Action testCode)
-        => CosmosTestHelpers.Instance.NoSyncTest(testCode);
-
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder.ConfigureWarnings(
             w => w.Ignore(CosmosEventId.NoPartitionKeyDefined)));

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -26,50 +26,44 @@ public class NorthwindSelectQueryCosmosTest : NorthwindSelectQueryTestBase<North
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Projection_with_Value_Property(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Select(o => new { Value = o.OrderID }),
-                    e => e.Value);
+    public virtual async Task Projection_with_Value_Property(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Select(o => new { Value = o.OrderID }),
+            e => e.Value);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Value" : c["OrderID"]}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Projection_when_arithmetic_expression_precedence(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_when_arithmetic_expression_precedence(a);
+    public override async Task Projection_when_arithmetic_expression_precedence(bool async)
+    {
+        await base.Projection_when_arithmetic_expression_precedence(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"A" : (c["OrderID"] / (c["OrderID"] / 2)), "B" : ((c["OrderID"] / c["OrderID"]) / 2)}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Projection_when_arithmetic_expressions(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_when_arithmetic_expressions(a);
+    public override async Task Projection_when_arithmetic_expressions(bool async)
+    {
+        await base.Projection_when_arithmetic_expressions(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"OrderID" : c["OrderID"], "Double" : (c["OrderID"] * 2), "Add" : (c["OrderID"] + 23), "Sub" : (100000 - c["OrderID"]), "Divide" : (c["OrderID"] / (c["OrderID"] / 2)), "Literal" : 42, "o" : c}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Projection_when_arithmetic_mixed(bool async)
     {
@@ -87,19 +81,17 @@ WHERE (c["Discriminator"] = "Order")
         AssertSql();
     }
 
-    public override Task Projection_when_null_value(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_when_null_value(a);
+    public override async Task Projection_when_null_value(bool async)
+    {
+        await base.Projection_when_null_value(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Region"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     public override async Task Projection_when_client_evald_subquery(bool async)
     {
@@ -109,34 +101,30 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
-    public override Task Project_to_object_array(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Project_to_object_array(a);
+    public override async Task Project_to_object_array(bool async)
+    {
+        await base.Project_to_object_array(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"], c["ReportsTo"], c["Title"]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """);
-            });
+    }
 
-    public override Task Projection_of_entity_type_into_object_array(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_of_entity_type_into_object_array(a);
+    public override async Task Projection_of_entity_type_into_object_array(bool async)
+    {
+        await base.Projection_of_entity_type_into_object_array(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task Projection_of_multiple_entity_types_into_object_array(bool async)
     {
@@ -146,34 +134,30 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Projection_of_entity_type_into_object_list(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_of_entity_type_into_object_list(a);
+    public override async Task Projection_of_entity_type_into_object_list(bool async)
+    {
+        await base.Projection_of_entity_type_into_object_list(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
-    public override Task Project_to_int_array(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Project_to_int_array(a);
+    public override async Task Project_to_int_array(bool async)
+    {
+        await base.Project_to_int_array(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"], c["ReportsTo"]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """);
-            });
+    }
 
     public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
     {
@@ -185,14 +169,11 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 
     public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                () => base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            () => base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 @__boolean_0='false'
 
 SELECT VALUE {"c" : @__boolean_0}
@@ -200,173 +181,148 @@ FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY @__boolean_0
 """);
-        }
     }
 
-    public override Task Select_scalar(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_scalar(a);
+    public override async Task Select_scalar(bool async)
+    {
+        await base.Select_scalar(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_one(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_one(a);
+    public override async Task Select_anonymous_one(bool async)
+    {
+        await base.Select_anonymous_one(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_two(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_two(a);
+    public override async Task Select_anonymous_two(bool async)
+    {
+        await base.Select_anonymous_two(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"], c["Phone"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_three(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_three(a);
+    public override async Task Select_anonymous_three(bool async)
+    {
+        await base.Select_anonymous_three(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"], c["Phone"], c["Country"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_bool_constant_true(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_bool_constant_true(a);
+    public override async Task Select_anonymous_bool_constant_true(bool async)
+    {
+        await base.Select_anonymous_bool_constant_true(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "ConstantTrue" : true}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_constant_in_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_constant_in_expression(a);
+    public override async Task Select_anonymous_constant_in_expression(bool async)
+    {
+        await base.Select_anonymous_constant_in_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "Expression" : (LENGTH(c["CustomerID"]) + 5)}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_conditional_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_conditional_expression(a);
+    public override async Task Select_anonymous_conditional_expression(bool async)
+    {
+        await base.Select_anonymous_conditional_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"ProductID" : c["ProductID"], "IsAvailable" : (c["UnitsInStock"] > 0)}
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_with_object(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_with_object(a);
+    public override async Task Select_anonymous_with_object(bool async)
+    {
+        await base.Select_anonymous_with_object(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"], c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_constant_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_constant_int(a);
+    public override async Task Select_constant_int(bool async)
+    {
+        await base.Select_constant_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : 0}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_constant_null_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_constant_null_string(a);
+    public override async Task Select_constant_null_string(bool async)
+    {
+        await base.Select_constant_null_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : null}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_local(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_local(a);
+    public override async Task Select_local(bool async)
+    {
+        await base.Select_local(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__x_0='10'
 
 SELECT VALUE {"c" : @__x_0}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_scalar_primitive_after_take(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_scalar_primitive_after_take(a);
+    public override async Task Select_scalar_primitive_after_take(bool async)
+    {
+        await base.Select_scalar_primitive_after_take(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='9'
 
 SELECT c["EmployeeID"]
@@ -374,35 +330,31 @@ FROM root c
 WHERE (c["Discriminator"] = "Employee")
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Select_project_filter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_project_filter(a);
+    public override async Task Select_project_filter(bool async)
+    {
+        await base.Select_project_filter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CompanyName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
-    public override Task Select_project_filter2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_project_filter2(a);
+    public override async Task Select_project_filter2(bool async)
+    {
+        await base.Select_project_filter2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
     public override async Task Select_nested_collection(bool async)
     {
@@ -468,185 +420,161 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
         AssertSql();
     }
 
-    public override Task New_date_time_in_anonymous_type_works(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.New_date_time_in_anonymous_type_works(a);
+    public override async Task New_date_time_in_anonymous_type_works(bool async)
+    {
+        await base.New_date_time_in_anonymous_type_works(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT 1
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_int_to_long_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_int_to_long_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : (c["OrderID"] + c["OrderID"])}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(
+    public override async Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(
         bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(a);
+    {
+        await base.Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(a);
+    public override async Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(bool async)
+    {
+        await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : -(c["OrderID"])}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(a);
+    public override async Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(bool async)
+    {
+        await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_length_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_length_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_from_length_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_from_length_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT LENGTH(c["CustomerID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_method_call_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_method_call_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_from_method_call_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_from_method_call_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT ABS(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
-    public override Task Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(a);
+    public override async Task Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(bool async)
+    {
+        await base.Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
     public override async Task
         Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool async)
@@ -659,19 +587,17 @@ ORDER BY c["OrderID"]
         AssertSql();
     }
 
-    public override Task Select_conditional_with_null_comparison_in_test(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_conditional_with_null_comparison_in_test(a);
+    public override async Task Select_conditional_with_null_comparison_in_test(bool async)
+    {
+        await base.Select_conditional_with_null_comparison_in_test(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["CustomerID"] = null) ? true : (c["OrderID"] < 100))}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Projection_in_a_subquery_should_be_liftable(bool async)
     {
@@ -683,19 +609,17 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Projection_containing_DateTime_subtraction(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_containing_DateTime_subtraction(a);
+    public override async Task Projection_containing_DateTime_subtraction(bool async)
+    {
+        await base.Projection_containing_DateTime_subtraction(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 """);
-            });
+    }
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
     {
@@ -788,188 +712,162 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
         AssertSql();
     }
 
-    public override Task Select_datetime_year_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_year_component(a);
+    public override async Task Select_datetime_year_component(bool async)
+    {
+        await base.Select_datetime_year_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_month_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_month_component(a);
+    public override async Task Select_datetime_month_component(bool async)
+    {
+        await base.Select_datetime_month_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_day_of_year_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_day_of_year_component(a);
+    public override async Task Select_datetime_day_of_year_component(bool async)
+    {
+        await base.Select_datetime_day_of_year_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_day_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_day_component(a);
+    public override async Task Select_datetime_day_component(bool async)
+    {
+        await base.Select_datetime_day_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_hour_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_hour_component(a);
+    public override async Task Select_datetime_hour_component(bool async)
+    {
+        await base.Select_datetime_hour_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_minute_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_minute_component(a);
+    public override async Task Select_datetime_minute_component(bool async)
+    {
+        await base.Select_datetime_minute_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_second_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_second_component(a);
+    public override async Task Select_datetime_second_component(bool async)
+    {
+        await base.Select_datetime_second_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_datetime_millisecond_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_millisecond_component(a);
+    public override async Task Select_datetime_millisecond_component(bool async)
+    {
+        await base.Select_datetime_millisecond_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_byte_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_byte_constant(a);
+    public override async Task Select_byte_constant(bool async)
+    {
+        await base.Select_byte_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? 1 : 2)}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_short_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_short_constant(a);
+    public override async Task Select_short_constant(bool async)
+    {
+        await base.Select_short_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? 1 : 2)}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_bool_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_bool_constant(a);
+    public override async Task Select_bool_constant(bool async)
+    {
+        await base.Select_bool_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? true : false)}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Anonymous_projection_AsNoTracking_Selector(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Anonymous_projection_AsNoTracking_Selector(a);
+    public override async Task Anonymous_projection_AsNoTracking_Selector(bool async)
+    {
+        await base.Anonymous_projection_AsNoTracking_Selector(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Anonymous_projection_with_repeated_property_being_ordered(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Anonymous_projection_with_repeated_property_being_ordered(a);
+    public override async Task Anonymous_projection_with_repeated_property_being_ordered(bool async)
+    {
+        await base.Anonymous_projection_with_repeated_property_being_ordered(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"A" : c["CustomerID"]}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool async)
     {
@@ -979,19 +877,17 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Select_GetValueOrDefault_on_DateTime(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_GetValueOrDefault_on_DateTime(a);
+    public override async Task Select_GetValueOrDefault_on_DateTime(bool async)
+    {
+        await base.Select_GetValueOrDefault_on_DateTime(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool async)
     {
@@ -1001,33 +897,29 @@ WHERE (c["Discriminator"] = "Order")
         AssertSql();
     }
 
-    public override Task Client_method_in_projection_requiring_materialization_1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_in_projection_requiring_materialization_1(a);
+    public override async Task Client_method_in_projection_requiring_materialization_1(bool async)
+    {
+        await base.Client_method_in_projection_requiring_materialization_1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
-            });
+    }
 
-    public override Task Client_method_in_projection_requiring_materialization_2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_in_projection_requiring_materialization_2(a);
+    public override async Task Client_method_in_projection_requiring_materialization_2(bool async)
+    {
+        await base.Client_method_in_projection_requiring_materialization_2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
-            });
+    }
 
     public override async Task Multiple_select_many_with_predicate(bool async)
     {
@@ -1173,19 +1065,17 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
         AssertSql();
     }
 
-    public override Task Explicit_cast_in_arithmetic_operation_is_preserved(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Explicit_cast_in_arithmetic_operation_is_preserved(a);
+    public override async Task Explicit_cast_in_arithmetic_operation_is_preserved(bool async)
+    {
+        await base.Explicit_cast_in_arithmetic_operation_is_preserved(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"OrderID" : c["OrderID"], "c" : (c["OrderID"] + 1000)}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10250))
 """);
-            });
+    }
 
     public override async Task SelectMany_whose_selector_references_outer_source(bool async)
     {
@@ -1235,19 +1125,17 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10250))
         AssertSql();
     }
 
-    public override Task Coalesce_over_nullable_uint(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Coalesce_over_nullable_uint(a);
+    public override async Task Coalesce_over_nullable_uint(bool async)
+    {
+        await base.Coalesce_over_nullable_uint(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["EmployeeID"] != null) ? c["EmployeeID"] : 0)}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
     public override async Task Project_uint_through_collection_FirstOrDefault(bool async)
     {
@@ -1265,35 +1153,31 @@ WHERE (c["Discriminator"] = "Order")
         AssertSql();
     }
 
-    public override Task Reverse_changes_asc_order_to_desc(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Reverse_changes_asc_order_to_desc(a);
+    public override async Task Reverse_changes_asc_order_to_desc(bool async)
+    {
+        await base.Reverse_changes_asc_order_to_desc(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"] DESC
 """);
-            });
+    }
 
-    public override Task Reverse_changes_desc_order_to_asc(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Reverse_changes_desc_order_to_asc(a);
+    public override async Task Reverse_changes_desc_order_to_asc(bool async)
+    {
+        await base.Reverse_changes_desc_order_to_asc(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
 """);
-            });
+    }
 
     public override async Task Projection_AsEnumerable_projection(bool async)
     {
@@ -1303,20 +1187,18 @@ ORDER BY c["EmployeeID"]
         AssertSql();
     }
 
-    public override Task Projection_custom_type_in_both_sides_of_ternary(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_custom_type_in_both_sides_of_ternary(a);
+    public override async Task Projection_custom_type_in_both_sides_of_ternary(bool async)
+    {
+        await base.Projection_custom_type_in_both_sides_of_ternary(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : (c["City"] = "Seattle")}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
-            });
+    }
 
     public override async Task Projecting_multiple_collection_with_same_constant_works(bool async)
     {
@@ -1402,14 +1284,12 @@ ORDER BY c["CustomerID"]
         AssertSql();
     }
 
-    public override Task Projection_take_predicate_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_take_predicate_projection(a);
+    public override async Task Projection_take_predicate_projection(bool async)
+    {
+        await base.Projection_take_predicate_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT VALUE {"Aggregate" : ((c["CustomerID"] || " ") || c["City"])}
@@ -1418,16 +1298,14 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Projection_take_projection_doesnt_project_intermittent_column(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_take_projection_doesnt_project_intermittent_column(a);
+    public override async Task Projection_take_projection_doesnt_project_intermittent_column(bool async)
+    {
+        await base.Projection_take_projection_doesnt_project_intermittent_column(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='10'
 
 SELECT VALUE {"Aggregate" : ((c["CustomerID"] || " ") || c["City"])}
@@ -1436,7 +1314,7 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     public override async Task Projection_skip_projection_doesnt_project_intermittent_column(bool async)
     {
@@ -1500,20 +1378,18 @@ OFFSET 0 LIMIT @__p_0
         AssertSql();
     }
 
-    public override Task Ternary_in_client_eval_assigns_correct_types(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Ternary_in_client_eval_assigns_correct_types(a);
+    public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
+    {
+        await base.Ternary_in_client_eval_assigns_correct_types(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"CustomerID" : c["CustomerID"], "OrderDate" : c["OrderDate"], "c" : (c["OrderID"] - 10000)}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 ORDER BY c["OrderID"]
 """);
-            });
+    }
 
     public override async Task Collection_include_over_result_of_single_non_scalar(bool async)
     {
@@ -1667,20 +1543,16 @@ ORDER BY c["OrderID"]
 
     public override async Task Reverse_after_orderby_thenby(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Assert.ThrowsAsync<CosmosException>(
-                () => base.Reverse_after_orderby_thenby(async));
+        await Assert.ThrowsAsync<CosmosException>(
+            () => base.Reverse_after_orderby_thenby(async));
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"] DESC, c["City"]
 """);
-        }
     }
 
     public override async Task Reverse_after_orderBy_and_take(bool async)
@@ -1711,295 +1583,253 @@ ORDER BY c["EmployeeID"] DESC, c["City"]
         AssertSql();
     }
 
-    public override Task Select_bool_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_bool_closure(a);
+    public override async Task Select_bool_closure(bool async)
+    {
+        await base.Select_bool_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT 1
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """,
-                    //
-                    """
+            //
+            """
 SELECT 1
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_datetime_DayOfWeek_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_DayOfWeek_component(a);
+    public override async Task Select_datetime_DayOfWeek_component(bool async)
+    {
+        await base.Select_datetime_DayOfWeek_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Reverse_after_multiple_orderbys(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Reverse_after_multiple_orderbys(a);
+    public override async Task Reverse_after_multiple_orderbys(bool async)
+    {
+        await base.Reverse_after_multiple_orderbys(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Always does sync evaluation.")]
     public override async Task VisitLambda_should_not_be_visited_trivially(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await base.VisitLambda_should_not_be_visited_trivially(async);
+        await base.VisitLambda_should_not_be_visited_trivially(async);
 
-            AssertSql(
-                """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND STARTSWITH(c["CustomerID"], "A"))
 """);
-        }
     }
 
-    public override Task Projecting_nullable_struct(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projecting_nullable_struct(a);
+    public override async Task Projecting_nullable_struct(bool async)
+    {
+        await base.Projecting_nullable_struct(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"], (c["CustomerID"] = "ALFKI") AS c, c["OrderID"], LENGTH(c["CustomerID"]) AS c0
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_customer_identity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_customer_identity(a);
+    public override async Task Select_customer_identity(bool async)
+    {
+        await base.Select_customer_identity(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Projection_with_parameterized_constructor(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_with_parameterized_constructor(a);
+    public override async Task Projection_with_parameterized_constructor(bool async)
+    {
+        await base.Projection_with_parameterized_constructor(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Select_anonymous_nested(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_nested(a);
+    public override async Task Select_anonymous_nested(bool async)
+    {
+        await base.Select_anonymous_nested(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["City"], c["Country"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Cast_on_top_level_projection_brings_explicit_Cast(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Cast_on_top_level_projection_brings_explicit_Cast(a);
+    public override async Task Cast_on_top_level_projection_brings_explicit_Cast(bool async)
+    {
+        await base.Cast_on_top_level_projection_brings_explicit_Cast(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_empty(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_empty(a);
+    public override async Task Select_anonymous_empty(bool async)
+    {
+        await base.Select_anonymous_empty(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT 1
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_scalar_primitive(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_scalar_primitive(a);
+    public override async Task Select_scalar_primitive(bool async)
+    {
+        await base.Select_scalar_primitive(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
-            });
+    }
 
-    public override Task Select_into(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_into(a);
+    public override async Task Select_into(bool async)
+    {
+        await base.Select_into(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Projection_with_parameterized_constructor_with_member_assignment(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_with_parameterized_constructor_with_member_assignment(a);
+    public override async Task Projection_with_parameterized_constructor_with_member_assignment(bool async)
+    {
+        await base.Projection_with_parameterized_constructor_with_member_assignment(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c, c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Select_datetime_TimeOfDay_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_TimeOfDay_component(a);
+    public override async Task Select_datetime_TimeOfDay_component(bool async)
+    {
+        await base.Select_datetime_TimeOfDay_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_with_complex_expression_that_can_be_funcletized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_with_complex_expression_that_can_be_funcletized(a);
+    public override async Task Select_with_complex_expression_that_can_be_funcletized(bool async)
+    {
+        await base.Select_with_complex_expression_that_can_be_funcletized(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT INDEX_OF(c["ContactName"], "") AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Select_datetime_Ticks_component(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_datetime_Ticks_component(a);
+    public override async Task Select_datetime_Ticks_component(bool async)
+    {
+        await base.Select_datetime_Ticks_component(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task Select_anonymous_literal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_anonymous_literal(a);
+    public override async Task Select_anonymous_literal(bool async)
+    {
+        await base.Select_anonymous_literal(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"X" : 10}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_customer_table(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_customer_table(a);
+    public override async Task Select_customer_table(bool async)
+    {
+        await base.Select_customer_table(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Select_over_10_nested_ternary_condition(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Select_over_10_nested_ternary_condition(a);
+    public override async Task Select_over_10_nested_ternary_condition(bool async)
+    {
+        await base.Select_over_10_nested_ternary_condition(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"c" : ((c["CustomerID"] = "1") ? "01" : ((c["CustomerID"] = "2") ? "02" : ((c["CustomerID"] = "3") ? "03" : ((c["CustomerID"] = "4") ? "04" : ((c["CustomerID"] = "5") ? "05" : ((c["CustomerID"] = "6") ? "06" : ((c["CustomerID"] = "7") ? "07" : ((c["CustomerID"] = "8") ? "08" : ((c["CustomerID"] = "9") ? "09" : ((c["CustomerID"] = "10") ? "10" : ((c["CustomerID"] = "11") ? "11" : null)))))))))))}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Using_enumerable_parameter_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Using_enumerable_parameter_in_projection(a);
+    public override async Task Using_enumerable_parameter_in_projection(bool async)
+    {
+        await base.Using_enumerable_parameter_in_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "F"))
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
     public override Task List_from_result_of_single_result(bool async)
@@ -2013,19 +1843,17 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "F"))
     public override Task List_from_result_of_single_result_3(bool async)
         => base.List_from_result_of_single_result_3(async);
 
-    public override Task Entity_passed_to_DTO_constructor_works(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Entity_passed_to_DTO_constructor_works(a);
+    public override async Task Entity_passed_to_DTO_constructor_works(bool async)
+    {
+        await base.Entity_passed_to_DTO_constructor_works(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
     public override async Task Set_operation_in_pending_collection(bool async)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -26,128 +26,108 @@ public class NorthwindWhereQueryCosmosTest : NorthwindWhereQueryTestBase<Northwi
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_add(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => o.OrderID + 10 == 10258));
+    public virtual async Task Where_add(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID + 10 == 10258));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] + 10) = 10258))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_subtract(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => o.OrderID - 10 == 10238));
+    public virtual async Task Where_subtract(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID - 10 == 10238));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] - 10) = 10238))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_multiply(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => o.OrderID * 1 == 10248));
+    public virtual async Task Where_multiply(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID * 1 == 10248));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] * 1) = 10248))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_divide(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => o.OrderID / 1 == 10248));
+    public virtual async Task Where_divide(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID / 1 == 10248));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] / 1) = 10248))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_modulo(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => o.OrderID % 10248 == 0));
+    public virtual async Task Where_modulo(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID % 10248 == 0));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] % 10248) = 0))
 """);
-            });
+    }
 
     public override async Task Where_bitwise_or(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    // Bitwise operators on booleans. Issue #13168.
-                    await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or(async));
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or(async));
 
-                    AssertSql(
-                        """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")))
 """);
-                });
-        }
     }
 
-    public override Task Where_bitwise_and(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bitwise_and(a);
+    public override async Task Where_bitwise_and(bool async)
+    {
+        await base.Where_bitwise_and(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")))
 """);
-            });
+    }
 
     public override async Task Where_bitwise_xor(bool async)
     {
@@ -161,307 +141,273 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") & (c["
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_bitwise_leftshift(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => (o.OrderID << 1) == 20496));
+    public virtual async Task Where_bitwise_leftshift(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => (o.OrderID << 1) == 20496));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] << 1) = 20496))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_bitwise_rightshift(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => (o.OrderID >> 1) == 5124));
+    public virtual async Task Where_bitwise_rightshift(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => (o.OrderID >> 1) == 5124));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] >> 1) = 5124))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_logical_and(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Customer>().Where(c => c.City == "Seattle" && c.ContactTitle == "Owner"));
+    public virtual async Task Where_logical_and(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.City == "Seattle" && c.ContactTitle == "Owner"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["City"] = "Seattle") AND (c["ContactTitle"] = "Owner")))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_logical_or(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" || c.CustomerID == "ANATR"));
+    public virtual async Task Where_logical_or(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" || c.CustomerID == "ANATR"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ANATR")))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_logical_not(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Customer>().Where(c => !(c.City != "Seattle")));
+    public virtual async Task Where_logical_not(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => !(c.City != "Seattle")));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT((c["City"] != "Seattle")))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_equality(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo == 2));
+    public virtual async Task Where_equality(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo == 2));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_inequality(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo != 2));
+    public virtual async Task Where_inequality(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo != 2));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] != 2))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_greaterthan(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo > 2));
+    public virtual async Task Where_greaterthan(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo > 2));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] > 2))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_greaterthanorequal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo >= 2));
+    public virtual async Task Where_greaterthanorequal(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo >= 2));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] >= 2))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_lessthan(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo < 3));
+    public virtual async Task Where_lessthan(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo < 3));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] < 3))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_lessthanorequal(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Employee>().Where(e => e.ReportsTo <= 2));
+    public virtual async Task Where_lessthanorequal(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.ReportsTo <= 2));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] <= 2))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_string_concat(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Customer>().Where(c => c.CustomerID + "END" == "ALFKIEND"));
+    public virtual async Task Where_string_concat(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID + "END" == "ALFKIEND"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || "END") = "ALFKIEND"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_unary_minus(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => -o.OrderID == -10248));
+    public virtual async Task Where_unary_minus(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => -o.OrderID == -10248));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (-(c["OrderID"]) = -10248))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_bitwise_not(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Order>().Where(o => ~o.OrderID == -10249));
+    public virtual async Task Where_bitwise_not(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => ~o.OrderID == -10249));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = -10249))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_ternary(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
+    public virtual async Task Where_ternary(bool async)
+    {
+        await AssertQuery(
+            async,
 #pragma warning disable IDE0029 // Use coalesce expression
-                    ss => ss.Set<Customer>().Where(c => (c.Region != null ? c.Region : "SP") == "BC"));
+            ss => ss.Set<Customer>().Where(c => (c.Region != null ? c.Region : "SP") == "BC"));
 #pragma warning restore IDE0029 // Use coalesce expression
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region"] : "SP") = "BC"))
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_coalesce(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await AssertQuery(
-                    a,
-                    ss => ss.Set<Customer>().Where(c => (c.Region ?? "SP") == "BC"));
+    public virtual async Task Where_coalesce(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => (c.Region ?? "SP") == "BC"));
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region"] : "SP") = "BC"))
 """);
-            });
+    }
 
-    public override Task Where_simple(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple(a);
+    public override async Task Where_simple(bool async)
+    {
+        await base.Where_simple(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
     private static readonly Expression<Func<Order, bool>> _filter = o => o.CustomerID == "ALFKI";
 
@@ -475,13 +421,10 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
     public override async Task<string> Where_simple_closure(bool async)
     {
-        await Fixture.NoSyncTest(
-            async, async a =>
-            {
-                var queryString = await base.Where_simple_closure(a);
+        var queryString = await base.Where_simple_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_0='London'
 
 SELECT c
@@ -489,122 +432,109 @@ FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """);
 
-                Assert.Equal(
-                    """
+        Assert.Equal(
+            """
 -- @__city_0='London'
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """, queryString, ignoreLineEndingDifferences: true,
-                    ignoreWhiteSpaceDifferences: true);
-            });
+            ignoreWhiteSpaceDifferences: true);
 
         return null;
     }
 
-    public override Task Where_indexer_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_indexer_closure(a);
+    public override async Task Where_indexer_closure(bool async)
+    {
+        await base.Where_indexer_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__p_0))
 """);
-            });
+    }
 
-    public override Task Where_dictionary_key_access_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_dictionary_key_access_closure(a);
+    public override async Task Where_dictionary_key_access_closure(bool async)
+    {
+        await base.Where_dictionary_key_access_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__get_Item_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__get_Item_0))
 """);
-            });
+    }
 
-    public override Task Where_tuple_item_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_tuple_item_closure(a);
+    public override async Task Where_tuple_item_closure(bool async)
+    {
+        await base.Where_tuple_item_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__predicateTuple_Item2_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item2_0))
 """);
-            });
+    }
 
-    public override Task Where_named_tuple_item_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_named_tuple_item_closure(a);
+    public override async Task Where_named_tuple_item_closure(bool async)
+    {
+        await base.Where_named_tuple_item_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__predicateTuple_Item2_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item2_0))
 """);
-            });
+    }
 
-    public override Task Where_simple_closure_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_closure_constant(a);
+    public override async Task Where_simple_closure_constant(bool async)
+    {
+        await base.Where_simple_closure_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__predicate_0='true'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND @__predicate_0)
 """);
-            });
+    }
 
-    public override Task Where_simple_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_closure_via_query_cache(a);
+    public override async Task Where_simple_closure_via_query_cache(bool async)
+    {
+        await base.Where_simple_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """,
-                    //
-                    """
+            //
+            """
 @__city_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """);
-            });
+    }
 
     public override async Task Where_method_call_nullable_type_closure_via_query_cache(bool async)
     {
@@ -622,221 +552,203 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
         AssertSql();
     }
 
-    public override Task Where_method_call_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_method_call_closure_via_query_cache(a);
+    public override async Task Where_method_call_closure_via_query_cache(bool async)
+    {
+        await base.Where_method_call_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__GetCity_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
 """,
-                    //
-                    """
+            //
+            """
 @__GetCity_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
 """);
-            });
+    }
 
-    public override Task Where_field_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_field_access_closure_via_query_cache(a);
+    public override async Task Where_field_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_field_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_InstanceFieldValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__city_InstanceFieldValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldValue_0))
 """);
-            });
+    }
 
-    public override Task Where_property_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_property_access_closure_via_query_cache(a);
+    public override async Task Where_property_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_property_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_InstancePropertyValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstancePropertyValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__city_InstancePropertyValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstancePropertyValue_0))
 """);
-            });
+    }
 
-    public override Task Where_static_field_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_static_field_access_closure_via_query_cache(a);
+    public override async Task Where_static_field_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_static_field_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__StaticFieldValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__StaticFieldValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0))
 """);
-            });
+    }
 
-    public override Task Where_static_property_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_static_property_access_closure_via_query_cache(a);
+    public override async Task Where_static_property_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_static_property_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__StaticPropertyValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__StaticPropertyValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue_0))
 """);
-            });
+    }
 
-    public override Task Where_nested_field_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_nested_field_access_closure_via_query_cache(a);
+    public override async Task Where_nested_field_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_nested_field_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_Nested_InstanceFieldValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstanceFieldValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__city_Nested_InstanceFieldValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstanceFieldValue_0))
 """);
-            });
+    }
 
-    public override Task Where_nested_property_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_nested_property_access_closure_via_query_cache(a);
+    public override async Task Where_nested_property_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_nested_property_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__city_Nested_InstancePropertyValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstancePropertyValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__city_Nested_InstancePropertyValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstancePropertyValue_0))
 """);
-            });
+    }
 
-    public override Task Where_new_instance_field_access_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_new_instance_field_access_query_cache(a);
+    public override async Task Where_new_instance_field_access_query_cache(bool async)
+    {
+        await base.Where_new_instance_field_access_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__InstanceFieldValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__InstanceFieldValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """);
-            });
+    }
 
-    public override Task Where_new_instance_field_access_closure_via_query_cache(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_new_instance_field_access_closure_via_query_cache(a);
+    public override async Task Where_new_instance_field_access_closure_via_query_cache(bool async)
+    {
+        await base.Where_new_instance_field_access_closure_via_query_cache(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__InstanceFieldValue_0='London'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """,
-                    //
-                    """
+            //
+            """
 @__InstanceFieldValue_0='Seattle'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """);
-            });
+    }
 
     public override async Task Where_simple_closure_via_query_cache_nullable_type(bool async)
     {
@@ -858,46 +770,36 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_
     public override Task Where_subquery_closure_via_query_cache(bool async)
         => Task.CompletedTask;
 
-    public override Task Where_simple_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_shadow(a);
+    public override async Task Where_simple_shadow(bool async)
+    {
+        await base.Where_simple_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
-            });
+    }
 
-    public override Task Where_simple_shadow_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_shadow_projection(a);
+    public override async Task Where_simple_shadow_projection(bool async)
+    {
+        await base.Where_simple_shadow_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Title"]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
-            });
+    }
 
     public override async Task Where_simple_shadow_subquery(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    await Assert.ThrowsAsync<EqualException>(() => base.Where_simple_shadow_subquery(a));
+        await Assert.ThrowsAsync<EqualException>(() => base.Where_simple_shadow_subquery(async));
 
-                    AssertSql(
-                        """
+        AssertSql(
+            """
 @__p_0='5'
 
 SELECT c
@@ -906,8 +808,6 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative
 ORDER BY c["EmployeeID"]
 OFFSET 0 LIMIT @__p_0
 """);
-                });
-        }
     }
 
     public override async Task Where_shadow_subquery_FirstOrDefault(bool async)
@@ -968,273 +868,241 @@ OFFSET 0 LIMIT @__p_0
         AssertSql();
     }
 
-    public override Task Where_equals_method_string(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_method_string(a);
+    public override async Task Where_equals_method_string(bool async)
+    {
+        await base.Where_equals_method_string(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
-    public override Task Where_equals_method_string_with_ignore_case(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_method_string_with_ignore_case(a);
+    public override async Task Where_equals_method_string_with_ignore_case(bool async)
+    {
+        await base.Where_equals_method_string_with_ignore_case(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["City"], "London", true))
 """);
-            });
+    }
 
-    public override Task Where_equals_method_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_method_int(a);
+    public override async Task Where_equals_method_int(bool async)
+    {
+        await base.Where_equals_method_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """);
-            });
+    }
 
-    public override Task Where_equals_using_object_overload_on_mismatched_types(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_using_object_overload_on_mismatched_types(a);
+    public override async Task Where_equals_using_object_overload_on_mismatched_types(bool async)
+    {
+        await base.Where_equals_using_object_overload_on_mismatched_types(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND false)
 """);
-            });
+    }
 
-    public override Task Where_equals_using_int_overload_on_mismatched_types(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_using_int_overload_on_mismatched_types(a);
+    public override async Task Where_equals_using_int_overload_on_mismatched_types(bool async)
+    {
+        await base.Where_equals_using_int_overload_on_mismatched_types(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='1'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = @__p_0))
 """);
-            });
+    }
 
-    public override Task Where_equals_on_mismatched_types_nullable_int_long(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_on_mismatched_types_nullable_int_long(a);
+    public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool async)
+    {
+        await base.Where_equals_on_mismatched_types_nullable_int_long(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND false)
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND false)
 """);
-            });
+    }
 
-    public override Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_on_mismatched_types_nullable_long_nullable_int(a);
+    public override async Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool async)
+    {
+        await base.Where_equals_on_mismatched_types_nullable_long_nullable_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND false)
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND false)
 """);
-            });
+    }
 
-    public override Task Where_equals_on_mismatched_types_int_nullable_int(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_on_mismatched_types_int_nullable_int(a);
+    public override async Task Where_equals_on_mismatched_types_int_nullable_int(bool async)
+    {
+        await base.Where_equals_on_mismatched_types_int_nullable_int(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__intPrm_0='2'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__intPrm_0))
 """,
-                    //
-                    """
+            //
+            """
 @__intPrm_0='2'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__intPrm_0 = c["ReportsTo"]))
 """);
-            });
+    }
 
-    public override Task Where_equals_on_matched_nullable_int_types(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_on_matched_nullable_int_types(a);
+    public override async Task Where_equals_on_matched_nullable_int_types(bool async)
+    {
+        await base.Where_equals_on_matched_nullable_int_types(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__nullableIntPrm_0='2'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo"]))
 """,
-                    //
-                    """
+            //
+            """
 @__nullableIntPrm_0='2'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm_0))
 """);
-            });
+    }
 
-    public override Task Where_equals_on_null_nullable_int_types(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_equals_on_null_nullable_int_types(a);
+    public override async Task Where_equals_on_null_nullable_int_types(bool async)
+    {
+        await base.Where_equals_on_null_nullable_int_types(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__nullableIntPrm_0=null
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo"]))
 """,
-                    //
-                    """
+            //
+            """
 @__nullableIntPrm_0=null
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm_0))
 """);
-            });
+    }
 
-    public override Task Where_comparison_nullable_type_not_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_comparison_nullable_type_not_null(a);
+    public override async Task Where_comparison_nullable_type_not_null(bool async)
+    {
+        await base.Where_comparison_nullable_type_not_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 """);
-            });
+    }
 
-    public override Task Where_comparison_nullable_type_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_comparison_nullable_type_null(a);
+    public override async Task Where_comparison_nullable_type_null(bool async)
+    {
+        await base.Where_comparison_nullable_type_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = null))
 """);
-            });
+    }
 
-    public override Task Where_string_length(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_length(a);
+    public override async Task Where_string_length(bool async)
+    {
+        await base.Where_string_length(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LENGTH(c["City"]) = 6))
 """);
-            });
+    }
 
-    public override Task Where_string_indexof(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_indexof(a);
+    public override async Task Where_string_indexof(bool async)
+    {
+        await base.Where_string_indexof(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["City"], "Sea") != -1))
 """);
-            });
+    }
 
-    public override Task Where_string_replace(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_replace(a);
+    public override async Task Where_string_replace(bool async)
+    {
+        await base.Where_string_replace(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["City"], "Sea", "Rea") = "Reattle"))
 """);
-            });
+    }
 
-    public override Task Where_string_substring(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_substring(a);
+    public override async Task Where_string_substring(bool async)
+    {
+        await base.Where_string_substring(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["City"], 1, 2) = "ea"))
 """);
-            });
+    }
 
     public override async Task Where_datetime_now(bool async)
     {
@@ -1244,37 +1112,33 @@ WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["City"], 1, 2) = "ea")
         AssertSql();
     }
 
-    public override Task Where_datetime_utcnow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_datetime_utcnow(a);
+    public override async Task Where_datetime_utcnow(bool async)
+    {
+        await base.Where_datetime_utcnow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__myDatetime_0='2015-04-10T00:00:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatetime_0))
 """);
-            });
+    }
 
-    public override Task Where_datetimeoffset_utcnow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_datetimeoffset_utcnow(a);
+    public override async Task Where_datetimeoffset_utcnow(bool async)
+    {
+        await base.Where_datetimeoffset_utcnow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__myDatetimeOffset_0='2015-04-10T00:00:00-08:00'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatetimeOffset_0))
 """);
-            });
+    }
 
     public override async Task Where_datetime_today(bool async)
     {
@@ -1380,117 +1244,101 @@ WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatet
         AssertSql();
     }
 
-    public override Task Where_simple_reversed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_reversed(a);
+    public override async Task Where_simple_reversed(bool async)
+    {
+        await base.Where_simple_reversed(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ("London" = c["City"]))
 """);
-            });
+    }
 
-    public override Task Where_is_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_is_null(a);
+    public override async Task Where_is_null(bool async)
+    {
+        await base.Where_is_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
-            });
+    }
 
-    public override Task Where_null_is_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_null_is_null(a);
+    public override async Task Where_null_is_null(bool async)
+    {
+        await base.Where_null_is_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Where_constant_is_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_constant_is_null(a);
+    public override async Task Where_constant_is_null(bool async)
+    {
+        await base.Where_constant_is_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """);
-            });
+    }
 
-    public override Task Where_is_not_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_is_not_null(a);
+    public override async Task Where_is_not_null(bool async)
+    {
+        await base.Where_is_not_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """);
-            });
+    }
 
-    public override Task Where_null_is_not_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_null_is_not_null(a);
+    public override async Task Where_null_is_not_null(bool async)
+    {
+        await base.Where_null_is_not_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """);
-            });
+    }
 
-    public override Task Where_constant_is_not_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_constant_is_not_null(a);
+    public override async Task Where_constant_is_not_null(bool async)
+    {
+        await base.Where_constant_is_not_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Where_identity_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_identity_comparison(a);
+    public override async Task Where_identity_comparison(bool async)
+    {
+        await base.Where_identity_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = c["City"]))
 """);
-            });
+    }
 
     public override async Task Where_in_optimization_multiple(bool async)
     {
@@ -1540,14 +1388,12 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = c["City"]))
         AssertSql();
     }
 
-    public override Task Where_primitive(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_primitive(a);
+    public override async Task Where_primitive(bool async)
+    {
+        await base.Where_primitive(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='9'
 
 SELECT c["EmployeeID"]
@@ -1555,35 +1401,31 @@ FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Where_bool_member(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member(a);
+    public override async Task Where_bool_member(bool async)
+    {
+        await base.Where_bool_member(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 """);
-            });
+    }
 
-    public override Task Where_bool_member_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_false(a);
+    public override async Task Where_bool_member_false(bool async)
+    {
+        await base.Where_bool_member_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 """);
-            });
+    }
 
     public override async Task Where_bool_client_side_negated(bool async)
     {
@@ -1593,337 +1435,293 @@ WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
         AssertSql();
     }
 
-    public override Task Where_bool_member_negated_twice(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_negated_twice(a);
+    public override async Task Where_bool_member_negated_twice(bool async)
+    {
+        await base.Where_bool_member_negated_twice(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(NOT((c["Discontinued"] = true))))
 """);
-            });
+    }
 
-    public override Task Where_bool_member_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_shadow(a);
+    public override async Task Where_bool_member_shadow(bool async)
+    {
+        await base.Where_bool_member_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 """);
-            });
+    }
 
-    public override Task Where_bool_member_false_shadow(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_false_shadow(a);
+    public override async Task Where_bool_member_false_shadow(bool async)
+    {
+        await base.Where_bool_member_false_shadow(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 """);
-            });
+    }
 
-    public override Task Where_bool_member_equals_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_equals_constant(a);
+    public override async Task Where_bool_member_equals_constant(bool async)
+    {
+        await base.Where_bool_member_equals_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = true))
 """);
-            });
+    }
 
-    public override Task Where_bool_member_in_complex_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_in_complex_predicate(a);
+    public override async Task Where_bool_member_in_complex_predicate(bool async)
+    {
+        await base.Where_bool_member_in_complex_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (((c["ProductID"] > 100) AND c["Discontinued"]) OR (c["Discontinued"] = true)))
 """);
-            });
+    }
 
-    public override Task Where_bool_member_compared_to_binary_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_compared_to_binary_expression(a);
+    public override async Task Where_bool_member_compared_to_binary_expression(bool async)
+    {
+        await base.Where_bool_member_compared_to_binary_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = (c["ProductID"] > 50)))
 """);
-            });
+    }
 
-    public override Task Where_not_bool_member_compared_to_not_bool_member(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_not_bool_member_compared_to_not_bool_member(a);
+    public override async Task Where_not_bool_member_compared_to_not_bool_member(bool async)
+    {
+        await base.Where_not_bool_member_compared_to_not_bool_member(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = NOT(c["Discontinued"])))
 """);
-            });
+    }
 
-    public override Task Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(a);
+    public override async Task Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(bool async)
+    {
+        await base.Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT((c["ProductID"] > 50)) = NOT((c["ProductID"] > 20))))
 """);
-            });
+    }
 
-    public override Task Where_not_bool_member_compared_to_binary_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_not_bool_member_compared_to_binary_expression(a);
+    public override async Task Where_not_bool_member_compared_to_binary_expression(bool async)
+    {
+        await base.Where_not_bool_member_compared_to_binary_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = (c["ProductID"] > 50)))
 """);
-            });
+    }
 
-    public override Task Where_bool_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_parameter(a);
+    public override async Task Where_bool_parameter(bool async)
+    {
+        await base.Where_bool_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm_0='true'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND @__prm_0)
 """);
-            });
+    }
 
-    public override Task Where_bool_parameter_compared_to_binary_expression(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_parameter_compared_to_binary_expression(a);
+    public override async Task Where_bool_parameter_compared_to_binary_expression(bool async)
+    {
+        await base.Where_bool_parameter_compared_to_binary_expression(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm_0='true'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] > 50) != @__prm_0))
 """);
-            });
+    }
 
-    public override Task Where_bool_member_and_parameter_compared_to_binary_expression_nested(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_member_and_parameter_compared_to_binary_expression_nested(a);
+    public override async Task Where_bool_member_and_parameter_compared_to_binary_expression_nested(bool async)
+    {
+        await base.Where_bool_member_and_parameter_compared_to_binary_expression_nested(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm_0='true'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = ((c["ProductID"] > 50) != @__prm_0)))
 """);
-            });
+    }
 
-    public override Task Where_de_morgan_or_optimized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_de_morgan_or_optimized(a);
+    public override async Task Where_de_morgan_or_optimized(bool async)
+    {
+        await base.Where_de_morgan_or_optimized(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] OR (c["ProductID"] < 20))))
 """);
-            });
+    }
 
-    public override Task Where_de_morgan_and_optimized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_de_morgan_and_optimized(a);
+    public override async Task Where_de_morgan_and_optimized(bool async)
+    {
+        await base.Where_de_morgan_and_optimized(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] AND (c["ProductID"] < 20))))
 """);
-            });
+    }
 
-    public override Task Where_complex_negated_expression_optimized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_complex_negated_expression_optimized(a);
+    public override async Task Where_complex_negated_expression_optimized(bool async)
+    {
+        await base.Where_complex_negated_expression_optimized(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((NOT((NOT(c["Discontinued"]) AND (c["ProductID"] < 60))) OR NOT((c["ProductID"] > 30)))))
 """);
-            });
+    }
 
-    public override Task Where_short_member_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_short_member_comparison(a);
+    public override async Task Where_short_member_comparison(bool async)
+    {
+        await base.Where_short_member_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] > 10))
 """);
-            });
+    }
 
-    public override Task Where_comparison_to_nullable_bool(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_comparison_to_nullable_bool(a);
+    public override async Task Where_comparison_to_nullable_bool(bool async)
+    {
+        await base.Where_comparison_to_nullable_bool(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ENDSWITH(c["CustomerID"], "KI") = true))
 """);
-            });
+    }
 
-    public override Task Where_true(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_true(a);
+    public override async Task Where_true(bool async)
+    {
+        await base.Where_true(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Where_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_false(a);
+    public override async Task Where_false(bool async)
+    {
+        await base.Where_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """);
-            });
+    }
 
-    public override Task Where_bool_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_bool_closure(a);
+    public override async Task Where_bool_closure(bool async)
+    {
+        await base.Where_bool_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Where_default(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_default(a);
+    public override async Task Where_default(bool async)
+    {
+        await base.Where_default(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Fax"] = null))
 """);
-            });
+    }
 
-    public override Task Where_expression_invoke_1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_expression_invoke_1(a);
+    public override async Task Where_expression_invoke_1(bool async)
+    {
+        await base.Where_expression_invoke_1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Where_expression_invoke_2(bool async)
     {
@@ -1933,19 +1731,17 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Where_expression_invoke_3(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_expression_invoke_3(a);
+    public override async Task Where_expression_invoke_3(bool async)
+    {
+        await base.Where_expression_invoke_3(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task Where_concat_string_int_comparison1(bool async)
     {
@@ -1979,30 +1775,26 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Where_string_concat_method_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_concat_method_comparison(a);
+    public override async Task Where_string_concat_method_comparison(bool async)
+    {
+        await base.Where_string_concat_method_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__i_0='A'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AAROUT"))
 """);
-            });
+    }
 
-    public override Task Where_string_concat_method_comparison_2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_concat_method_comparison_2(a);
+    public override async Task Where_string_concat_method_comparison_2(bool async)
+    {
+        await base.Where_string_concat_method_comparison_2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__i_0='A'
 @__j_1='B'
 
@@ -2010,16 +1802,14 @@ SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || c["CustomerID"])) = "ABANATR"))
 """);
-            });
+    }
 
-    public override Task Where_string_concat_method_comparison_3(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_string_concat_method_comparison_3(a);
+    public override async Task Where_string_concat_method_comparison_3(bool async)
+    {
+        await base.Where_string_concat_method_comparison_3(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__i_0='A'
 @__j_1='B'
 @__k_2='C'
@@ -2028,79 +1818,69 @@ SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || (@__k_2 || c["CustomerID"]))) = "ABCANTON"))
 """);
-            });
+    }
 
-    public override Task Where_ternary_boolean_condition_true(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_ternary_boolean_condition_true(a);
+    public override async Task Where_ternary_boolean_condition_true(bool async)
+    {
+        await base.Where_ternary_boolean_condition_true(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 """);
-            });
+    }
 
-    public override Task Where_ternary_boolean_condition_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_ternary_boolean_condition_false(a);
+    public override async Task Where_ternary_boolean_condition_false(bool async)
+    {
+        await base.Where_ternary_boolean_condition_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] < 20))
 """);
-            });
+    }
 
-    public override Task Where_ternary_boolean_condition_with_another_condition(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_ternary_boolean_condition_with_another_condition(a);
+    public override async Task Where_ternary_boolean_condition_with_another_condition(bool async)
+    {
+        await base.Where_ternary_boolean_condition_with_another_condition(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__productId_0='15'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] < @__productId_0) AND (c["UnitsInStock"] >= 20)))
 """);
-            });
+    }
 
-    public override Task Where_ternary_boolean_condition_with_false_as_result_true(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_ternary_boolean_condition_with_false_as_result_true(a);
+    public override async Task Where_ternary_boolean_condition_with_false_as_result_true(bool async)
+    {
+        await base.Where_ternary_boolean_condition_with_false_as_result_true(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 """);
-            });
+    }
 
-    public override Task Where_ternary_boolean_condition_with_false_as_result_false(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_ternary_boolean_condition_with_false_as_result_false(a);
+    public override async Task Where_ternary_boolean_condition_with_false_as_result_false(bool async)
+    {
+        await base.Where_ternary_boolean_condition_with_false_as_result_false(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND false)
 """);
-            });
+    }
 
     public override async Task Where_compare_constructed_equal(bool async)
     {
@@ -2174,47 +1954,41 @@ WHERE ((c["Discriminator"] = "Product") AND false)
         AssertSql();
     }
 
-    public override Task Where_compare_null(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_compare_null(a);
+    public override async Task Where_compare_null(bool async)
+    {
+        await base.Where_compare_null(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["Region"] = null) AND (c["Country"] = "UK")))
 """);
-            });
+    }
 
-    public override Task Where_Is_on_same_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Is_on_same_type(a);
+    public override async Task Where_Is_on_same_type(bool async)
+    {
+        await base.Where_Is_on_same_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Where_chain(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_chain(a);
+    public override async Task Where_chain(bool async)
+    {
+        await base.Where_chain(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "QUICK")) AND (c["OrderDate"] > "1998-01-01T00:00:00"))
 """);
-            });
+    }
 
     public override async Task Where_navigation_contains(bool async)
     {
@@ -2229,21 +2003,19 @@ WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "QUICK")) AND (c["
         AssertSql();
     }
 
-    public override Task Where_array_index(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_array_index(a);
+    public override async Task Where_array_index(bool async)
+    {
+        await base.Where_array_index(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='ALFKI'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 """);
-            });
+    }
 
     public override async Task Where_multiple_contains_in_subquery_with_or(bool async)
     {
@@ -2285,35 +2057,31 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
         AssertSql();
     }
 
-    public override Task Time_of_day_datetime(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Time_of_day_datetime(a);
+    public override async Task Time_of_day_datetime(bool async)
+    {
+        await base.Time_of_day_datetime(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
-            });
+    }
 
-    public override Task TypeBinary_short_circuit(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.TypeBinary_short_circuit(a);
+    public override async Task TypeBinary_short_circuit(bool async)
+    {
+        await base.TypeBinary_short_circuit(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='false'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND @__p_0)
 """);
-            });
+    }
 
     public override async Task Decimal_cast_to_double_works(bool async)
     {
@@ -2323,19 +2091,17 @@ WHERE ((c["Discriminator"] = "Order") AND @__p_0)
         AssertSql();
     }
 
-    public override Task Where_is_conditional(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_is_conditional(a);
+    public override async Task Where_is_conditional(bool async)
+    {
+        await base.Where_is_conditional(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
 """);
-            });
+    }
 
     public override async Task Filter_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
     {
@@ -2505,61 +2271,53 @@ WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
         AssertSql();
     }
 
-    public override Task Where_list_object_contains_over_value_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_list_object_contains_over_value_type(a);
+    public override async Task Where_list_object_contains_over_value_type(bool async)
+    {
+        await base.Where_list_object_contains_over_value_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
-            });
+    }
 
-    public override Task Where_array_of_object_contains_over_value_type(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_array_of_object_contains_over_value_type(a);
+    public override async Task Where_array_of_object_contains_over_value_type(bool async)
+    {
+        await base.Where_array_of_object_contains_over_value_type(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
-            });
+    }
 
-    public override Task Filter_with_EF_Property_using_closure_for_property_name(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_with_EF_Property_using_closure_for_property_name(a);
+    public override async Task Filter_with_EF_Property_using_closure_for_property_name(bool async)
+    {
+        await base.Filter_with_EF_Property_using_closure_for_property_name(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task Filter_with_EF_Property_using_function_for_property_name(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_with_EF_Property_using_function_for_property_name(a);
+    public override async Task Filter_with_EF_Property_using_function_for_property_name(bool async)
+    {
+        await base.Filter_with_EF_Property_using_function_for_property_name(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
     public override async Task FirstOrDefault_over_scalar_projection_compared_to_null(bool async)
     {
@@ -2689,33 +2447,29 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
         AssertSql();
     }
 
-    public override Task Where_Contains_and_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Contains_and_comparison(a);
+    public override async Task Where_Contains_and_comparison(bool async)
+    {
+        await base.Where_Contains_and_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISSA", "WHITC") AND (c["City"] = "Seattle")))
 """);
-            });
+    }
 
-    public override Task Where_Contains_or_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_Contains_or_comparison(a);
+    public override async Task Where_Contains_or_comparison(bool async)
+    {
+        await base.Where_Contains_or_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISSA") OR (c["City"] = "Seattle")))
 """);
-            });
+    }
 
     public override async Task Where_Like_and_comparison(bool async)
     {
@@ -2731,278 +2485,240 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISS
         AssertSql();
     }
 
-    public override Task GetType_on_non_hierarchy1(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_on_non_hierarchy1(a);
+    public override async Task GetType_on_non_hierarchy1(bool async)
+    {
+        await base.GetType_on_non_hierarchy1(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task GetType_on_non_hierarchy2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_on_non_hierarchy2(a);
+    public override async Task GetType_on_non_hierarchy2(bool async)
+    {
+        await base.GetType_on_non_hierarchy2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """);
-            });
+    }
 
-    public override Task GetType_on_non_hierarchy3(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_on_non_hierarchy3(a);
+    public override async Task GetType_on_non_hierarchy3(bool async)
+    {
+        await base.GetType_on_non_hierarchy3(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND false)
 """);
-            });
+    }
 
-    public override Task GetType_on_non_hierarchy4(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.GetType_on_non_hierarchy4(a);
+    public override async Task GetType_on_non_hierarchy4(bool async)
+    {
+        await base.GetType_on_non_hierarchy4(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
-            });
+    }
 
-    public override Task Case_block_simplification_works_correctly(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Case_block_simplification_works_correctly(a);
+    public override async Task Case_block_simplification_works_correctly(bool async)
+    {
+        await base.Case_block_simplification_works_correctly(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] = null) ? "OR" : c["Region"]) = "OR"))
 """);
-            });
+    }
 
-    public override Task Where_compare_null_with_cast_to_object(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_compare_null_with_cast_to_object(a);
+    public override async Task Where_compare_null_with_cast_to_object(bool async)
+    {
+        await base.Where_compare_null_with_cast_to_object(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
-            });
+    }
 
-    public override Task Where_compare_with_both_cast_to_object(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_compare_with_both_cast_to_object(a);
+    public override async Task Where_compare_with_both_cast_to_object(bool async)
+    {
+        await base.Where_compare_with_both_cast_to_object(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
-    public override Task Where_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_projection(a);
+    public override async Task Where_projection(bool async)
+    {
+        await base.Where_projection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["CompanyName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
-            });
+    }
 
-    public override Task Enclosing_class_settable_member_generates_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Enclosing_class_settable_member_generates_parameter(a);
+    public override async Task Enclosing_class_settable_member_generates_parameter(bool async)
+    {
+        await base.Enclosing_class_settable_member_generates_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__SettableProperty_0='10274'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__SettableProperty_0))
 """,
-                    //
-                    """
+            //
+            """
 @__SettableProperty_0='10275'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__SettableProperty_0))
 """);
-            });
+    }
 
-    public override Task Enclosing_class_readonly_member_generates_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Enclosing_class_readonly_member_generates_parameter(a);
+    public override async Task Enclosing_class_readonly_member_generates_parameter(bool async)
+    {
+        await base.Enclosing_class_readonly_member_generates_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__ReadOnlyProperty_0='10275'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__ReadOnlyProperty_0))
 """);
-            });
+    }
 
-    public override Task Enclosing_class_const_member_does_not_generate_parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Enclosing_class_const_member_does_not_generate_parameter(a);
+    public override async Task Enclosing_class_const_member_does_not_generate_parameter(bool async)
+    {
+        await base.Enclosing_class_const_member_does_not_generate_parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10274))
 """);
-            });
+    }
 
-    public override Task Generic_Ilist_contains_translates_to_server(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Generic_Ilist_contains_translates_to_server(a);
+    public override async Task Generic_Ilist_contains_translates_to_server(bool async)
+    {
+        await base.Generic_Ilist_contains_translates_to_server(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("Seattle"))
 """);
-            });
+    }
 
-    public override Task Multiple_OrElse_on_same_column_converted_to_in_with_overlap(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Multiple_OrElse_on_same_column_converted_to_in_with_overlap(a);
+    public override async Task Multiple_OrElse_on_same_column_converted_to_in_with_overlap(bool async)
+    {
+        await base.Multiple_OrElse_on_same_column_converted_to_in_with_overlap(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")) OR (c["CustomerID"] = "ANATR")))
 """);
-            });
+    }
 
-    public override Task Multiple_OrElse_on_same_column_with_null_constant_comparison_converted_to_in(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Multiple_OrElse_on_same_column_with_null_constant_comparison_converted_to_in(a);
+    public override async Task Multiple_OrElse_on_same_column_with_null_constant_comparison_converted_to_in(bool async)
+    {
+        await base.Multiple_OrElse_on_same_column_with_null_constant_comparison_converted_to_in(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = null)) OR (c["Region"] = "BC")))
 """);
-            });
+    }
 
-    public override Task Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(a);
+    public override async Task Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(bool async)
+    {
+        await base.Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR (c["CustomerID"] = "ANTON")))
 """);
-            });
+    }
 
-    public override Task Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in_with_overlap(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in_with_overlap(a);
+    public override async Task Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in_with_overlap(bool async)
+    {
+        await base.Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in_with_overlap(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ANTON") OR c["CustomerID"] IN ("ALFKI", "ANATR")) OR (c["CustomerID"] = "ALFKI")))
 """);
-            });
+    }
 
-    public override Task Constant_array_Contains_OrElse_another_Contains_gets_combined_to_one_in_with_overlap(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Constant_array_Contains_OrElse_another_Contains_gets_combined_to_one_in_with_overlap(a);
+    public override async Task Constant_array_Contains_OrElse_another_Contains_gets_combined_to_one_in_with_overlap(bool async)
+    {
+        await base.Constant_array_Contains_OrElse_another_Contains_gets_combined_to_one_in_with_overlap(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR c["CustomerID"] IN ("ALFKI", "ANTON")))
 """);
-            });
+    }
 
-    public override Task Constant_array_Contains_AndAlso_another_Contains_gets_combined_to_one_in_with_overlap(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Constant_array_Contains_AndAlso_another_Contains_gets_combined_to_one_in_with_overlap(a);
+    public override async Task Constant_array_Contains_AndAlso_another_Contains_gets_combined_to_one_in_with_overlap(bool async)
+    {
+        await base.Constant_array_Contains_AndAlso_another_Contains_gets_combined_to_one_in_with_overlap(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] NOT IN ("ALFKI", "ANATR") AND c["CustomerID"] NOT IN ("ALFKI", "ANTON")))
 """);
-            });
+    }
 
-    public override Task Multiple_AndAlso_on_same_column_converted_to_in_using_parameters(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Multiple_AndAlso_on_same_column_converted_to_in_using_parameters(a);
+    public override async Task Multiple_AndAlso_on_same_column_converted_to_in_using_parameters(bool async)
+    {
+        await base.Multiple_AndAlso_on_same_column_converted_to_in_using_parameters(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm1_0='ALFKI'
 @__prm2_1='ANATR'
 @__prm3_2='ANTON'
@@ -3011,16 +2727,14 @@ SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] != @__prm1_0) AND (c["CustomerID"] != @__prm2_1)) AND (c["CustomerID"] != @__prm3_2)))
 """);
-            });
+    }
 
-    public override Task Array_of_parameters_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Array_of_parameters_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(a);
+    public override async Task Array_of_parameters_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(bool async)
+    {
+        await base.Array_of_parameters_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm1_0='ALFKI'
 @__prm2_1='ANATR'
 
@@ -3028,46 +2742,40 @@ SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN (@__prm1_0, @__prm2_1) OR (c["CustomerID"] = "ANTON")))
 """);
-            });
+    }
 
-    public override Task Multiple_OrElse_on_same_column_with_null_parameter_comparison_converted_to_in(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Multiple_OrElse_on_same_column_with_null_parameter_comparison_converted_to_in(a);
+    public override async Task Multiple_OrElse_on_same_column_with_null_parameter_comparison_converted_to_in(bool async)
+    {
+        await base.Multiple_OrElse_on_same_column_with_null_parameter_comparison_converted_to_in(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm_0=null
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = @__prm_0)) OR (c["Region"] = "BC")))
 """);
-            });
+    }
 
-    public override Task Parameter_array_Contains_OrElse_comparison_with_constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Parameter_array_Contains_OrElse_comparison_with_constant(a);
+    public override async Task Parameter_array_Contains_OrElse_comparison_with_constant(bool async)
+    {
+        await base.Parameter_array_Contains_OrElse_comparison_with_constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR (c["CustomerID"] = "ANTON")))
 """);
-            });
+    }
 
-    public override Task Parameter_array_Contains_OrElse_comparison_with_parameter_with_overlap(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Parameter_array_Contains_OrElse_comparison_with_parameter_with_overlap(a);
+    public override async Task Parameter_array_Contains_OrElse_comparison_with_parameter_with_overlap(bool async)
+    {
+        await base.Parameter_array_Contains_OrElse_comparison_with_parameter_with_overlap(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__prm1_0='ANTON'
 @__prm2_2='ALFKI'
 
@@ -3075,49 +2783,43 @@ SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = @__prm1_0) OR c["CustomerID"] IN ("ALFKI", "ANATR")) OR (c["CustomerID"] = @__prm2_2)))
 """);
-            });
+    }
 
-    public override Task Two_sets_of_comparison_combine_correctly(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Two_sets_of_comparison_combine_correctly(a);
+    public override async Task Two_sets_of_comparison_combine_correctly(bool async)
+    {
+        await base.Two_sets_of_comparison_combine_correctly(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") AND ((c["CustomerID"] = "ANATR") OR (c["CustomerID"] = "ANTON"))))
 """);
-            });
+    }
 
-    public override Task Two_sets_of_comparison_combine_correctly2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Two_sets_of_comparison_combine_correctly2(a);
+    public override async Task Two_sets_of_comparison_combine_correctly2(bool async)
+    {
+        await base.Two_sets_of_comparison_combine_correctly2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] != "WA") AND (c["Region"] != "OR")) AND (c["Region"] != null)) OR ((c["Region"] != "WA") AND (c["Region"] != null))))
 """);
-            });
+    }
 
-    public override Task Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(a);
+    public override async Task Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(bool async)
+    {
+        await base.Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
-            });
+    }
 
     public override async Task Where_nested_field_access_closure_via_query_cache_error_null(bool async)
     {
@@ -3133,28 +2835,24 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
         AssertSql();
     }
 
-    public override Task Where_simple_shadow_projection_mixed(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_simple_shadow_projection_mixed(a);
+    public override async Task Where_simple_shadow_projection_mixed(bool async)
+    {
+        await base.Where_simple_shadow_projection_mixed(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"e" : c, "Title" : c["Title"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
-            });
+    }
 
-    public override Task Where_primitive_tracked(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_primitive_tracked(a);
+    public override async Task Where_primitive_tracked(bool async)
+    {
+        await base.Where_primitive_tracked(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='9'
 
 SELECT c
@@ -3162,16 +2860,14 @@ FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Where_primitive_tracked2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_primitive_tracked2(a);
+    public override async Task Where_primitive_tracked2(bool async)
+    {
+        await base.Where_primitive_tracked2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='9'
 
 SELECT VALUE {"e" : c}
@@ -3179,89 +2875,79 @@ FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
-    public override Task Where_poco_closure(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_poco_closure(a);
+    public override async Task Where_poco_closure(bool async)
+    {
+        await base.Where_poco_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__entity_equality_customer_0_CustomerID='ALFKI'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_customer_0_CustomerID))
 """,
-                    //
-                    """
+            //
+            """
 @__entity_equality_customer_0_CustomerID='ANATR'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_customer_0_CustomerID))
 """);
-            });
+    }
 
-    public override Task Where_concat_string_string_comparison(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Where_concat_string_string_comparison(a);
+    public override async Task Where_concat_string_string_comparison(bool async)
+    {
+        await base.Where_concat_string_string_comparison(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__i_0='A'
 
 SELECT c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AALFKI"))
 """);
-            });
+    }
 
-    public override Task EF_Constant(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Constant(a);
+    public override async Task EF_Constant(bool async)
+    {
+        await base.EF_Constant(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task EF_Constant_with_subtree(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Constant_with_subtree(a);
+    public override async Task EF_Constant_with_subtree(bool async)
+    {
+        await base.EF_Constant_with_subtree(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+    }
 
-    public override Task EF_Constant_does_not_parameterized_as_part_of_bigger_subtree(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Constant_does_not_parameterized_as_part_of_bigger_subtree(a);
+    public override async Task EF_Constant_does_not_parameterized_as_part_of_bigger_subtree(bool async)
+    {
+        await base.EF_Constant_does_not_parameterized_as_part_of_bigger_subtree(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = ("ALF" || "KI")))
 """);
-            });
+    }
 
     public override async Task EF_Constant_with_non_evaluatable_argument_throws(bool async)
     {
@@ -3270,53 +2956,47 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = ("ALF" || "KI"))
         AssertSql();
     }
 
-    public override Task EF_Parameter(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Parameter(a);
+    public override async Task EF_Parameter(bool async)
+    {
+        await base.EF_Parameter(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='ALFKI'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 """);
-            });
+    }
 
-    public override Task EF_Parameter_with_subtree(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Parameter_with_subtree(a);
+    public override async Task EF_Parameter_with_subtree(bool async)
+    {
+        await base.EF_Parameter_with_subtree(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='ALFKI'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 """);
-            });
+    }
 
-    public override Task EF_Parameter_does_not_parameterized_as_part_of_bigger_subtree(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.EF_Parameter_does_not_parameterized_as_part_of_bigger_subtree(a);
+    public override async Task EF_Parameter_does_not_parameterized_as_part_of_bigger_subtree(bool async)
+    {
+        await base.EF_Parameter_does_not_parameterized_as_part_of_bigger_subtree(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__id_0='ALF'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = (@__id_0 || "KI")))
 """);
-            });
+    }
 
     public override async Task EF_Parameter_with_non_evaluatable_argument_throws(bool async)
     {
@@ -3325,83 +3005,79 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = (@__id_0 || "KI"
         AssertSql();
     }
 
-    public override Task Implicit_cast_in_predicate(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Implicit_cast_in_predicate(a);
+    public override async Task Implicit_cast_in_predicate(bool async)
+    {
+        await base.Implicit_cast_in_predicate(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
 """,
-                    //
-                    """
+            //
+            """
 @__prm_Value_0='1337'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__prm_Value_0))
 """,
-                    //
-                    """
+            //
+            """
 @__ToString_0='1337'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__ToString_0))
 """,
-                    //
-                    """
+            //
+            """
 @__p_0='1337'
 
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__p_0))
 """,
-                    //
-                    """
+            //
+            """
 SELECT c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
 """);
-            });
+    }
 
-    public override Task Interface_casting_though_generic_method(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Interface_casting_though_generic_method(a);
+    public override async Task Interface_casting_though_generic_method(bool async)
+    {
+        await base.Interface_casting_though_generic_method(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__id_0='10252'
 
 SELECT VALUE {"Id" : c["OrderID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__id_0))
 """,
-                    //
-                    """
+            //
+            """
 SELECT VALUE {"Id" : c["OrderID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
-                    //
-                    """
+            //
+            """
 SELECT VALUE {"Id" : c["OrderID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
-                    //
-                    """
+            //
+            """
 SELECT VALUE {"Id" : c["OrderID"]}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """);
-            });
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -23,123 +23,105 @@ public class OwnedQueryCosmosTest : OwnedQueryTestBase<OwnedQueryCosmosTest.Owne
         => base.Query_with_owned_entity_equality_operator(async);
 
     [ConditionalTheory(Skip = "Count #16146")]
-    public override Task Navigation_rewrite_on_owned_collection(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_collection(a);
+    public override async Task Navigation_rewrite_on_owned_collection(bool async)
+    {
+        await base.Navigation_rewrite_on_owned_collection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""LeafB"") OR ((c[""Discriminator""] = ""LeafA"") OR ((c[""Discriminator""] = ""Branch"") OR (c[""Discriminator""] = ""OwnedPerson""))))
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Issue#16926")]
-    public override Task Navigation_rewrite_on_owned_collection_with_composition(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_collection_with_composition(a);
+    public override async Task Navigation_rewrite_on_owned_collection_with_composition(bool async)
+    {
+        await base.Navigation_rewrite_on_owned_collection_with_composition(async);
 
-                AssertSql(" ");
-            });
+        AssertSql(" ");
+    }
 
     [ConditionalTheory(Skip = "Issue#16926")]
-    public override Task Navigation_rewrite_on_owned_collection_with_composition_complex(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_collection_with_composition_complex(a);
+    public override async Task Navigation_rewrite_on_owned_collection_with_composition_complex(bool async)
+    {
+        await base.Navigation_rewrite_on_owned_collection_with_composition_complex(async);
 
-                AssertSql(" ");
-            });
+        AssertSql(" ");
+    }
 
-    public override Task Navigation_rewrite_on_owned_reference_projecting_entity(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_reference_projecting_entity(a);
+    public override async Task Navigation_rewrite_on_owned_reference_projecting_entity(bool async)
+    {
+        await base.Navigation_rewrite_on_owned_reference_projecting_entity(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["Country"]["Name"] = "USA"))
 """);
-            });
+    }
 
-    public override Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_reference_projecting_scalar(a);
+    public override async Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool async)
+    {
+        await base.Navigation_rewrite_on_owned_reference_projecting_scalar(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["PersonAddress"]["Country"]["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["Country"]["Name"] = "USA"))
 """);
-            });
+    }
 
-    public override Task Query_for_base_type_loads_all_owned_navs(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Query_for_base_type_loads_all_owned_navs(a);
+    public override async Task Query_for_base_type_loads_all_owned_navs(bool async)
+    {
+        await base.Query_for_base_type_loads_all_owned_navs(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Query_for_branch_type_loads_all_owned_navs(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Query_for_branch_type_loads_all_owned_navs(a);
+    public override async Task Query_for_branch_type_loads_all_owned_navs(bool async)
+    {
+        await base.Query_for_branch_type_loads_all_owned_navs(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Branch", "LeafA")
 """);
-            });
+    }
 
-    public override Task Query_for_branch_type_loads_all_owned_navs_tracking(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Query_for_branch_type_loads_all_owned_navs_tracking(a);
+    public override async Task Query_for_branch_type_loads_all_owned_navs_tracking(bool async)
+    {
+        await base.Query_for_branch_type_loads_all_owned_navs_tracking(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("Branch", "LeafA")
 """);
-            });
+    }
 
-    public override Task Query_for_leaf_type_loads_all_owned_navs(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Query_for_leaf_type_loads_all_owned_navs(a);
+    public override async Task Query_for_leaf_type_loads_all_owned_navs(bool async)
+    {
+        await base.Query_for_leaf_type_loads_all_owned_navs(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "LeafA")
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "LeftJoin #17314")]
     public override Task Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(bool async)
@@ -207,19 +189,17 @@ WHERE (c["Discriminator"] = "LeafA")
     public override Task Query_with_owned_entity_equality_object_method(bool async)
         => base.Query_with_owned_entity_equality_object_method(async);
 
-    public override Task Query_with_OfType_eagerly_loads_correct_owned_navigations(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Query_with_OfType_eagerly_loads_correct_owned_navigations(a);
+    public override async Task Query_with_OfType_eagerly_loads_correct_owned_navigations(bool async)
+    {
+        await base.Query_with_OfType_eagerly_loads_correct_owned_navigations(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Discriminator"] = "LeafA"))
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Distinct ordering #16156")]
     public override Task Query_when_subquery(bool async)
@@ -261,89 +241,77 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
     public override Task GroupBy_with_multiple_aggregates_on_owned_navigation_properties(bool async)
         => base.GroupBy_with_multiple_aggregates_on_owned_navigation_properties(async);
 
-    public override Task Can_query_on_indexer_properties(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_on_indexer_properties(a);
+    public override async Task Can_query_on_indexer_properties(bool async)
+    {
+        await base.Can_query_on_indexer_properties(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Name"] = "Mona Cy"))
 """);
-            });
+    }
 
-    public override Task Can_query_on_owned_indexer_properties(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_on_owned_indexer_properties(a);
+    public override async Task Can_query_on_owned_indexer_properties(bool async)
+    {
+        await base.Can_query_on_owned_indexer_properties(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
-            });
+    }
 
-    public override Task Can_query_on_indexer_property_when_property_name_from_closure(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_on_indexer_property_when_property_name_from_closure(a);
+    public override async Task Can_query_on_indexer_property_when_property_name_from_closure(bool async)
+    {
+        await base.Can_query_on_indexer_property_when_property_name_from_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Name"] = "Mona Cy"))
 """);
-            });
+    }
 
-    public override Task Can_project_indexer_properties(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_project_indexer_properties(a);
+    public override async Task Can_project_indexer_properties(bool async)
+    {
+        await base.Can_project_indexer_properties(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Can_project_owned_indexer_properties(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_project_owned_indexer_properties(a);
+    public override async Task Can_project_owned_indexer_properties(bool async)
+    {
+        await base.Can_project_owned_indexer_properties(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["PersonAddress"]["AddressLine"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Can_project_indexer_properties_converted(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_project_indexer_properties_converted(a);
+    public override async Task Can_project_indexer_properties_converted(bool async)
+    {
+        await base.Can_project_indexer_properties_converted(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "OrderBy requires composite index #17246")]
     public override async Task Can_OrderBy_indexer_properties(bool async)
@@ -417,33 +385,29 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
         AssertSql(" ");
     }
 
-    public override Task Projecting_indexer_property_ignores_include(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projecting_indexer_property_ignores_include(a);
+    public override async Task Projecting_indexer_property_ignores_include(bool async)
+    {
+        await base.Projecting_indexer_property_ignores_include(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Nation" : c["PersonAddress"]["ZipCode"]}
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Projecting_indexer_property_ignores_include_converted(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projecting_indexer_property_ignores_include_converted(a);
+    public override async Task Projecting_indexer_property_ignores_include_converted(bool async)
+    {
+        await base.Projecting_indexer_property_ignores_include_converted(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT VALUE {"Nation" : c["PersonAddress"]["ZipCode"]}
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
     [ConditionalTheory(Skip = "Subquery #17246")]
     public override async Task Indexer_property_is_pushdown_into_subquery(bool isAsync)
@@ -516,73 +480,63 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
         AssertSql();
     }
 
-    public override Task Filter_on_indexer_using_closure(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_on_indexer_using_closure(a);
+    public override async Task Filter_on_indexer_using_closure(bool async)
+    {
+        await base.Filter_on_indexer_using_closure(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
-            });
+    }
 
-    public override Task Filter_on_indexer_using_function_argument(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Filter_on_indexer_using_function_argument(a);
+    public override async Task Filter_on_indexer_using_function_argument(bool async)
+    {
+        await base.Filter_on_indexer_using_function_argument(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
-            });
+    }
 
     public override Task Preserve_includes_when_applying_skip_take_after_anonymous_type_select(bool async)
         => AssertTranslationFailed(() => base.Preserve_includes_when_applying_skip_take_after_anonymous_type_select(async));
 
-    public override Task Can_project_owned_indexer_properties_converted(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_project_owned_indexer_properties_converted(a);
+    public override async Task Can_project_owned_indexer_properties_converted(bool async)
+    {
+        await base.Can_project_owned_indexer_properties_converted(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c["PersonAddress"]["AddressLine"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Can_query_owner_with_different_owned_types_having_same_property_name_in_hierarchy(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Can_query_owner_with_different_owned_types_having_same_property_name_in_hierarchy(a);
+    public override async Task Can_query_owner_with_different_owned_types_having_same_property_name_in_hierarchy(bool async)
+    {
+        await base.Can_query_owner_with_different_owned_types_having_same_property_name_in_hierarchy(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("HeliumBalloon", "HydrogenBalloon")
 """);
-            });
+    }
 
-    public override Task Client_method_skip_take_loads_owned_navigations_variation_2(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_skip_take_loads_owned_navigations_variation_2(a);
+    public override async Task Client_method_skip_take_loads_owned_navigations_variation_2(bool async)
+    {
+        await base.Client_method_skip_take_loads_owned_navigations_variation_2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='1'
 @__p_1='2'
 
@@ -592,16 +546,14 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-            });
+    }
 
-    public override Task Client_method_skip_take_loads_owned_navigations(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_skip_take_loads_owned_navigations(a);
+    public override async Task Client_method_skip_take_loads_owned_navigations(bool async)
+    {
+        await base.Client_method_skip_take_loads_owned_navigations(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='1'
 @__p_1='2'
 
@@ -611,92 +563,74 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
 OFFSET @__p_0 LIMIT @__p_1
 """);
-            });
+    }
 
     public override async Task Non_nullable_property_through_optional_navigation(bool async)
     {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await CosmosTestHelpers.Instance.NoSyncTest(
-                async, async a =>
-                {
-                    await base.Non_nullable_property_through_optional_navigation(a);
+        await base.Non_nullable_property_through_optional_navigation(async);
 
-                    AssertSql(
-                        """
+        AssertSql(
+            """
 SELECT c["Throned"]["Value"]
 FROM root c
 WHERE (c["Discriminator"] = "Barton")
 """);
-                });
-        }
     }
 
-    public override Task Owned_entity_without_owner_does_not_throw_for_identity_resolution(bool async, bool useAsTracking)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Owned_entity_without_owner_does_not_throw_for_identity_resolution(a, useAsTracking);
+    public override async Task Owned_entity_without_owner_does_not_throw_for_identity_resolution(bool async, bool useAsTracking)
+    {
+        await base.Owned_entity_without_owner_does_not_throw_for_identity_resolution(async, useAsTracking);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Simple_query_entity_with_owned_collection(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Simple_query_entity_with_owned_collection(a);
+    public override async Task Simple_query_entity_with_owned_collection(bool async)
+    {
+        await base.Simple_query_entity_with_owned_collection(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] = "Star")
 """);
-            });
+    }
 
-    public override Task Throw_for_owned_entities_without_owner_in_tracking_query(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Throw_for_owned_entities_without_owner_in_tracking_query(a);
+    public override async Task Throw_for_owned_entities_without_owner_in_tracking_query(bool async)
+    {
+        await base.Throw_for_owned_entities_without_owner_in_tracking_query(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
-            });
+    }
 
-    public override Task Unmapped_property_projection_loads_owned_navigations(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Unmapped_property_projection_loads_owned_navigations(a);
+    public override async Task Unmapped_property_projection_loads_owned_navigations(bool async)
+    {
+        await base.Unmapped_property_projection_loads_owned_navigations(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 SELECT c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Id"] = 1))
 """);
-            });
+    }
 
-    public override Task Client_method_take_loads_owned_navigations(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_take_loads_owned_navigations(a);
+    public override async Task Client_method_take_loads_owned_navigations(bool async)
+    {
+        await base.Client_method_take_loads_owned_navigations(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='2'
 
 SELECT c
@@ -705,18 +639,16 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public override Task Client_method_take_loads_owned_navigations_variation_2(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Client_method_take_loads_owned_navigations_variation_2(a);
+    public override async Task Client_method_take_loads_owned_navigations_variation_2(bool async)
+    {
+        await base.Client_method_take_loads_owned_navigations_variation_2(async);
 
-                AssertSql(
-                    """
+        AssertSql(
+            """
 @__p_0='2'
 
 SELECT c
@@ -725,7 +657,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
 OFFSET 0 LIMIT @__p_0
 """);
-            });
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
@@ -742,8 +674,9 @@ OFFSET 0 LIMIT @__p_0
             => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder.ConfigureWarnings(
-                w => w.Ignore(CosmosEventId.NoPartitionKeyDefined)));
+            => base.AddOptions(
+                builder.ConfigureWarnings(
+                    w => w.Ignore(CosmosEventId.NoPartitionKeyDefined)));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {

--- a/test/EFCore.Cosmos.FunctionalTests/QueryExpressionInterceptionWithDiagnosticsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/QueryExpressionInterceptionWithDiagnosticsCosmosTest.cs
@@ -10,15 +10,6 @@ public class QueryExpressionInterceptionWithDiagnosticsCosmosTest(
     : QueryExpressionInterceptionTestBase(fixture),
         IClassFixture<QueryExpressionInterceptionWithDiagnosticsCosmosTest.InterceptionCosmosFixture>
 {
-    public override Task Intercept_query_passively(bool async, bool inject)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Intercept_query_passively(a, inject));
-
-    public override Task Intercept_query_with_multiple_interceptors(bool async, bool inject)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Intercept_query_with_multiple_interceptors(a, inject));
-
-    public override Task Intercept_to_change_query_expression(bool async, bool inject)
-        => CosmosTestHelpers.Instance.NoSyncTest(async, a => base.Intercept_to_change_query_expression(a, inject));
-
     public class InterceptionCosmosFixture : InterceptionFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.Cosmos.FunctionalTests/Storage/CosmosDatabaseCreatorTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Storage/CosmosDatabaseCreatorTest.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Storage;
 
 #nullable disable
@@ -10,7 +13,7 @@ public class CosmosDatabaseCreatorTest
     public static IEnumerable<object[]> IsAsyncData = new object[][] { [false], [true] };
 
     [ConditionalFact]
-    public async Task EnsureCreated_returns_true_when_database_does_not_exist()
+    public async Task EnsureCreatedAsync_returns_true_when_database_does_not_exist()
     {
         await using var testDatabase = CosmosTestStore.Create("NonExisting");
         try
@@ -27,7 +30,7 @@ public class CosmosDatabaseCreatorTest
     }
 
     [ConditionalFact]
-    public async Task EnsureCreated_returns_true_when_database_exists_but_collections_do_not()
+    public async Task EnsureCreatedAsync_returns_true_when_database_exists_but_collections_do_not()
     {
         await using var testDatabase = CosmosTestStore.Create("EnsureCreatedTest");
         try
@@ -43,47 +46,58 @@ public class CosmosDatabaseCreatorTest
         }
     }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public Task EnsureCreated_returns_false_when_database_and_collections_exist(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await using var testDatabase = CosmosTestStore.Create("EnsureCreatedReady");
-                await testDatabase.InitializeAsync(
-                    testDatabase.ServiceProvider, testStore => new BloggingContext((CosmosTestStore)testStore));
+    [ConditionalFact]
+    public async Task EnsureCreatedAsync_returns_false_when_database_and_collections_exist()
+    {
+        await using var testDatabase = CosmosTestStore.Create("EnsureCreatedReady");
+        await testDatabase.InitializeAsync(
+            testDatabase.ServiceProvider, testStore => new BloggingContext((CosmosTestStore)testStore));
 
-                using var context = new BloggingContext(testDatabase);
-                var creator = context.GetService<IDatabaseCreator>();
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
 
-                Assert.False(a ? await creator.EnsureCreatedAsync() : creator.EnsureCreated());
-            });
+        Assert.False(await creator.EnsureCreatedAsync());
+    }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public Task EnsureDeleted_returns_true_when_database_exists(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await using var testDatabase = await CosmosTestStore.CreateInitializedAsync("EnsureDeleteBlogging");
-                using var context = new BloggingContext(testDatabase);
-                var creator = context.GetService<IDatabaseCreator>();
+    [ConditionalFact]
+    public async Task EnsureDeletedAsync_returns_true_when_database_exists()
+    {
+        await using var testDatabase = await CosmosTestStore.CreateInitializedAsync("EnsureDeleteBlogging");
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
 
-                Assert.True(a ? await creator.EnsureDeletedAsync() : creator.EnsureDeleted());
-            });
+        Assert.True(await creator.EnsureDeletedAsync());
+    }
 
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public Task EnsureDeleted_returns_false_when_database_does_not_exist(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await using var testDatabase = CosmosTestStore.Create("EnsureDeleteBlogging");
-                using var context = new BloggingContext(testDatabase);
-                var creator = context.GetService<IDatabaseCreator>();
+    [ConditionalFact]
+    public async Task EnsureDeletedAsync_returns_false_when_database_does_not_exist()
+    {
+        await using var testDatabase = CosmosTestStore.Create("EnsureDeleteBlogging");
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
 
-                Assert.False(a ? await creator.EnsureDeletedAsync() : creator.EnsureDeleted());
-            });
+        Assert.False(await creator.EnsureDeletedAsync());
+    }
+
+    [ConditionalFact]
+    public async Task EnsureDeleted_sync_is_not_supported()
+    {
+        await using var testDatabase = CosmosTestStore.Create("EnsureDeleteBlogging");
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
+
+        CosmosTestHelpers.Instance.AssertSyncNotSupported(() => creator.EnsureDeleted());
+    }
+
+    [ConditionalFact]
+    public async Task EnsureCreated_sync_is_not_supported()
+    {
+        await using var testDatabase = CosmosTestStore.Create("EnsureDeleteBlogging");
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
+
+        CosmosTestHelpers.Instance.AssertSyncNotSupported(() => creator.EnsureCreated());
+    }
 
     private class BloggingContext(CosmosTestStore testStore) : DbContext
     {

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosDbConfiguredConditionAttribute.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosDbConfiguredConditionAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -11,6 +12,6 @@ public class CosmosDbConfiguredConditionAttribute : Attribute, ITestCondition
     public string SkipReason
         => "Unable to connect to Cosmos DB. Please install/start the emulator service or configure a valid endpoint.";
 
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
         => CosmosTestStore.IsConnectionAvailableAsync();
 }

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
@@ -35,12 +35,12 @@ public class CosmosTestHelpers : TestHelpers
 
     public override LoggingDefinitions LoggingDefinitions { get; } = new CosmosLoggingDefinitions();
 
-    public async Task NoSyncTest(bool async, Func<bool, Task> testCode)
+    public async Task AssertSyncNotSupported(Func<Task> testCode)
     {
         try
         {
-            await testCode(async);
-            Assert.True(async);
+            await testCode();
+            Assert.Fail("Sync code did not fail.");
         }
         catch (InvalidOperationException e)
         {
@@ -48,8 +48,6 @@ public class CosmosTestHelpers : TestHelpers
             {
                 throw;
             }
-
-            Assert.False(async);
         }
         catch (DbUpdateException e)
         {
@@ -57,12 +55,10 @@ public class CosmosTestHelpers : TestHelpers
             {
                 throw;
             }
-
-            Assert.False(async);
         }
     }
 
-    public void NoSyncTest(Action testCode)
+    public void AssertSyncNotSupported(Action testCode)
     {
         try
         {

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/ITestCondition.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/ITestCondition.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit.Sdk;
+
 namespace Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 public interface ITestCondition
 {
-    ValueTask<bool> IsMetAsync();
+    ValueTask<bool> IsMetAsync(XunitTestCase testCase);
 
     string SkipReason { get; }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/PlatformSkipConditionAttribute.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/PlatformSkipConditionAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
@@ -10,7 +11,7 @@ public sealed class PlatformSkipConditionAttribute(TestPlatform excludedPlatform
 {
     private readonly TestPlatform _excludedPlatforms = excludedPlatforms;
 
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
         => new(CanRunOnThisPlatform(_excludedPlatforms));
 
     public string SkipReason { get; set; } = "Test cannot run on this platform.";

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/SkipSyncAttribute.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/SkipSyncAttribute.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+
+public class SkipSyncTestsAttribute : Attribute, ITestCondition
+{
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
+    {
+        if (testCase is not
+            {
+                Method: IMethodInfo method,
+                TestMethodArguments: object[] arguments
+            }
+            || method.GetParameters()?.ToList() is not { Count: > 0 } parameters)
+        {
+            return new(true);
+        }
+
+        var asyncParameterIndex = parameters.FindIndex(
+            p => p is { Name: "async", ParameterType: var parameterType }
+                && parameterType.ToRuntimeType() == typeof(bool));
+
+        return (asyncParameterIndex > -1
+            && arguments.Length >= asyncParameterIndex + 1
+            && arguments[asyncParameterIndex] is false)
+            ? new(false)
+            : new(true);
+    }
+
+    public string SkipReason
+        => "Synchronous I/O test skipped.";
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/XunitTestCaseExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/XunitTestCaseExtensions.cs
@@ -32,7 +32,7 @@ public static class XunitTestCaseExtensions
 
         foreach (var attribute in attributes)
         {
-            if (!await attribute.IsMetAsync())
+            if (!await attribute.IsMetAsync(testCase))
             {
                 skipReasons.Add(attribute.SkipReason);
             }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -11,7 +12,7 @@ public sealed class SqlServerConditionAttribute(SqlServerCondition conditions) :
 {
     public SqlServerCondition Conditions { get; set; } = conditions;
 
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
     {
         var isMet = true;
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConfiguredConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConfiguredConditionAttribute.cs
@@ -3,13 +3,14 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
 public sealed class SqlServerConfiguredConditionAttribute : Attribute, ITestCondition
 {
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
         => new(TestEnvironment.IsConfigured && (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !TestEnvironment.IsLocalDb));
 
     public string SkipReason

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SpatialiteRequiredAttribute.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SpatialiteRequiredAttribute.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -17,7 +18,7 @@ public sealed class SpatialiteRequiredAttribute : Attribute, ITestCondition
                 return SpatialiteLoader.TryLoad(connection);
             });
 
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
         => new(_loaded.Value);
 
     public string SkipReason

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteVersionConditionAttribute.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteVersionConditionAttribute.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -40,7 +41,7 @@ public sealed class SqliteVersionConditionAttribute : Attribute, ITestCondition
         }
     }
 
-    public ValueTask<bool> IsMetAsync()
+    public ValueTask<bool> IsMetAsync(XunitTestCase testCase)
     {
         if (Current == _skip)
         {


### PR DESCRIPTION
Re-push of #33756

https://github.com/dotnet/efcore/pull/33386 removed sync I/O support from Cosmos; the approach for the tests was to override e.g. all query tests, and introduce a special "NoSyncTest" wrapper to catch the special exception thrown when the test runs in the sync variant, and introduces is (async) checks in many tests. This forces us to deal with the sync case in each and every test.

This draft PR proposes to instead handle this via a simple [SkipSyncTests] attribute, which is used at the assembly level; if the test method being executed has a bool async parameter, and that parameter has a false argument, the test is skipped. We can then add a few targeted tests for the sync case which check that the appropriate exception is thrown.