### PR TITLE
Cosmos: add translations for date/time components

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosMemberTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMemberTranslatorProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
@@ -27,8 +29,9 @@ public class CosmosMemberTranslatorProvider : IMemberTranslatorProvider
         _plugins.AddRange(plugins.SelectMany(p => p.Translators));
         _translators.AddRange(
         [
-            new CosmosStringMemberTranslator(sqlExpressionFactory),
-            new CosmosDateTimeMemberTranslator(sqlExpressionFactory)
+            new CosmosDateTimeMemberTranslator(sqlExpressionFactory),
+            new CosmosNullableMemberTranslator(sqlExpressionFactory),
+            new CosmosStringMemberTranslator(sqlExpressionFactory)
         ]);
     }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -28,11 +28,12 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
 
         _translators.AddRange(
         [
+            new CosmosDateTimeMethodTranslator(sqlExpressionFactory),
             new CosmosEqualsTranslator(sqlExpressionFactory),
-            new CosmosStringMethodTranslator(sqlExpressionFactory),
-            new CosmosRandomTranslator(sqlExpressionFactory),
             new CosmosMathTranslator(sqlExpressionFactory),
+            new CosmosRandomTranslator(sqlExpressionFactory),
             new CosmosRegexTranslator(sqlExpressionFactory),
+            new CosmosStringMethodTranslator(sqlExpressionFactory),
             new CosmosTypeCheckingTranslator(sqlExpressionFactory)
             //new LikeTranslator(sqlExpressionFactory),
             //new EnumHasFlagTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMemberTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMemberTranslator.cs
@@ -25,16 +25,34 @@ public class CosmosDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionF
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
         var declaringType = member.DeclaringType;
-        if ((declaringType == typeof(DateTime)
-                || declaringType == typeof(DateTimeOffset))
-            && member.Name == nameof(DateTime.UtcNow))
+
+        if (declaringType != typeof(DateTime) && declaringType != typeof(DateTimeOffset))
         {
-            return sqlExpressionFactory.Function(
-                "GetCurrentDateTime",
-                [],
-                returnType);
+            return null;
         }
 
-        return null;
+        return member.Name switch
+        {
+            nameof(DateTime.Year) => DatePart("yyyy"),
+            nameof(DateTime.Month) => DatePart("mm"),
+            nameof(DateTime.Day) => DatePart("dd"),
+            nameof(DateTime.Hour) => DatePart("hh"),
+            nameof(DateTime.Minute) => DatePart("mi"),
+            nameof(DateTime.Second) => DatePart("ss"),
+            nameof(DateTime.Millisecond) => DatePart("ms"),
+            nameof(DateTime.Microsecond) => DatePart("mcs"),
+            nameof(DateTime.Nanosecond) => DatePart("ns"),
+
+            nameof(DateTime.UtcNow)
+                => sqlExpressionFactory.Function(
+                    "GetCurrentDateTime",
+                    [],
+                    returnType),
+
+            _ => null
+        };
+
+        SqlFunctionExpression DatePart(string part)
+            => sqlExpressionFactory.Function("DateTimePart", arguments: [sqlExpressionFactory.Constant(part), instance!], returnType);
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMethodTranslator.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CosmosDateTimeMethodTranslator(ISqlExpressionFactory sqlExpressionFactory) : IMethodCallTranslator
+{
+    private static readonly Dictionary<MethodInfo, string> MethodInfoDatePartMapping = new()
+    {
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddYears), [typeof(int)])!, "yyyy" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMonths), [typeof(int)])!, "mm" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddDays), [typeof(double)])!, "dd" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddHours), [typeof(double)])!, "hh" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMinutes), [typeof(double)])!, "mi" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddSeconds), [typeof(double)])!, "ss" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMilliseconds), [typeof(double)])!, "ms" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMicroseconds), [typeof(double)])!, "mcs" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddYears), [typeof(int)])!, "yyyy" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMonths), [typeof(int)])!, "mm" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddDays), [typeof(double)])!, "dd" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddHours), [typeof(double)])!, "hh" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMinutes), [typeof(double)])!, "mi" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddSeconds), [typeof(double)])!, "ss" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMilliseconds), [typeof(double)])!, "ms" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMicroseconds), [typeof(double)])!, "mcs" }
+    };
+
+    private static readonly Dictionary<MethodInfo, string> MethodInfoDateDiffMapping = new()
+    {
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.ToUnixTimeSeconds), Type.EmptyTypes)!, "second" },
+        { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.ToUnixTimeMilliseconds), Type.EmptyTypes)!, "millisecond" }
+    };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType != typeof(DateTime) && method.DeclaringType != typeof(DateTimeOffset))
+        {
+            return null;
+        }
+
+        if (MethodInfoDatePartMapping.TryGetValue(method, out var datePart)
+            && instance != null)
+        {
+            return sqlExpressionFactory.Function(
+                "DateTimeAdd",
+                arguments: [sqlExpressionFactory.Constant(datePart), arguments[0], instance],
+                instance.Type,
+                instance.TypeMapping);
+        }
+
+        return null;
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosNullableMemberTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosNullableMemberTranslator.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class NullableMemberTranslator(ISqlExpressionFactory sqlExpressionFactory) : IMemberTranslator
+public class CosmosNullableMemberTranslator(ISqlExpressionFactory sqlExpressionFactory) : IMemberTranslator
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateTimeMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateTimeMethodTranslator.cs
@@ -12,9 +12,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
+public class SqlServerDateTimeMethodTranslator(
+    ISqlExpressionFactory sqlExpressionFactory,
+    IRelationalTypeMappingSource typeMappingSource)
+    : IMethodCallTranslator
 {
-    private readonly Dictionary<MethodInfo, string> _methodInfoDatePartMapping = new()
+    private static readonly Dictionary<MethodInfo, string> MethodInfoDatePartMapping = new()
     {
         { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddYears), [typeof(int)])!, "year" },
         { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMonths), [typeof(int)])!, "month" },
