### PR TITLE
Work on Cosmos primitive collections, subquery and general query infra

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -38,14 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("CanConnectNotSupported");
 
         /// <summary>
-        ///     The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.
-        /// </summary>
-        public static string CannotTranslateNonConstantNewArrayExpression(object? newArrayExpression)
-            => string.Format(
-                GetString("CannotTranslateNonConstantNewArrayExpression", nameof(newArrayExpression)),
-                newArrayExpression);
-
-        /// <summary>
         ///     None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.
         /// </summary>
         public static string ConnectionInfoMissing
@@ -88,6 +80,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("ETagNonStringStoreType", nameof(property), nameof(entityType), nameof(propertyType)),
                 property, entityType, propertyType);
+
+        /// <summary>
+        ///     The 'Except()' LINQ operator isn't supported by Cosmos.
+        /// </summary>
+        public static string ExceptNotSupported
+            => GetString("ExceptNotSupported");
 
         /// <summary>
         ///     The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.
@@ -172,6 +170,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("NoIdProperty", nameof(entityType)),
                 entityType);
+
+        /// <summary>
+        ///     Cosmos subqueries must be correlated, referencing values from the outer query.
+        /// </summary>
+        public static string NonCorrelatedSubqueriesNotSupported
+            => GetString("NonCorrelatedSubqueriesNotSupported");
 
         /// <summary>
         ///     Including navigation '{navigation}' is not supported as the navigation is not embedded in same resource.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -123,9 +123,6 @@
   <data name="CanConnectNotSupported" xml:space="preserve">
     <value>The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.</value>
   </data>
-  <data name="CannotTranslateNonConstantNewArrayExpression" xml:space="preserve">
-    <value>The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.</value>
-  </data>
   <data name="ConnectionInfoMissing" xml:space="preserve">
     <value>None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.</value>
   </data>
@@ -143,6 +140,9 @@
   </data>
   <data name="ETagNonStringStoreType" xml:space="preserve">
     <value>The type of the etag property '{property}' on '{entityType}' is '{propertyType}'. All etag properties must be strings or have a string value converter.</value>
+  </data>
+  <data name="ExceptNotSupported" xml:space="preserve">
+    <value>The 'Except()' LINQ operator isn't supported by Cosmos.</value>
   </data>
   <data name="IdNonStringStoreType" xml:space="preserve">
     <value>The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.</value>
@@ -212,6 +212,9 @@
   </data>
   <data name="NoIdProperty" xml:space="preserve">
     <value>The entity type '{entityType}' does not have a property mapped to the 'id' property in the database. Add a property mapped to 'id'.</value>
+  </data>
+  <data name="NonCorrelatedSubqueriesNotSupported" xml:space="preserve">
+    <value>Cosmos subqueries must be correlated, referencing values from the outer query.</value>
   </data>
   <data name="NonEmbeddedIncludeNotSupported" xml:space="preserve">
     <value>Including navigation '{navigation}' is not supported as the navigation is not embedded in same resource.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryRootProcessor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryRootProcessor.cs
