### PR TITLE
Add support for `object` in `SqlServerConvertTranslator`

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerConvertTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerConvertTranslator.cs
@@ -37,7 +37,8 @@ public class SqlServerConvertTranslator : IMethodCallTranslator
         typeof(int),
         typeof(long),
         typeof(short),
-        typeof(string)
+        typeof(string),
+        typeof(object)
     ];
 
     private static readonly MethodInfo[] SupportedMethods

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1312,6 +1312,7 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToBoolean(Convert.ToInt16(o.OrderID % 3)),
             o => Convert.ToBoolean(Convert.ToInt32(o.OrderID % 3)),
             o => Convert.ToBoolean(Convert.ToInt64(o.OrderID % 3)),
+            o => Convert.ToBoolean((object)Convert.ToInt32(o.OrderID % 3))
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1337,7 +1338,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToByte(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToByte(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToByte(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToByte(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToByte(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToByte((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1363,7 +1365,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToDecimal(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToDecimal(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToDecimal(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToDecimal(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToDecimal(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToDecimal((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1389,7 +1392,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToDouble(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToDouble(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToDouble(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToDouble(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToDouble(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToDouble((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1415,7 +1419,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToInt16(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToInt16(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToInt16(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToInt16(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToInt16(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToInt16((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1441,7 +1446,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToInt32(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToInt32(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToInt32(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToInt32(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToInt32(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToInt32((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1467,7 +1473,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToInt64(Convert.ToInt16(o.OrderID % 1)) >= 0,
             o => Convert.ToInt64(Convert.ToInt32(o.OrderID % 1)) >= 0,
             o => Convert.ToInt64(Convert.ToInt64(o.OrderID % 1)) >= 0,
-            o => Convert.ToInt64(Convert.ToString(o.OrderID % 1)) >= 0
+            o => Convert.ToInt64(Convert.ToString(o.OrderID % 1)) >= 0,
+            o => Convert.ToInt64((object)Convert.ToString(o.OrderID % 1)) >= 0
         };
 
         foreach (var convertMethod in convertMethods)
@@ -1494,6 +1501,7 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             o => Convert.ToString(Convert.ToInt32(o.OrderID % 1)) != "10",
             o => Convert.ToString(Convert.ToInt64(o.OrderID % 1)) != "10",
             o => Convert.ToString(Convert.ToString(o.OrderID % 1)) != "10",
+            o => Convert.ToString((object)Convert.ToString(o.OrderID % 1)) != "10",
             o => Convert.ToString(o.OrderDate.Value).Contains("1997") || Convert.ToString(o.OrderDate.Value).Contains("1998")
         };
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1833,6 +1833,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bit, CONVERT(int, [o].[OrderID] % 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bit, CONVERT(bigint, [o].[OrderID] % 3)) = CAST(1 AS bit)
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bit, CONVERT(int, [o].[OrderID] % 3)) = CAST(1 AS bit)
 """);
     }
 
@@ -1887,6 +1893,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(tinyint, CONVERT(int, [o].[OrderID
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(tinyint, CONVERT(bigint, [o].[OrderID] % 1)) >= CAST(0 AS tinyint)
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(tinyint, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= CAST(0 AS tinyint)
 """,
             //
             """
@@ -1953,6 +1965,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(decimal(18, 2), CONVERT(bigint, [o
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(decimal(18, 2), CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= 0.0
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(decimal(18, 2), CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= 0.0
 """);
     }
 
@@ -2007,6 +2025,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(float, CONVERT(int, [o].[OrderID] 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(float, CONVERT(bigint, [o].[OrderID] % 1)) >= 0.0E0
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(float, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= 0.0E0
 """,
             //
             """
@@ -2073,6 +2097,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(smallint, CONVERT(bigint, [o].[Ord
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(smallint, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= CAST(0 AS smallint)
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(smallint, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= CAST(0 AS smallint)
 """);
     }
 
@@ -2127,6 +2157,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(int, CONVERT(int, [o].[OrderID] % 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(int, CONVERT(bigint, [o].[OrderID] % 1)) >= 0
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(int, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= 0
 """,
             //
             """
@@ -2193,6 +2229,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bigint, CONVERT(bigint, [o].[Order
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bigint, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= CAST(0 AS bigint)
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(bigint, CONVERT(nvarchar(max), [o].[OrderID] % 1)) >= CAST(0 AS bigint)
 """);
     }
 
@@ -2247,6 +2289,12 @@ WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(nvarchar(max), CONVERT(int, [o].[O
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(nvarchar(max), CONVERT(bigint, [o].[OrderID] % 1)) <> N'10'
+""",
+            //
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI' AND CONVERT(nvarchar(max), CONVERT(nvarchar(max), [o].[OrderID] % 1)) <> N'10'
 """,
             //
             """


### PR DESCRIPTION
Fixes #30818

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Added support for `object` type arguments for Convert methods in `SqlServerConvertTranslator`

        Fixes #30818
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

