### PR TITLE
Cosmos: work on Skip/Take, undefined 

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+
+/// <summary>
+///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+///     The methods on this class are accessed via <see cref="EF.Functions" />.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
+///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Cosmos with EF Core</see> for more information and examples.
+/// </remarks>
+public static class CosmosDbFunctionsExtensions
+{
+    /// <summary>
+    ///     Returns a boolean indicating if the property has been assigned a value. Corresponds to the Cosmos <c>IS_DEFINED</c> function.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Cosmos with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="expression">The expression to check.</param>
+    /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/nosql/query/is-defined">Cosmos <c>IS_DEFINED_</c> function</seealso>
+    public static bool IsDefined(this DbFunctions _, object? expression)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(IsDefined)));
+
+    /// <summary>
+    ///     Coalesces a Cosmos <c>undefined</c> value via the <c>??</c> operator.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Cosmos with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="expression1">
+    ///     The expression to coalesce. This expression will be returned unless it is <c>undefined</c>, in which case
+    ///     <paramref name="expression2" /> will be returned.
+    /// </param>
+    /// <param name="expression2">The expression to be returned if <paramref name="expression1" /> is <c>undefined</c>.</param>
+    /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/nosql/query/ternary-coalesce-operators#coalesce-operator">Cosmos coalesce operator</seealso>
+    public static T CoalesceUndefined<T>(
+        this DbFunctions _,
+        T expression1,
+        T expression2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CoalesceUndefined)));
+}

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -126,6 +126,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 property1, property2, entityType, storeName);
 
         /// <summary>
+        ///     Skip, Take, First/FirstOrDefault and Single/SingleOrDefault aren't supported in subqueries since Cosmos doesn't support LIMIT/OFFSET in subqueries.
+        /// </summary>
+        public static string LimitOffsetNotSupportedInSubqueries
+            => GetString("LimitOffsetNotSupportedInSubqueries");
+
+        /// <summary>
         ///     'Reverse' could not be translated to the server because there is no ordering on the server side.
         /// </summary>
         public static string MissingOrderingInSelectExpression

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -159,6 +159,9 @@
   <data name="JsonPropertyCollision" xml:space="preserve">
     <value>Both properties '{property1}' and '{property2}' on entity type '{entityType}' are mapped to '{storeName}'. Map one of the properties to a different JSON property.</value>
   </data>
+  <data name="LimitOffsetNotSupportedInSubqueries" xml:space="preserve">
+    <value>Skip, Take, First/FirstOrDefault and Single/SingleOrDefault aren't supported in subqueries since Cosmos doesn't support LIMIT/OFFSET in subqueries.</value>
+  </data>
   <data name="LogExecutedCreateItem" xml:space="preserve">
     <value>Executed CreateItem ({elapsed} ms, {charge} RU) ActivityId='{activityId}', Container='{container}', Id='{id}', Partition='{partitionKey}'</value>
     <comment>Information CosmosEventId.ExecutedCreateItem string string string string string string?</comment>
@@ -242,6 +245,9 @@
   </data>
   <data name="OffsetRequiresLimit" xml:space="preserve">
     <value>Cosmos SQL does not allow Offset without Limit. Consider specifying a 'Take' operation on the query.</value>
+  </data>
+  <data name="SingleFirstOrDefaultNotSupportedOnNonNullableQueries" xml:space="preserve">
+    <value>SingleOrDefault and FirstOrDefault cannot be used Cosmos SQL does not allow Offset without Limit. Consider specifying a 'Take' operation on the query.</value>
   </data>
   <data name="OneOfTwoValuesMustBeSet" xml:space="preserve">
     <value>Exactly one of '{param1}' or '{param2}' must be set.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -32,7 +32,8 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
             new CosmosStringMethodTranslator(sqlExpressionFactory),
             new CosmosRandomTranslator(sqlExpressionFactory),
             new CosmosMathTranslator(sqlExpressionFactory),
-            new CosmosRegexTranslator(sqlExpressionFactory)
+            new CosmosRegexTranslator(sqlExpressionFactory),
+            new CosmosTypeCheckingTranslator(sqlExpressionFactory)
             //new LikeTranslator(sqlExpressionFactory),
             //new EnumHasFlagTranslator(sqlExpressionFactory),
             //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