@@ -1,7 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
@@ -10,17 +9,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class FromSqlExpression(Type clrType, string sql, Expression arguments)
-    : Expression, IPrintableExpression
+public class CosmosQueryRootProcessor : QueryRootProcessor
 {
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public sealed override ExpressionType NodeType
-        => ExpressionType.Extension;
+    private readonly IModel _model;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,7 +19,11 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Sql { get; } = sql;
+    public CosmosQueryRootProcessor(QueryTranslationPreprocessorDependencies dependencies, QueryCompilationContext queryCompilationContext)
+        : base(dependencies, queryCompilationContext)
+    {
+        _model = queryCompilationContext.Model;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -36,7 +31,8 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Arguments { get; } = arguments;
+    protected override bool ShouldConvertToInlineQueryRoot(Expression expression)
+        => true;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -44,35 +40,17 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual FromSqlExpression Update(Expression arguments)
-        => arguments != Arguments
-            ? new FromSqlExpression(Type, Sql, arguments)
-            : this;
+    protected override bool ShouldConvertToParameterQueryRoot(ParameterExpression parameterExpression)
+        => true;
 
     /// <inheritdoc />
-    protected override Expression VisitChildren(ExpressionVisitor visitor)
-        => this;
+    protected override Expression VisitExtension(Expression node)
+        => node switch
+        {
+            // We skip FromSqlQueryRootExpression, since that contains the arguments as an object array parameter, and don't want to convert
+            // that to a query root
+            FromSqlQueryRootExpression e => e,
 
-    /// <inheritdoc />
-    public override Type Type { get; } = clrType;
-
-    /// <inheritdoc />
-    void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append(Sql);
-
-    /// <inheritdoc />
-    public override bool Equals(object? obj)
-        => obj != null
-            && (ReferenceEquals(this, obj)
-                || obj is FromSqlExpression fromSqlExpression
-                && Equals(fromSqlExpression));
-
-    private bool Equals(FromSqlExpression fromSqlExpression)
-        => base.Equals(fromSqlExpression)
-            && Sql == fromSqlExpression.Sql
-            && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
-
-    /// <inheritdoc />
-    public override int GetHashCode()
-        => HashCode.Combine(base.GetHashCode(), Sql);
+            _ => base.VisitExtension(node)
+        };
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessor.cs
@@ -27,4 +27,8 @@ public class CosmosQueryTranslationPreprocessor(
 
         return query;
     }
+
+    /// <inheritdoc />
+    protected override Expression ProcessQueryRoots(Expression expression)
+        => new CosmosQueryRootProcessor(Dependencies, QueryCompilationContext).Visit(expression);
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public static class CosmosQueryUtils
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryConvertToArray(
+        ShapedQueryExpression source,
+        ITypeMappingSource typeMappingSource,
+        [NotNullWhen(true)] out SqlExpression? array,
+        bool ignoreOrderings = false)
+        => TryConvertToArray(source, typeMappingSource, out array, out _, ignoreOrderings);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryConvertToArray(
+        ShapedQueryExpression source,
+        ITypeMappingSource typeMappingSource,
+        [NotNullWhen(true)] out SqlExpression? array,
+        [NotNullWhen(true)] out SqlExpression? projection,
+        bool ignoreOrderings = false)
+    {
+        if (TryExtractBareArray(source, out array, out var projectedScalar, ignoreOrderings))
+        {
+            projection = projectedScalar;
+            return true;
+        }
+
+        // Otherwise, wrap the subquery with an ARRAY() operator, converting the subquery to an array first.
+        if (source.QueryExpression is SelectExpression subquery
+            && TryGetProjection(source, out projection))
+        {
+            subquery.ApplyProjection();
+
+            // TODO: Should the type be an array, or enumerable/queryable?
+            var arrayClrType = projection.Type.MakeArrayType();
+            // TODO: Temporary hack - need to perform proper derivation of the array type mapping from the element (e.g. for
+            // value conversion).
+            var arrayTypeMapping = typeMappingSource.FindMapping(arrayClrType);
+
+            array = new ArrayExpression(subquery, arrayClrType, arrayTypeMapping);
+            return true;
+        }
+
+        array = null;
+        projection = null;
+        return false;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryExtractBareArray(
+        ShapedQueryExpression source,
+        [NotNullWhen(true)] out SqlExpression? array,
+        bool ignoreOrderings = false)
+        => TryExtractBareArray(source, out array, out _, ignoreOrderings);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryExtractBareArray(
+        ShapedQueryExpression source,
+        [NotNullWhen(true)] out SqlExpression? array,
+        [NotNullWhen(true)] out ScalarReferenceExpression? projectedScalarReference,
+        bool ignoreOrderings = false)
+    {
+        if (source.QueryExpression is not SelectExpression
+            {
+                Predicate: null,
+                IsDistinct: false,
+                Limit: null,
+                Offset: null
+            } select
+            || (!ignoreOrderings && select.Orderings.Count > 0)
+            || !TryGetProjection(source, out var projection)
+            || projection is not ScalarReferenceExpression scalarReferenceProjection)
+        {
+            array = null;
+            projectedScalarReference = null;
+            return false;
+        }
+
+        switch (source.QueryExpression)
+        {
+            // For properties: SELECT i FROM i IN c.SomeArray
+            // So just match any SelectExpression with IN.
+            case SelectExpression {
+                Sources: [{ WithIn: true, ContainerExpression: SqlExpression a } arraySource],
+            } when scalarReferenceProjection.Name == arraySource.Alias:
+            {
+                array = a;
+                projectedScalarReference = scalarReferenceProjection;
+                return true;
+            }
+
+            // For inline and parameter arrays the case is unfortunately more difficult; Cosmos doesn't allow SELECT i FROM i IN [1,2,3]
+            // or SELECT i FROM i IN @p.
+            // So we instead generate SELECT i FROM i IN (SELECT VALUE [1,2,3]), which needs to be match here.
+            case SelectExpression
+            {
+                Sources:
+                [
+                    {
+                        WithIn: true,
+                        ContainerExpression: SelectExpression
+                        {
+                            Sources: [],
+                            Predicate: null,
+                            Offset: null,
+                            Limit: null,
+                            Orderings: [],
+                            IsDistinct: false,
+                            UsesSingleValueProjection: true,
+                            Projection: [{Expression: SqlExpression a}]
+                        },
+                    } arraySource
+                ]
+            } when scalarReferenceProjection.Name == arraySource.Alias:
+            {
+                array = a;
+                projectedScalarReference = scalarReferenceProjection;
+                return true;
+            }
+
+            default:
+                array = null;
+                projectedScalarReference = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryGetProjection(
+        ShapedQueryExpression shapedQueryExpression,
+        [NotNullWhen(true)] out SqlExpression? projectedScalarReference)
+    {
+        var shaperExpression = shapedQueryExpression.ShaperExpression;
+        // No need to check ConvertChecked since this is convert node which we may have added during projection
+        if (shaperExpression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression
+            && unaryExpression.Operand.Type.IsNullableType()
+            && unaryExpression.Operand.Type.UnwrapNullableType() == unaryExpression.Type)
+        {
+            shaperExpression = unaryExpression.Operand;
+        }
+
+        if (shapedQueryExpression.QueryExpression is SelectExpression selectExpression
+            && shaperExpression is ProjectionBindingExpression { ProjectionMember: ProjectionMember projectionMember }
+            && selectExpression.GetMappedProjection(projectionMember) is SqlExpression projection)
+        {
+            projectedScalarReference = projection;
+            return true;
+        }
+
+        projectedScalarReference = null;
+        return false;
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -16,10 +16,12 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 {
     private readonly QueryCompilationContext _queryCompilationContext;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
+    private readonly ITypeMappingSource _typeMappingSource;
     private readonly IMemberTranslatorProvider _memberTranslatorProvider;
     private readonly IMethodCallTranslatorProvider _methodCallTranslatorProvider;
     private readonly CosmosSqlTranslatingExpressionVisitor _sqlTranslator;
     private readonly CosmosProjectionBindingExpressionVisitor _projectionBindingExpressionVisitor;
+    private readonly bool _subquery;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,21 +33,26 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
         QueryCompilationContext queryCompilationContext,
         ISqlExpressionFactory sqlExpressionFactory,
+        ITypeMappingSource typeMappingSource,
         IMemberTranslatorProvider memberTranslatorProvider,
         IMethodCallTranslatorProvider methodCallTranslatorProvider)
         : base(dependencies, queryCompilationContext, subquery: false)
     {
         _queryCompilationContext = queryCompilationContext;
         _sqlExpressionFactory = sqlExpressionFactory;
+        _typeMappingSource = typeMappingSource;
         _memberTranslatorProvider = memberTranslatorProvider;
         _methodCallTranslatorProvider = methodCallTranslatorProvider;
         _sqlTranslator = new CosmosSqlTranslatingExpressionVisitor(
             queryCompilationContext,
             _sqlExpressionFactory,
+            _typeMappingSource,
             _memberTranslatorProvider,
-            _methodCallTranslatorProvider);
+            _methodCallTranslatorProvider,
+            this);
         _projectionBindingExpressionVisitor =
             new CosmosProjectionBindingExpressionVisitor(_queryCompilationContext.Model, _sqlTranslator);
+        _subquery = false;
     }
 
     /// <summary>
@@ -60,15 +67,19 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     {
         _queryCompilationContext = parentVisitor._queryCompilationContext;
         _sqlExpressionFactory = parentVisitor._sqlExpressionFactory;
+        _typeMappingSource = parentVisitor._typeMappingSource;
         _memberTranslatorProvider = parentVisitor._memberTranslatorProvider;
         _methodCallTranslatorProvider = parentVisitor._methodCallTranslatorProvider;
         _sqlTranslator = new CosmosSqlTranslatingExpressionVisitor(
             QueryCompilationContext,
             _sqlExpressionFactory,
+            _typeMappingSource,
             _memberTranslatorProvider,
-            _methodCallTranslatorProvider);
+            _methodCallTranslatorProvider,
+            parentVisitor);
         _projectionBindingExpressionVisitor =
             new CosmosProjectionBindingExpressionVisitor(_queryCompilationContext.Model, _sqlTranslator);
+        _subquery = true;
     }
 
     /// <summary>
@@ -193,16 +204,23 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
     /// <inheritdoc />
     protected override Expression VisitExtension(Expression extensionExpression)
-        => extensionExpression switch
+    {
+        switch (extensionExpression)
         {
-            FromSqlQueryRootExpression fromSqlQueryRootExpression
-                => CreateShapedQueryExpression(
+            case EntityQueryRootExpression when _subquery:
+                AddTranslationErrorDetails(CosmosStrings.NonCorrelatedSubqueriesNotSupported);
+                return QueryCompilationContext.NotTranslatedExpression;
+
+            case FromSqlQueryRootExpression fromSqlQueryRootExpression:
+                return CreateShapedQueryExpression(
                     fromSqlQueryRootExpression.EntityType,
                     _sqlExpressionFactory.Select(
-                        fromSqlQueryRootExpression.EntityType, fromSqlQueryRootExpression.Sql, fromSqlQueryRootExpression.Argument)),
+                        fromSqlQueryRootExpression.EntityType, fromSqlQueryRootExpression.Sql, fromSqlQueryRootExpression.Argument));
 
-            _ => base.VisitExtension(extensionExpression)
-        };
+            default:
+                return base.VisitExtension(extensionExpression);
+        }
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -219,8 +237,17 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override ShapedQueryExpression TranslateSubquery(Expression expression)
-        => throw new InvalidOperationException(CoreStrings.TranslationFailed(expression.Print()));
+    public override ShapedQueryExpression? TranslateSubquery(Expression expression)
+    {
+        var subqueryVisitor = CreateSubqueryVisitor();
+        var translation = subqueryVisitor.Translate(expression) as ShapedQueryExpression;
+        if (translation == null && subqueryVisitor.TranslationErrorDetails != null)
+        {
+            AddTranslationErrorDetails(subqueryVisitor.TranslationErrorDetails);
+        }
+
+        return translation;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -255,7 +282,34 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateAny(ShapedQueryExpression source, LambdaExpression? predicate)
-        => null;
+    {
+        if (predicate != null)
+        {
+            var translatedSource = TranslateWhere(source, predicate);
+            if (translatedSource == null)
+            {
+                return null;
+            }
+
+            source = translatedSource;
+        }
+
+        var subquery = (SelectExpression)source.QueryExpression;
+        subquery.ClearProjection();
+        subquery.ApplyProjection();
+        if (subquery.Limit == null
+            && subquery.Offset == null)
+        {
+            subquery.ClearOrdering();
+        }
+
+        var translation = _sqlExpressionFactory.Exists(subquery);
+        var selectExpression = new SelectExpression(subquery.Container, translation);
+
+        return source.Update(
+            selectExpression,
+            Expression.Convert(new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(bool?)), typeof(bool)));
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -302,7 +356,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateConcat(ShapedQueryExpression source1, ShapedQueryExpression source2)
-        => null;
+        => TranslateSetOperation(source1, source2, "ARRAY_CONCAT");
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -311,7 +365,26 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateContains(ShapedQueryExpression source, Expression item)
-        => null;
+    {
+        // Simplify x.Array.Contains[1] => ARRAY_CONTAINS(x.Array, 1) insert of IN+subquery
+        if (CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true)
+            && TranslateExpression(item) is SqlExpression translatedItem
+            && source.QueryExpression is SelectExpression { Container: var container })
+        {
+            if (array is ArrayConstantExpression arrayConstant)
+            {
+                var inExpression = _sqlExpressionFactory.In(translatedItem, arrayConstant.Items);
+                return source.Update(new SelectExpression(container, inExpression), source.ShaperExpression);
+            }
+
+            (translatedItem, array) = _sqlExpressionFactory.ApplyTypeMappingsOnItemAndArray(translatedItem, array);
+            var simplifiedTranslation = _sqlExpressionFactory.Function("ARRAY_CONTAINS", new[] { array, translatedItem }, typeof(bool));
+            return source.UpdateQueryExpression(new SelectExpression(container, simplifiedTranslation));
+        }
+
+        // TODO: Translation to IN, with scalars and with subquery
+        return null;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -321,6 +394,15 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     /// </summary>
     protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
     {
+        // Simplify x.Array.Count() => ARRAY_LENGTH(x.Array) instead of (SELECT COUNT(1) FROM i IN x.Array))
+        if (predicate is null
+            && CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true)
+            && source.QueryExpression is SelectExpression { Container: var container })
+        {
+            var simplifiedTranslation = _sqlExpressionFactory.Function("ARRAY_LENGTH", new[] { array }, typeof(int));
+            return source.UpdateQueryExpression(new SelectExpression(container, simplifiedTranslation));
+        }
+
         var selectExpression = (SelectExpression)source.QueryExpression;
         if (selectExpression.IsDistinct
             || selectExpression.Limit != null
@@ -384,7 +466,22 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         ShapedQueryExpression source,
         Expression index,
         bool returnDefault)
-        => null;
+    {
+        // Simplify x.Array[1] => x.Array[1] (using the Cosmos array subscript operator) instead of a subquery with LIMIT/OFFSET
+        if (!returnDefault
+            && CosmosQueryUtils.TryExtractBareArray(source, out var array, out var projectedScalarReference)
+            && TranslateExpression(index) is { } translatedIndex
+            && source.QueryExpression is SelectExpression { Container: var container })
+        {
+            var arrayIndex = _sqlExpressionFactory.ArrayIndex(
+                array, translatedIndex, projectedScalarReference.Type, projectedScalarReference.TypeMapping);
+            return source.UpdateQueryExpression(new SelectExpression(container, arrayIndex));
+        }
+
+        // Note that Cosmos doesn't support OFFSET/LIMIT in subqueries, so this translation is for top-level entity querying only.
+        // TODO: Translate with OFFSET/LIMIT
+        return null;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -393,7 +490,10 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateExcept(ShapedQueryExpression source1, ShapedQueryExpression source2)
-        => null;
+    {
+        AddTranslationErrorDetails(CosmosStrings.ExceptNotSupported);
+        return null;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -464,7 +564,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateIntersect(ShapedQueryExpression source1, ShapedQueryExpression source2)
-        => null;
+        => TranslateSetOperation(source1, source2, "SetIntersect", ignoreOrderings: true);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -808,7 +908,11 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
         if (translation != null)
         {
-            if (selectExpression.Orderings.Count == 0)
+            // Ordering of documents is not guaranteed in Cosmos, so we warn for Skip without OrderBy.
+            // However, when querying on JSON arrays within documents, the order of elements is guaranteed, and Skip without OrderBy is
+            // fine. Since subqueries must be correlated (i.e. reference an array in the outer query), we use that to decide whether to
+            // warn or not.
+            if (selectExpression.Orderings.Count == 0 && !_subquery)
             {
                 _queryCompilationContext.Logger.RowLimitingOperationWithoutOrderByWarning();
             }
@@ -872,7 +976,11 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
         if (translation != null)
         {
-            if (selectExpression.Orderings.Count == 0)
+            // Ordering of documents is not guaranteed in Cosmos, so we warn for Take without OrderBy.
+            // However, when querying on JSON arrays within documents, the order of elements is guaranteed, and Take without OrderBy is
+            // fine. Since subqueries must be correlated (i.e. reference an array in the outer query), we use that to decide whether to
+            // warn or not.
+            if (selectExpression.Orderings.Count == 0 && !_subquery)
             {
                 _queryCompilationContext.Logger.RowLimitingOperationWithoutOrderByWarning();
             }
@@ -919,7 +1027,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2)
-        => null;
+        => TranslateSetOperation(source1, source2, "SetUnion", ignoreOrderings: true);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1075,6 +1183,168 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
             return property != null && entityType.GetPartitionKeyPropertyNames().Contains(property.Name);
         }
+    }
+
+    #region Queryable collection support
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateMemberAccess(Expression source, MemberIdentity member)
+    {
+        // TODO: the below immediately wraps the JSON array property in a subquery (SELECT VALUE i FROM i IN c.Array).
+        // TODO: This isn't strictly necessary, as c.Array can be referenced directly; however, that would mean producing a
+        // TODO: ShapedQueryExpression that doesn't wrap a SelectExpression, but rather a KeyAccessExpression directly; this isn't currently
+        // TODO: supported.
+
+        // Attempt to translate access into a primitive collection property
+        if (_sqlTranslator.TryBindMember(_sqlTranslator.Visit(source), member, out var translatedExpression, out var property)
+            && property is IProperty { IsPrimitiveCollection: true }
+            && translatedExpression is SqlExpression sqlExpression
+            && WrapPrimitiveCollectionAsShapedQuery(
+                sqlExpression,
+                sqlExpression.Type.GetSequenceType(),
+                sqlExpression.TypeMapping!.ElementTypeMapping!) is { } primitiveCollectionTranslation)
+        {
+            return primitiveCollectionTranslation;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateInlineQueryRoot(InlineQueryRootExpression inlineQueryRootExpression)
+    {
+        // The below produces an InlineArrayExpression ([1,2,3]), wrapped by a SelectExpression (SELECT VALUE [1,2,3]).
+        // This is because a bare inline array can only appear in the projection. For example, the following is wrong:
+        // SELECT i FROM i IN [1,2,3] (syntax error)
+        var values = inlineQueryRootExpression.Values;
+        var translatedItems = new SqlExpression[values.Count];
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (TranslateExpression(values[i]) is not SqlExpression translatedItem)
+            {
+                return null;
+            }
+
+            translatedItems[i] = translatedItem;
+        }
+
+        // TODO: Do we need full-on type mapping inference like in relational?
+        // TODO: The following currently just gets the type mapping from the CLR type, which ignores e.g. value converters on
+        // TODO: properties compared against
+        var elementClrType = inlineQueryRootExpression.ElementType;
+        var elementTypeMapping = _typeMappingSource.FindMapping(elementClrType)!;
+        var arrayTypeMapping = _typeMappingSource.FindMapping(elementClrType.MakeArrayType()); // TODO: IEnumerable?
+        var inlineArray = new ArrayConstantExpression(elementClrType, translatedItems, arrayTypeMapping);
+
+        // Unfortunately, Cosmos doesn't support selecting directly from an inline array: SELECT i FROM i IN [1,2,3] (syntax error)
+        // We must wrap the inline array in a subquery: SELECT VALUE i FROM (SELECT VALUE [1,2,3])
+        var innerSelect = new SelectExpression(
+            [new ProjectionExpression(inlineArray, null!)],
+            sources: [],
+            orderings: [],
+            container: null!)
+        {
+            UsesSingleValueProjection = true
+        };
+
+        return WrapPrimitiveCollectionAsShapedQuery(innerSelect, elementClrType, elementTypeMapping);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateParameterQueryRoot(ParameterQueryRootExpression parameterQueryRootExpression)
+    {
+        if (parameterQueryRootExpression.ParameterExpression.Name?.StartsWith(
+                QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal)
+            != true)
+        {
+            return null;
+        }
+
+        // TODO: Do we need full-on type mapping inference like in relational?
+        // TODO: The following currently just gets the type mapping from the CLR type, which ignores e.g. value converters on
+        // TODO: properties compared against
+        var elementClrType = parameterQueryRootExpression.ElementType;
+        var arrayTypeMapping = _typeMappingSource.FindMapping(elementClrType.MakeArrayType()); // TODO: IEnumerable?
+        var elementTypeMapping = _typeMappingSource.FindMapping(elementClrType)!;
+        var sqlParameterExpression = new SqlParameterExpression(parameterQueryRootExpression.ParameterExpression, arrayTypeMapping);
+
+        // Unfortunately, Cosmos doesn't support selecting directly from an inline array: SELECT i FROM i IN [1,2,3] (syntax error)
+        // We must wrap the inline array in a subquery: SELECT VALUE i FROM (SELECT VALUE [1,2,3])
+        var innerSelect = new SelectExpression(
+            [new ProjectionExpression(sqlParameterExpression, null!)],
+            sources: [],
+            orderings: [],
+            container: null!)
+        {
+            UsesSingleValueProjection = true
+        };
+
+        return WrapPrimitiveCollectionAsShapedQuery(innerSelect, elementClrType, elementTypeMapping);
+    }
+
+    private ShapedQueryExpression WrapPrimitiveCollectionAsShapedQuery(
+        Expression containerExpression,
+        Type elementClrType,
+        CoreTypeMapping elementTypeMapping)
+    {
+        // TODO: Do proper alias management: #33894
+        var selectExpression = SelectExpression.CreateForPrimitiveCollection(
+            new SourceExpression(containerExpression, "i", withIn: true),
+            elementClrType,
+            elementTypeMapping);
+        var shaperExpression = (Expression)new ProjectionBindingExpression(
+            selectExpression, new ProjectionMember(), elementClrType.MakeNullable());
+        if (shaperExpression.Type != elementClrType)
+        {
+            Check.DebugAssert(
+                elementClrType.MakeNullable() == shaperExpression.Type,
+                "expression.Type must be nullable of targetType");
+
+            shaperExpression = Expression.Convert(shaperExpression, elementClrType);
+        }
+
+        return new ShapedQueryExpression(selectExpression, shaperExpression);
+    }
+
+    #endregion Queryable collection support
+
+    private ShapedQueryExpression? TranslateSetOperation(
+        ShapedQueryExpression source1,
+        ShapedQueryExpression source2,
+        string functionName,
+        bool ignoreOrderings = false)
+    {
+        if (CosmosQueryUtils.TryConvertToArray(source1, _typeMappingSource, out var array1, out var projection1, ignoreOrderings)
+            && CosmosQueryUtils.TryConvertToArray(source2, _typeMappingSource, out var array2, out var projection2, ignoreOrderings)
+            && projection1.Type == projection2.Type
+            && (projection1.TypeMapping ?? projection2.TypeMapping) is CoreTypeMapping typeMapping)
+        {
+            var translation = _sqlExpressionFactory.Function(functionName, [array1, array2], projection1.Type, typeMapping);
+            var select = SelectExpression.CreateForPrimitiveCollection(
+                new SourceExpression(translation, "i", withIn: true),
+                projection1.Type,
+                typeMapping);
+            return source1.UpdateQueryExpression(select);
+        }
+
+        // TODO: can also handle subqueries via ARRAY()
+        return null;
     }
 
     private SqlExpression? TranslateExpression(Expression expression)

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 public class CosmosQueryableMethodTranslatingExpressionVisitorFactory(
     QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
     ISqlExpressionFactory sqlExpressionFactory,
+    ITypeMappingSource typeMappingSource,
     IMemberTranslatorProvider memberTranslatorProvider,
     IMethodCallTranslatorProvider methodCallTranslatorProvider)
     : IQueryableMethodTranslatingExpressionVisitorFactory
@@ -32,6 +33,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitorFactory(
             Dependencies,
             queryCompilationContext,
             sqlExpressionFactory,
+            typeMappingSource,
             memberTranslatorProvider,
             methodCallTranslatorProvider);
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -106,7 +106,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                                     _ownerMappings[accessExpression] =
                                         (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
                                     break;
-                                case RootReferenceExpression:
+                                case ObjectReferenceExpression:
                                     innerAccessExpression = jObjectParameter;
                                     break;
                                 default:
@@ -623,9 +623,9 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
                             ownerJObjectExpression = ownerInfo.JObjectExpression;
                         }
-                        else if (jObjectExpression is RootReferenceExpression rootReferenceExpression)
+                        else if (jObjectExpression is ObjectReferenceExpression objectReferenceExpression)
                         {
-                            ownerJObjectExpression = rootReferenceExpression;
+                            ownerJObjectExpression = objectReferenceExpression;
                         }
                         else if (jObjectExpression is ObjectAccessExpression objectAccessExpression)
                         {
@@ -691,10 +691,10 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             {
                 innerExpression = innerVariable;
             }
-            else if (jObjectExpression is RootReferenceExpression rootReferenceExpression)
+            else if (jObjectExpression is ObjectReferenceExpression objectReferenceExpression)
             {
                 innerExpression = CreateGetValueExpression(
-                    jObjectParameter, rootReferenceExpression.Alias, typeof(JObject));
+                    jObjectParameter, objectReferenceExpression.Name, typeof(JObject));
             }
             else if (jObjectExpression is ObjectAccessExpression objectAccessExpression)
             {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
@@ -45,8 +45,13 @@ public class CosmosValueConverterCompensatingExpressionVisitor(ISqlExpressionFac
             changed |= updatedProjection != item;
         }
 
-        var fromExpression = (RootReferenceExpression)Visit(selectExpression.FromExpression);
-        changed |= fromExpression != selectExpression.FromExpression;
+        var sources = new List<SourceExpression>();
+        foreach (var item in selectExpression.Sources)
+        {
+            var updatedSource = (SourceExpression)Visit(item);
+            sources.Add(updatedSource);
+            changed |= updatedSource != item;
+        }
 
         var predicate = TryCompensateForBoolWithValueConverter((SqlExpression?)Visit(selectExpression.Predicate));
         changed |= predicate != selectExpression.Predicate;
@@ -63,7 +68,7 @@ public class CosmosValueConverterCompensatingExpressionVisitor(ISqlExpressionFac
         var offset = (SqlExpression?)Visit(selectExpression.Offset);
 
         return changed
-            ? selectExpression.Update(projections, fromExpression, predicate, orderings, limit, offset)
+            ? selectExpression.Update(projections, sources, predicate, orderings, limit, offset)
             : selectExpression;
     }
 

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ArrayConstantExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ArrayConstantExpression.cs
@@ -1,17 +1,22 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
+///     Represents an inline array in a Cosmos SQL query, e.g. [1, 2, c.Id].
+/// </summary>
+/// <seealso href="https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/constants">CosmosDB constant expressions</seealso>
+/// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-/// </summary>
-public class FromSqlExpression(Type clrType, string sql, Expression arguments)
-    : Expression, IPrintableExpression
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class ArrayConstantExpression(Type elementClrType, IReadOnlyList<SqlExpression> items, CoreTypeMapping? typeMapping = null)
+    : SqlExpression(typeof(IEnumerable<>).MakeGenericType(elementClrType), typeMapping)
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,8 +24,7 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public sealed override ExpressionType NodeType
-        => ExpressionType.Extension;
+    public virtual IReadOnlyList<SqlExpression> Items { get; } = items;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,7 +32,11 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Sql { get; } = sql;
+    protected override ArrayConstantExpression VisitChildren(ExpressionVisitor visitor)
+        => visitor.VisitAndConvert(Items) is var newItems
+            && ReferenceEquals(newItems, Items)
+                ? this
+                : new ArrayConstantExpression(Type, newItems);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -36,43 +44,41 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Arguments { get; } = arguments;
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("[");
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual FromSqlExpression Update(Expression arguments)
-        => arguments != Arguments
-            ? new FromSqlExpression(Type, Sql, arguments)
-            : this;
+        var count = Items.Count;
+        for (var i = 0; i < count; i++)
+        {
+            expressionPrinter.Visit(Items[i]);
 
-    /// <inheritdoc />
-    protected override Expression VisitChildren(ExpressionVisitor visitor)
-        => this;
+            if (i < count - 1)
+            {
+                expressionPrinter.Append(", ");
+            }
+        }
 
-    /// <inheritdoc />
-    public override Type Type { get; } = clrType;
-
-    /// <inheritdoc />
-    void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append(Sql);
+        expressionPrinter.Append("]");
+    }
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
-        => obj != null
-            && (ReferenceEquals(this, obj)
-                || obj is FromSqlExpression fromSqlExpression
-                && Equals(fromSqlExpression));
+        => obj is ArrayConstantExpression other && Equals(other);
 
-    private bool Equals(FromSqlExpression fromSqlExpression)
-        => base.Equals(fromSqlExpression)
-            && Sql == fromSqlExpression.Sql
-            && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
+    private bool Equals(ArrayConstantExpression? other)
+        => ReferenceEquals(this, other) || (base.Equals(other) && Items.SequenceEqual(other.Items));
 
     /// <inheritdoc />
     public override int GetHashCode()
-        => HashCode.Combine(base.GetHashCode(), Sql);
+    {
+        var hashCode = new HashCode();
+
+        foreach (var item in Items)
+        {
+            hashCode.Add(item);
+        }
+
+        return hashCode.ToHashCode();
+    }
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ArrayExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ArrayExpression.cs
@@ -1,17 +1,25 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
+///     Represents a Cosmos ARRAY() expression, which projects the result of a query as an array (e.g.
+///     <c>ARRAY (SELECT VALUE t.name FROM t in p.tags)</c>).
+/// </summary>
+/// <seealso href="https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/subquery#array-expression">
+///     CosmosDB array expression
+/// </seealso>
+/// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-/// </summary>
-public class FromSqlExpression(Type clrType, string sql, Expression arguments)
-    : Expression, IPrintableExpression
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class ArrayExpression(SelectExpression subquery, Type arrayClrType, CoreTypeMapping? arrayTypeMapping = null)
+    : SqlExpression(arrayClrType, arrayTypeMapping)
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,8 +27,7 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public sealed override ExpressionType NodeType
-        => ExpressionType.Extension;
+    public virtual SelectExpression Subquery { get; } = subquery;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,7 +35,11 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Sql { get; } = sql;
+    protected override ArrayExpression VisitChildren(ExpressionVisitor visitor)
+        => visitor.Visit(Subquery) is var newQuery
+            && ReferenceEquals(newQuery, Subquery)
+                ? this
+                : new ArrayExpression((SelectExpression)newQuery, Type, TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -36,43 +47,21 @@ public class FromSqlExpression(Type clrType, string sql, Expression arguments)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Arguments { get; } = arguments;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual FromSqlExpression Update(Expression arguments)
-        => arguments != Arguments
-            ? new FromSqlExpression(Type, Sql, arguments)
-            : this;
-
-    /// <inheritdoc />
-    protected override Expression VisitChildren(ExpressionVisitor visitor)
-        => this;
-
-    /// <inheritdoc />
-    public override Type Type { get; } = clrType;
-
-    /// <inheritdoc />
-    void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append(Sql);
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("ARRAY (");
+        expressionPrinter.Visit(Subquery);
+        expressionPrinter.Append(")");
+    }
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
-        => obj != null
-            && (ReferenceEquals(this, obj)
-                || obj is FromSqlExpression fromSqlExpression
-                && Equals(fromSqlExpression));
+        => obj is ArrayExpression other && Equals(other);
 
-    private bool Equals(FromSqlExpression fromSqlExpression)
-        => base.Equals(fromSqlExpression)
-            && Sql == fromSqlExpression.Sql
-            && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
+    private bool Equals(ArrayExpression? other)
+        => ReferenceEquals(this, other) || (base.Equals(other) && Subquery.Equals(other.Subquery));
 
     /// <inheritdoc />
     public override int GetHashCode()
-        => HashCode.Combine(base.GetHashCode(), Sql);
+        => HashCode.Combine(base.GetHashCode(), Subquery);
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ExistsExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ExistsExpression.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     <para>
+///         An expression that represents projecting a SQL EXISTS expression.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+/// <seealso href="https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/subquery#exists-expression">CosmosDB subqueries</seealso>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class ExistsExpression : SqlExpression
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ExistsExpression(SelectExpression subquery, CoreTypeMapping? typeMapping)
+        : base(typeof(bool), typeMapping)
+    {
+        Subquery = subquery;
+    }
+
+    /// <summary>
+    ///     The subquery for which to check for element existence.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual SelectExpression Subquery { get; }
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => Update((SelectExpression)visitor.Visit(Subquery));
+
+    /// <summary>
+    ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+    ///     return this expression.
+    /// </summary>
+    /// <param name="subquery">The <see cref="Subquery" /> property of the result.</param>
+    /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual ExistsExpression Update(SelectExpression subquery)
+        => subquery == Subquery
+            ? this
+            : new ExistsExpression(subquery, TypeMapping);
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("EXISTS (");
+        using (expressionPrinter.Indent())
+        {
+            expressionPrinter.Visit(Subquery);
+        }
+
+        expressionPrinter.Append(")");
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is ExistsExpression other && Equals(other);
+
+    private bool Equals(ExistsExpression? other)
+        => ReferenceEquals(this, other) || (base.Equals(other) && Subquery.Equals(other.Subquery));
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Subquery);
+}

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectArrayProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectArrayProjectionExpression.cs
@@ -38,7 +38,7 @@ public class ObjectArrayProjectionExpression : Expression, IPrintableExpression,
         InnerProjection = innerProjection
             ?? new EntityProjectionExpression(
                 targetType,
-                new RootReferenceExpression(targetType, ""));
+                new ObjectReferenceExpression(targetType, ""));
     }
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ReadItemExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ReadItemExpression.cs
@@ -80,7 +80,7 @@ public class ReadItemExpression : Expression
         ProjectionExpression = new ProjectionExpression(
             new EntityProjectionExpression(
                 entityType,
-                new RootReferenceExpression(entityType, RootAlias)),
+                new ObjectReferenceExpression(entityType, RootAlias)),
             RootAlias);
 
         EntityType = entityType;

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarReferenceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarReferenceExpression.cs
@@ -1,20 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Internal;
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
+///     Represents a reference to a JSON value in the Cosmos SQL query, e.g. the first <c>i</c> in <c>SELECT i FROM i IN x.y</c>.
+///     When referencing a non-scalar, <see cref="ObjectReferenceExpression" /> is used instead.
+/// </summary>
+/// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-/// </summary>
-[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
-    : Expression, IPrintableExpression
+/// </remarks>
+public class ScalarReferenceExpression(string name, Type clrType, CoreTypeMapping? typeMapping = null)
+    : SqlExpression(clrType, typeMapping), IAccessExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -22,7 +23,7 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override Type Type { get; } = type;
+    public virtual string Name { get; } = name;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,7 +31,8 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual CoreTypeMapping? TypeMapping { get; } = typeMapping;
+    string IAccessExpression.Name
+        => Name;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -39,7 +41,7 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitChildren(ExpressionVisitor visitor)
-        => throw new InvalidOperationException(CosmosStrings.VisitChildrenMustBeOverridden);
+        => this;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,8 +49,8 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public sealed override ExpressionType NodeType
-        => ExpressionType.Extension;
+    public override string ToString()
+        => Name;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -56,11 +58,8 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract void Print(ExpressionPrinter expressionPrinter);
-
-    /// <inheritdoc />
-    void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
-        => Print(expressionPrinter);
+    protected override void Print(ExpressionPrinter expressionPrinter)
+        => expressionPrinter.Append(Name);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -69,21 +68,12 @@ public abstract class SqlExpression(Type type, CoreTypeMapping? typeMapping)
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override bool Equals(object? obj)
-        => obj != null
-            && (ReferenceEquals(this, obj)
-                || obj is SqlExpression sqlExpression
-                && Equals(sqlExpression));
+        => obj is ScalarReferenceExpression other && Equals(other);
 
-    private bool Equals(SqlExpression sqlExpression)
-        => Type == sqlExpression.Type
-            && TypeMapping?.Equals(sqlExpression.TypeMapping) == true;
+    private bool Equals(ScalarReferenceExpression other)
+        => ReferenceEquals(this, other) || (base.Equals(other) && Name == other.Name);
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
+    /// <inheritdoc />
     public override int GetHashCode()
-        => HashCode.Combine(Type, TypeMapping);
+        => HashCode.Combine(base.GetHashCode(), Name);
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarSubqueryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarSubqueryExpression.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     <para>
+///         An expression that represents projecting a scalar SQL value from a subquery.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class ScalarSubqueryExpression : SqlExpression
+{
+    /// <summary>
+    ///     Creates a new instance of the <see cref="ScalarSubqueryExpression" /> class.
+    /// </summary>
+    /// <param name="subquery">A subquery projecting single row with a single scalar projection.</param>
+    public ScalarSubqueryExpression(SelectExpression subquery)
+        : this(
+            subquery,
+            subquery.Projection[0].Expression is SqlExpression sqlExpression
+                ? sqlExpression.TypeMapping
+                : throw new UnreachableException("Can't construct scalar subquery over SelectExpresison with non-SqlExpression projection"))
+    {
+        Subquery = subquery;
+    }
+
+    private ScalarSubqueryExpression(SelectExpression subquery, CoreTypeMapping? typeMapping)
+        : base(subquery.Projection[0].Type, typeMapping)
+    {
+        Subquery = subquery;
+    }
+
+    /// <summary>
+    ///     The subquery projecting single row with single scalar projection.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual SelectExpression Subquery { get; }
+
+    /// <summary>
+    ///     Applies supplied type mapping to this expression.
+    /// </summary>
+    /// <param name="typeMapping">A relational type mapping to apply.</param>
+    /// <returns>A new expression which has supplied type mapping.</returns>
+    public virtual SqlExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
+        => new ScalarSubqueryExpression(Subquery, typeMapping);
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => Update((SelectExpression)visitor.Visit(Subquery));
+
+    /// <summary>
+    ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+    ///     return this expression.
+    /// </summary>
+    /// <param name="subquery">The <see cref="Subquery" /> property of the result.</param>
+    /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual ScalarSubqueryExpression Update(SelectExpression subquery)
+        => subquery == Subquery
+            ? this
+            : new ScalarSubqueryExpression(subquery);
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("(");
+        using (expressionPrinter.Indent())
+        {
+            expressionPrinter.Visit(Subquery);
+        }
+
+        expressionPrinter.Append(")");
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is ScalarSubqueryExpression other && Equals(other);
+
+    private bool Equals(ScalarSubqueryExpression? other)
+        => ReferenceEquals(this, other) || (base.Equals(other) && Subquery.Equals(other.Subquery));
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Subquery);
+}

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
@@ -13,11 +13,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SelectExpression : Expression
+[DebuggerDisplay("{PrintShortSql(), nq}")]
+public class SelectExpression : Expression, IPrintableExpression
 {
     private const string RootAlias = "c";
 
     private IDictionary<ProjectionMember, Expression> _projectionMapping = new Dictionary<ProjectionMember, Expression>();
+    private readonly List<SourceExpression> _sources = [];
     private readonly List<ProjectionExpression> _projection = [];
     private readonly List<OrderingExpression> _orderings = [];
 
@@ -33,8 +35,11 @@ public class SelectExpression : Expression
     {
         // TODO: All queries should reference a non-null container ID, but GetContainer returns null for owned entities.
         Container = entityType.GetContainer()!;
-        FromExpression = new RootReferenceExpression(entityType, RootAlias);
-        _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, FromExpression);
+
+        // TODO: Redo aliasing
+        _sources = [new SourceExpression(new ObjectReferenceExpression(entityType, "root"), RootAlias)];
+        _projectionMapping[new ProjectionMember()]
+            = new EntityProjectionExpression(entityType, new ObjectReferenceExpression(entityType, RootAlias));
     }
 
     /// <summary>
@@ -47,22 +52,71 @@ public class SelectExpression : Expression
     {
         // TODO: All queries should reference a non-null container ID, but GetContainer returns null for owned entities.
         Container = entityType.GetContainer()!;
-        FromExpression = new FromSqlExpression(entityType, RootAlias, sql, argument);
+        var fromSql = new FromSqlExpression(entityType.ClrType, sql, argument);
+        _sources = [new SourceExpression(fromSql, RootAlias)];
         _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(
-            entityType, new RootReferenceExpression(entityType, RootAlias));
+            entityType, new ObjectReferenceExpression(entityType, RootAlias));
     }
 
-    private SelectExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SelectExpression(
         List<ProjectionExpression> projections,
-        RootReferenceExpression fromExpression,
+        List<SourceExpression> sources,
         List<OrderingExpression> orderings,
         string container)
     {
         _projection = projections;
-        FromExpression = fromExpression;
+        _sources = sources;
         _orderings = orderings;
         Container = container;
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SelectExpression(string container, SqlExpression projection)
+        : this(container)
+        => _projectionMapping[new ProjectionMember()] = projection;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SelectExpression(string? container)
+    {
+        // TODO: Move container out of SelectExpression to QueryCompilationContext
+        Container = container!;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static SelectExpression CreateForPrimitiveCollection(
+        SourceExpression source,
+        Type elementClrType,
+        CoreTypeMapping elementTypeMapping)
+        => new(container: null)
+        {
+            _sources = { source },
+            _projectionMapping =
+            {
+                [new ProjectionMember()] = new ScalarReferenceExpression(source.Alias, elementClrType, elementTypeMapping)
+            },
+            UsesSingleValueProjection = true
+        };
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -82,12 +136,25 @@ public class SelectExpression : Expression
         => _projection;
 
     /// <summary>
+    ///     If set, indicates that the <see cref="SelectExpression" /> has a Cosmos VALUE projection, which does not get wrapped in a
+    ///     JSON object. If <see langword="true" />, <see cref="Projection" /> must contain a single item.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual bool UsesSingleValueProjection { get; init; }
+
+    /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual RootReferenceExpression FromExpression { get; }
+    public virtual IReadOnlyList<SourceExpression> Sources
+        => _sources;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -138,6 +205,15 @@ public class SelectExpression : Expression
     /// </summary>
     public virtual Expression GetMappedProjection(ProjectionMember projectionMember)
         => _projectionMapping[projectionMember];
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void ClearProjection()
+        => _projectionMapping.Clear();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -465,8 +541,13 @@ public class SelectExpression : Expression
             }
         }
 
-        var fromExpression = (RootReferenceExpression)visitor.Visit(FromExpression);
-        changed |= fromExpression != FromExpression;
+        var sources = new List<SourceExpression>();
+        foreach (var source in _sources)
+        {
+            var visitedSource = (SourceExpression)visitor.Visit(source);
+            changed |= visitedSource != source;
+            sources.Add(visitedSource);
+        }
 
         var predicate = (SqlExpression?)visitor.Visit(Predicate);
         changed |= predicate != Predicate;
@@ -487,7 +568,7 @@ public class SelectExpression : Expression
 
         if (changed)
         {
-            var newSelectExpression = new SelectExpression(projections, fromExpression, orderings, Container)
+            var newSelectExpression = new SelectExpression(projections, sources, orderings, Container)
             {
                 _projectionMapping = projectionMapping,
                 Predicate = predicate,
@@ -510,7 +591,7 @@ public class SelectExpression : Expression
     /// </summary>
     public virtual SelectExpression Update(
         List<ProjectionExpression> projections,
-        RootReferenceExpression fromExpression,
+        List<SourceExpression> sources,
         SqlExpression? predicate,
         List<OrderingExpression> orderings,
         SqlExpression? limit,
@@ -522,7 +603,7 @@ public class SelectExpression : Expression
             projectionMapping[projectionMember] = expression;
         }
 
-        return new SelectExpression(projections, fromExpression, orderings, Container)
+        return new SelectExpression(projections, sources, orderings, Container)
         {
             _projectionMapping = projectionMapping,
             Predicate = predicate,
@@ -531,4 +612,123 @@ public class SelectExpression : Expression
             IsDistinct = IsDistinct
         };
     }
+
+    #region Print
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void Print(ExpressionPrinter expressionPrinter)
+    {
+        PrintProjections(expressionPrinter);
+        expressionPrinter.AppendLine();
+        PrintSql(expressionPrinter);
+    }
+
+    private void PrintProjections(ExpressionPrinter expressionPrinter)
+    {
+        if (_projectionMapping.Count > 0)
+        {
+            expressionPrinter.AppendLine("Projection Mapping:");
+            using (expressionPrinter.Indent())
+            {
+                foreach (var (projectionMember, expression) in _projectionMapping)
+                {
+                    expressionPrinter.AppendLine();
+                    expressionPrinter.Append(projectionMember.ToString()).Append(" -> ");
+                    expressionPrinter.Visit(expression);
+                }
+            }
+        }
+    }
+
+    private void PrintSql(ExpressionPrinter expressionPrinter, bool withTags = true)
+    {
+        if (withTags)
+        {
+            // foreach (var tag in Tags)
+            // {
+            //     expressionPrinter.Append($"-- {tag}");
+            // }
+        }
+
+        expressionPrinter.Append("SELECT ");
+
+        if (IsDistinct)
+        {
+            expressionPrinter.Append("DISTINCT ");
+        }
+
+        if (Projection.Any())
+        {
+            if (UsesSingleValueProjection)
+            {
+                expressionPrinter.Append("VALUE ");
+            }
+
+            expressionPrinter.VisitCollection(Projection);
+        }
+        else
+        {
+            expressionPrinter.Append("1");
+        }
+
+        if (Sources.Any())
+        {
+            expressionPrinter.AppendLine().Append("FROM ");
+
+            expressionPrinter.VisitCollection(Sources, p => p.AppendLine());
+        }
+
+        if (Predicate != null)
+        {
+            expressionPrinter.AppendLine().Append("WHERE ");
+            expressionPrinter.Visit(Predicate);
+        }
+
+        if (Orderings.Any())
+        {
+            expressionPrinter.AppendLine().Append("ORDER BY ");
+            expressionPrinter.VisitCollection(Orderings);
+        }
+
+        if (Offset != null)
+        {
+            expressionPrinter.AppendLine().Append("OFFSET ");
+            expressionPrinter.Visit(Offset);
+            expressionPrinter.Append(" ROWS");
+
+            if (Limit != null)
+            {
+                expressionPrinter.Append(" FETCH NEXT ");
+                expressionPrinter.Visit(Limit);
+                expressionPrinter.Append(" ROWS ONLY");
+            }
+        }
+    }
+
+    private string PrintShortSql()
+    {
+        var expressionPrinter = new ExpressionPrinter();
+        PrintSql(expressionPrinter, withTags: false);
+        return expressionPrinter.ToString();
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         Expand this property in the debugger for a human-readable representation of this <see cref="SelectExpression" />.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the debug strings.
+    ///         They are designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual string DebugView
+        => this.Print();
+
+    #endregion Print
 }

--- a/src/EFCore.Cosmos/Query/Internal/IQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/IQuerySqlGeneratorFactory.cs
@@ -17,5 +17,5 @@ public interface IQuerySqlGeneratorFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    QuerySqlGenerator Create();
+    CosmosQuerySqlGenerator Create();
 }

--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -37,6 +37,14 @@ public interface ISqlExpressionFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    (SqlExpression, SqlExpression) ApplyTypeMappingsOnItemAndArray(SqlExpression item, SqlExpression array);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     SqlBinaryExpression? MakeBinary(
         ExpressionType operatorType,
         SqlExpression left,
@@ -58,6 +66,13 @@ public interface ISqlExpressionFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     SqlBinaryExpression NotEqual(SqlExpression left, SqlExpression right);
+
+    /// <summary>
+    ///     Creates a new <see cref="ExistsExpression" /> which represents an EXISTS operation in a SQL tree.
+    /// </summary>
+    /// <param name="subquery">A subquery to check existence of.</param>
+    /// <returns>An expression representing an EXISTS operation in a SQL tree.</returns>
+    ExistsExpression Exists(SelectExpression subquery);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -199,6 +214,14 @@ public interface ISqlExpressionFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     SqlBinaryExpression IsNotNull(SqlExpression operand);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    SqlBinaryExpression ArrayIndex(SqlExpression left, SqlExpression right, Type type, CoreTypeMapping? typeMapping = null);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/QuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/QuerySqlGeneratorFactory.cs
@@ -17,6 +17,6 @@ public class QuerySqlGeneratorFactory(ITypeMappingSource typeMappingSource) : IQ
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual QuerySqlGenerator Create()
+    public virtual CosmosQuerySqlGenerator Create()
         => new(typeMappingSource);
 }

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -28,20 +28,42 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             EntityProjectionExpression entityProjectionExpression => VisitEntityProjection(entityProjectionExpression),
             ObjectArrayProjectionExpression arrayProjectionExpression => VisitObjectArrayProjection(arrayProjectionExpression),
             FromSqlExpression fromSqlExpression => VisitFromSql(fromSqlExpression),
-            RootReferenceExpression rootReferenceExpression => VisitRootReference(rootReferenceExpression),
+            ObjectReferenceExpression objectReferenceExpression => VisitObjectReference(objectReferenceExpression),
             KeyAccessExpression keyAccessExpression => VisitKeyAccess(keyAccessExpression),
             ObjectAccessExpression objectAccessExpression => VisitObjectAccess(objectAccessExpression),
+            ScalarSubqueryExpression scalarSubqueryExpression => VisitScalarSubquery(scalarSubqueryExpression),
             SqlBinaryExpression sqlBinaryExpression => VisitSqlBinary(sqlBinaryExpression),
             SqlConstantExpression sqlConstantExpression => VisitSqlConstant(sqlConstantExpression),
             SqlUnaryExpression sqlUnaryExpression => VisitSqlUnary(sqlUnaryExpression),
             SqlConditionalExpression sqlConditionalExpression => VisitSqlConditional(sqlConditionalExpression),
             SqlParameterExpression sqlParameterExpression => VisitSqlParameter(sqlParameterExpression),
             InExpression inExpression => VisitIn(inExpression),
+            ArrayConstantExpression inlineArrayExpression => VisitArrayConstant(inlineArrayExpression),
+            SourceExpression sourceExpression => VisitSource(sourceExpression),
             SqlFunctionExpression sqlFunctionExpression => VisitSqlFunction(sqlFunctionExpression),
             OrderingExpression orderingExpression => VisitOrdering(orderingExpression),
+            ScalarReferenceExpression valueReferenceExpression => VisitValueReference(valueReferenceExpression),
+            ExistsExpression existsExpression => VisitExists(existsExpression),
+            ArrayExpression arrayExpression => VisitArray(arrayExpression),
 
             _ => base.VisitExtension(extensionExpression)
         };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitExists(ExistsExpression existsExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitArray(ArrayExpression arrayExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -74,6 +96,22 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected abstract Expression VisitIn(InExpression inExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitArrayConstant(ArrayConstantExpression arrayConstantExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitSource(SourceExpression sourceExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -137,7 +175,15 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract Expression VisitRootReference(RootReferenceExpression rootReferenceExpression);
+    protected abstract Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitObjectReference(ObjectReferenceExpression objectReferenceExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -170,4 +216,12 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected abstract Expression VisitSelect(SelectExpression selectExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitValueReference(ScalarReferenceExpression scalarReferenceExpression);
 }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMapping.cs
@@ -31,6 +31,7 @@ public class CosmosTypeMapping : CoreTypeMapping
         Type clrType,
         ValueComparer? comparer = null,
         ValueComparer? keyComparer = null,
+        CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null)
         : base(
             new CoreTypeMappingParameters(
@@ -38,6 +39,7 @@ public class CosmosTypeMapping : CoreTypeMapping
                 converter: null,
                 comparer,
                 keyComparer,
+                elementMapping: elementMapping,
                 jsonValueReaderWriter: jsonValueReaderWriter))
     {
     }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -646,12 +646,9 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     ((SelectExpression)projectionBindingExpression.QueryExpression)
                     .GetProjection(projectionBindingExpression));
 
-            case ShapedQueryExpression shapedQueryExpression:
-                if (shapedQueryExpression.ResultCardinality == ResultCardinality.Enumerable)
-                {
-                    return QueryCompilationContext.NotTranslatedExpression;
-                }
-
+            // This case is for a subquery embedded in a lambda, returning a scalar, e.g. Where(b => b.Posts.Count() > 0).
+            // For most cases, generate a scalar subquery (WHERE (SELECT COUNT(*) FROM Posts) > 0).
+            case ShapedQueryExpression { ResultCardinality: not ResultCardinality.Enumerable } shapedQueryExpression:
                 var shaperExpression = shapedQueryExpression.ShaperExpression;
                 ProjectionBindingExpression? mappedProjectionBindingExpression = null;
 
@@ -1022,7 +1019,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             }
         }
 
-        var translation = enumerableExpression != null
+        Expression? translation = enumerableExpression != null
             ? TranslateAggregateMethod(enumerableExpression, method, scalarArguments)
             : Dependencies.MethodCallTranslatorProvider.Translate(
                 _model, sqlObject, method, scalarArguments, _queryCompilationContext.Logger);
@@ -1032,26 +1029,26 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             return translation;
         }
 
-        var subqueryTranslation = TranslateAsSubquery(methodCallExpression);
-        if (subqueryTranslation == QueryCompilationContext.NotTranslatedExpression)
+        translation = TranslateAsSubquery(methodCallExpression);
+        if (translation != QueryCompilationContext.NotTranslatedExpression)
         {
-            if (method == StringEqualsWithStringComparison
-                || method == StringEqualsWithStringComparisonStatic)
-            {
-                AddTranslationErrorDetails(CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
-            }
-            else
-            {
-                AddTranslationErrorDetails(
-                    CoreStrings.QueryUnableToTranslateMethod(
-                        method.DeclaringType?.DisplayName(),
-                        method.Name));
-            }
-
-            return QueryCompilationContext.NotTranslatedExpression;
+            return translation;
         }
 
-        return subqueryTranslation;
+        if (method == StringEqualsWithStringComparison
+            || method == StringEqualsWithStringComparisonStatic)
+        {
+            AddTranslationErrorDetails(CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+        }
+        else
+        {
+            AddTranslationErrorDetails(
+                CoreStrings.QueryUnableToTranslateMethod(
+                    method.DeclaringType?.DisplayName(),
+                    method.Name));
+        }
+
+        return QueryCompilationContext.NotTranslatedExpression;
 
         Expression TranslateAsSubquery(Expression expression)
         {

--- a/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
@@ -32,7 +32,7 @@ public class ExistsExpression : SqlExpression
     }
 
     /// <summary>
-    ///     The subquery to check existence of.
+    ///     The subquery for which to check for element existence.
     /// </summary>
     public virtual SelectExpression Subquery { get; }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3432,7 +3432,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             _sqlAliasManager.GenerateTableAlias(_tables is [{ Alias: string singleTableAlias }] ? singleTableAlias : "subquery");
 
         var subquery = new SelectExpression(
-            subqueryAlias, _tables.ToList(), _groupBy.ToList(), [], _orderings.ToList(), Annotations, _sqlAliasManager)
+            subqueryAlias, _tables.ToList(), _groupBy.ToList(), projections: [], _orderings.ToList(), Annotations, _sqlAliasManager)
         {
             IsDistinct = IsDistinct,
             Predicate = Predicate,
@@ -4284,6 +4284,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             RelationalExpressionQuotingUtilities.QuoteTags(Tags),
             RelationalExpressionQuotingUtilities.QuoteAnnotations(Annotations));
 
+    #region Print
+
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
@@ -4437,6 +4439,8 @@ public sealed partial class SelectExpression : TableExpressionBase
     [EntityFrameworkInternal]
     public string DebugView
         => this.Print();
+
+    #endregion Print
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -53,7 +53,9 @@ public class ExpressionPrinter : ExpressionVisitor
         { ExpressionType.Modulo, " % " },
         { ExpressionType.And, " & " },
         { ExpressionType.Or, " | " },
-        { ExpressionType.ExclusiveOr, " ^ " }
+        { ExpressionType.ExclusiveOr, " ^ " },
+        { ExpressionType.LeftShift, " << " },
+        { ExpressionType.RightShift, " >> " }
     };
 
     /// <summary>

--- a/src/EFCore/Storage/Json/JsonValueReaderWriterSource.cs
+++ b/src/EFCore/Storage/Json/JsonValueReaderWriterSource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+
 namespace Microsoft.EntityFrameworkCore.Storage.Json;
 
 /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
@@ -94,7 +94,10 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT VALUE {"Value" : ((c["Discriminator"] = "Kiwi") ? c["FoundOn"] : 0)}
+SELECT VALUE
+{
+    "Value" : ((c["Discriminator"] = "Kiwi") ? c["FoundOn"] : 0)
+}
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -136,7 +139,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ((c["Discriminator"] = "Kiwi"
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : (c["Discriminator"] = "Kiwi")}
+SELECT (c["Discriminator"] = "Kiwi") AS c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -422,7 +425,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT VALUE {"Predator" : c["Name"]}
+SELECT c["Name"] AS Predator
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ("Kiwi" = c["Discriminator"]))
 """);
@@ -517,7 +520,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : (c["IsFlightless"] ? 0 : 1)}
+SELECT (c["IsFlightless"] ? 0 : 1) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1911,8 +1911,12 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT(CONTAINS(c["CompanyName"], c["C
                 await base.String_Contains_negated_in_projection(a);
 
                 AssertSql(
-"""
-SELECT VALUE {"Id" : c["CustomerID"], "Value" : NOT(CONTAINS(c["CompanyName"], c["ContactName"]))}
+                    """
+SELECT VALUE
+{
+    "Id" : c["CustomerID"],
+    "Value" : NOT(CONTAINS(c["CompanyName"], c["ContactName"]))
+}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -37,7 +37,10 @@ public class NorthwindSelectQueryCosmosTest : NorthwindSelectQueryTestBase<North
 
                 AssertSql(
                     """
-SELECT VALUE {"Value" : c["OrderID"]}
+SELECT VALUE
+{
+    "Value" : c["OrderID"]
+}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -51,7 +54,11 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT VALUE {"A" : (c["OrderID"] / (c["OrderID"] / 2)), "B" : ((c["OrderID"] / c["OrderID"]) / 2)}
+SELECT VALUE
+{
+    "A" : (c["OrderID"] / (c["OrderID"] / 2)),
+    "B" : ((c["OrderID"] / c["OrderID"]) / 2)
+}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -65,7 +72,16 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT VALUE {"OrderID" : c["OrderID"], "Double" : (c["OrderID"] * 2), "Add" : (c["OrderID"] + 23), "Sub" : (100000 - c["OrderID"]), "Divide" : (c["OrderID"] / (c["OrderID"] / 2)), "Literal" : 42, "o" : c}
+SELECT VALUE
+{
+    "OrderID" : c["OrderID"],
+    "Double" : (c["OrderID"] * 2),
+    "Add" : (c["OrderID"] + 23),
+    "Sub" : (100000 - c["OrderID"]),
+    "Divide" : (c["OrderID"] / (c["OrderID"] / 2)),
+    "Literal" : 42,
+    "o" : c
+}
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -169,7 +185,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"], c["ReportsTo"]
+SELECT [c["EmployeeID"], c["ReportsTo"]] AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """);
@@ -195,7 +211,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
                 """
 @__boolean_0='false'
 
-SELECT VALUE {"c" : @__boolean_0}
+SELECT @__boolean_0 AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY @__boolean_0
@@ -267,7 +283,11 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"CustomerID" : c["CustomerID"], "ConstantTrue" : true}
+SELECT VALUE
+{
+    "CustomerID" : c["CustomerID"],
+    "ConstantTrue" : true
+}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -281,7 +301,11 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"CustomerID" : c["CustomerID"], "Expression" : (LENGTH(c["CustomerID"]) + 5)}
+SELECT VALUE
+{
+    "CustomerID" : c["CustomerID"],
+    "Expression" : (LENGTH(c["CustomerID"]) + 5)
+}
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -295,7 +319,11 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"ProductID" : c["ProductID"], "IsAvailable" : (c["UnitsInStock"] > 0)}
+SELECT VALUE
+{
+    "ProductID" : c["ProductID"],
+    "IsAvailable" : (c["UnitsInStock"] > 0)
+}
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 """);
@@ -323,7 +351,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : 0}
+SELECT 0 AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -337,7 +365,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : null}
+SELECT null AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -353,7 +381,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__x_0='10'
 
-SELECT VALUE {"c" : @__x_0}
+SELECT @__x_0 AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -550,7 +578,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : (c["OrderID"] + c["OrderID"])}
+SELECT (c["OrderID"] + c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -581,7 +609,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : -(c["OrderID"])}
+SELECT -(c["OrderID"]) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -667,7 +695,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["CustomerID"] = null) ? true : (c["OrderID"] < 100))}
+SELECT ((c["CustomerID"] = null) ? true : (c["OrderID"] < 100)) AS c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -908,7 +936,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? 1 : 2)}
+SELECT ((c["CustomerID"] = "ALFKI") ? 1 : 2) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -922,7 +950,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? 1 : 2)}
+SELECT ((c["CustomerID"] = "ALFKI") ? 1 : 2) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -936,7 +964,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["CustomerID"] = "ALFKI") ? true : false)}
+SELECT ((c["CustomerID"] = "ALFKI") ? true : false) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -964,7 +992,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT VALUE {"A" : c["CustomerID"]}
+SELECT c["CustomerID"] AS A
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1181,7 +1209,11 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 
                 AssertSql(
                     """
