### PR TITLE
Clean up container management in Cosmos

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -132,6 +132,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("MissingOrderingInSelectExpression");
 
         /// <summary>
+        ///     Cosmos container '{container1}' is referenced by the query, but '{container2}' is already being referenced. A query can only reference a single Cosmos container.
+        /// </summary>
+        public static string MultipleContainersReferencedInQuery(object? container1, object? container2)
+            => string.Format(
+                GetString("MultipleContainersReferencedInQuery", nameof(container1), nameof(container2)),
+                container1, container2);
+
+        /// <summary>
         ///     Navigation '{entityType}.{navigationName}' doesn't point to an embedded entity.
         /// </summary>
         public static string NavigationPropertyIsNotAnEmbeddedEntity(object? entityType, object? navigationName)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -198,6 +198,9 @@
   <data name="MissingOrderingInSelectExpression" xml:space="preserve">
     <value>'Reverse' could not be translated to the server because there is no ordering on the server side.</value>
   </data>
+  <data name="MultipleContainersReferencedInQuery" xml:space="preserve">
+    <value>Cosmos container '{container1}' is referenced by the query, but '{container2}' is already being referenced. A query can only reference a single Cosmos container.</value>
+  </data>
   <data name="NavigationPropertyIsNotAnEmbeddedEntity" xml:space="preserve">
     <value>Navigation '{entityType}.{navigationName}' doesn't point to an embedded entity.</value>
   </data>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContext.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContext.cs
