### PR TITLE
Fix UpdateExpression.VisitChildren to visit the setter column

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
@@ -93,12 +93,14 @@ public sealed class UpdateExpression : Expression, IRelationalQuotableExpression
         for (var (i, n) = (0, ColumnValueSetters.Count); i < n; i++)
         {
             var columnValueSetter = ColumnValueSetters[i];
+            var newColumn = (ColumnExpression)visitor.Visit(columnValueSetter.Column);
             var newValue = (SqlExpression)visitor.Visit(columnValueSetter.Value);
+
             if (columnValueSetters != null)
             {
-                columnValueSetters.Add(columnValueSetter with { Value = newValue });
+                columnValueSetters.Add(new ColumnValueSetter(newColumn, newValue));
             }
-            else if (!ReferenceEquals(newValue, columnValueSetter.Value))
+            else if (!ReferenceEquals(newColumn, columnValueSetter.Column) || !ReferenceEquals(newValue, columnValueSetter.Value))
             {
                 columnValueSetters = new List<ColumnValueSetter>(n);
                 for (var j = 0; j < i; j++)
@@ -106,7 +108,7 @@ public sealed class UpdateExpression : Expression, IRelationalQuotableExpression
                     columnValueSetters.Add(ColumnValueSetters[j]);
                 }
 
-                columnValueSetters.Add(columnValueSetter with { Value = newValue });
+                columnValueSetters.Add(new ColumnValueSetter(newColumn, newValue));
             }
         }
 

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -60,6 +60,20 @@ public abstract class NonSharedModelBulkUpdatesTestBase : NonSharedModelTestBase
             RelationalStrings.ExecuteDeleteOnTableSplitting(nameof(Owner)));
     }
 
+    [ConditionalTheory] // #33937, #33946
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Replace_ColumnExpression_in_column_setter(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context28671>();
+
+        await AssertUpdate(
+            async,
+            contextFactory.CreateContext,
+            ss => ss.Set<Owner>().SelectMany(e => e.OwnedCollections),
+            s => s.SetProperty(o => o.Value, "SomeValue"),
+            rowsAffectedCount: 0);
+    }
+
     protected class Context28671(DbContextOptions options) : DbContext(options)
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -62,6 +62,19 @@ FROM [Owner] AS [o]
         AssertSql();
     }
 
+    public override async Task Replace_ColumnExpression_in_column_setter(bool async)
+    {
+        await base.Replace_ColumnExpression_in_column_setter(async);
+
+        AssertSql(
+            """
+UPDATE [o0]
+SET [o0].[Value] = N'SomeValue'
+FROM [Owner] AS [o]
+INNER JOIN [OwnedCollection] AS [o0] ON [o].[Id] = [o0].[OwnerId]
+""");
+    }
+
     public override async Task Update_non_owned_property_on_entity_with_owned(bool async)
     {
         await base.Update_non_owned_property_on_entity_with_owned(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Data.Sqlite;
+
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
@@ -57,6 +59,20 @@ DELETE FROM "Owner" AS "o"
         await base.Delete_aggregate_root_when_table_sharing_with_non_owned_throws(async);
 
         AssertSql();
+    }
+
+    public override async Task Replace_ColumnExpression_in_column_setter(bool async)
+    {
+        // #33947
+        await Assert.ThrowsAsync<SqliteException>(() => base.Replace_ColumnExpression_in_column_setter(async));
+
+        AssertSql(
+            """
+UPDATE "OwnedCollection" AS "o0"
+SET "Value" = 'SomeValue'
+FROM "Owner" AS "o"
+INNER JOIN "OwnedCollection" AS "o0" ON "o"."Id" = "o0"."OwnerId"
+""");
     }
 
     public override async Task Update_non_owned_property_on_entity_with_owned(bool async)


### PR DESCRIPTION
The problem here was a bug in UpdateExpression.VisitChildren: for column setters, it was visiting the values but not the columns. In 9.0, our alias post-processing logic now replaces columns in the entire tree when rewriting aliases, but the columns inside UpdateExpression weren't being changed because of this, causing incorrect SQL.

Fixes #33937