-SELECT VALUE {"OrderID" : c["OrderID"], "c" : (c["OrderID"] + 1000)}
+SELECT VALUE
+{
+    "OrderID" : c["OrderID"],
+    "c" : (c["OrderID"] + 1000)
+}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10250))
 """);
@@ -1243,7 +1275,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10250))
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["EmployeeID"] != null) ? c["EmployeeID"] : 0)}
+SELECT ((c["EmployeeID"] != null) ? c["EmployeeID"] : 0) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1311,7 +1343,7 @@ ORDER BY c["EmployeeID"]
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : (c["City"] = "Seattle")}
+SELECT (c["City"] = "Seattle") AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1412,7 +1444,7 @@ ORDER BY c["CustomerID"]
                     """
 @__p_0='10'
 
-SELECT VALUE {"Aggregate" : ((c["CustomerID"] || " ") || c["City"])}
+SELECT ((c["CustomerID"] || " ") || c["City"]) AS Aggregate
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
@@ -1430,7 +1462,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='10'
 
-SELECT VALUE {"Aggregate" : ((c["CustomerID"] || " ") || c["City"])}
+SELECT ((c["CustomerID"] || " ") || c["City"]) AS Aggregate
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1508,7 +1540,12 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT VALUE {"CustomerID" : c["CustomerID"], "OrderDate" : c["OrderDate"], "c" : (c["OrderID"] - 10000)}
+SELECT VALUE
+{
+    "CustomerID" : c["CustomerID"],
+    "OrderDate" : c["OrderDate"],
+    "c" : (c["OrderID"] - 10000)
+}
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 ORDER BY c["OrderID"]
@@ -1953,7 +1990,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT VALUE {"X" : 10}
+SELECT 10 AS X
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1981,7 +2018,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT VALUE {"c" : ((c["CustomerID"] = "1") ? "01" : ((c["CustomerID"] = "2") ? "02" : ((c["CustomerID"] = "3") ? "03" : ((c["CustomerID"] = "4") ? "04" : ((c["CustomerID"] = "5") ? "05" : ((c["CustomerID"] = "6") ? "06" : ((c["CustomerID"] = "7") ? "07" : ((c["CustomerID"] = "8") ? "08" : ((c["CustomerID"] = "9") ? "09" : ((c["CustomerID"] = "10") ? "10" : ((c["CustomerID"] = "11") ? "11" : null)))))))))))}
+SELECT ((c["CustomerID"] = "1") ? "01" : ((c["CustomerID"] = "2") ? "02" : ((c["CustomerID"] = "3") ? "03" : ((c["CustomerID"] = "4") ? "04" : ((c["CustomerID"] = "5") ? "05" : ((c["CustomerID"] = "6") ? "06" : ((c["CustomerID"] = "7") ? "07" : ((c["CustomerID"] = "8") ? "08" : ((c["CustomerID"] = "9") ? "09" : ((c["CustomerID"] = "10") ? "10" : ((c["CustomerID"] = "11") ? "11" : null))))))))))) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Xunit.Sdk;
@@ -467,7 +468,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
     public override async Task Where_as_queryable_expression(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.Where_as_queryable_expression(async));
 
         AssertSql();
