### PR TITLE
Cosmos: Translate string.Contains/StartsWith/EndsWith with OrdinalIgnoreCase

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosStringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosStringMethodTranslator.cs
@@ -24,11 +24,20 @@ public class CosmosStringMethodTranslator(ISqlExpressionFactory sqlExpressionFac
     private static readonly MethodInfo ContainsMethodInfo
         = typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string)])!;
 
+    private static readonly MethodInfo ContainsWithStringComparisonMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string), typeof(StringComparison)])!;
+
     private static readonly MethodInfo StartsWithMethodInfo
         = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [typeof(string)])!;
 
+    private static readonly MethodInfo StartsWithWithStringComparisonMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [typeof(string), typeof(StringComparison)])!;
+
     private static readonly MethodInfo EndsWithMethodInfo
         = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string)])!;
+
+    private static readonly MethodInfo EndsWithWithStringComparisonMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string), typeof(StringComparison)])!;
 
     private static readonly MethodInfo ToLowerMethodInfo
         = typeof(string).GetRuntimeMethod(nameof(string.ToLower), [])!;
@@ -119,14 +128,77 @@ public class CosmosStringMethodTranslator(ISqlExpressionFactory sqlExpressionFac
                 return TranslateSystemFunction("CONTAINS", typeof(bool), instance, arguments[0]);
             }
 
+            if (ContainsWithStringComparisonMethodInfo.Equals(method))
+            {
+                if (arguments[1] is SqlConstantExpression { Value: StringComparison comparisonType })
+                {
+                    return comparisonType switch
+                    {
+                        StringComparison.Ordinal
+                            => TranslateSystemFunction(
+                                "CONTAINS", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(false)),
+                        StringComparison.OrdinalIgnoreCase
+                            => TranslateSystemFunction(
+                                "CONTAINS", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(true)),
+
+                        _ => null // TODO: Explicit translation error for unsupported StringComparison argument (depends on #26410)
+                    };
+                }
+
+                // TODO: Explicit translation error for non-constant StringComparison argument (depends on #26410)
+                return null;
+            }
+
             if (StartsWithMethodInfo.Equals(method))
             {
                 return TranslateSystemFunction("STARTSWITH", typeof(bool), instance, arguments[0]);
             }
 
+            if (StartsWithWithStringComparisonMethodInfo.Equals(method))
+            {
+                if (arguments[1] is SqlConstantExpression { Value: StringComparison comparisonType })
+                {
+                    return comparisonType switch
+                    {
+                        StringComparison.Ordinal
+                            => TranslateSystemFunction(
+                                "STARTSWITH", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(false)),
+                        StringComparison.OrdinalIgnoreCase
+                            => TranslateSystemFunction(
+                                "STARTSWITH", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(true)),
+
+                        _ => null // TODO: Explicit translation error for unsupported StringComparison argument (depends on #26410)
+                    };
+                }
+
+                // TODO: Explicit translation error for non-constant StringComparison argument (depends on #26410)
+                return null;
+            }
+
             if (EndsWithMethodInfo.Equals(method))
             {
                 return TranslateSystemFunction("ENDSWITH", typeof(bool), instance, arguments[0]);
+            }
+
+            if (EndsWithWithStringComparisonMethodInfo.Equals(method))
+            {
+                if (arguments[1] is SqlConstantExpression { Value: StringComparison comparisonType })
+                {
+                    return comparisonType switch
+                    {
+                        StringComparison.Ordinal
+                            => TranslateSystemFunction(
+                                "ENDSWITH", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(false)),
+                        StringComparison.OrdinalIgnoreCase
+                            => TranslateSystemFunction(
+                                "ENDSWITH", typeof(bool), instance, arguments[0], sqlExpressionFactory.Constant(true)),
+
+                        _ => null // TODO: Explicit translation error for unsupported StringComparison argument (depends on #26410)
+                    };
+                }
+
+                // TODO: Explicit translation error for non-constant StringComparison argument (depends on #26410)
+                return null;
             }
 
             if (ToLowerMethodInfo.Equals(method))

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -24,6 +24,8 @@ public class NorthwindFunctionsQueryCosmosTest : NorthwindFunctionsQueryTestBase
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    #region String.StartsWith
+
     public override Task String_StartsWith_Literal(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -95,6 +97,47 @@ FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
             });
