### PR TITLE
Fix `unhex()` nullability

### DIFF
--- a/src/EFCore.Sqlite.Core/Extensions/SqliteDbFunctionsExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteDbFunctionsExtensions.cs
@@ -52,7 +52,7 @@ public static class SqliteDbFunctionsExtensions
     /// </remarks>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="value">The hexadecimal string.</param>
-    /// <returns>Decoded hexadecimal string as binary value.</returns>
+    /// <returns>Decoded hexadecimal string as binary value or <see langword="null" /> if <paramref name="value" /> is not an hexadecimal string.</returns>
     public static byte[]? Unhex(this DbFunctions _, string value)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Unhex)));
 
@@ -66,7 +66,10 @@ public static class SqliteDbFunctionsExtensions
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="value">The hexadecimal string.</param>
     /// <param name="ignoreChars">Characters that are ignored in <paramref name="value" />.</param>
-    /// <returns>Decoded hexadecimal string as binary value.</returns>
+    /// <returns>
+    ///     Decoded hexadecimal string as binary value or <see langword="null" /> if ignoring the characters from
+    ///     <paramref name="ignoreChars" /> in <paramref name="value" /> does not result in an hexadecimal string.
+    /// </returns>
     public static byte[]? Unhex(this DbFunctions _, string value, string ignoreChars)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Unhex)));
 

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteDbFunctionsExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteDbFunctionsExtensions.cs
@@ -53,7 +53,7 @@ public static class SqliteDbFunctionsExtensions
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="value">The hexadecimal string.</param>
     /// <returns>Decoded hexadecimal string as binary value.</returns>
-    public static byte[] Unhex(this DbFunctions _, string value)
+    public static byte[]? Unhex(this DbFunctions _, string value)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Unhex)));
 
     /// <summary>
@@ -67,7 +67,7 @@ public static class SqliteDbFunctionsExtensions
     /// <param name="value">The hexadecimal string.</param>
     /// <param name="ignoreChars">Characters that are ignored in <paramref name="value" />.</param>
     /// <returns>Decoded hexadecimal string as binary value.</returns>
-    public static byte[] Unhex(this DbFunctions _, string value, string ignoreChars)
+    public static byte[]? Unhex(this DbFunctions _, string value, string ignoreChars)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Unhex)));
 
     /// <summary>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -567,8 +567,19 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         bool isNullable)
         => typeMapping switch
         {
+            // In general unhex returns NULL whenever the decoding fails.
+            // In this case, assume that `expression` can only be a valid hex
+            // string (or NULL), hence the decoding cannot fail, i.e. unhex
+            // simply propagates the nullability from its argument.
+
             ByteArrayTypeMapping
-                => sqlExpressionFactory.Function("unhex", new[] { expression }, isNullable, new[] { true }, typeof(byte[]), typeMapping),
+                => sqlExpressionFactory.Function(
+                    "unhex",
+                    new[] { expression },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(byte[]),
+                    typeMapping),
 
             _ => expression
         };

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -568,9 +568,11 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         => typeMapping switch
         {
             // In general unhex returns NULL whenever the decoding fails.
-            // In this case, assume that `expression` can only be a valid hex
-            // string (or NULL), hence the decoding cannot fail, i.e. unhex
-            // simply propagates the nullability from its argument.
+            // In this case, we assume that the decoding cannot fail, because we
+            // rely on the user to correctly model the database schema and
+            // contents. Under this assumption, `expression` can only be a valid
+            // hex string or NULL, hence unhex simply propagates the nullability
+            // from its argument.
 
             ByteArrayTypeMapping
                 => sqlExpressionFactory.Function(

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteHexMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteHexMethodTranslator.cs
@@ -61,11 +61,13 @@ public class SqliteHexMethodTranslator : IMethodCallTranslator
         if (method.Equals(UnhexMethodInfo)
             || method.Equals(UnhexWithIgnoreCharsMethodInfo))
         {
+            // unhex returns NULL whenever the decoding fails, hence mark as
+            // nullable and use an all-false argumentsPropagateNullability
             return _sqlExpressionFactory.Function(
                 "unhex",
                 arguments.Skip(1),
                 nullable: true,
-                arguments.Skip(1).Select(_ => true).ToArray(),
+                argumentsPropagateNullability: arguments.Skip(1).Select(_ => false).ToArray(),
                 typeof(byte[]));
         }
 


### PR DESCRIPTION
Add a test for the computation of the nullability of `unhex()` and fix its implementation.

Fixes #33864.