@@ -912,7 +913,7 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task Where_shadow_subquery_FirstOrDefault(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.Where_shadow_subquery_FirstOrDefault(async));
 
         AssertSql();
@@ -927,7 +928,7 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task Where_subquery_correlated(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.Where_subquery_correlated(async));
 
         AssertSql();
@@ -2271,7 +2272,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))
 
     public override async Task Where_subquery_FirstOrDefault_is_null(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.Where_subquery_FirstOrDefault_is_null(async));
 
         AssertSql();
@@ -2339,7 +2340,7 @@ WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
 
     public override async Task Filter_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.Filter_non_nullable_value_after_FirstOrDefault_on_empty_collection(async));
 
         AssertSql();
@@ -2513,9 +2514,11 @@ WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
 
                 AssertSql(
                     """
+@__orderIds_0='[10248,10249]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
+WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 """);
             });
 
@@ -2527,9 +2530,11 @@ WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 
                 AssertSql(
                     """
+@__orderIds_0='[10248,10249]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
+WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 """);
             });
 
@@ -2563,7 +2568,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
     public override async Task FirstOrDefault_over_scalar_projection_compared_to_null(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.FirstOrDefault_over_scalar_projection_compared_to_null(async));
 
         AssertSql();
@@ -2571,7 +2576,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
     public override async Task FirstOrDefault_over_scalar_projection_compared_to_not_null(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // Uncorrelated subquery, not supported by Cosmos
         await AssertTranslationFailed(() => base.FirstOrDefault_over_scalar_projection_compared_to_not_null(async));
 
         AssertSql();
@@ -2697,9 +2702,11 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
+@__customerIds_0='["ALFKI","FISSA","WHITC"]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISSA", "WHITC") AND (c["City"] = "Seattle")))
+WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c["CustomerID"]) AND (c["City"] = "Seattle")))
 """);
             });
 
@@ -2711,9 +2718,11 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISS
 
                 AssertSql(
                     """
