### PR TITLE
Fix optimization of `CASE op WHEN`

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -498,9 +498,7 @@ public class SqlNullabilityProcessor
     /// <returns>An optimized sql expression.</returns>
     protected virtual SqlExpression VisitCase(CaseExpression caseExpression, bool allowOptimizedExpansion, out bool nullable)
     {
-        // if there is no 'else' there is a possibility of null, when none of the conditions are met
-        // otherwise the result is nullable if any of the WhenClause results OR ElseResult is nullable
-        nullable = caseExpression.ElseResult == null;
+        nullable = false;
         var currentNonNullableColumnsCount = _nonNullableColumns.Count;
         var currentNullValueColumnsCount = _nullValueColumns.Count;
 
@@ -558,6 +556,10 @@ public class SqlNullabilityProcessor
         {
             elseResult = Visit(caseExpression.ElseResult, out var elseResultNullable);
             nullable |= elseResultNullable;
+
+            // if there is no 'else' there is a possibility of null, when none of the conditions are met
+            // otherwise the result is nullable if any of the WhenClause results OR ElseResult is nullable
+            nullable |= elseResult == null;
         }
 
         RestoreNonNullableColumnsList(currentNonNullableColumnsCount);

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerObjectToStringTranslator.cs
@@ -82,13 +82,14 @@ public class SqlServerObjectToStringTranslator : IMethodCallTranslator
             if (instance is ColumnExpression { IsNullable: true })
             {
                 return _sqlExpressionFactory.Case(
+                    instance,
                     new[]
                     {
                         new CaseWhenClause(
-                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
+                            _sqlExpressionFactory.Constant(false),
                             _sqlExpressionFactory.Constant(false.ToString())),
                         new CaseWhenClause(
-                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(true)),
+                            _sqlExpressionFactory.Constant(true),
                             _sqlExpressionFactory.Constant(true.ToString()))
                     },
                     _sqlExpressionFactory.Constant(null, typeof(string)));
@@ -98,10 +99,10 @@ public class SqlServerObjectToStringTranslator : IMethodCallTranslator
                 new[]
                 {
                     new CaseWhenClause(
-                        _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
-                        _sqlExpressionFactory.Constant(false.ToString()))
+                        instance,
+                        _sqlExpressionFactory.Constant(true.ToString()))
                 },
-                _sqlExpressionFactory.Constant(true.ToString()));
+                _sqlExpressionFactory.Constant(false.ToString()));
         }
 
         return TypeMapping.TryGetValue(instance.Type, out var storeType)

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteObjectToStringTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteObjectToStringTranslator.cs
@@ -77,13 +77,14 @@ public class SqliteObjectToStringTranslator : IMethodCallTranslator
             if (instance is ColumnExpression { IsNullable: true })
             {
                 return _sqlExpressionFactory.Case(
+                    instance,
                     new[]
                     {
                         new CaseWhenClause(
-                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
+                            _sqlExpressionFactory.Constant(false),
                             _sqlExpressionFactory.Constant(false.ToString())),
                         new CaseWhenClause(
-                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(true)),
+                            _sqlExpressionFactory.Constant(true),
                             _sqlExpressionFactory.Constant(true.ToString()))
                     },
                     _sqlExpressionFactory.Constant(null, typeof(string)));
@@ -93,10 +94,10 @@ public class SqliteObjectToStringTranslator : IMethodCallTranslator
                 new[]
                 {
                     new CaseWhenClause(
-                        _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
-                        _sqlExpressionFactory.Constant(false.ToString()))
+                        instance,
+                        _sqlExpressionFactory.Constant(true.ToString()))
                 },
-                _sqlExpressionFactory.Constant(true.ToString()));
+                _sqlExpressionFactory.Constant(false.ToString()));
         }
 
         return TypeMapping.Contains(instance.Type)

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
@@ -129,6 +129,16 @@ public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<Nul
                 new CaseWhenClause(args[4], args[5]),
             ]))
         );
+
+        modelBuilder.HasDbFunction(
+            typeof(NullSemanticsQueryFixtureBase).GetMethod(nameof(BoolSwitch)),
+            b => b.HasTranslation(args => new CaseExpression(
+                operand: args[0],
+                [
+                    new CaseWhenClause(new SqlConstantExpression(true, typeMapping: BoolTypeMapping.Default), args[1]),
+                    new CaseWhenClause(new SqlConstantExpression(false, typeMapping: BoolTypeMapping.Default), args[2]),
+                ]))
+        );
     }
 
     public static int? Cases(bool c1, int v1, bool c2, int v2, bool c3, int v3) =>
@@ -136,4 +146,11 @@ public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<Nul
         c2 ? v2 :
         c3 ? v3 :
         null;