+
+    public override Task String_StartsWith_with_StringComparison_Ordinal(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_StartsWith_with_StringComparison_Ordinal(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", false))
+""");
+            });
+
+    public override Task String_StartsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_StartsWith_with_StringComparison_OrdinalIgnoreCase(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", true))
+""");
+            });
+
+    public override async Task String_StartsWith_with_StringComparison_unsupported(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await base.String_StartsWith_with_StringComparison_unsupported(async);
+        }
+    }
+
+    #endregion String.StartsWith
+
+    #region String.EndsWith
 
     public override Task String_EndsWith_Literal(bool async)
         => Fixture.NoSyncTest(
@@ -168,6 +211,47 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "m"))
 """);
             });
 
+    public override Task String_EndsWith_with_StringComparison_Ordinal(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_EndsWith_with_StringComparison_Ordinal(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", false))
+""");
+            });
+
+    public override Task String_EndsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_EndsWith_with_StringComparison_OrdinalIgnoreCase(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", true))
+""");
+            });
+
+    public override async Task String_EndsWith_with_StringComparison_unsupported(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await base.String_EndsWith_with_StringComparison_unsupported(async);
+        }
+    }
+
+    #endregion String.EndsWith
+
+    #region String.Contains
+
     public override Task String_Contains_Literal(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -208,6 +292,45 @@ FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], c["ContactName"]))
 """);
             });
+
+    public override Task String_Contains_with_StringComparison_Ordinal(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_Contains_with_StringComparison_Ordinal(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", false))
+""");
+            });
+
+    public override Task String_Contains_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.String_Contains_with_StringComparison_OrdinalIgnoreCase(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", true))
+""");
+            });
+
+    public override async Task String_Contains_with_StringComparison_unsupported(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await base.String_Contains_with_StringComparison_unsupported(async);
+        }
+    }
+
+    #endregion String.Contains
 
     public override Task String_FirstOrDefault_MethodCall(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindFunctionsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindFunctionsQueryInMemoryTest.cs
@@ -4,4 +4,16 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class NorthwindFunctionsQueryInMemoryTest(NorthwindQueryInMemoryFixture<NoopModelCustomizer> fixture)
-    : NorthwindFunctionsQueryTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>(fixture);
+    : NorthwindFunctionsQueryTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>(fixture)
+{
+    // StringComparison.CurrentCulture{,IgnoreCase} and InvariantCulture{,IgnoreCase} are not supported in real providers, but the in-memory
+    // provider does support them.
+    public override Task String_StartsWith_with_StringComparison_unsupported(bool async)
+        => Task.CompletedTask;
+
+    public override Task String_EndsWith_with_StringComparison_unsupported(bool async)
+        => Task.CompletedTask;
+
+    public override Task String_Contains_with_StringComparison_unsupported(bool async)
+        => Task.CompletedTask;
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
@@ -15,6 +15,36 @@ public abstract class NorthwindFunctionsQueryRelationalTestBase<TFixture> : Nort
     {
     }
 
+    // StartsWith with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_StartsWith_with_StringComparison_Ordinal(bool async)
+        => AssertTranslationFailed(() => base.String_StartsWith_with_StringComparison_Ordinal(async));
+
+    // StartsWith with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_StartsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertTranslationFailed(() => base.String_StartsWith_with_StringComparison_OrdinalIgnoreCase(async));
+
+    // EndsWith with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_EndsWith_with_StringComparison_Ordinal(bool async)
+        => AssertTranslationFailed(() => base.String_EndsWith_with_StringComparison_Ordinal(async));
+
+    // EndsWith with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_EndsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertTranslationFailed(() => base.String_EndsWith_with_StringComparison_OrdinalIgnoreCase(async));
+
+    // Contains with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_Contains_with_StringComparison_Ordinal(bool async)
+        => AssertTranslationFailed(() => base.String_Contains_with_StringComparison_Ordinal(async));
+
+    // Contains with StringComparison not supported in relational databases, where the column collation is used to control comparison
+    // semantics.
+    public override Task String_Contains_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertTranslationFailed(() => base.String_Contains_with_StringComparison_OrdinalIgnoreCase(async));
+
     protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -34,6 +34,8 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
     {
     }
 
+    #region String.StartsWith
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task String_StartsWith_Literal(bool async)
@@ -75,6 +77,49 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_StartsWith_with_StringComparison_Ordinal(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CompanyName.StartsWith("Qu", StringComparison.Ordinal)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_StartsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CompanyName.StartsWith("Qu", StringComparison.OrdinalIgnoreCase)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task String_StartsWith_with_StringComparison_unsupported(bool async)
+    {
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CompanyName.StartsWith("Qu", StringComparison.CurrentCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.CurrentCultureIgnoreCase))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("Qu", StringComparison.InvariantCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("Qu", StringComparison.InvariantCultureIgnoreCase))));
+    }
+
+    #endregion String.StartsWith
+
+    #region String.EndsWith
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task String_EndsWith_Literal(bool async)
         => AssertQuery(
             async,
@@ -111,6 +156,50 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith(LocalMethod2())));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_EndsWith_with_StringComparison_Ordinal(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("DY", StringComparison.Ordinal)),
+            assertEmpty: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_EndsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("DY", StringComparison.OrdinalIgnoreCase)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task String_EndsWith_with_StringComparison_unsupported(bool async)
+    {
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("Qu", StringComparison.CurrentCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.CurrentCultureIgnoreCase))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("Qu", StringComparison.InvariantCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("Qu", StringComparison.InvariantCultureIgnoreCase))));
+    }
+
+    #endregion String.EndsWith
+
+    #region String.Contains
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -155,6 +244,47 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             async,
             ss => ss.Set<Customer>().Select(c => new { Id = c.CustomerID, Value = !c.CompanyName.Contains(c.ContactName) }),
             elementSorter: e => e.Id);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_with_StringComparison_Ordinal(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.Ordinal)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_with_StringComparison_OrdinalIgnoreCase(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.OrdinalIgnoreCase)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task String_Contains_with_StringComparison_unsupported(bool async)