+@__customerIds_0='["ALFKI","FISSA"]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "FISSA") OR (c["City"] = "Seattle")))
+WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c["CustomerID"]) OR (c["City"] = "Seattle")))
 """);
             });
 
@@ -2905,9 +2914,11 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10274))
 
                 AssertSql(
                     """
+@__cities_0='["Seattle"]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("Seattle"))
+WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City"]))
 """);
             });
 
@@ -3054,9 +3065,11 @@ WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Regi
 
                 AssertSql(
                     """
+@__array_0='["ALFKI","ANATR"]'
+
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR (c["CustomerID"] = "ANTON")))
+WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__array_0, c["CustomerID"]) OR (c["CustomerID"] = "ANTON")))
 """);
             });
 
@@ -3069,11 +3082,12 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANAT
                 AssertSql(
                     """
 @__prm1_0='ANTON'
+@__array_1='["ALFKI","ANATR"]'
 @__prm2_2='ALFKI'
 
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = @__prm1_0) OR c["CustomerID"] IN ("ALFKI", "ANATR")) OR (c["CustomerID"] = @__prm2_2)))
+WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = @__prm1_0) OR ARRAY_CONTAINS(@__array_1, c["CustomerID"])) OR (c["CustomerID"] = @__prm2_2)))
 """);
             });
 
@@ -3141,7 +3155,11 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 
                 AssertSql(
                     """
