### PR TITLE
[SMALL] Fix to #33886 - Query/Json: additional small fixes for JSON escaping

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -110,4 +110,10 @@ public class SqlServerSqlGenerationHelper : RelationalSqlGenerationHelper
     /// <returns>An SQL string to release the savepoint.</returns>
     public override string GenerateReleaseSavepointStatement(string name)
         => throw new NotSupportedException(SqlServerStrings.NoSavepointRelease);
+
+    /// <inheritdoc />
+    public override string DelimitJsonPathElement(string pathElement)
+        => !char.IsAsciiLetter(pathElement[0])
+            ? $"\"{EscapeJsonPathElement(pathElement)}\""
+            : base.DelimitJsonPathElement(pathElement);
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
@@ -14,7 +14,7 @@ public class JsonOwnedCustomNameRoot
 
     public int Number { get; set; }
 
-    [JsonPropertyName("CustomEnum")]
+    [JsonPropertyName("1CustomEnum")]
     public JsonEnum Enum { get; set; }
 
     [JsonPropertyName("Custom#OwnedReferenceBranch`-=[]\\;',./~!@#$%^&*()_+{}|:\"<>?独角兽π獨角獸")]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -213,7 +213,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-SELECT [j].[Id], CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomEnum') AS int) AS [Enum]
+SELECT [j].[Id], CAST(JSON_VALUE([j].[json_reference_custom_naming], '$."1CustomEnum"') AS int) AS [Enum]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }


### PR DESCRIPTION
SqlServer doesn't allow un-escaped json path to start with a number. Credit goes to @Charlieface who pointed out the problem.

Fixes #33886