@@ -32,7 +35,7 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
         { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMilliseconds), [typeof(double)])!, "millisecond" }
     };
 
-    private static readonly Dictionary<MethodInfo, string> _methodInfoDateDiffMapping = new()
+    private static readonly Dictionary<MethodInfo, string> MethodInfoDateDiffMapping = new()
     {
         { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.ToUnixTimeSeconds), Type.EmptyTypes)!, "second" },
         { typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.ToUnixTimeMilliseconds), Type.EmptyTypes)!, "millisecond" }
@@ -46,23 +49,6 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
         .GetRuntimeMethod(
             nameof(SqlServerDbFunctionsExtensions.AtTimeZone), [typeof(DbFunctions), typeof(DateTime), typeof(string)])!;
 
-    private readonly ISqlExpressionFactory _sqlExpressionFactory;
-    private readonly IRelationalTypeMappingSource _typeMappingSource;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public SqlServerDateTimeMethodTranslator(
-        ISqlExpressionFactory sqlExpressionFactory,
-        IRelationalTypeMappingSource typeMappingSource)
-    {
-        _sqlExpressionFactory = sqlExpressionFactory;
-        _typeMappingSource = typeMappingSource;
-    }
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -75,7 +61,7 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
-        if (_methodInfoDatePartMapping.TryGetValue(method, out var datePart)
+        if (MethodInfoDatePartMapping.TryGetValue(method, out var datePart)
             && instance != null)
         {
             // Some Add methods accept a double, and SQL Server DateAdd does not accept number argument outside of int range
@@ -88,14 +74,14 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
             // Our default mapping for DateTime is datetime2, so we force constants to be datetime instead here.
             if (instance is SqlConstantExpression instanceConstant)
             {
-                instance = instanceConstant.ApplyTypeMapping(_typeMappingSource.FindMapping(typeof(DateTime), "datetime"));
+                instance = instanceConstant.ApplyTypeMapping(typeMappingSource.FindMapping(typeof(DateTime), "datetime"));
             }
 
-            return _sqlExpressionFactory.Function(
+            return sqlExpressionFactory.Function(
                 "DATEADD",
-                new[] { _sqlExpressionFactory.Fragment(datePart), _sqlExpressionFactory.Convert(arguments[0], typeof(int)), instance },
+                arguments: [sqlExpressionFactory.Fragment(datePart), sqlExpressionFactory.Convert(arguments[0], typeof(int)), instance],
                 nullable: true,
-                argumentsPropagateNullability: new[] { false, true, true },
+                argumentsPropagateNullability: [false, true, true],
                 instance.Type,
                 instance.TypeMapping);
         }
@@ -116,7 +102,7 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
                     "datetimeoffset"
                         => operandTypeMapping,
                     "datetime" or "datetime2" or "smalldatetime"
-                        => _typeMappingSource.FindMapping(
+                        => typeMappingSource.FindMapping(
                             typeof(DateTimeOffset), "datetimeoffset", precision: operandTypeMapping.Precision),
                     _ => null
                 };
@@ -130,28 +116,28 @@ public class SqlServerDateTimeMethodTranslator : IMethodCallTranslator
             {
                 // Our constant representation for datetime/datetimeoffset is an untyped string literal, which the AT TIME ZONE expression
                 // does not accept. Type it explicitly.
-                operand = _sqlExpressionFactory.Convert(operand, operand.Type);
+                operand = sqlExpressionFactory.Convert(operand, operand.Type);
             }
 
             return new AtTimeZoneExpression(
                 operand,
-                _sqlExpressionFactory.ApplyTypeMapping(timeZone, _typeMappingSource.FindMapping("varchar")),
+                sqlExpressionFactory.ApplyTypeMapping(timeZone, typeMappingSource.FindMapping("varchar")),
                 typeof(DateTimeOffset),
                 resultTypeMapping);
         }
 
-        if (_methodInfoDateDiffMapping.TryGetValue(method, out var timePart))
+        if (MethodInfoDateDiffMapping.TryGetValue(method, out var timePart))
         {
-            return _sqlExpressionFactory.Function(
+            return sqlExpressionFactory.Function(
                 "DATEDIFF_BIG",
-                new[]
-                {
-                    _sqlExpressionFactory.Fragment(timePart),
-                    _sqlExpressionFactory.Constant(DateTimeOffset.UnixEpoch, instance!.TypeMapping),
+                arguments:
+                [
+                    sqlExpressionFactory.Fragment(timePart),
+                    sqlExpressionFactory.Constant(DateTimeOffset.UnixEpoch, instance!.TypeMapping),
                     instance
-                },
+                ],
                 nullable: true,
-                argumentsPropagateNullability: new[] { false, true, true },
+                argumentsPropagateNullability: [false, true, true],
                 typeof(long));
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -712,18 +712,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
     }
 
     public override Task Projection_containing_DateTime_subtraction(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Projection_containing_DateTime_subtraction(a);
-
-                AssertSql(
-                    """
-SELECT c["OrderDate"]
-FROM root c
-WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
-""");
-            });
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Projection_containing_DateTime_subtraction(async));
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
     {
@@ -824,7 +813,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("yyyy", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -838,7 +827,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("mm", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -848,6 +837,7 @@ WHERE (c["Discriminator"] = "Order")
         => Fixture.NoSyncTest(
             async, async a =>
             {
+                // DateTime.DayOfYear not supported by Cosmos
                 await base.Select_datetime_day_of_year_component(a);
 
                 AssertSql(
@@ -866,7 +856,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("dd", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -880,7 +870,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("hh", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -894,7 +884,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("mi", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -908,7 +898,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("ss", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -922,7 +912,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT DateTimePart("ms", c["OrderDate"]) AS c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1543,8 +1533,10 @@ OFFSET 0 LIMIT @__p_0
 SELECT VALUE
 {
     "CustomerID" : c["CustomerID"],
+    "c" : (c["OrderDate"] != null),
     "OrderDate" : c["OrderDate"],
-    "c" : (c["OrderID"] - 10000)
+    "c0" : (c["OrderID"] - 10000),
+    "c1" : ((c["OrderDate"] != null) = false)
 }
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1293,77 +1293,125 @@ WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatet
         AssertSql();
     }
 
-    public override async Task Where_date_add_year_constant_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_date_add_year_constant_component(async));
+    public override Task Where_date_add_year_constant_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_date_add_year_constant_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", DateTimeAdd("yyyy", -1, c["OrderDate"])) = 1997))
+""");
+            });
 
-    public override async Task Where_datetime_year_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_year_component(async));
+    public override Task Where_datetime_year_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_year_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", c["OrderDate"]) = 1998))
+""");
+            });
 
-    public override async Task Where_datetime_month_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_month_component(async));
+    public override Task Where_datetime_month_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_month_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mm", c["OrderDate"]) = 4))
+""");
+            });
 
     public override async Task Where_datetime_dayOfYear_component(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
+        // DateTime.DayOfYear not supported by Cosmos
         await AssertTranslationFailed(() => base.Where_datetime_dayOfYear_component(async));
 
         AssertSql();
     }
 
-    public override async Task Where_datetime_day_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_day_component(async));
+    public override Task Where_datetime_day_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_day_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("dd", c["OrderDate"]) = 4))
+""");
+            });
 
-    public override async Task Where_datetime_hour_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_hour_component(async));
+    public override Task Where_datetime_hour_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_hour_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("hh", c["OrderDate"]) = 0))
+""");
+            });
 
-    public override async Task Where_datetime_minute_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_minute_component(async));
+    public override Task Where_datetime_minute_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_minute_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mi", c["OrderDate"]) = 0))
+""");
+            });
 
-    public override async Task Where_datetime_second_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_second_component(async));
+    public override Task Where_datetime_second_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_second_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ss", c["OrderDate"]) = 0))
+""");
+            });
 
-    public override async Task Where_datetime_millisecond_component(bool async)
-    {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Where_datetime_millisecond_component(async));
+    public override Task Where_datetime_millisecond_component(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_datetime_millisecond_component(a);
 
-        AssertSql();
-    }
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ms", c["OrderDate"]) = 0))
+""");
+            });
 
     public override async Task Where_datetimeoffset_now_component(bool async)
     {


### PR DESCRIPTION
Also add translation for `Nullable<T>.Value`, and do some cleanup on the SQL Server/SQLite translators.

Closes #33975
