### PR TITLE
Revert broken validation for JSON properties with no JsonValueReaderWriter

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -2800,14 +2800,6 @@ public class RelationalModelValidator : ModelValidator
                     RelationalStrings.JsonEntityWithMultiplePropertiesMappedToSameJsonProperty(
                         jsonEntityType.DisplayName(), jsonPropertyName));
             }
-
-            var jsonValueReaderWriter = property.GetJsonValueReaderWriter() ?? property.GetTypeMapping().JsonValueReaderWriter;
-            if (jsonValueReaderWriter is null)
-            {
-                throw new InvalidOperationException(
-                    RelationalStrings.JsonValueReadWriterMissingOnTypeMapping(
-                        property.GetTypeMapping().GetType().Name, property.Name, jsonEntityType.DisplayName()));
-            }
         }
 
         foreach (var navigation in jsonEntityType.GetDeclaredNavigations())

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.Json.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.Json.cs
@@ -422,31 +422,6 @@ public partial class RelationalModelValidatorTest
     }
 
     [ConditionalFact]
-    public void Json_entity_with_property_without_JsonValueReaderWriter()
-    {
-        var modelBuilder = CreateConventionModelBuilder();
-        modelBuilder.Entity<ValidatorJsonEntityBasic>(
-            b =>
-            {
-                b.OwnsOne(
-                    x => x.OwnedReference, bb =>
-                    {
-                        bb.Property(x => x.Name).Metadata.SetJsonValueReaderWriterType(null);
-                        bb.Property(x => x.Number).HasJsonPropertyName("Foo");
-                        bb.ToJson("reference");
-                        bb.Ignore(x => x.NestedReference);
-                        bb.Ignore(x => x.NestedCollection);
-                    });
-                b.Ignore(x => x.OwnedCollection);
-            });
-
-        // The test model uses TestStringTypeMapping, which indeed doesn't have a JsonValueReaderWriter
-        VerifyError(
-            RelationalStrings.JsonValueReadWriterMissingOnTypeMapping("TestStringTypeMapping", "Name", "ValidatorJsonOwnedRoot"),
-            modelBuilder);
-    }
-
-    [ConditionalFact]
     public void Json_on_base_and_derived_mapped_to_same_column_throws()
     {
         var modelBuilder = CreateConventionModelBuilder();

--- a/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-
 namespace Microsoft.EntityFrameworkCore;
 
 [SpatialiteRequired]
@@ -173,6 +170,41 @@ public class JsonTypesSqliteTest : JsonTypesRelationalTestBase
 
     public override Task Can_read_write_collection_of_nullable_GUID_JSON_values(string expected)
         => base.Can_read_write_collection_of_nullable_GUID_JSON_values("""{"Prop":["00000000-0000-0000-0000-000000000000",null,"8C44242F-8E3F-4A20-8BE8-98C7C1AADEBD","FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"]}""");
+
+    public override Task Can_read_write_ulong_enum_JSON_values(EnumU64 value, string json)
+        => Can_read_and_write_JSON_value<EnumU64Type, EnumU64>(nameof(EnumU64Type.EnumU64), value, json);
+
+    public override Task Can_read_write_nullable_ulong_enum_JSON_values(object? value, string json)
+        => Can_read_and_write_JSON_value<NullableEnumU64Type, EnumU64?>(
+            nameof(NullableEnumU64Type.EnumU64),
+            value == null ? default(EnumU64?) : (EnumU64)value, json);
+
+    public override Task Can_read_write_collection_of_ulong_enum_JSON_values()
+        => Can_read_and_write_JSON_value<EnumU64CollectionType, List<EnumU64>>(
+            nameof(EnumU64CollectionType.EnumU64),
+            [
+                EnumU64.Min,
+                EnumU64.Max,
+                EnumU64.Default,
+                EnumU64.One,
+                (EnumU64)8
+            ],
+            """{"Prop":[0,18446744073709551615,0,1,8]}""",
+            mappedCollection: true);
+
+    public override Task Can_read_write_collection_of_nullable_ulong_enum_JSON_values()
+        => Can_read_and_write_JSON_value<NullableEnumU64CollectionType, List<EnumU64?>>(
+            nameof(NullableEnumU64CollectionType.EnumU64),
+            [
+                EnumU64.Min,
+                null,
+                EnumU64.Max,
+                EnumU64.Default,
+                EnumU64.One,
+                (EnumU64?)8
+            ],
+            """{"Prop":[0,null,18446744073709551615,0,1,8]}""",
+            mappedCollection: true);
 
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;


### PR DESCRIPTION
To fix the build. Opened #33907 to track doing this validation properly.