### PR TITLE
Fix SQL Server translation of `IndexOf`

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringMethodTranslator.cs
@@ -336,26 +336,30 @@ public class SqlServerStringMethodTranslator : IMethodCallTranslator
                 method.ReturnType);
         }
 
-        charIndexExpression = _sqlExpressionFactory.Subtract(charIndexExpression, _sqlExpressionFactory.Constant(1));
-
         // If the pattern is an empty string, we need to special case to always return 0 (since CHARINDEX return 0, which we'd subtract to
         // -1). Handle separately for constant and non-constant patterns.
-        if (searchExpression is SqlConstantExpression { Value : string constantSearchPattern })
+        if (searchExpression is SqlConstantExpression { Value: "" })
         {
-            return constantSearchPattern == string.Empty
-                ? _sqlExpressionFactory.Constant(0, typeof(int))
-                : charIndexExpression;
+            return _sqlExpressionFactory.Case(
+                [new(_sqlExpressionFactory.IsNotNull(instance), _sqlExpressionFactory.Constant(0))],
+                elseResult: null
+            );
         }
 
-        return _sqlExpressionFactory.Case(
-            new[]
-            {
-                new CaseWhenClause(
-                    _sqlExpressionFactory.Equal(
-                        searchExpression,
-                        _sqlExpressionFactory.Constant(string.Empty, stringTypeMapping)),
-                    _sqlExpressionFactory.Constant(0))
-            },
-            charIndexExpression);
+        SqlExpression offsetExpression = searchExpression is SqlConstantExpression
+            ? _sqlExpressionFactory.Constant(1)
+            : _sqlExpressionFactory.Case(
+                new[]
+                {
+                    new CaseWhenClause(
+                        _sqlExpressionFactory.Equal(
+                            searchExpression,
+                            _sqlExpressionFactory.Constant(string.Empty, stringTypeMapping)),
+                        _sqlExpressionFactory.Constant(0))
+                },
+                _sqlExpressionFactory.Constant(1));
+
+
+        return _sqlExpressionFactory.Subtract(charIndexExpression, offsetExpression);
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1107,7 +1107,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (LOWER(c["CustomerID"]) = "alfki"))
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "") = 0))
+WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["Region"], "") = 0))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1962,7 +1962,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT INDEX_OF(c["ContactName"], "") AS c
+SELECT INDEX_OF(c["Region"], "") AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -957,13 +957,13 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
                     || (e.NullableStringA != null && e.NullableStringA.IndexOf("oo") != e.NullableIntB)).Select(e => e.Id));
     }
 
-    [ConditionalTheory(Skip = "Issue #18773")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_IndexOf_empty(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.IndexOf("") == e.NullableIntA).Select(e => e.Id),
-            ss => ss.Set<NullSemanticsEntity1>().Where(e => 0 == e.NullableIntA).Select(e => e.Id));
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => 0 == e.NullableIntA || (e.NullableStringA == null && e.NullableIntA == null)).Select(e => e.Id));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1542,7 +1542,9 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
     public virtual Task Indexof_with_emptystring(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf(string.Empty) == 0));
+            ss => ss.Set<Customer>().Where(c => c.Region.IndexOf(string.Empty) == 0),
+            ss => ss.Set<Customer>().Where(c => c.Region != null && c.Region.IndexOf(string.Empty) == 0)
+        );
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1506,7 +1506,8 @@ public abstract class NorthwindSelectQueryTestBase<TFixture> : QueryTestBase<TFi
     public virtual Task Select_with_complex_expression_that_can_be_funcletized(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf("")),
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => (int?)c.Region.IndexOf("")),
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.Region == null ? default(int?) : c.Region.IndexOf("")),
             assertOrder: true);
 
     [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -2318,6 +2318,9 @@ WHERE [o].[CustomerID] = N'ALFKI' AND (CONVERT(nvarchar(max), [o].[OrderDate]) L
             """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+WHERE CASE
+    WHEN [c].[Region] IS NOT NULL THEN 0
+END = 0
 """);
     }
 
@@ -2343,9 +2346,9 @@ WHERE CHARINDEX(N'a', [c].[ContactName]) - 1 = 1
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CASE
+WHERE CHARINDEX(@__pattern_0, [c].[ContactName]) - CASE
     WHEN @__pattern_0 = N'' THEN 0
-    ELSE CHARINDEX(@__pattern_0, [c].[ContactName]) - 1
+    ELSE 1
 END = 1
 """);
     }
@@ -2791,9 +2794,9 @@ WHERE CHARINDEX('123', CONVERT(varchar(11), [o].[OrderID])) - 1 = -1
             """
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE CASE
+WHERE CHARINDEX(CONVERT(varchar(11), [o].[OrderID]), '123') - CASE
     WHEN CONVERT(varchar(11), [o].[OrderID]) = '' THEN 0
-    ELSE CHARINDEX(CONVERT(varchar(11), [o].[OrderID]), '123') - 1
+    ELSE 1
 END = -1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5762,9 +5762,9 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
 ) AS [c0]
-ORDER BY CASE
+ORDER BY CHARINDEX(@__searchTerm_0, [c0].[City]) - CASE
     WHEN @__searchTerm_0 = N'' THEN 0
-    ELSE CHARINDEX(@__searchTerm_0, [c0].[City]) - 1
+    ELSE 1
 END, [c0].[City]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1387,7 +1387,9 @@ CROSS APPLY (
 
         AssertSql(
             """
-SELECT 0
+SELECT CASE
+    WHEN [c].[Region] IS NOT NULL THEN 0
+END
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1631,7 +1631,15 @@ WHERE (CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1 <> [e].[Nullable
         await base.Where_IndexOf_empty(async);
 
         AssertSql(
-            @"");
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableStringA] IS NOT NULL THEN 0
+END = [e].[NullableIntA] OR (CASE
+    WHEN [e].[NullableStringA] IS NOT NULL THEN 0
+END IS NULL AND [e].[NullableIntA] IS NULL)
+""");
     }
 
     public override async Task Select_IndexOf(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -1021,7 +1021,7 @@ WHERE "c"."Region" IS NULL OR trim("c"."Region") = ''
             """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE instr("c"."ContactName", '') - 1 = 0
+WHERE instr("c"."Region", '') - 1 = 0
 """);
     }
 


### PR DESCRIPTION
This updates the translation of `IndexOf` on SQL Server so that it propagates nullability in the standard way.
This fixes the mismatch reported in https://github.com/dotnet/efcore/issues/18773#issuecomment-551286696 and effectively aligns it with the current behavior of the SQLite translation.

Fixes https://github.com/dotnet/efcore/issues/18773