### PR TITLE
Simplify `COALESCE` based on the nullability of its arguments

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -88,7 +88,7 @@ public class SqlFunctionExpression : SqlExpression
         Type type,
         RelationalTypeMapping? typeMapping)
         : this(
-            instance, schema, name, niladic: true, arguments: null, nullable, instancePropagatesNullability,
+            instance, schema, name, arguments: null, nullable, instancePropagatesNullability,
             argumentsPropagateNullability: null, builtIn, type, typeMapping)
     {
     }
@@ -165,24 +165,6 @@ public class SqlFunctionExpression : SqlExpression
     {
     }
 
-    private SqlFunctionExpression(
-        SqlExpression? instance,
-        string? schema,
-        string name,
-        IEnumerable<SqlExpression> arguments,
-        bool nullable,
-        bool? instancePropagatesNullability,
-        IEnumerable<bool> argumentsPropagateNullability,
-        bool builtIn,
-        Type type,
-        RelationalTypeMapping? typeMapping)
-        : this(
-            instance, schema, name, niladic: false, arguments, nullable,
-            instancePropagatesNullability, argumentsPropagateNullability, builtIn,
-            type, typeMapping)
-    {
-    }
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -194,7 +176,6 @@ public class SqlFunctionExpression : SqlExpression
         SqlExpression? instance,
         string? schema,
         string name,
-        bool niladic,
         IEnumerable<SqlExpression>? arguments,
         bool nullable,
         bool? instancePropagatesNullability,
@@ -207,7 +188,6 @@ public class SqlFunctionExpression : SqlExpression
         Instance = instance;
         Name = name;
         Schema = schema;
-        IsNiladic = niladic;
         IsBuiltIn = builtIn;
         Arguments = arguments?.ToList();
         IsNullable = nullable;
@@ -240,7 +220,7 @@ public class SqlFunctionExpression : SqlExpression
     ///     A bool value indicating if the function is niladic.
     /// </summary>
     [MemberNotNullWhen(false, nameof(Arguments), nameof(ArgumentsPropagateNullability))]
-    public virtual bool IsNiladic { get; }
+    public virtual bool IsNiladic => Arguments is null;
 
     /// <summary>
     ///     A bool value indicating if the function is built-in.
@@ -295,7 +275,6 @@ public class SqlFunctionExpression : SqlExpression
                 instance,
                 Schema,
                 Name,
-                IsNiladic,
                 arguments,
                 IsNullable,
                 InstancePropagatesNullability,
@@ -316,7 +295,6 @@ public class SqlFunctionExpression : SqlExpression
             Instance,
             Schema,
             Name,
-            IsNiladic,
             Arguments,
             IsNullable,
             InstancePropagatesNullability,
