### PR TITLE
Remove optimization of `NOT(a != b)`

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -67,7 +67,7 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
             && sqlUnaryExpression.Type == typeof(bool)
             && sqlUnaryExpression.Operand is SqlBinaryExpression
             {
-                OperatorType: ExpressionType.Equal or ExpressionType.NotEqual
+                OperatorType: ExpressionType.Equal
             } sqlBinaryOperand)
         {
             if (sqlBinaryOperand.Left.Type == typeof(bool)


### PR DESCRIPTION
It is implemented incorrectly (as if the expression was `NOT(a == b)`) and it is currently unused.

See https://github.com/dotnet/efcore/pull/23711#pullrequestreview-2105963675