-SELECT VALUE {"e" : c, "Title" : c["Title"]}
+SELECT VALUE
+{
+    "e" : c,
+    "Title" : c["Title"]
+}
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
@@ -3174,7 +3192,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='9'
 
-SELECT VALUE {"e" : c}
+SELECT c AS e
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
@@ -3379,25 +3397,25 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
                     """
 @__id_0='10252'
 
-SELECT VALUE {"Id" : c["OrderID"]}
+SELECT c["OrderID"] AS Id
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__id_0))
 """,
                     //
                     """
-SELECT VALUE {"Id" : c["OrderID"]}
+SELECT c["OrderID"] AS Id
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
                     //
                     """
-SELECT VALUE {"Id" : c["OrderID"]}
+SELECT c["OrderID"] AS Id
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
                     //
                     """
-SELECT VALUE {"Id" : c["OrderID"]}
+SELECT c["OrderID"] AS Id
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -425,7 +425,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT VALUE {"Nation" : c["PersonAddress"]["ZipCode"]}
+SELECT c["PersonAddress"]["ZipCode"] AS Nation
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -439,7 +439,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT VALUE {"Nation" : c["PersonAddress"]["ZipCode"]}
+SELECT c["PersonAddress"]["ZipCode"] AS Nation
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -1,0 +1,1533 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+using Xunit.Sdk;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class PrimitiveCollectionsQueryCosmosTest : PrimitiveCollectionsQueryTestBase<
+    PrimitiveCollectionsQueryCosmosTest.PrimitiveCollectionsQueryCosmosFixture>
+{
+    public PrimitiveCollectionsQueryCosmosTest(PrimitiveCollectionsQueryCosmosFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override Task Inline_collection_of_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_of_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Int"] IN (10, 999))
+""");
+            });
+
+    public override Task Inline_collection_of_nullable_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_of_nullable_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["NullableInt"] IN (10, 999))
+""");
+            });
+
+    public override Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_of_nullable_ints_Contains_null(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["NullableInt"] IN (999) OR (c["NullableInt"] = null)))
+""");
+            });
+
+    public override Task Inline_collection_Count_with_zero_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Count_with_zero_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE COUNT(1)
+    FROM i IN (SELECT VALUE [])
+    WHERE (i > c["Id"])) = 1))
+""");
+            });
+
+    public override Task Inline_collection_Count_with_one_value(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Count_with_one_value(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE COUNT(1)
+    FROM i IN (SELECT VALUE [2])
+    WHERE (i > c["Id"])) = 1))
+""");
+            });
+
+    public override Task Inline_collection_Count_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Count_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE COUNT(1)
+    FROM i IN (SELECT VALUE [2, 999])
+    WHERE (i > c["Id"])) = 1))
+""");
+            });
+
+    public override Task Inline_collection_Count_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Count_with_three_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE COUNT(1)
+    FROM i IN (SELECT VALUE [2, 999, 1000])
+    WHERE (i > c["Id"])) = 2))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_zero_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_zero_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (true = false))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_one_value(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_one_value(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, 999))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_three_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, 999, 1000))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_EF_Constant(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_EF_Constant(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, 999, 1000))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_all_parameters(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_all_parameters(a);
+
+                AssertSql(
+                    """
+@__i_0='2'
+@__j_1='999'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (@__i_0, @__j_1))
+""");
+            });
+
+    public override Task Inline_collection_Contains_with_constant_and_parameter(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_constant_and_parameter(a);
+
+                AssertSql(
+                    """
+@__j_0='999'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, @__j_0))
+""");
+            });
+
+    // TODO: Remove incorrect null semantics compensation for Cosmos: #31063
+    public override Task Inline_collection_Contains_with_mixed_value_types(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Inline_collection_Contains_with_mixed_value_types(async));
+
+    // TODO: Remove incorrect null semantics compensation for Cosmos: #31063
+    public override Task Inline_collection_List_Contains_with_mixed_value_types(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Inline_collection_List_Contains_with_mixed_value_types(async));
+
+    public override Task Inline_collection_Contains_as_Any_with_predicate(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_as_Any_with_predicate(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, 999))
+""");
+            });
+
+    public override Task Inline_collection_negated_Contains_as_All(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_negated_Contains_as_All(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] NOT IN (2, 999))
+""");
+            });
+
+    public override Task Inline_collection_Min_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Min_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MIN(i)
+    FROM i IN (SELECT VALUE [30, c["Int"]])) = 30))
+""");
+            });
+
+    public override Task Inline_collection_List_Min_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_List_Min_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MIN(i)
+    FROM i IN (SELECT VALUE [30, c["Int"]])) = 30))
+""");
+            });
+
+    public override Task Inline_collection_Max_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Max_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MAX(i)
+    FROM i IN (SELECT VALUE [30, c["Int"]])) = 30))
+""");
+            });
+
+    public override Task Inline_collection_List_Max_with_two_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_List_Max_with_two_values(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MAX(i)
+    FROM i IN (SELECT VALUE [30, c["Int"]])) = 30))
+""");
+            });
+
+    public override Task Inline_collection_Min_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Min_with_three_values(a);
+
+                AssertSql(
+                    """
+@__i_0='25'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MIN(i)
+    FROM i IN (SELECT VALUE [30, c["Int"], @__i_0])) = 25))
+""");
+            });
+
+    public override Task Inline_collection_List_Min_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_List_Min_with_three_values(a);
+
+                AssertSql(
+                    """
+@__i_0='25'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MIN(i)
+    FROM i IN (SELECT VALUE [30, c["Int"], @__i_0])) = 25))
+""");
+            });
+
+    public override Task Inline_collection_Max_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+        await base.Inline_collection_Max_with_three_values(a);
+
+        AssertSql(
+            """
+@__i_0='35'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MAX(i)
+    FROM i IN (SELECT VALUE [30, c["Int"], @__i_0])) = 35))
+""");
+            });
+
+    public override Task Inline_collection_List_Max_with_three_values(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_List_Max_with_three_values(a);
+
+                AssertSql(
+                    """
+@__i_0='35'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE MAX(i)
+    FROM i IN (SELECT VALUE [30, c["Int"], @__i_0])) = 35))
+""");
+            });
+
+    public override Task Parameter_collection_Count(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_Count(a);
+
+                AssertSql(
+                    """
+@__ids_0='[2,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
+    SELECT VALUE COUNT(1)
+    FROM i IN (SELECT VALUE @__ids_0)
+    WHERE (i > c["Id"])) = 1))
+""");
+            });
+
+    public override Task Parameter_collection_of_ints_Contains_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_ints_Contains_int(a);
+
+                AssertSql(
+                    """
+@__ints_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__ints_0, c["Int"]))
+""",
+                    //
+                    """
+@__ints_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__ints_0, c["Int"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_ints_Contains_nullable_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_ints_Contains_nullable_int(a);
+
+                AssertSql(
+                    """
+@__ints_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__ints_0, c["NullableInt"]))
+""",
+                    //
+                    """
+@__ints_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__ints_0, c["NullableInt"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_ints_Contains_int(a);
+
+                AssertSql(
+                    """
+@__nullableInts_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__nullableInts_0, c["Int"]))
+""",
+                    //
+                    """
+@__nullableInts_0='[10,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__nullableInts_0, c["Int"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(a);
+
+                AssertSql(
+                    """
+@__nullableInts_0='[null,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"]))
+""",
+                    //
+                    """
+@__nullableInts_0='[null,999]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_strings_Contains_string(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_strings_Contains_string(a);
+
+                AssertSql(
+                    """
+@__strings_0='["10","999"]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_0, c["String"]))
+""",
+                    //
+                    """
+@__strings_0='["10","999"]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__strings_0, c["String"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_strings_Contains_nullable_string(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_strings_Contains_nullable_string(a);
+
+                AssertSql(
+                    """
+@__strings_0='["10","999"]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
+""",
+                    //
+                    """
+@__strings_0='["10","999"]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_nullable_strings_Contains_string(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_strings_Contains_string(a);
+
+                AssertSql(
+                    """
+@__strings_0='["10",null]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_0, c["String"]))
+""",
+                    //
+                    """
+@__strings_0='["10",null]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__strings_0, c["String"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_nullable_strings_Contains_nullable_string(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_strings_Contains_nullable_string(a);
+
+                AssertSql(
+                    """
+@__strings_0='["999",null]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
+""",
+                    //
+                    """
+@__strings_0='["999",null]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"])))
+""");
+            });
+
+    public override Task Parameter_collection_of_DateTimes_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_DateTimes_Contains(a);
+
+                AssertSql(
+                    """
+@__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__dateTimes_0, c["DateTime"]))
+""");
+            });
+
+    public override Task Parameter_collection_of_bools_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_bools_Contains(a);
+
+                AssertSql(
+                    """
+@__bools_0='[true]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__bools_0, c["Bool"]))
+""");
+            });
+
+    public override Task Parameter_collection_of_enums_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_enums_Contains(a);
+
+                AssertSql(
+                    """
+@__enums_0='[0,3]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__enums_0, c["Enum"]))
+""");
+            });
+
+    public override Task Parameter_collection_null_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_null_Contains(a);
+
+                AssertSql(
+                    """
+@__ints_0=null
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__ints_0, c["Int"]))
+""");
+            });
+
+    public override Task Column_collection_of_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["Ints"], 10))
+""");
+            });
+
+    public override Task Column_collection_of_nullable_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_nullable_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["NullableInts"], 10))
+""");
+            });
+
+    public override Task Column_collection_of_nullable_ints_Contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_nullable_ints_Contains_null(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["NullableInts"], null))
+""");
+            });
+
+    public override Task Column_collection_of_strings_contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_strings_contains_null(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["Strings"], null))
+""");
+            });
+
+    public override Task Column_collection_of_nullable_strings_contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_nullable_strings_contains_null(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["NullableStrings"], null))
+""");
+            });
+
+    public override Task Column_collection_of_bools_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_bools_Contains(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(c["Bools"], true))
+""");
+            });
+
+    public override Task Column_collection_Count_method(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Count_method(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(c["Ints"]) = 2))
+""");
+            });
+
+    public override Task Column_collection_Length(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Length(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(c["Ints"]) = 2))
+""");
+            });
+
+    public override Task Column_collection_index_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_index_int(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"][1] = 10))
+""");
+            });
+
+    public override Task Column_collection_index_string(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_index_string(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Strings"][1] = "10"))
+""");
+            });
+
+    public override Task Column_collection_index_datetime(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_index_datetime(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["DateTimes"][1] = "2020-01-10T12:30:00Z"))
+""");
+            });
+
+    public override Task Column_collection_index_beyond_end(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_index_beyond_end(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"][999] = 10))
+""");
+            });
+
+    public override async Task Nullable_reference_column_collection_index_equals_nullable_column(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<EqualException>(() => base.Nullable_reference_column_collection_index_equals_nullable_column(async));
+
+            AssertSql(
+                """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["NullableStrings"][2] = c["NullableString"]))
+""");
+        }
+    }
+
+    public override Task Non_nullable_reference_column_collection_index_equals_nullable_column(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Non_nullable_reference_column_collection_index_equals_nullable_column(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (EXISTS (
+    SELECT 1
+    FROM i IN c["Strings"]) AND (c["Strings"][1] = c["NullableString"])))
+""");
+            });
+
+    public override async Task Inline_collection_index_Column(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos, and neither is LIMIT/OFFSET within subqueries.
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Inline_collection_index_Column(async));
+
+            Assert.Contains("The specified query includes 'member indexer' which is currently not supported.", exception.Message);
+        }
+    }
+
+    public override async Task Inline_collection_value_index_Column(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos, and neither is LIMIT/OFFSET within subqueries.
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Inline_collection_value_index_Column(async));
+
+            Assert.Contains("The specified query includes 'member indexer' which is currently not supported.", exception.Message);
+        }
+    }
+
+    public override async Task Inline_collection_List_value_index_Column(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos, and neither is LIMIT/OFFSET within subqueries.
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Inline_collection_List_value_index_Column(async));
+
+            Assert.Contains("The specified query includes 'member indexer' which is currently not supported.", exception.Message);
+        }
+    }
+
+    public override async Task Parameter_collection_index_Column_equal_Column(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos, and neither is LIMIT/OFFSET within subqueries.
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Parameter_collection_index_Column_equal_Column(async));
+
+            Assert.Contains("The specified query includes 'member indexer' which is currently not supported.", exception.Message);
+        }
+    }
+
+    public override async Task Parameter_collection_index_Column_equal_constant(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos, and neither is LIMIT/OFFSET within subqueries.
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Parameter_collection_index_Column_equal_constant(async));
+
+            Assert.Contains("The specified query includes 'member indexer' which is currently not supported.", exception.Message);
+        }
+    }
+
+    public override Task Column_collection_ElementAt(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_ElementAt(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"][1] = 10))
+""");
+            });
+
+    public override async Task Column_collection_Skip(bool async)
+    {
+        // TODO: Count after Distinct requires subquery pushdown
+        await AssertTranslationFailed(() => base.Column_collection_Skip(async));
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_Take(bool async)
+    {
+        // TODO: IN with subquery
+        await AssertTranslationFailed(() => base.Column_collection_Take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_Skip_Take(bool async)
+    {
+        // TODO: Count after Distinct requires subquery pushdown
+        await AssertTranslationFailed(() => base.Column_collection_Skip_Take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_OrderByDescending_ElementAt(bool async)
+    {
+        // TODO: ElementAt over composed query (non-simple array)
+        await AssertTranslationFailed(() => base.Column_collection_OrderByDescending_ElementAt(async));
+
+        AssertSql();
+    }
+
+    public override Task Column_collection_Any(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Any(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND EXISTS (
+    SELECT 1
+    FROM i IN c["Ints"]))
+""");
+            });
+
+    public override async Task Column_collection_Distinct(bool async)
+    {
+        // TODO: Count after Distinct requires subquery pushdown
+        await AssertTranslationFailed(() => base.Column_collection_Distinct(async));
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_SelectMany(bool async)
+    {
+        // TODO: SelectMany
+        await AssertTranslationFailed(() => base.Column_collection_SelectMany(async));
+
+        AssertSql();
+    }
+
+    public override Task Column_collection_projection_from_top_level(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_projection_from_top_level(a);
+
+                AssertSql(
+                    """
+SELECT c["Ints"]
+FROM root c
+WHERE (c["Discriminator"] = "PrimitiveCollectionsEntity")
+ORDER BY c["Id"]
+""");
+            });
+
+    public override async Task Column_collection_Join_parameter_collection(bool async)
+    {
+        // Cosmos join support. Issue #16920.
+        await AssertTranslationFailed(() => base.Column_collection_Join_parameter_collection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Inline_collection_Join_ordered_column_collection(bool async)
+    {
+        // Cosmos join support. Issue #16920.
+        await AssertTranslationFailed(() => base.Column_collection_Join_parameter_collection(async));
+
+        AssertSql();
+    }
+
+    public override Task Parameter_collection_Concat_column_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_Concat_column_collection(a);
+
+                AssertSql(
+                    """
+@__ints_0='[11,111]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(ARRAY_CONCAT(@__ints_0, c["Ints"])) = 2))
+""");
+            });
+
+    public override Task Column_collection_Union_parameter_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Union_parameter_collection(a);
+
+                AssertSql(
+                    """
+@__ints_0='[11,111]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(SetUnion(c["Ints"], @__ints_0)) = 2))
+""");
+            });
+
+    public override Task Column_collection_Intersect_inline_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Intersect_inline_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(SetIntersect(c["Ints"], [11, 111])) = 2))
+""");
+            });
+
+    public override async Task Inline_collection_Except_column_collection(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
+            () => base.Inline_collection_Except_column_collection(async),
+            CosmosStrings.ExceptNotSupported);
+
+        AssertSql();
+    }
+
+    public override Task Column_collection_Where_Union(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Where_Union(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(SetUnion(ARRAY (
+    SELECT VALUE i
+    FROM i IN c["Ints"]
+    WHERE (i > 100)), [50])) = 2))
+""");
+            });
+
+    public override Task Column_collection_equality_parameter_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_equality_parameter_collection(a);
+
+                AssertSql(
+                    """
+@__ints_0='[1,10]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"] = @__ints_0))
+""");
+            });
+
+    public override Task Column_collection_Concat_parameter_collection_equality_inline_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Concat_parameter_collection_equality_inline_collection(a);
+
+                AssertSql(
+                    """
+@__ints_0='[1,10]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_CONCAT(c["Ints"], @__ints_0) = [1,11,111,1,10]))
+""");
+            });
+
+    public override Task Column_collection_equality_inline_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_equality_inline_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"] = [1,10]))
+""");
+            });
+
+    public override Task Column_collection_equality_inline_collection_with_parameters(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_equality_inline_collection_with_parameters(a);
+
+                AssertSql(
+                    """
+@__i_0='1'
+@__j_1='10'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Ints"] = [@__i_0, @__j_1]))
+""");
+            });
+
+    public override Task Column_collection_Where_equality_inline_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_Where_equality_inline_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY (
+    SELECT VALUE i
+    FROM i IN c["Ints"]
+    WHERE (i != 11)) = [1,111]))
+""");
+            });
+
+    public override async Task Parameter_collection_in_subquery_Union_column_collection_as_compiled_query(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Parameter_collection_in_subquery_Union_column_collection_as_compiled_query(async));
+
+            // Note that even if the query didn't attempt to do offset without limit, Cosmos still doesn't support OFFSET/LIMIT in subqueries,
+            // so this test would fail anyway.
+            Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+
+            AssertSql();
+        }
+    }
+
+    public override Task Parameter_collection_in_subquery_Union_column_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_in_subquery_Union_column_collection(a);
+
+                AssertSql(
+                    """
+@__Skip_0='[111]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(SetUnion(@__Skip_0, c["Ints"])) = 3))
+""");
+            });
+
+    public override async Task Parameter_collection_in_subquery_Union_column_collection_nested(bool async)
+    {
+        // TODO: Subquery pushdown
+        await AssertTranslationFailed(() => base.Parameter_collection_in_subquery_Union_column_collection_nested(async));
+
+        AssertSql();
+    }
+
+    public override void Parameter_collection_in_subquery_and_Convert_as_compiled_query()
+    {
+        // Array indexer over a parameter array ([1,2,3][0]) isn't supported by Cosmos.
+        // TODO: general OFFSET/LIMIT support
+        AssertTranslationFailed(() => base.Parameter_collection_in_subquery_and_Convert_as_compiled_query());
+
+        AssertSql();
+    }
+
+    public override async Task Parameter_collection_in_subquery_Count_as_compiled_query(bool async)
+    {
+        // TODO: Count after Skip requires subquery pushdown
+        await AssertTranslationFailed(() => base.Parameter_collection_in_subquery_Count_as_compiled_query(async));
+
+        AssertSql();
+    }
+
+    public override async Task Parameter_collection_in_subquery_Union_another_parameter_collection_as_compiled_query(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Parameter_collection_in_subquery_Union_another_parameter_collection_as_compiled_query(async));
+
+            // Note that even if the query didn't attempt to do offset without limit, Cosmos still doesn't support OFFSET/LIMIT in
+            // subqueries, so this test would fail anyway.
+            Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+
+            AssertSql();
+        }
+    }
+
+    public override async Task Column_collection_in_subquery_Union_parameter_collection(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Column_collection_in_subquery_Union_parameter_collection(async));
+
+            // Note that even if the query didn't attempt to do offset without limit, Cosmos still doesn't support OFFSET/LIMIT in subqueries,
+            // so this test would fail anyway.
+            Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+
+            AssertSql();
+        }
+    }
+
+    public override Task Project_collection_of_ints_simple(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_collection_of_ints_simple(a);
+
+                AssertSql(
+                    """
+SELECT c["Ints"]
+FROM root c
+WHERE (c["Discriminator"] = "PrimitiveCollectionsEntity")
+ORDER BY c["Id"]
+""");
+            });
+
+    public override async Task Project_collection_of_ints_ordered(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Project_collection_of_ints_ordered(async));
+
+            Assert.Contains("'ORDER BY' is not supported in subqueries.", exception.Message);
+        }
+    }
+
+    // TODO: Project out primitive collection subquery: #33797
+    public override async Task Project_collection_of_datetimes_filtered(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_collection_of_datetimes_filtered(async));
+        }
+    }
+
+    public override async Task Project_collection_of_nullable_ints_with_paging(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception =
+                await Assert.ThrowsAsync<CosmosException>(() => base.Project_collection_of_nullable_ints_with_paging(async: true));
+
+            Assert.Contains("'OFFSET LIMIT' clause is not supported in subqueries.", exception.Message);
+        }
+    }
+
+    public override async Task Project_collection_of_nullable_ints_with_paging2(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_collection_of_nullable_ints_with_paging2(async: true));
+
+            // Note that even if the query didn't attempt to do offset without limit, Cosmos still doesn't support OFFSET/LIMIT in subqueries,
+            // so this test would fail anyway.
+            Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+
+            AssertSql();
+        }
+    }
+
+    public override async Task Project_collection_of_nullable_ints_with_paging3(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_collection_of_nullable_ints_with_paging3(async));
+
+            // Note that even if the query didn't attempt to do offset without limit, Cosmos still doesn't support OFFSET/LIMIT in subqueries,
+            // so this test would fail anyway.
+            Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+
+            AssertSql();
+        }
+    }
+
+    // TODO: Project out primitive collection subquery: #33797
+    public override async Task Project_collection_of_ints_with_distinct(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<InvalidCastException>(() => base.Project_collection_of_ints_with_distinct(async));
+        }
+    }
+
+    public override Task Project_collection_of_nullable_ints_with_distinct(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_collection_of_nullable_ints_with_distinct(a);
+
+                AssertSql(
+                    """
+SELECT VALUE {"c" : [c["String"], "foo"]}
+FROM root c
+WHERE (c["Discriminator"] = "PrimitiveCollectionsEntity")
+""");
+            });
+
+    // TODO: Project out primitive collection subquery: #33797
+    public override async Task Project_collection_of_ints_with_ToList_and_FirstOrDefault(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<InvalidCastException>(() => base.Project_collection_of_ints_with_ToList_and_FirstOrDefault(async));
+        }
+    }
+
+    // TODO: Project out primitive collection subquery: #33797
+    public override async Task Project_empty_collection_of_nullables_and_collection_only_containing_nulls(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<InvalidCastException>(
+                () => base.Project_empty_collection_of_nullables_and_collection_only_containing_nulls(async));
+        }
+    }
+
+    public override async Task Project_multiple_collections(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // TODO: Project out primitive collection subquery: #33797
+            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_multiple_collections(async));
+        }
+    }
+
+    public override Task Project_primitive_collections_element(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_primitive_collections_element(a);
+
+                AssertSql(
+                    """
+SELECT VALUE
+{
+    "Indexer" : c["Ints"][0],
+    "EnumerableElementAt" : c["DateTimes"][0],
+    "QueryableElementAt" : c["Strings"][1]
+}
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["Id"] < 4))
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_inline_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_inline_collection(a);
+
+                // The following should be SELECT VALUE [c["String"], "foo"], #33779
+                AssertSql(
+                    """
+SELECT [c["String"], "foo"] AS c
+FROM root c
+WHERE (c["Discriminator"] = "PrimitiveCollectionsEntity")
+""");
+            });
+
+    public override async Task Project_inline_collection_with_Union(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // TODO: Project out primitive collection subquery: #33797
+            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_inline_collection_with_Union(async));
+        }
+    }
+
+    public override async Task Project_inline_collection_with_Concat(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // TODO: Project out primitive collection subquery: #33797
+            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_inline_collection_with_Concat(async));
+        }
+    }
+
+    public override Task Nested_contains_with_Lists_and_no_inferred_type_mapping(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Nested_contains_with_Lists_and_no_inferred_type_mapping(a);
+
+                AssertSql(
+                    """
+@__strings_1='["one","two","three"]'
+@__ints_0='[1,2,3]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two")))
+""");
+            });
+
+    public override Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Nested_contains_with_arrays_and_no_inferred_type_mapping(a);
+
+                AssertSql(
+                    """
+@__strings_1='["one","two","three"]'
+@__ints_0='[1,2,3]'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two")))
+""");
+            });
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public class PrimitiveCollectionsQueryCosmosFixture : PrimitiveCollectionsQueryFixtureBase
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory
+            => CosmosTestStoreFactory.Instance;
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder.ConfigureWarnings(
+                w => w.Ignore(CosmosEventId.NoPartitionKeyDefined)));
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/PrimitiveCollectionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrimitiveCollectionsQueryRelationalTestBase.cs
@@ -51,4 +51,9 @@ public class PrimitiveCollectionsQueryRelationalTestBase<TFixture>(TFixture fixt
 
         Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
     }