+    {
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.CurrentCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.CurrentCultureIgnoreCase))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.InvariantCulture))));
+
+        await AssertTranslationFailed(() =>
+            AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.InvariantCultureIgnoreCase))));
+    }
+
+    #endregion String.Contains
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -77,6 +77,8 @@ WHERE [o].[OrderDate] <= @__myDatetime_0
 """);
     }
 
+    #region String.StartsWith
+
     public override async Task String_StartsWith_Literal(bool async)
     {
         await base.String_StartsWith_Literal(async);
@@ -139,6 +141,31 @@ WHERE [c].[ContactName] LIKE N'M%'
 """);
     }
 
+    public override async Task String_StartsWith_with_StringComparison_Ordinal(bool async)
+    {
+        await base.String_StartsWith_with_StringComparison_Ordinal(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_StartsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+    {
+        await base.String_StartsWith_with_StringComparison_OrdinalIgnoreCase(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_StartsWith_with_StringComparison_unsupported(bool async)
+    {
+        await base.String_StartsWith_with_StringComparison_unsupported(async);
+
+        AssertSql();
+    }
+
+    #endregion String.StartsWith
+
+    #region String.EndsWith
+
     public override async Task String_EndsWith_Literal(bool async)
     {
         await base.String_EndsWith_Literal(async);
@@ -200,6 +227,29 @@ FROM [Customers] AS [c]
 WHERE [c].[ContactName] LIKE N'%m'
 """);
     }
+
+    public override async Task String_EndsWith_with_StringComparison_Ordinal(bool async)
+    {
+        await base.String_EndsWith_with_StringComparison_Ordinal(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_EndsWith_with_StringComparison_OrdinalIgnoreCase(bool async)
+    {
+        await base.String_EndsWith_with_StringComparison_OrdinalIgnoreCase(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_EndsWith_with_StringComparison_unsupported(bool async)
+    {
+        await base.String_EndsWith_with_StringComparison_unsupported(async);
+
+        AssertSql();
+    }
+
+    #endregion String.EndsWith
 
     public override async Task String_Contains_Literal(bool async)
     {
@@ -2839,6 +2889,27 @@ SELECT [c].[CustomerID] AS [Id], CASE
 END AS [Value]
 FROM [Customers] AS [c]
 """);
+    }
+
+    public override async Task String_Contains_with_StringComparison_Ordinal(bool async)
+    {
+        await base.String_Contains_with_StringComparison_Ordinal(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_Contains_with_StringComparison_OrdinalIgnoreCase(bool async)
+    {
+        await base.String_Contains_with_StringComparison_OrdinalIgnoreCase(async);
+
+        AssertSql();
+    }
+
+    public override async Task String_Contains_with_StringComparison_unsupported(bool async)
+    {
+        await base.String_Contains_with_StringComparison_unsupported(async);
+
+        AssertSql();
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
Closes #25250