@@ -353,13 +331,12 @@ public class SqlFunctionExpression : SqlExpression
         => New(
             _quotingConstructor ??= typeof(SqlFunctionExpression).GetConstructor(
             [
-                typeof(SqlExpression), typeof(string), typeof(string), typeof(bool), typeof(IEnumerable<SqlExpression>),
+                typeof(SqlExpression), typeof(string), typeof(string), typeof(IEnumerable<SqlExpression>),
                 typeof(bool), typeof(bool), typeof(IEnumerable<bool>), typeof(bool), typeof(Type), typeof(RelationalTypeMapping)
             ])!,
             RelationalExpressionQuotingUtilities.QuoteOrNull(Instance),
             Constant(Schema, typeof(string)),
             Constant(Name),
-            Constant(IsNiladic),
             Arguments is null
                 ? Constant(null, typeof(IEnumerable<SqlExpression>))
                 : NewArrayInit(typeof(SqlExpression), initializers: Arguments.Select(a => a.Quote())),
@@ -408,7 +385,6 @@ public class SqlFunctionExpression : SqlExpression
 
     private bool Equals(SqlFunctionExpression sqlFunctionExpression)
         => base.Equals(sqlFunctionExpression)
-            && IsNiladic == sqlFunctionExpression.IsNiladic
             && Name == sqlFunctionExpression.Name
             && Schema == sqlFunctionExpression.Schema
             && ((Instance == null && sqlFunctionExpression.Instance == null)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -311,20 +311,39 @@ public class SqlFunctionExpression : SqlExpression
     /// <param name="arguments">The <see cref="Arguments" /> property of the result.</param>
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public virtual SqlFunctionExpression Update(SqlExpression? instance, IReadOnlyList<SqlExpression>? arguments)
-        => instance != Instance || (arguments != null && Arguments != null && !arguments.SequenceEqual(Arguments))
-            ? new SqlFunctionExpression(
+        => Update(instance, arguments, ArgumentsPropagateNullability);
+
+    /// <summary>
+    ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+    ///     return this expression.
+    /// </summary>
+    /// <param name="instance">The <see cref="Instance" /> property of the result.</param>
+    /// <param name="arguments">The <see cref="Arguments" /> property of the result.</param>
+    /// <param name="argumentsPropagateNullability">The <see cref="ArgumentsPropagateNullability" /> property of the result. If omitted,
+    /// the current ArgumentsPropagateNullability will be used.</param>
+    /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
+    public virtual SqlFunctionExpression Update(
+        SqlExpression? instance,
+        IReadOnlyList<SqlExpression>? arguments,
+        IReadOnlyList<bool>? argumentsPropagateNullability)
+        => instance == Instance
+            && ((arguments == Arguments) || (arguments != null && Arguments != null && arguments.SequenceEqual(Arguments)))
+            && ((argumentsPropagateNullability == ArgumentsPropagateNullability)
+                || (argumentsPropagateNullability != null
+                    && ArgumentsPropagateNullability != null
+                    && argumentsPropagateNullability.SequenceEqual(ArgumentsPropagateNullability)))
+            ? this
+            : new SqlFunctionExpression(
                 instance,
                 Schema,
                 Name,
-                IsNiladic,
                 arguments,
                 IsNullable,
                 InstancePropagatesNullability,
-                ArgumentsPropagateNullability,
+                argumentsPropagateNullability,
                 IsBuiltIn,
                 Type,
-                TypeMapping)
-            : this;
+                TypeMapping);
 
     /// <inheritdoc />
     public override Expression Quote()

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringAggregateMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringAggregateMethodTranslator.cs
@@ -101,7 +101,7 @@ public class SqlServerStringAggregateMethodTranslator : IAggregateMethodCallTran
                     source,
                     enumerableArgumentIndex: 0,
                     nullable: true,
-                    argumentsPropagateNullability: new[] { false, true },
+                    argumentsPropagateNullability: new[] { false, false },
                     typeof(string)),
                 _sqlExpressionFactory.Constant(string.Empty, typeof(string)),
                 resultTypeMapping);

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
@@ -93,7 +93,7 @@ public class SqliteStringAggregateMethodTranslator : IAggregateMethodCallTransla
                         sqlExpression.TypeMapping)
                 },
                 nullable: true,
-                argumentsPropagateNullability: new[] { false, true },
+                argumentsPropagateNullability: new[] { false, false },
                 typeof(string)),
             _sqlExpressionFactory.Constant(string.Empty, typeof(string)),
             sqlExpression.TypeMapping);

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -619,6 +619,18 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_coalesce_shortcircuit(bool async)
+        => AssertQueryScalar(async, ss => ss.Set<NullSemanticsEntity1>().Where(e => (bool?)(e.BoolA | e.BoolB) ?? e.NullableBoolA ?? true)
+            .Select(e => e.Id));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_coalesce_shortcircuit_many(bool async)
+        => AssertQueryScalar(async, ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableBoolA ?? (bool?)(e.BoolA | e.BoolB) ?? e.NullableBoolB ?? e.BoolB)
+            .Select(e => e.Id));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_equal_nullable_with_null_value_parameter(bool async)
     {
         string prm = null;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1215,10 +1215,10 @@ LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
         AssertSql(
             """
 SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
         WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END, CAST(0 AS bit))
+    END
     ELSE NULL
 END
 FROM [Gears] AS [g]
@@ -4033,7 +4033,7 @@ FROM [Factions] AS [f]
         await base.ToString_enum_property_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE [g].[Rank]
     WHEN 0 THEN N'None'
     WHEN 1 THEN N'Private'
@@ -4044,7 +4044,7 @@ SELECT CASE [g].[Rank]
     WHEN 32 THEN N'Major'
     WHEN 64 THEN N'Colonel'
     WHEN 128 THEN N'General'
-    ELSE COALESCE(CAST([g].[Rank] AS nvarchar(max)), N'')
+    ELSE CAST([g].[Rank] AS nvarchar(max))
 END
 FROM [Gears] AS [g]
 """);
@@ -5759,7 +5759,7 @@ SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0, 42)
+    ORDER BY [w].[Id]), 0)
 FROM [Gears] AS [g]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -420,7 +420,7 @@ GROUP BY [c].[City]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CONCAT_WS(N'|', [c].[CompanyName], COALESCE(@__foo_0, N''), N'', N'bar') = N'Around the Horn|foo||bar'