+
+    // TODO: Requires converting the results of a subquery (relational rowset) to a primitive collection for comparison,
+    // not yet supported (#33792)
+    public override async Task Column_collection_Where_equality_inline_collection(bool async)
+        => await AssertTranslationFailed(() => base.Column_collection_Where_equality_inline_collection(async));
 }

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -38,7 +38,8 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             // ReSharper disable once UseArrayEmptyMethod
-            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int[0].Count(i => i > c.Id) == 1));
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int[0].Count(i => i > c.Id) == 1),
+            assertEmpty: true);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -232,7 +233,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
         await AssertQuery(
             async,
-            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new List<int>() { 30, c.Int, i }.Max() == 35));
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new List<int> { 30, c.Int, i }.Max() == 35));
     }
 
     [ConditionalTheory]
@@ -502,6 +503,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => false),
             assertEmpty: true);
 
+    // TODO: This test is incorrect, see #33784
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Nullable_reference_column_collection_index_equals_nullable_column(bool async)
@@ -700,12 +702,19 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Inline_collection_Except_column_collection(bool async)
-        // Note that since the VALUES is on the left side of the set operation, it must assign column names, otherwise the column coming
-        // out of the set operation has undetermined naming.
+        // Note that in relational, since the VALUES is on the left side of the set operation, it must assign column names, otherwise the
+        // column coming out of the set operation has undetermined naming.
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(
                 c => new[] { 11, 111 }.Except(c.Ints).Count(i => i % 2 == 1) == 2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_Union(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i > 100).Union(new[] { 50 }).Count() == 2));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -750,6 +759,14 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints == new[] { i, j }),
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.SequenceEqual(new[] { i, j })));
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_equality_inline_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i != 11) == new[] { 1, 111 }),
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i != 11).SequenceEqual(new[] { 1, 111 })));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -730,6 +730,9 @@ ORDER BY [p].[Id]
     public override Task Inline_collection_Except_column_collection(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Inline_collection_Except_column_collection(async));
 