@@ -13,6 +13,17 @@ public class CosmosQueryCompilationContext(QueryCompilationContextDependencies d
     : QueryCompilationContext(dependencies, async)
 {
     /// <summary>
+    ///     The name of the Cosmos container against which this query will be executed.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual string? CosmosContainer { get; internal set; }
+
+    /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -31,7 +31,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitorFactory(
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new CosmosQueryableMethodTranslatingExpressionVisitor(
             Dependencies,
-            queryCompilationContext,
+            (CosmosQueryCompilationContext)queryCompilationContext,
             sqlExpressionFactory,
             typeMappingSource,
             memberTranslatorProvider,

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -27,7 +27,8 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         private readonly Func<CosmosQueryContext, JObject, T> _shaper;
         private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
         private readonly Type _contextType;
-        private readonly PartitionKey _partitionKeyValue;
+        private readonly string _cosmosContainer;
+        private readonly PartitionKey _cosmosPartitionKeyValue;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
         private readonly bool _standAloneStateManager;
         private readonly bool _threadSafetyChecksEnabled;
@@ -39,6 +40,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             SelectExpression selectExpression,
             Func<CosmosQueryContext, JObject, T> shaper,
             Type contextType,
+            string cosmosContainer,
             PartitionKey partitionKeyValueFromExtension,
             bool standAloneStateManager,
             bool threadSafetyChecksEnabled)
@@ -61,7 +63,8 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 throw new InvalidOperationException(CosmosStrings.PartitionKeyMismatch(partitionKeyValueFromExtension, partitionKey));
             }
 
-            _partitionKeyValue = partitionKey != PartitionKey.None ? partitionKey : partitionKeyValueFromExtension;
+            _cosmosPartitionKeyValue = partitionKey != PartitionKey.None ? partitionKey : partitionKeyValueFromExtension;
+            _cosmosContainer = cosmosContainer;
         }
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -107,10 +110,10 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         {
             private readonly QueryingEnumerable<T> _queryingEnumerable;
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly SelectExpression _selectExpression;
             private readonly Func<CosmosQueryContext, JObject, T> _shaper;
             private readonly Type _contextType;
-            private readonly PartitionKey _partitionKeyValue;
+            private readonly string _cosmosContainer;
+            private readonly PartitionKey _cosmosPartitionKeyValue;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _standAloneStateManager;
             private readonly IConcurrencyDetector _concurrencyDetector;
@@ -123,9 +126,9 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 _queryingEnumerable = queryingEnumerable;
                 _cosmosQueryContext = queryingEnumerable._cosmosQueryContext;
                 _shaper = queryingEnumerable._shaper;
-                _selectExpression = queryingEnumerable._selectExpression;
                 _contextType = queryingEnumerable._contextType;
-                _partitionKeyValue = queryingEnumerable._partitionKeyValue;
+                _cosmosContainer = queryingEnumerable._cosmosContainer;
+                _cosmosPartitionKeyValue = queryingEnumerable._cosmosPartitionKeyValue;
                 _queryLogger = queryingEnumerable._queryLogger;
                 _standAloneStateManager = queryingEnumerable._standAloneStateManager;
                 _exceptionDetector = _cosmosQueryContext.ExceptionDetector;
@@ -156,8 +159,8 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
                             _enumerator = _cosmosQueryContext.CosmosClient
                                 .ExecuteSqlQuery(
-                                    _selectExpression.Container,
-                                    _partitionKeyValue,
+                                    _cosmosContainer,
+                                    _cosmosPartitionKeyValue,
                                     sqlQuery)
                                 .GetEnumerator();
                             _cosmosQueryContext.InitializeStateManager(_standAloneStateManager);
@@ -206,10 +209,10 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         {
             private readonly QueryingEnumerable<T> _queryingEnumerable;
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly SelectExpression _selectExpression;
             private readonly Func<CosmosQueryContext, JObject, T> _shaper;
             private readonly Type _contextType;
-            private readonly PartitionKey _partitionKeyValue;
+            private readonly string _cosmosContainer;
+            private readonly PartitionKey _cosmosPartitionKeyValue;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _standAloneStateManager;
             private readonly CancellationToken _cancellationToken;
@@ -223,9 +226,9 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 _queryingEnumerable = queryingEnumerable;
                 _cosmosQueryContext = queryingEnumerable._cosmosQueryContext;
                 _shaper = queryingEnumerable._shaper;
-                _selectExpression = queryingEnumerable._selectExpression;
                 _contextType = queryingEnumerable._contextType;
-                _partitionKeyValue = queryingEnumerable._partitionKeyValue;
+                _cosmosContainer = queryingEnumerable._cosmosContainer;
+                _cosmosPartitionKeyValue = queryingEnumerable._cosmosPartitionKeyValue;
                 _queryLogger = queryingEnumerable._queryLogger;
                 _standAloneStateManager = queryingEnumerable._standAloneStateManager;
                 _exceptionDetector = _cosmosQueryContext.ExceptionDetector;
@@ -254,8 +257,8 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
                             _enumerator = _cosmosQueryContext.CosmosClient
                                 .ExecuteSqlQueryAsync(
-                                    _selectExpression.Container,
-                                    _partitionKeyValue,
+                                    _cosmosContainer,
+                                    _cosmosPartitionKeyValue,
                                     sqlQuery)
                                 .GetAsyncEnumerator(_cancellationToken);
                             _cosmosQueryContext.InitializeStateManager(_standAloneStateManager);

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -22,6 +22,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
     private sealed class ReadItemQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IQueryingEnumerable
     {
         private readonly CosmosQueryContext _cosmosQueryContext;
+        private readonly string _cosmosContainer;
         private readonly ReadItemExpression _readItemExpression;
         private readonly Func<CosmosQueryContext, JObject, T> _shaper;
         private readonly Type _contextType;
@@ -31,6 +32,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
         public ReadItemQueryingEnumerable(
             CosmosQueryContext cosmosQueryContext,
+            string cosmosContainer,
             ReadItemExpression readItemExpression,
             Func<CosmosQueryContext, JObject, T> shaper,
             Type contextType,
@@ -38,6 +40,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             bool threadSafetyChecksEnabled)
         {
             _cosmosQueryContext = cosmosQueryContext;
+            _cosmosContainer = cosmosContainer;
             _readItemExpression = readItemExpression;
             _shaper = shaper;
             _contextType = contextType;
@@ -169,7 +172,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         private sealed class Enumerator : IEnumerator<T>, IAsyncEnumerator<T>
         {
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly ReadItemExpression _readItemExpression;
+            private readonly string _cosmosContainer;
             private readonly Func<CosmosQueryContext, JObject, T> _shaper;
             private readonly Type _contextType;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
@@ -185,7 +188,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             public Enumerator(ReadItemQueryingEnumerable<T> readItemEnumerable, CancellationToken cancellationToken = default)
             {
                 _cosmosQueryContext = readItemEnumerable._cosmosQueryContext;
-                _readItemExpression = readItemEnumerable._readItemExpression;
+                _cosmosContainer = readItemEnumerable._cosmosContainer;
                 _shaper = readItemEnumerable._shaper;
                 _contextType = readItemEnumerable._contextType;
                 _queryLogger = readItemEnumerable._queryLogger;
@@ -227,7 +230,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                             EntityFrameworkEventSource.Log.QueryExecuting();
 
                             _item = _cosmosQueryContext.CosmosClient.ExecuteReadItem(
-                                _readItemExpression.Container,
+                                _cosmosContainer,
                                 partitionKeyValue,
                                 resourceId);
 
@@ -279,7 +282,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                             EntityFrameworkEventSource.Log.QueryExecuting();
 
                             _item = await _cosmosQueryContext.CosmosClient.ExecuteReadItemAsync(
-                                    _readItemExpression.Container,
+                                    _cosmosContainer,
                                     partitionKeyValue,
                                     resourceId,
                                     _cancellationToken)

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -35,6 +35,11 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor(
     /// </summary>
     protected override Expression VisitShapedQuery(ShapedQueryExpression shapedQueryExpression)
     {
+        if (cosmosQueryCompilationContext.CosmosContainer is null)
+        {
+            throw new UnreachableException("No Cosmos container was set during query processing.");
+        }
+
         var jObjectParameter = Parameter(typeof(JObject), "jObject");
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
@@ -64,6 +69,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor(
                     Constant(selectExpression),
                     Constant(shaperLambda.Compile()),
                     Constant(_contextType),
+                    Constant(cosmosQueryCompilationContext.CosmosContainer),
                     Constant(_partitionKeyValueFromExtension, typeof(PartitionKey)),
                     Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
@@ -85,6 +91,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor(
                     Convert(
                         QueryCompilationContext.QueryContextParameter,
                         typeof(CosmosQueryContext)),
+                    Constant(cosmosQueryCompilationContext.CosmosContainer),
                     Constant(readItemExpression),
                     Constant(shaperReadItemLambda.Compile()),
                     Constant(_contextType),

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ReadItemExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ReadItemExpression.cs
@@ -38,14 +38,6 @@ public class ReadItemExpression : Expression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Container { get; }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public virtual ProjectionExpression ProjectionExpression { get; }
 
     /// <summary>
@@ -74,9 +66,6 @@ public class ReadItemExpression : Expression
         IEntityType entityType,
         IDictionary<IProperty, string> propertyParameters)
     {
-        Container = entityType.GetContainer()
-            ?? throw new UnreachableException("No container ID, or trying to perform ReadItem on owned entity type");
-
         ProjectionExpression = new ProjectionExpression(
             new EntityProjectionExpression(
                 entityType,


### PR DESCRIPTION
~**NOTE: This PR is based on top of #33895, review 2nd commit only**~

The Cosmos container is currently extracted from the entity type and stored inside SelectExpression - but it doesn't belong there. For one thing, there can be multiple SelectExpressions in a single query (e.g. subqueries), but queries can only ever reference a single container. There was also some hacky stuff around owned entities, which aren't considered to have a (direct) container, but SelectExpression required one.

Removed the container concept from SelectExpression altogether, and moved it to CosmosQueryCompilationContext (which is scoped to the entire query) - like the partition key. 
