### PR TITLE
Fix and enable `Bitwise_and_on_expression_with_like_and_null_check_being_compared_to_false`

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestModels.Operators;
@@ -30,7 +30,7 @@ public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
         return ctx.SaveChangesAsync();
     }
 
-    [ConditionalFact(Skip = "issue #30245")]
+    [ConditionalFact]
     public virtual async Task Bitwise_and_on_expression_with_like_and_null_check_being_compared_to_false()
     {
         var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);
@@ -40,6 +40,7 @@ public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
                         from o2 in ExpectedData.OperatorEntitiesString
                         from o3 in ExpectedData.OperatorEntitiesBool
                         where ((o2.Value == "B" || o3.Value) & (o1.Value != null))
+                        orderby o1.Id, o2.Id, o3.Id
                         select new
                         {
                             Value1 = o1.Value,
@@ -51,6 +52,7 @@ public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
                       from o2 in context.Set<OperatorEntityString>()
                       from o3 in context.Set<OperatorEntityBool>()
                       where ((EF.Functions.Like(o2.Value, "B") || o3.Value) & (o1.Value != null)) != false
+                      orderby o1.Id, o2.Id, o3.Id
                       select new
                       {
                           Value1 = o1.Value,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -19,7 +19,21 @@ public class OperatorsQuerySqlServerTest : OperatorsQueryTestBase
     {
         await base.Bitwise_and_on_expression_with_like_and_null_check_being_compared_to_false();
 
-        AssertSql("");
+        AssertSql(
+            """
+SELECT [o].[Value] AS [Value1], [o0].[Value] AS [Value2], [o1].[Value] AS [Value3]
+FROM [OperatorEntityString] AS [o]
+CROSS JOIN [OperatorEntityString] AS [o0]
+CROSS JOIN [OperatorEntityBool] AS [o1]
+WHERE CASE
+    WHEN ([o0].[Value] LIKE N'B' AND [o0].[Value] IS NOT NULL) OR [o1].[Value] = CAST(1 AS bit) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END & CASE
+    WHEN [o].[Value] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(1 AS bit)
+ORDER BY [o].[Id], [o0].[Id], [o1].[Id]
+""");
     }
 
     public override async Task Complex_predicate_with_bitwise_and_modulo_and_negation()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -25,13 +25,7 @@ SELECT [o].[Value] AS [Value1], [o0].[Value] AS [Value2], [o1].[Value] AS [Value
 FROM [OperatorEntityString] AS [o]
 CROSS JOIN [OperatorEntityString] AS [o0]
 CROSS JOIN [OperatorEntityBool] AS [o1]
-WHERE CASE
-    WHEN ([o0].[Value] LIKE N'B' AND [o0].[Value] IS NOT NULL) OR [o1].[Value] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END & CASE
-    WHEN [o].[Value] IS NOT NULL THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END = CAST(1 AS bit)
+WHERE (([o0].[Value] LIKE N'B' AND [o0].[Value] IS NOT NULL) OR [o1].[Value] = CAST(1 AS bit)) AND [o].[Value] IS NOT NULL
 ORDER BY [o].[Id], [o0].[Id], [o1].[Id]
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
@@ -23,7 +23,7 @@ SELECT "o"."Value" AS "Value1", "o0"."Value" AS "Value2", "o1"."Value" AS "Value
 FROM "OperatorEntityString" AS "o"
 CROSS JOIN "OperatorEntityString" AS "o0"
 CROSS JOIN "OperatorEntityBool" AS "o1"
-WHERE (("o0"."Value" LIKE 'B' AND "o0"."Value" IS NOT NULL) OR "o1"."Value") & ("o"."Value" IS NOT NULL)
+WHERE (("o0"."Value" LIKE 'B' AND "o0"."Value" IS NOT NULL) OR "o1"."Value") AND "o"."Value" IS NOT NULL
 ORDER BY "o"."Id", "o0"."Id", "o1"."Id"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
@@ -17,7 +17,15 @@ public class OperatorsQuerySqliteTest : OperatorsQueryTestBase
     {
         await base.Bitwise_and_on_expression_with_like_and_null_check_being_compared_to_false();
 
-        AssertSql("");
+        AssertSql(
+            """
+SELECT "o"."Value" AS "Value1", "o0"."Value" AS "Value2", "o1"."Value" AS "Value3"
+FROM "OperatorEntityString" AS "o"
+CROSS JOIN "OperatorEntityString" AS "o0"
+CROSS JOIN "OperatorEntityBool" AS "o1"
+WHERE (("o0"."Value" LIKE 'B' AND "o0"."Value" IS NOT NULL) OR "o1"."Value") & ("o"."Value" IS NOT NULL)
+ORDER BY "o"."Id", "o0"."Id", "o1"."Id"
+""");
     }
 
     public override async Task Complex_predicate_with_bitwise_and_modulo_and_negation()


### PR DESCRIPTION
The result ordering needs to be consistent; apart from that, the test already passes.