+WHERE CONCAT_WS(N'|', [c].[CompanyName], @__foo_0, N'', N'bar') = N'Around the Horn|foo||bar'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2202,10 +2202,7 @@ WHERE COALESCE([e].[NullableBoolA], CAST(1 AS bit)) = CAST(1 AS bit)
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE COALESCE(CASE
-    WHEN [e].[BoolA] = CAST(1 AS bit) OR [e].[BoolB] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END, [e].[NullableBoolA], CAST(1 AS bit)) = CAST(1 AS bit)
+WHERE [e].[BoolA] = CAST(1 AS bit) OR [e].[BoolB] = CAST(1 AS bit)
 """);
     }
 
@@ -2220,7 +2217,7 @@ FROM [Entities1] AS [e]
 WHERE COALESCE([e].[NullableBoolA], CASE
     WHEN [e].[BoolA] = CAST(1 AS bit) OR [e].[BoolB] = CAST(1 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [e].[NullableBoolB], [e].[BoolB]) = CAST(1 AS bit)
+END) = CAST(1 AS bit)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2194,6 +2194,36 @@ WHERE COALESCE([e].[NullableBoolA], CAST(1 AS bit)) = CAST(1 AS bit)
 """);
     }
 
+    public override async Task Where_coalesce_shortcircuit(bool async)
+    {
+        await base.Where_coalesce_shortcircuit(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE COALESCE(CASE
+    WHEN [e].[BoolA] = CAST(1 AS bit) OR [e].[BoolB] = CAST(1 AS bit) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [e].[NullableBoolA], CAST(1 AS bit)) = CAST(1 AS bit)
+""");
+    }
+
+    public override async Task Where_coalesce_shortcircuit_many(bool async)
+    {
+        await base.Where_coalesce_shortcircuit_many(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE COALESCE([e].[NullableBoolA], CASE
+    WHEN [e].[BoolA] = CAST(1 AS bit) OR [e].[BoolB] = CAST(1 AS bit) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [e].[NullableBoolB], [e].[BoolB]) = CAST(1 AS bit)
+""");
+    }
+
     public override async Task Where_equal_nullable_with_null_value_parameter(bool async)
     {
         await base.Where_equal_nullable_with_null_value_parameter(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -1709,10 +1709,10 @@ LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
         AssertSql(
             """
 SELECT CASE
-    WHEN [u].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
+    WHEN [u].[LeaderNickname] IS NOT NULL THEN CASE
         WHEN CAST(LEN([u].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END, CAST(0 AS bit))
+    END
     ELSE NULL
 END
 FROM (
@@ -5414,7 +5414,7 @@ LEFT JOIN (
         await base.ToString_enum_property_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE [u].[Rank]
     WHEN 0 THEN N'None'
     WHEN 1 THEN N'Private'
@@ -5425,7 +5425,7 @@ SELECT CASE [u].[Rank]
     WHEN 32 THEN N'Major'
     WHEN 64 THEN N'Colonel'
     WHEN 128 THEN N'General'
-    ELSE COALESCE(CAST([u].[Rank] AS nvarchar(max)), N'')
+    ELSE CAST([u].[Rank] AS nvarchar(max))
 END
 FROM (
     SELECT [g].[Rank]
@@ -7861,7 +7861,7 @@ SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
     WHERE [u].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0, 42)
+    ORDER BY [w].[Id]), 0)
 FROM (
     SELECT [g].[FullName]
     FROM [Gears] AS [g]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -1449,10 +1449,10 @@ LEFT JOIN [Cities] AS [c] ON [s].[AssignedCityName] = [c].[Name]
         AssertSql(
             """
 SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
         WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END, CAST(0 AS bit))
+    END
     ELSE NULL
 END
 FROM [Gears] AS [g]
@@ -4692,7 +4692,7 @@ LEFT JOIN (
         await base.ToString_enum_property_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE [g].[Rank]
     WHEN 0 THEN N'None'
     WHEN 1 THEN N'Private'
@@ -4703,7 +4703,7 @@ SELECT CASE [g].[Rank]
     WHEN 32 THEN N'Major'
     WHEN 64 THEN N'Colonel'
     WHEN 128 THEN N'General'
-    ELSE COALESCE(CAST([g].[Rank] AS nvarchar(max)), N'')
+    ELSE CAST([g].[Rank] AS nvarchar(max))
 END
 FROM [Gears] AS [g]
 """);
@@ -6618,7 +6618,7 @@ SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0, 42)
+    ORDER BY [w].[Id]), 0)
 FROM [Gears] AS [g]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -851,7 +851,7 @@ SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0, 42)
+    ORDER BY [w].[Id]), 0)
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """);
     }
@@ -2660,10 +2660,10 @@ WHERE 0 = 1
         AssertSql(
             """
 SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
         WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END, CAST(0 AS bit))
+    END
     ELSE NULL
 END
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -4803,7 +4803,7 @@ WHERE 2 & [g].[Rank] = [g].[Rank]
         await base.ToString_enum_property_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE [g].[Rank]
     WHEN 0 THEN N'None'
     WHEN 1 THEN N'Private'
@@ -4814,7 +4814,7 @@ SELECT CASE [g].[Rank]
     WHEN 32 THEN N'Major'
     WHEN 64 THEN N'Colonel'
     WHEN 128 THEN N'General'
-    ELSE COALESCE(CAST([g].[Rank] AS nvarchar(max)), N'')
+    ELSE CAST([g].[Rank] AS nvarchar(max))
 END
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -3312,7 +3312,7 @@ WHERE instr("s"."Banner", char("l"."ThreatLevelByte")) > 0
         AssertSql(
             """
 SELECT CASE
-    WHEN "g"."LeaderNickname" IS NOT NULL THEN COALESCE(length("g"."Nickname") = 5, 0)
+    WHEN "g"."LeaderNickname" IS NOT NULL THEN length("g"."Nickname") = 5
     ELSE NULL
 END
 FROM "Gears" AS "g"
@@ -3440,7 +3440,7 @@ ORDER BY "s"."Id", "g"."Nickname"
         await base.ToString_enum_property_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE "g"."Rank"
     WHEN 0 THEN 'None'
     WHEN 1 THEN 'Private'
@@ -3451,7 +3451,7 @@ SELECT CASE "g"."Rank"
     WHEN 32 THEN 'Major'
     WHEN 64 THEN 'Colonel'
     WHEN 128 THEN 'General'
-    ELSE COALESCE(CAST("g"."Rank" AS TEXT), '')
+    ELSE CAST("g"."Rank" AS TEXT)
 END
 FROM "Gears" AS "g"
 """);
@@ -5629,7 +5629,7 @@ SELECT COALESCE((
     FROM "Weapons" AS "w"
     WHERE "g"."FullName" = "w"."OwnerFullName"
     ORDER BY "w"."Id"
-    LIMIT 1), 0, 42)
+    LIMIT 1), 0)
 FROM "Gears" AS "g"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -917,7 +917,7 @@ WHERE ("e"."NullableBoolA" = "e"."NullableBoolB" AND "e"."NullableBoolA" IS NOT 
             """
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE COALESCE("e"."BoolA" OR "e"."BoolB", "e"."NullableBoolA", 1)
+WHERE "e"."BoolA" OR "e"."BoolB"
 """);
     }
 
@@ -929,7 +929,7 @@ WHERE COALESCE("e"."BoolA" OR "e"."BoolB", "e"."NullableBoolA", 1)
             """
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE COALESCE("e"."NullableBoolA", "e"."BoolA" OR "e"."BoolB", "e"."NullableBoolB", "e"."BoolB")
+WHERE COALESCE("e"."NullableBoolA", "e"."BoolA" OR "e"."BoolB")
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -909,6 +909,30 @@ WHERE ("e"."NullableBoolA" = "e"."NullableBoolB" AND "e"."NullableBoolA" IS NOT 
 """);
     }
 
+    public override async Task Where_coalesce_shortcircuit(bool async)
+    {
+        await base.Where_coalesce_shortcircuit(async);
+
+        AssertSql(
+            """
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE COALESCE("e"."BoolA" OR "e"."BoolB", "e"."NullableBoolA", 1)
+""");
+    }
+
+    public override async Task Where_coalesce_shortcircuit_many(bool async)
+    {
+        await base.Where_coalesce_shortcircuit_many(async);
+
+        AssertSql(
+            """
+SELECT "e"."Id"
+FROM "Entities1" AS "e"
+WHERE COALESCE("e"."NullableBoolA", "e"."BoolA" OR "e"."BoolB", "e"."NullableBoolB", "e"."BoolB")
+""");
+    }
+
     public override async Task Join_uses_database_semantics(bool async)
     {
         await base.Join_uses_database_semantics(async);


### PR DESCRIPTION
Drop all of the arguments after the first non-nullable sub-expressions.
Simplify unary `COALESCE` to its argument.