@@ -87,7 +87,7 @@ public static class CosmosQueryUtils
     public static bool TryExtractBareArray(
         ShapedQueryExpression source,
         [NotNullWhen(true)] out SqlExpression? array,
-        [NotNullWhen(true)] out ScalarReferenceExpression? projectedScalarReference,
+        [NotNullWhen(true)] out SqlExpression? projectedScalarReference,
         bool ignoreOrderings = false)
     {
         if (source.QueryExpression is not SelectExpression

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlBinaryExpression.cs
@@ -14,32 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 /// </summary>
 public class SqlBinaryExpression : SqlExpression
 {
-    private static readonly ISet<ExpressionType> AllowedOperators = new HashSet<ExpressionType>
-    {
-        ExpressionType.Add,
-        ExpressionType.Subtract,
-        ExpressionType.Multiply,
-        ExpressionType.Divide,
-        ExpressionType.Modulo,
-        ExpressionType.And,
-        ExpressionType.AndAlso,
-        ExpressionType.Or,
-        ExpressionType.OrElse,
-        ExpressionType.LessThan,
-        ExpressionType.LessThanOrEqual,
-        ExpressionType.GreaterThan,
-        ExpressionType.GreaterThanOrEqual,
-        ExpressionType.Equal,
-        ExpressionType.NotEqual,
-        ExpressionType.ExclusiveOr,
-        ExpressionType.RightShift,
-        ExpressionType.LeftShift,
-        ExpressionType.ArrayIndex
-    };
-
-    internal static bool IsValidOperator(ExpressionType operatorType)
-        => AllowedOperators.Contains(operatorType);
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -115,6 +89,36 @@ public class SqlBinaryExpression : SqlExpression
             ? new SqlBinaryExpression(OperatorType, left, right, Type, TypeMapping)
             : this;
 
+    internal static bool IsValidOperator(ExpressionType operatorType)
+    {
+        switch (operatorType)
+        {
+            case ExpressionType.Add:
+            case ExpressionType.Subtract:
+            case ExpressionType.Multiply:
+            case ExpressionType.Divide:
+            case ExpressionType.Modulo:
+            case ExpressionType.And:
+            case ExpressionType.AndAlso:
+            case ExpressionType.Or:
+            case ExpressionType.OrElse:
+            case ExpressionType.LessThan:
+            case ExpressionType.LessThanOrEqual:
+            case ExpressionType.GreaterThan:
+            case ExpressionType.GreaterThanOrEqual:
+            case ExpressionType.Equal:
+            case ExpressionType.NotEqual:
+            case ExpressionType.ExclusiveOr:
+            case ExpressionType.RightShift:
+            case ExpressionType.LeftShift:
+            case ExpressionType.ArrayIndex:
+            case ExpressionType.Coalesce:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -123,6 +127,15 @@ public class SqlBinaryExpression : SqlExpression
     /// </summary>
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
+        if (OperatorType is ExpressionType.ArrayIndex)
+        {
+            expressionPrinter.Visit(Left);
+            expressionPrinter.Append("[");
+            expressionPrinter.Visit(Right);
+            expressionPrinter.Append("]");
+            return;
+        }
+
         var requiresBrackets = RequiresBrackets(Left);
 
         if (requiresBrackets)

--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -205,6 +205,14 @@ public interface ISqlExpressionFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    SqlExpression CoalesceUndefined(SqlExpression left, SqlExpression right, CoreTypeMapping? typeMapping = null);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     SqlBinaryExpression IsNull(SqlExpression operand);
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -131,8 +131,8 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
                         : typeMappingSource.FindMapping(right.Type, model));
                 resultType = typeof(bool);
                 resultTypeMapping = _boolTypeMapping;
-            }
                 break;
+            }
 
             case ExpressionType.AndAlso:
             case ExpressionType.OrElse:
@@ -140,8 +140,8 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
                 inferredTypeMapping = _boolTypeMapping;
                 resultType = typeof(bool);
                 resultTypeMapping = _boolTypeMapping;
-            }
                 break;
+            }
 
             case ExpressionType.Add:
             case ExpressionType.Subtract:
@@ -152,14 +152,16 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
             case ExpressionType.RightShift:
             case ExpressionType.And:
             case ExpressionType.Or:
+            case ExpressionType.Coalesce:
             {
                 inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
                 resultType = inferredTypeMapping?.ClrType ?? left.Type;
                 resultTypeMapping = inferredTypeMapping;
-            }
                 break;
+            }
 
             case ExpressionType.ArrayIndex:
