### PR TITLE
[release/8.0] Add missing check for predicate in primitive collection simplifications

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -28,6 +28,9 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     private static readonly bool UseOldBehavior32374 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32374", out var enabled32374) && enabled32374;
 
+    private static readonly bool UseOldBehavior33932 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue33932", out var enabled33932) && enabled33932;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -446,8 +449,9 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                     Offset: null,
                     Orderings: [],
                     Projection: [{ Expression: ColumnExpression { Name: "value", Table: var projectionColumnTable } }]
-                }
+                } subquery
             }
+            && (UseOldBehavior33932 || subquery.Predicate is null)
             && projectionColumnTable == openJsonExpression)
         {
             var newInExpression = _sqlExpressionFactory.In(translatedItem, parameter);
@@ -493,6 +497,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 ]
             } selectExpression
             && TranslateExpression(index) is { } translatedIndex
+            && (UseOldBehavior33932 || selectExpression.Predicate is null)
             && orderingTable == openJsonExpression)
         {
             // Index on JSON array

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -388,6 +388,20 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Count_with_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Count(i => i > 1) == 2));
+
+    [ConditionalTheory] // #33932
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_Where_Count(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Where(i => i > 1).Count() == 2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_index_int(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -468,6 +468,12 @@ WHERE 0 = 1
     public override Task Column_collection_Length(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Length(async));
 
+    public override Task Column_collection_Count_with_predicate(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Count_with_predicate(async));
+
+    public override Task Column_collection_Where_Count(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_Where_Count(async));
+
     public override Task Column_collection_index_int(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_index_int(async));
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -663,6 +663,36 @@ WHERE (
 """);
     }
 
+    public override async Task Column_collection_Count_with_predicate(bool async)
+    {
+        await base.Column_collection_Count_with_predicate(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] > 1) = 2
+""");
+    }
+
+    public override async Task Column_collection_Where_Count(bool async)
+    {
+        await base.Column_collection_Where_Count(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] > 1) = 2
+""");
+    }
+
     public override async Task Column_collection_index_int(bool async)
     {
         await base.Column_collection_index_int(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -649,6 +649,37 @@ WHERE json_array_length("p"."Ints") = 2
 """);
     }
 
+    public override async Task Column_collection_Count_with_predicate(bool async)
+    {
+        await base.Column_collection_Count_with_predicate(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM json_each("p"."Ints") AS "i"
+    WHERE "i"."value" > 1) = 2
+""");
+    }
+
+    // #33932
+    public override async Task Column_collection_Where_Count(bool async)
+    {
+        await base.Column_collection_Where_Count(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM json_each("p"."Ints") AS "i"
+    WHERE "i"."value" > 1) = 2
+""");
+    }
+
     public override async Task Column_collection_index_int(bool async)
     {
         await base.Column_collection_index_int(async);


### PR DESCRIPTION
Fixes #33932, backports #33933

**Description**
In the query pipeilne, we pattern match specific LINQ operators to translate to specialized functions/operators. For example, on SQLite, the query fragment Where(b => b.Ints.Count() == 8) is translated to json_array_length(b.Ints) = 8, rather than the full subquery translation (SELECT COUNT(*) FROM json_each(b.Ints)) == 8).

Unfortunately, in many of the sites where this sort of pattern matching occurs, I left out checking the predicate. As a result, we perform these simplifications even when we shouldn't. For example, Where(b => b.Ints.Where(i => i > 3).Count() == 8) also translates to json_array_length(b.Ints) = 8, effectively ignoring the Where().

**Customer impact**
When a customer composes certain LINQ operators on a JSON query that already has a Where(), incorrect SQL is generated (without the WHERE) and incorrect results are returned (data corruption).

**How found**
Found while working on unrelated query pipeline improvements.

**Regression**
No, JSON collection querying is a new feature in EF8.

**Testing**
Test added.

**Risk**
Very low - one-line, very straightforward fix (in multiple sites). Quirk added.