+    public override Task Column_collection_Where_Union(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Inline_collection_Except_column_collection(async));
+
     public override async Task Column_collection_equality_parameter_collection(bool async)
     {
         await base.Column_collection_equality_parameter_collection(async);
@@ -766,6 +769,13 @@ WHERE [p].[Ints] = N'[1,10]'
     public override async Task Column_collection_equality_inline_collection_with_parameters(bool async)
     {
         await base.Column_collection_equality_inline_collection_with_parameters(async);
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_Where_equality_inline_collection(bool async)
+    {
+        await base.Column_collection_Where_equality_inline_collection(async);
 
         AssertSql();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -837,6 +837,7 @@ WHERE CAST(JSON_VALUE([p].[Ints], '$[999]') AS int) = 10
 
     public override async Task Nullable_reference_column_collection_index_equals_nullable_column(bool async)
     {
+        // TODO: This test is incorrect, see #33784
         await base.Nullable_reference_column_collection_index_equals_nullable_column(async);
 
         AssertSql(
@@ -1191,6 +1192,27 @@ WHERE (
 """);
     }
 
+    public override async Task Column_collection_Where_Union(bool async)
+    {
+        await base.Column_collection_Where_Union(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [i].[value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+        WHERE [i].[value] > 100
+        UNION
+        SELECT [v].[Value] AS [value]
+        FROM (VALUES (CAST(50 AS int))) AS [v]([Value])
+    ) AS [u]) = 2
+""");
+    }
+
     public override async Task Column_collection_equality_parameter_collection(bool async)
     {
         await base.Column_collection_equality_parameter_collection(async);
@@ -1227,6 +1249,13 @@ WHERE [p].[Ints] = N'[1,10]'
     public override async Task Column_collection_equality_inline_collection_with_parameters(bool async)
     {
         await base.Column_collection_equality_inline_collection_with_parameters(async);
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_Where_equality_inline_collection(bool async)
+    {
+        await base.Column_collection_Where_equality_inline_collection(async);
 
         AssertSql();
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -1167,6 +1167,26 @@ WHERE (
 """);
     }
 
+    public override async Task Column_collection_Where_Union(bool async)
+    {
+        await base.Column_collection_Where_Union(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT "i"."value"
+        FROM json_each("p"."Ints") AS "i"
+        WHERE "i"."value" > 100
+        UNION
+        SELECT CAST(50 AS INTEGER) AS "Value"
+    ) AS "u") = 2
+""");
+    }
+
     public override async Task Column_collection_equality_parameter_collection(bool async)
     {
         await base.Column_collection_equality_parameter_collection(async);
@@ -1203,6 +1223,13 @@ WHERE "p"."Ints" = '[1,10]'
     public override async Task Column_collection_equality_inline_collection_with_parameters(bool async)
     {
         await base.Column_collection_equality_inline_collection_with_parameters(async);
+
+        AssertSql();
+    }
+
+    public override async Task Column_collection_Where_equality_inline_collection(bool async)
+    {
+        await base.Column_collection_Where_equality_inline_collection(async);
 
         AssertSql();
     }


### PR DESCRIPTION
This is the 1st PR doing work on the Cosmos pipeline; the main goal here is to support primitive collections, but this also brings in lots of other necessary query infra, modernizes the pipeline and aligns it with latest best practices and relational. Subsequent PRs should be smaller/more incremental.

This PR leaves certain things unimplemented which I intend to work on very soon (to avoid one huge PR), not everything is tracked via issues (but I have my own list etc.).



Implements #25701 for primitive collections
Implements #25700 for primitive collections
Largely implements #25765
Fixes #33858