+            {
                 // TODO: This infers based on the CLR type; need to properly infer based on the element type mapping
                 // TODO: being applied here (e.g. WHERE @p[1] = c.PropertyWithValueConverter)
                 var arrayTypeMapping = left.TypeMapping
@@ -170,6 +172,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
                     ApplyDefaultTypeMapping(right),
                     sqlBinaryExpression.Type,
                     typeMapping ?? sqlBinaryExpression.TypeMapping);
+            }
 
             default:
                 throw new InvalidOperationException(
@@ -493,6 +496,15 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
         => SqlUnaryExpression.IsValidOperator(operatorType)
             ? (SqlUnaryExpression)ApplyTypeMapping(new SqlUnaryExpression(operatorType, operand, type, null), typeMapping)
             : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression CoalesceUndefined(SqlExpression left, SqlExpression right, CoreTypeMapping? typeMapping = null)
+        => MakeBinary(ExpressionType.Coalesce, left, right, typeMapping)!;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosTypeCheckingTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosTypeCheckingTranslator.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CosmosTypeCheckingTranslator(ISqlExpressionFactory sqlExpressionFactory) : IMethodCallTranslator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType != typeof(CosmosDbFunctionsExtensions))
+        {
+            return null;
+        }
+
+        return method.Name switch
+        {
+            nameof(CosmosDbFunctionsExtensions.IsDefined)
+                => sqlExpressionFactory.Function("IS_DEFINED", [arguments[1]], typeof(bool)),
+
+            nameof(CosmosDbFunctionsExtensions.CoalesceUndefined)
+                => sqlExpressionFactory.CoalesceUndefined(arguments[1], arguments[2]),
+
+            _ => null
+        };
+    }
+}

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -17,25 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// </summary>
 public class QuerySqlGenerator : SqlExpressionVisitor
 {
-    private static readonly Dictionary<ExpressionType, string> OperatorMap = new()
-    {
-        { ExpressionType.Equal, " = " },
-        { ExpressionType.NotEqual, " <> " },
-        { ExpressionType.GreaterThan, " > " },
-        { ExpressionType.GreaterThanOrEqual, " >= " },
-        { ExpressionType.LessThan, " < " },
-        { ExpressionType.LessThanOrEqual, " <= " },
-        { ExpressionType.AndAlso, " AND " },
-        { ExpressionType.OrElse, " OR " },
-        { ExpressionType.Add, " + " },
-        { ExpressionType.Subtract, " - " },
-        { ExpressionType.Multiply, " * " },
-        { ExpressionType.Divide, " / " },
-        { ExpressionType.Modulo, " % " },
-        { ExpressionType.And, " & " },
-        { ExpressionType.Or, " | " }
-    };
-
     private readonly IRelationalCommandBuilderFactory _relationalCommandBuilderFactory;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
     private IRelationalCommandBuilder _relationalCommandBuilder;
@@ -1098,7 +1079,26 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     /// <param name="binaryExpression">A SQL binary operation.</param>
     /// <returns>A string representation of the binary operator.</returns>
     protected virtual string GetOperator(SqlBinaryExpression binaryExpression)
-        => OperatorMap[binaryExpression.OperatorType];
+        => binaryExpression.OperatorType switch
+        {
+            ExpressionType.Equal => " = ",
+            ExpressionType.NotEqual => " <> ",
+            ExpressionType.GreaterThan => " > ",
+            ExpressionType.GreaterThanOrEqual => " >= ",
+            ExpressionType.LessThan => " < ",
+            ExpressionType.LessThanOrEqual => " <= ",
+            ExpressionType.AndAlso => " AND ",
+            ExpressionType.OrElse => " OR ",
+            ExpressionType.Add => " + ",
+            ExpressionType.Subtract => " - ",
+            ExpressionType.Multiply => " * ",
+            ExpressionType.Divide => " / ",
+            ExpressionType.Modulo => " % ",
+            ExpressionType.And => " & ",
+            ExpressionType.Or => " | ",
+
+            _ => throw new UnreachableException($"Unsupported unary OperatorType: {binaryExpression.OperatorType}")
+        };
 
     /// <summary>
     ///     Generates SQL for the TOP clause of the given SELECT expression.

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
@@ -14,34 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </summary>
 public class SqlBinaryExpression : SqlExpression
 {
-    private static readonly ISet<ExpressionType> AllowedOperators = new HashSet<ExpressionType>
-    {
-        ExpressionType.Add,
-        ExpressionType.Subtract,
-        ExpressionType.Multiply,
-        ExpressionType.Divide,
-        ExpressionType.Modulo,
-        //ExpressionType.Power,
-        ExpressionType.And,
-        ExpressionType.AndAlso,
-        ExpressionType.Or,
-        ExpressionType.OrElse,
-        ExpressionType.LessThan,
-        ExpressionType.LessThanOrEqual,
-        ExpressionType.GreaterThan,
-        ExpressionType.GreaterThanOrEqual,
-        ExpressionType.Equal,
-        ExpressionType.NotEqual
-        //ExpressionType.ExclusiveOr,
-        //ExpressionType.ArrayIndex,
-        //ExpressionType.RightShift,
-        //ExpressionType.LeftShift,
-    };
-
     private static ConstructorInfo? _quotingConstructor;
-
-    internal static bool IsValidOperator(ExpressionType operatorType)
-        => AllowedOperators.Contains(operatorType);
 
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlBinaryExpression" /> class.
@@ -106,6 +79,32 @@ public class SqlBinaryExpression : SqlExpression
         => left != Left || right != Right
             ? new SqlBinaryExpression(OperatorType, left, right, Type, TypeMapping)
             : this;
+
+    internal static bool IsValidOperator(ExpressionType operatorType)
+    {
+        switch (operatorType)
+        {
+            case ExpressionType.Add:
+            case ExpressionType.Subtract:
+            case ExpressionType.Multiply:
+            case ExpressionType.Divide:
+            case ExpressionType.Modulo:
+            case ExpressionType.And:
+            case ExpressionType.AndAlso:
+            case ExpressionType.Or:
+            case ExpressionType.OrElse:
+            case ExpressionType.LessThan:
+            case ExpressionType.LessThanOrEqual:
+            case ExpressionType.GreaterThan:
+            case ExpressionType.GreaterThanOrEqual:
+            case ExpressionType.Equal:
+            case ExpressionType.NotEqual:
+            case ExpressionType.Coalesce:
+                return true;
+            default:
+                return false;
+        }
+    }
 
     /// <inheritdoc />
     public override Expression Quote()

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -644,12 +644,5 @@ internal static class SharedTypeExtensions
     }
 
     public static ConstantExpression GetDefaultValueConstant(this Type type)
-        => (ConstantExpression)GenerateDefaultValueConstantMethod
-            .MakeGenericMethod(type).Invoke(null, [])!;
-
-    private static readonly MethodInfo GenerateDefaultValueConstantMethod =
-        typeof(SharedTypeExtensions).GetTypeInfo().GetDeclaredMethod(nameof(GenerateDefaultValueConstant))!;
-
-    private static ConstantExpression GenerateDefaultValueConstant<TDefault>()
-        => Expression.Constant(default(TDefault), typeof(TDefault));
+        => Expression.Constant(type.IsValueType ? RuntimeHelpers.GetUninitializedObject(type) : null, type);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -42,6 +42,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 
     public override async Task Contains_over_keyless_entity_throws(bool async)
     {
+        // TODO: #33931
         // The subquery inside the Contains gets executed separately during shaper generation - and synchronously (even in
         // the async variant of the test), but Cosmos doesn't support sync I/O. So both sync and async variants fail because of unsupported
         // sync I/O.

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -614,6 +614,37 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_First(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.First() == 1),
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Ints.Length >= 1 ? c.Ints.First() : -1) == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_FirstOrDefault(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.FirstOrDefault() == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Single(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Single() == 1),
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Ints.Length >= 1 ? c.Ints.First() : -1) == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_SingleOrDefault(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.SingleOrDefault() == 1),
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Ints.Length >= 1 ? c.Ints[0] : -1) == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_Skip(bool async)
         => AssertQuery(
             async,
@@ -635,6 +666,27 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_Skip(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i > 1).Skip(1).Count() == 3));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_Take(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i > 1).Take(2).Count() == 2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_Skip_Take(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i > 1).Skip(1).Take(2).Count() == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_Contains_over_subquery(bool async)
         => AssertQuery(
             async,
@@ -649,6 +701,16 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
                 .Where(c => c.Ints.OrderByDescending(i => i).ElementAt(0) == 111),
             ss => ss.Set<PrimitiveCollectionsEntity>()
                 .Where(c => c.Ints.Length > 0 && c.Ints.OrderByDescending(i => i).ElementAt(0) == 111));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_ElementAt(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => c.Ints.Where(i => i > 1).ElementAt(0) == 11),
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => c.Ints.Where(i => i > 1).FirstOrDefault(0) == 11));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -703,6 +703,18 @@ WHERE (
     public override Task Column_collection_ElementAt(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_ElementAt(async));
 
+    public override Task Column_collection_First(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_First(async));
+
+    public override Task Column_collection_FirstOrDefault(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_FirstOrDefault(async));
+
+    public override Task Column_collection_Single(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Single(async));
+
+    public override Task Column_collection_SingleOrDefault(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_SingleOrDefault(async));
+
     public override Task Column_collection_Skip(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Skip(async));
 
@@ -712,11 +724,23 @@ WHERE (
     public override Task Column_collection_Skip_Take(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Skip_Take(async));
 
+    public override Task Column_collection_Where_Skip(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Where_Skip(async));
+
+    public override Task Column_collection_Where_Take(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Where_Take(async));
+
+    public override Task Column_collection_Where_Skip_Take(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Where_Skip_Take(async));
+
     public override Task Column_collection_Contains_over_subquery(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Skip_Take(async));
 
     public override Task Column_collection_OrderByDescending_ElementAt(bool async)
         => AssertTranslationFailed(() => base.Column_collection_OrderByDescending_ElementAt(async));
+
+    public override Task Column_collection_Where_ElementAt(bool async)
+        => AssertTranslationFailed(() => base.Column_collection_Where_ElementAt(async));
 
     public override Task Column_collection_Any(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Any(async));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -1010,6 +1010,66 @@ WHERE CAST(JSON_VALUE([p].[Ints], '$[1]') AS int) = 10
 """);
     }
 
+    public override async Task Column_collection_First(bool async)
+    {
+        await base.Column_collection_First(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT TOP(1) CAST([i].[value] AS int) AS [value]
+    FROM OPENJSON([p].[Ints]) AS [i]
+    ORDER BY CAST([i].[key] AS int)) = 1
+""");
+    }
+
+    public override async Task Column_collection_FirstOrDefault(bool async)
+    {
+        await base.Column_collection_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE COALESCE((
+    SELECT TOP(1) CAST([i].[value] AS int) AS [value]
+    FROM OPENJSON([p].[Ints]) AS [i]
+    ORDER BY CAST([i].[key] AS int)), 0) = 1
+""");
+    }
+
+    public override async Task Column_collection_Single(bool async)
+    {
+        await base.Column_collection_Single(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT TOP(1) CAST([i].[value] AS int) AS [value]
+    FROM OPENJSON([p].[Ints]) AS [i]
+    ORDER BY CAST([i].[key] AS int)) = 1
+""");
+    }
+
+    public override async Task Column_collection_SingleOrDefault(bool async)
+    {
+        await base.Column_collection_SingleOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE COALESCE((
+    SELECT TOP(1) CAST([i].[value] AS int) AS [value]
+    FROM OPENJSON([p].[Ints]) AS [i]
+    ORDER BY CAST([i].[key] AS int)), 0) = 1
+""");
+    }
+
     public override async Task Column_collection_Skip(bool async)
     {
         await base.Column_collection_Skip(async);
@@ -1062,6 +1122,65 @@ WHERE 11 IN (
 """);
     }
 