+
+    public static int BoolSwitch(bool x, int whenTrue, int whenFalse) =>
+        x switch
+        {
+            true => whenTrue,
+            false => whenFalse,
+        };
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1798,6 +1798,31 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task CaseOpWhen_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>()
+                .OrderBy(x => x.Id)
+                .Select(x => NullSemanticsQueryFixtureBase.BoolSwitch(
+                    x.StringA == "Foo", 3, 2
+                )),
+            assertOrder: true
+        );
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task CaseOpWhen_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>()
+                .Where(x => NullSemanticsQueryFixtureBase.BoolSwitch(
+                    x.StringA == "Foo", 3, 2
+                ) == 2),
+            assertOrder: true
+        );
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task False_compared_to_negated_is_null(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -4007,8 +4007,8 @@ FROM [Weapons] AS [w]
         AssertSql(
             """
 SELECT CASE
-    WHEN [w].[IsAutomatic] = CAST(0 AS bit) THEN N'False'
-    ELSE N'True'
+    WHEN [w].[IsAutomatic] = CAST(1 AS bit) THEN N'True'
+    ELSE N'False'
 END
 FROM [Weapons] AS [w]
 """);
@@ -4020,9 +4020,9 @@ FROM [Weapons] AS [w]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [f].[Eradicated] = CAST(0 AS bit) THEN N'False'
-    WHEN [f].[Eradicated] = CAST(1 AS bit) THEN N'True'
+SELECT CASE [f].[Eradicated]
+    WHEN CAST(0 AS bit) THEN N'False'
+    WHEN CAST(1 AS bit) THEN N'True'
     ELSE NULL
 END
 FROM [Factions] AS [f]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -1218,7 +1218,7 @@ OUTER APPLY (
     OUTER APPLY (
         SELECT [j].[Id], CAST(JSON_VALUE([o0].[value], '$.Date') AS datetime2) AS [Date], CAST(JSON_VALUE([o0].[value], '$.Enum') AS int) AS [Enum], JSON_QUERY([o0].[value], '$.Enums') AS [Enums], CAST(JSON_VALUE([o0].[value], '$.Fraction') AS decimal(18,2)) AS [Fraction], CAST(JSON_VALUE([o0].[value], '$.NullableEnum') AS int) AS [NullableEnum], JSON_QUERY([o0].[value], '$.NullableEnums') AS [NullableEnums], JSON_QUERY([o0].[value], '$.OwnedCollectionLeaf') AS [c], JSON_QUERY([o0].[value], '$.OwnedReferenceLeaf') AS [c0], [o0].[key], CAST([o0].[key] AS int) AS [c1]
         FROM OPENJSON(JSON_QUERY([o].[value], '$.OwnedCollectionBranch'), '$') AS [o0]
-        WHERE CAST(JSON_VALUE([o0].[value], '$.Date') AS datetime2) <> '2000-01-01T00:00:00.0000000' OR CAST(JSON_VALUE([o0].[value], '$.Date') AS datetime2) IS NULL
+        WHERE CAST(JSON_VALUE([o0].[value], '$.Date') AS datetime2) <> '2000-01-01T00:00:00.0000000'
     ) AS [o1]
 ) AS [s]
 ORDER BY [j].[Id], [s].[c1], [s].[key], [s].[c10]
@@ -1373,7 +1373,7 @@ OUTER APPLY (
     OUTER APPLY (
         SELECT [j].[Id], CAST(JSON_VALUE([o3].[value], '$.Date') AS datetime2) AS [Date], CAST(JSON_VALUE([o3].[value], '$.Enum') AS int) AS [Enum], JSON_QUERY([o3].[value], '$.Enums') AS [Enums], CAST(JSON_VALUE([o3].[value], '$.Fraction') AS decimal(18,2)) AS [Fraction], CAST(JSON_VALUE([o3].[value], '$.NullableEnum') AS int) AS [NullableEnum], JSON_QUERY([o3].[value], '$.NullableEnums') AS [NullableEnums], JSON_QUERY([o3].[value], '$.OwnedCollectionLeaf') AS [c], JSON_QUERY([o3].[value], '$.OwnedReferenceLeaf') AS [c0], [o3].[key], CAST([o3].[key] AS int) AS [c1]
         FROM OPENJSON(JSON_QUERY([o2].[value], '$.OwnedCollectionBranch'), '$') AS [o3]
-        WHERE CAST(JSON_VALUE([o3].[value], '$.Date') AS datetime2) <> '2000-01-01T00:00:00.0000000' OR CAST(JSON_VALUE([o3].[value], '$.Date') AS datetime2) IS NULL
+        WHERE CAST(JSON_VALUE([o3].[value], '$.Date') AS datetime2) <> '2000-01-01T00:00:00.0000000'
     ) AS [o5]
 ) AS [s]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2860,6 +2860,42 @@ ORDER BY [e].[Id]
 """);
     }
 
+    public override async Task CaseOpWhen_projection(bool async)
+    {
+        await base.CaseOpWhen_projection(async);
+
+        AssertSql(
+            """
+SELECT CASE CASE
+    WHEN [e].[StringA] = N'Foo' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+    WHEN 1 THEN 3
+    WHEN 0 THEN 2
+END
+FROM [Entities1] AS [e]
+ORDER BY [e].[Id]
+""");
+    }
+
+    public override async Task CaseOpWhen_predicate(bool async)
+    {
+        await base.CaseOpWhen_predicate(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE CASE CASE
+    WHEN [e].[StringA] = N'Foo' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+    WHEN 1 THEN 3
+    WHEN 0 THEN 2
+END = 2
+""");
+    }
+
     public override async Task Multiple_non_equality_comparisons_with_null_in_the_middle(bool async)
     {
         await base.Multiple_non_equality_comparisons_with_null_in_the_middle(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -12632,9 +12632,9 @@ GROUP BY [m].[CodeName]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [l].[Eradicated] = CAST(0 AS bit) THEN N'False'
-    WHEN [l].[Eradicated] = CAST(1 AS bit) THEN N'True'
+SELECT CASE [l].[Eradicated]
+    WHEN CAST(0 AS bit) THEN N'False'
+    WHEN CAST(1 AS bit) THEN N'True'
     ELSE NULL
 END
 FROM [LocustHordes] AS [l]
@@ -12693,8 +12693,8 @@ FROM [Weapons] AS [w]
         AssertSql(
             """
 SELECT CASE
-    WHEN [w].[IsAutomatic] = CAST(0 AS bit) THEN N'False'
-    ELSE N'True'
+    WHEN [w].[IsAutomatic] = CAST(1 AS bit) THEN N'True'
+    ELSE N'False'
 END
 FROM [Weapons] AS [w]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -10797,9 +10797,9 @@ GROUP BY [m].[CodeName]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [l].[Eradicated] = CAST(0 AS bit) THEN N'False'
-    WHEN [l].[Eradicated] = CAST(1 AS bit) THEN N'True'
+SELECT CASE [l].[Eradicated]
+    WHEN CAST(0 AS bit) THEN N'False'
+    WHEN CAST(1 AS bit) THEN N'True'
     ELSE NULL
 END
 FROM [Factions] AS [f]
@@ -10853,8 +10853,8 @@ FROM [Weapons] AS [w]
         AssertSql(
             """
 SELECT CASE
-    WHEN [w].[IsAutomatic] = CAST(0 AS bit) THEN N'False'
-    ELSE N'True'
+    WHEN [w].[IsAutomatic] = CAST(1 AS bit) THEN N'True'
+    ELSE N'False'
 END
 FROM [Weapons] AS [w]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -8259,9 +8259,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [f].[Eradicated] = CAST(0 AS bit) THEN N'False'
-    WHEN [f].[Eradicated] = CAST(1 AS bit) THEN N'True'
+SELECT CASE [f].[Eradicated]
+    WHEN CAST(0 AS bit) THEN N'False'
+    WHEN CAST(1 AS bit) THEN N'True'
     ELSE NULL
 END
 FROM [Factions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [f]
@@ -9192,8 +9192,8 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
         AssertSql(
             """
 SELECT CASE
-    WHEN [w].[IsAutomatic] = CAST(0 AS bit) THEN N'False'
-    ELSE N'True'
+    WHEN [w].[IsAutomatic] = CAST(1 AS bit) THEN N'True'
+    ELSE N'False'
 END
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -3187,8 +3187,8 @@ FROM "Weapons" AS "w"
         AssertSql(
             """
 SELECT CASE
-    WHEN NOT ("w"."IsAutomatic") THEN 'False'
-    ELSE 'True'
+    WHEN "w"."IsAutomatic" THEN 'True'
+    ELSE 'False'
 END
 FROM "Weapons" AS "w"
 """);
@@ -5994,9 +5994,9 @@ WHERE "g"."HasSoulPatch" AND (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN "f"."Eradicated" = 0 THEN 'False'
-    WHEN "f"."Eradicated" THEN 'True'
+SELECT CASE "f"."Eradicated"
+    WHEN 0 THEN 'False'
+    WHEN 1 THEN 'True'
     ELSE NULL
 END
 FROM "Factions" AS "f"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -256,6 +256,36 @@ ORDER BY "e"."Id"
 """);
     }
 
+    public override async Task CaseOpWhen_projection(bool async)
+    {
+        await base.CaseOpWhen_projection(async);
+
+        AssertSql(
+            """
+SELECT CASE "e"."StringA" = 'Foo'
+    WHEN 1 THEN 3
+    WHEN 0 THEN 2
+END
+FROM "Entities1" AS "e"
+ORDER BY "e"."Id"
+""");
+    }
+
+    public override async Task CaseOpWhen_predicate(bool async)
+    {
+        await base.CaseOpWhen_predicate(async);
+
+        AssertSql(
+            """
+SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
+FROM "Entities1" AS "e"
+WHERE CASE "e"."StringA" = 'Foo'
+    WHEN 1 THEN 3
+    WHEN 0 THEN 2
+END = 2
+""");
+    }
+
     public override async Task Bool_equal_nullable_bool_HasValue(bool async)
     {
         await base.Bool_equal_nullable_bool_HasValue(async);


### PR DESCRIPTION
The `CASE op WHEN ...` expression was incorrectly optimized as if it were a `CASE WHEN` expression if the test expressions contained a `TRUE` value.

This also makes it possible to use the `CASE op WHEN` expression to avoid duplicating some subexpressions in the translation of the bool to string conversion.

Fixes #33867.