### PR TITLE
Remove unneeded Cosmos 3-value logic compensation for InExpression 

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -254,12 +254,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 param1, param2);
 
         /// <summary>
-        ///     Only constants or parameters are currently allowed in Contains.
-        /// </summary>
-        public static string OnlyConstantsAndParametersAllowedInContains
-            => GetString("OnlyConstantsAndParametersAllowedInContains");
-
-        /// <summary>
         ///     The entity of type '{entityType}' is mapped as a part of the document mapped to '{missingEntityType}', but there is no tracked entity of this type with the corresponding key value. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
         public static string OrphanedNestedDocument(object? entityType, object? missingEntityType)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -246,9 +246,6 @@
   <data name="OneOfTwoValuesMustBeSet" xml:space="preserve">
     <value>Exactly one of '{param1}' or '{param2}' must be set.</value>
   </data>
-  <data name="OnlyConstantsAndParametersAllowedInContains" xml:space="preserve">
-    <value>Only constants or parameters are currently allowed in Contains.</value>
-  </data>
   <data name="OrphanedNestedDocument" xml:space="preserve">
     <value>The entity of type '{entityType}' is mapped as a part of the document mapped to '{missingEntityType}', but there is no tracked entity of this type with the corresponding key value. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
@@ -10,64 +10,34 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 public partial class CosmosShapedQueryCompilingExpressionVisitor
 {
-    private sealed class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
+    private sealed class InExpressionValuesExpandingExpressionVisitor(
+        ISqlExpressionFactory sqlExpressionFactory,
+        IReadOnlyDictionary<string, object> parametersValues)
+        : ExpressionVisitor
     {
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
-        private readonly IReadOnlyDictionary<string, object> _parametersValues;
-
-        public InExpressionValuesExpandingExpressionVisitor(
-            ISqlExpressionFactory sqlExpressionFactory,
-            IReadOnlyDictionary<string, object> parametersValues)
-        {
-            _sqlExpressionFactory = sqlExpressionFactory;
-            _parametersValues = parametersValues;
-        }
-
-        public override Expression Visit(Expression expression)
+        protected override Expression VisitExtension(Expression expression)
         {
             if (expression is InExpression inExpression)
             {
-                var inValues = new List<SqlExpression>();
-                var hasNullValue = false;
+                IReadOnlyList<SqlExpression> values;
 
                 switch (inExpression)
                 {
+                    case { Values: IReadOnlyList<SqlExpression> values2 }:
+                        values = values2;
+                        break;
+
+                    // TODO: IN with subquery (return immediately, nothing to do here)
+
                     case { ValuesParameter: SqlParameterExpression valuesParameter }:
                     {
                         var typeMapping = valuesParameter.TypeMapping;
-
-                        foreach (var value in (IEnumerable)_parametersValues[valuesParameter.Name])
+                        var mutableValues = new List<SqlExpression>();
+                        foreach (var value in (IEnumerable)parametersValues[valuesParameter.Name])
                         {
-                            if (value is null)
-                            {
-                                hasNullValue = true;
-                                continue;
-                            }
-
-                            inValues.Add(_sqlExpressionFactory.Constant(value, typeMapping));
+                            mutableValues.Add(sqlExpressionFactory.Constant(value, typeMapping));
                         }
-
-                        break;
-                    }
-
-                    case { Values: IReadOnlyList<SqlExpression> values }:
-                    {
-                        foreach (var value in values)
-                        {
-                            if (value is not (SqlConstantExpression or SqlParameterExpression))
-                            {
-                                throw new InvalidOperationException(CosmosStrings.OnlyConstantsAndParametersAllowedInContains);
-                            }
-
-                            if (IsNull(value))
-                            {
-                                hasNullValue = true;
-                                continue;
-                            }
-
-                            inValues.Add(value);
-                        }
-
+                        values = mutableValues;
                         break;
                     }
 
@@ -75,34 +45,12 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                         throw new UnreachableException();
                 }
 
-                var updatedInExpression = inValues.Count > 0
-                    ? _sqlExpressionFactory.In((SqlExpression)Visit(inExpression.Item), inValues)
-                    : null;
-
-                var nullCheckExpression = hasNullValue
-                    ? _sqlExpressionFactory.IsNull(inExpression.Item)
-                    : null;
-
-                if (updatedInExpression != null
-                    && nullCheckExpression != null)
-                {
-                    return _sqlExpressionFactory.OrElse(updatedInExpression, nullCheckExpression);
-                }
-
-                if (updatedInExpression == null
-                    && nullCheckExpression == null)
-                {
-                    return _sqlExpressionFactory.Equal(_sqlExpressionFactory.Constant(true), _sqlExpressionFactory.Constant(false));
-                }
-
-                return (SqlExpression)updatedInExpression ?? nullCheckExpression;
+                return values.Count == 0
+                    ? sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(false))
+                    : sqlExpressionFactory.In((SqlExpression)Visit(inExpression.Item), values);
             }
 
-            return base.Visit(expression);
+            return base.VisitExtension(expression);
         }
-
-        private bool IsNull(SqlExpression expression)
-            => expression is SqlConstantExpression { Value: null }
-                || expression is SqlParameterExpression { Name: string parameterName } && _parametersValues[parameterName] is null;
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1806,9 +1806,8 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
-"""
-                );
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN (null, null))
+""");
             });
 
     public override Task Contains_with_local_read_only_collection_inline(bool async)
@@ -1969,7 +1968,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND NOT((true = false)))
+WHERE ((c["Discriminator"] = "Customer") AND NOT(false))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4158,7 +4158,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equali
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI") OR (c["CustomerID"] = null)))
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN (null, "ALFKI"))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -55,7 +55,7 @@ WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["NullableInt"] 
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["NullableInt"] IN (999) OR (c["NullableInt"] = null)))
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["NullableInt"] IN (null, 999))
 """);
             });
 
@@ -137,7 +137,7 @@ WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (true = false))
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND false)
 """);
             });
 
@@ -230,13 +230,37 @@ WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Id"] IN (2, @_
 """);
             });
 
-    // TODO: Remove incorrect null semantics compensation for Cosmos: #31063
     public override Task Inline_collection_Contains_with_mixed_value_types(bool async)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Inline_collection_Contains_with_mixed_value_types(async));
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_Contains_with_mixed_value_types(a);
 
-    // TODO: Remove incorrect null semantics compensation for Cosmos: #31063
+                AssertSql(
+                    """
+@__i_0='11'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"])))
+""");
+            });
+
     public override Task Inline_collection_List_Contains_with_mixed_value_types(bool async)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Inline_collection_List_Contains_with_mixed_value_types(async));
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_List_Contains_with_mixed_value_types(a);
+
+                AssertSql(
+                    """
+@__i_0='11'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"])))
+""");
+            });
 
     public override Task Inline_collection_Contains_as_Any_with_predicate(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -147,7 +147,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
         await AssertQuery(
             async,
-            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new List<int>() { 999, i, c.Id, c.Id + c.Int }.Contains(c.Int)));
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new List<int> { 999, i, c.Id, c.Id + c.Int }.Contains(c.Int)));
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
~**NOTE: This PR is based on top of https://github.com/dotnet/efcore/pull/33895, review 2nd commit only**~

Closes #31063