+    public override async Task Column_collection_Where_Skip(bool async)
+    {
+        await base.Column_collection_Where_Skip(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT 1 AS empty
+        FROM OPENJSON([p].[Ints]) AS [i]
+        WHERE CAST([i].[value] AS int) > 1
+        ORDER BY CAST([i].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [i0]) = 3
+""");
+    }
+
+    public override async Task Column_collection_Where_Take(bool async)
+    {
+        await base.Column_collection_Where_Take(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT TOP(2) 1 AS empty
+        FROM OPENJSON([p].[Ints]) AS [i]
+        WHERE CAST([i].[value] AS int) > 1
+        ORDER BY CAST([i].[key] AS int)
+    ) AS [i0]) = 2
+""");
+    }
+
+    public override async Task Column_collection_Where_Skip_Take(bool async)
+    {
+        await base.Column_collection_Where_Skip_Take(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT 1 AS empty
+        FROM OPENJSON([p].[Ints]) AS [i]
+        WHERE CAST([i].[value] AS int) > 1
+        ORDER BY CAST([i].[key] AS int)
+        OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [i0]) = 1
+""");
+    }
+
     public override async Task Column_collection_Contains_over_subquery(bool async)
     {
         await base.Column_collection_Contains_over_subquery(async);
@@ -1091,6 +1210,23 @@ WHERE (
     FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
     ORDER BY [i].[value] DESC
     OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) = 111
+""");
+    }
+
+    public override async Task Column_collection_Where_ElementAt(bool async)
+    {
+        await base.Column_collection_Where_ElementAt(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT CAST([i].[value] AS int) AS [value]
+    FROM OPENJSON([p].[Ints]) AS [i]
+    WHERE CAST([i].[value] AS int) > 1
+    ORDER BY CAST([i].[key] AS int)
+    OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) = 11
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -992,6 +992,70 @@ WHERE "p"."Ints" ->> 1 = 10
 """);
     }
 
+    public override async Task Column_collection_First(bool async)
+    {
+        await base.Column_collection_First(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    ORDER BY "i"."key"
+    LIMIT 1) = 1
+""");
+    }
+
+    public override async Task Column_collection_FirstOrDefault(bool async)
+    {
+        await base.Column_collection_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE COALESCE((
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    ORDER BY "i"."key"
+    LIMIT 1), 0) = 1
+""");
+    }
+
+    public override async Task Column_collection_Single(bool async)
+    {
+        await base.Column_collection_Single(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    ORDER BY "i"."key"
+    LIMIT 1) = 1
+""");
+    }
+
+    public override async Task Column_collection_SingleOrDefault(bool async)
+    {
+        await base.Column_collection_SingleOrDefault(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE COALESCE((
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    ORDER BY "i"."key"
+    LIMIT 1), 0) = 1
+""");
+    }
+
     public override async Task Column_collection_Skip(bool async)
     {
         await base.Column_collection_Skip(async);
@@ -1045,6 +1109,66 @@ WHERE 11 IN (
 """);
     }
 
+    public override async Task Column_collection_Where_Skip(bool async)
+    {
+        await base.Column_collection_Where_Skip(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT 1
+        FROM json_each("p"."Ints") AS "i"
+        WHERE "i"."value" > 1
+        ORDER BY "i"."key"
+        LIMIT -1 OFFSET 1
+    ) AS "i0") = 3
+""");
+    }
+
+    public override async Task Column_collection_Where_Take(bool async)
+    {
+        await base.Column_collection_Where_Take(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT 1
+        FROM json_each("p"."Ints") AS "i"
+        WHERE "i"."value" > 1
+        ORDER BY "i"."key"
+        LIMIT 2
+    ) AS "i0") = 2
+""");
+    }
+
+    public override async Task Column_collection_Where_Skip_Take(bool async)
+    {
+        await base.Column_collection_Where_Skip_Take(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT 1
+        FROM json_each("p"."Ints") AS "i"
+        WHERE "i"."value" > 1
+        ORDER BY "i"."key"
+        LIMIT 2 OFFSET 1
+    ) AS "i0") = 1
+""");
+    }
+
     public override async Task Column_collection_Contains_over_subquery(bool async)
     {
         await base.Column_collection_Contains_over_subquery(async);
@@ -1074,6 +1198,23 @@ WHERE (
     FROM json_each("p"."Ints") AS "i"
     ORDER BY "i"."value" DESC
     LIMIT 1 OFFSET 0) = 111
+""");
+    }
+
+    public override async Task Column_collection_Where_ElementAt(bool async)
+    {
+        await base.Column_collection_Where_ElementAt(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    WHERE "i"."value" > 1
+    ORDER BY "i"."key"
+    LIMIT 1 OFFSET 0) = 11
 """);
     }
 


### PR DESCRIPTION
**This PR is based on top of #33933, review 2nd commit only**

Major changes:

* Make Skip/Take/ElementAt/First/Single work (almost) everywhere, translating to ARRAY_SLICE() within subqueries (where OFFSET/LIMIT isn't supported). For subqueries over bare arrays, we just extract the array and do ARRAY_SLICE() directly, otherwise we convert the subquery to an array via the ARRAY() operator and then compose the function.
* Support FirstOrDefault/SingleOrDefault by translating to the undefined-coalescing operator (`??`).
    * Also add EF.Functions.{IsDefined,CoalesceUndefined}
