### PR TITLE
 Support vector search on Cosmos DB

### DIFF
--- a/src/EFCore.Analyzers/EFDiagnostics.cs
+++ b/src/EFCore.Analyzers/EFDiagnostics.cs
@@ -18,4 +18,5 @@ public static class EFDiagnostics
     public const string PrecompiledQueryExperimental = "EF9100";
     public const string MetricsExperimental = "EF9101";
     public const string PagingExperimental = "EF9102";
+    public const string CosmosVectorSearchExperimental = "EF9103";
 }

--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -11,6 +11,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>$(NoWarn);EF9101</NoWarn> <!-- Metrics is experimental -->
     <NoWarn>$(NoWarn);EF9102</NoWarn> <!-- Paging is experimental -->
+    <NoWarn>$(NoWarn);EF9103</NoWarn> <!-- Vector search is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 
 /// <summary>
@@ -47,4 +49,145 @@ public static class CosmosDbFunctionsExtensions
         T expression1,
         T expression2)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CoalesceUndefined)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, using the distance function and data type defined using
+    ///     <see cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)"/>.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<byte> vector1, ReadOnlyMemory<byte> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<byte> vector1,
+        ReadOnlyMemory<byte> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="distanceFunction">The distance function to use.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<byte> vector1,
+        ReadOnlyMemory<byte> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, using the distance function and data type defined using
+    ///     <see cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)"/>.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<sbyte> vector1, ReadOnlyMemory<sbyte> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<sbyte> vector1,
+        ReadOnlyMemory<sbyte> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="distanceFunction">The distance function to use.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<sbyte> vector1,
+        ReadOnlyMemory<sbyte> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, using the distance function and data type defined using
+    ///     <see cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)"/>.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<float> vector1, ReadOnlyMemory<float> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<float> vector1,
+        ReadOnlyMemory<float> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="distanceFunction">The distance function to use.</param>
+    /// <param name="useBruteForce">A <see langword="bool"/> specifying how the computed value is used in an ORDER BY
+    /// expression. If <see langword="true"/>, then brute force is used, otherwise any index defined on the vector
+    /// property is leveraged.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<float> vector1,
+        ReadOnlyMemory<float> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosIndexBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosIndexBuilderExtensions.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Azure Cosmos DB-specific extension methods for <see cref="IndexBuilder"/>.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+/// </remarks>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public static class CosmosIndexBuilderExtensions
+{
+    /// <summary>
+    ///     Configures the index as a vector index with the given vector index type, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="indexType">The type of vector index to create.</param>
+    /// <returns>A builder to further configure the index.</returns>
+    public static IndexBuilder ForVectors(this IndexBuilder indexBuilder, VectorIndexType? indexType)
+    {
+        indexBuilder.Metadata.SetVectorIndexType(indexType);
+
+        return indexBuilder;
+    }
+
+    /// <summary>
+    ///     Configures whether the index as a vector index with the given vector index type, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="indexType">The type of vector index to create.</param>
+    /// <returns>A builder to further configure the index.</returns>
+    public static IndexBuilder<TEntity> ForVectors<TEntity>(
+        this IndexBuilder<TEntity> indexBuilder,
+        VectorIndexType? indexType)
+        => (IndexBuilder<TEntity>)ForVectors((IndexBuilder)indexBuilder, indexType);
+
+    /// <summary>
+    ///     Configures whether the index as a vector index with the given vector index type, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="indexType">The type of vector index to create.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionIndexBuilder? ForVectors(
+        this IConventionIndexBuilder indexBuilder,
+        VectorIndexType? indexType,
+        bool fromDataAnnotation = false)
+    {
+        if (indexBuilder.CanSetVectorIndexType(indexType, fromDataAnnotation))
+        {
+            indexBuilder.Metadata.SetVectorIndexType(indexType, fromDataAnnotation);
+            return indexBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the vector index can be configured for vectors.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="indexType">The index type to use.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the index can be configured for vectors.</returns>
+    public static bool CanSetVectorIndexType(
+        this IConventionIndexBuilder indexBuilder,
+        VectorIndexType? indexType,
+        bool fromDataAnnotation = false)
+        => indexBuilder.CanSetAnnotation(CosmosAnnotationNames.VectorIndexType, indexType, fromDataAnnotation);
+}

--- a/src/EFCore.Cosmos/Extensions/CosmosIndexExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosIndexExtensions.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Index extension methods for Azure Cosmos DB-specific metadata.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+/// </remarks>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public static class CosmosIndexExtensions
+{
+    /// <summary>
+    ///     Returns the vector index type to use, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    /// <returns>The index type to use, or <see langword="null" /> if none is set.</returns>
+    public static VectorIndexType? GetVectorIndexType(this IReadOnlyIndex index)
+        => (index is RuntimeIndex)
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (VectorIndexType?)index[CosmosAnnotationNames.VectorIndexType];
+
+    /// <summary>
+    ///     Sets the vector index type to use, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    /// <param name="indexType">The index type to use.</param>
+    public static void SetVectorIndexType(this IMutableIndex index, VectorIndexType? indexType)
+        => index.SetAnnotation(CosmosAnnotationNames.VectorIndexType, indexType);
+
+    /// <summary>
+    ///     Sets the vector index type to use, such as "flat", "diskANN", or "quantizedFlat".
+    ///     See <see href="https://aka.ms/ef-cosmos-vectors">Vector Search in Azure Cosmos DB for NoSQL</see> for more information.
+    /// </summary>
+    /// <param name="indexType">The index type to use.</param>
+    /// <param name="index">The index.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static string? SetVectorIndexType(
+        this IConventionIndex index,
+        VectorIndexType? indexType,
+        bool fromDataAnnotation = false)
+        => (string?)index.SetAnnotation(
+            CosmosAnnotationNames.VectorIndexType,
+            indexType,
+            fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for whether the <see cref="GetVectorIndexType"/>.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for whether the index is clustered.</returns>
+    public static ConfigurationSource? GetVectorIndexTypeConfigurationSource(this IConventionIndex property)
+        => property.FindAnnotation(CosmosAnnotationNames.VectorIndexType)?.GetConfigurationSource();
+}

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
@@ -239,13 +239,8 @@ public static class CosmosPropertyBuilderExtensions
 
     [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     private static CosmosVectorType CreateVectorType(DistanceFunction distanceFunction, int dimensions)
-    {
-        if (!Enum.IsDefined(distanceFunction))
-        {
-            throw new ArgumentException(CoreStrings.InvalidEnumValue(distanceFunction, nameof(distanceFunction), typeof(DistanceFunction)));
-        }
-
-        var vectorType = new CosmosVectorType(distanceFunction, dimensions);
-        return vectorType;
-    }
+        => Enum.IsDefined(distanceFunction)
+            ? new CosmosVectorType(distanceFunction, dimensions)
+            : throw new ArgumentException(
+                CoreStrings.InvalidEnumValue(distanceFunction, nameof(distanceFunction), typeof(DistanceFunction)));
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -105,6 +106,105 @@ public static class CosmosPropertyBuilderExtensions
         => propertyBuilder.CanSetAnnotation(CosmosAnnotationNames.PropertyName, name, fromDataAnnotation);
 
     /// <summary>
+    ///     Configures the property as a vector for Azure Cosmos DB.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="distanceFunction">The distance function for a vector comparisons.</param>
+    /// <param name="dimensions">The number of dimensions in the vector.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static PropertyBuilder IsVector(
+        this PropertyBuilder propertyBuilder,
+        DistanceFunction distanceFunction,
+        int dimensions)
+    {
+        propertyBuilder.Metadata.SetVectorType(CreateVectorType(distanceFunction, dimensions));
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    ///     Configures the property as a vector for Azure Cosmos DB.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="distanceFunction">The distance function for a vector comparisons.</param>
+    /// <param name="dimensions">The number of dimensions in the vector.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static PropertyBuilder<TProperty> IsVector<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        DistanceFunction distanceFunction,
+        int dimensions)
+        => (PropertyBuilder<TProperty>)IsVector((PropertyBuilder)propertyBuilder, distanceFunction, dimensions);
+
+    /// <summary>
+    ///     Configures the property as a vector for Azure Cosmos DB.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="distanceFunction">The distance function for a vector comparisons.</param>
+    /// <param name="dimensions">The number of dimensions in the vector.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static IConventionPropertyBuilder? IsVector(
+        this IConventionPropertyBuilder propertyBuilder,
+        DistanceFunction distanceFunction,
+        int dimensions,
+        bool fromDataAnnotation = false)
+    {
+        if (!propertyBuilder.CanSetIsVector(distanceFunction, dimensions, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        propertyBuilder.Metadata.SetVectorType(CreateVectorType(distanceFunction, dimensions), fromDataAnnotation);
+
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the vector type can be set.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="distanceFunction">The distance function for a vector comparisons.</param>
+    /// <param name="dimensions">The number of dimensions in the vector.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the vector type can be set.</returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static bool CanSetIsVector(
+        this IConventionPropertyBuilder propertyBuilder,
+        DistanceFunction distanceFunction,
+        int dimensions,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.CanSetAnnotation(
+            CosmosAnnotationNames.VectorType,
+            CreateVectorType(distanceFunction, dimensions),
+            fromDataAnnotation);
+
+    /// <summary>
     ///     Configures this property to be the etag concurrency token.
     /// </summary>
     /// <remarks>
@@ -136,4 +236,16 @@ public static class CosmosPropertyBuilderExtensions
     public static PropertyBuilder<TProperty> IsETagConcurrency<TProperty>(
         this PropertyBuilder<TProperty> propertyBuilder)
         => (PropertyBuilder<TProperty>)IsETagConcurrency((PropertyBuilder)propertyBuilder);
+
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    private static CosmosVectorType CreateVectorType(DistanceFunction distanceFunction, int dimensions)
+    {
+        if (!Enum.IsDefined(distanceFunction))
+        {
+            throw new ArgumentException(CoreStrings.InvalidEnumValue(distanceFunction, nameof(distanceFunction), typeof(DistanceFunction)));
+        }
+
+        var vectorType = new CosmosVectorType(distanceFunction, dimensions);
+        return vectorType;
+    }
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -73,12 +74,55 @@ public static class CosmosPropertyExtensions
             fromDataAnnotation)?.Value;
 
     /// <summary>
-    ///     Gets the <see cref="ConfigurationSource" /> the property name that the property is mapped to when targeting Cosmos.
+    ///     Gets the <see cref="ConfigurationSource" /> for the property name that the property is mapped to when targeting Cosmos.
     /// </summary>
     /// <param name="property">The property.</param>
     /// <returns>
-    ///     The <see cref="ConfigurationSource" /> the property name that the property is mapped to when targeting Cosmos.
+    ///     The <see cref="ConfigurationSource" /> for the property name that the property is mapped to when targeting Cosmos.
     /// </returns>
     public static ConfigurationSource? GetJsonPropertyNameConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(CosmosAnnotationNames.PropertyName)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns the definition of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>Returns the definition of the vector stored in this property.</returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static CosmosVectorType? GetVectorType(this IReadOnlyProperty property)
+        => (CosmosVectorType?)property[CosmosAnnotationNames.VectorType];
+
+    /// <summary>
+    ///     Sets the definition of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="vectorType">The type of vector stored in the property.</param>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static void SetVectorType(this IMutableProperty property, CosmosVectorType? vectorType)
+        => property.SetOrRemoveAnnotation(CosmosAnnotationNames.VectorType, vectorType);
+
+    /// <summary>
+    ///     Sets the definition of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="vectorType">The type of vector stored in the property.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static CosmosVectorType? SetVectorType(this IConventionProperty property, CosmosVectorType? vectorType, bool fromDataAnnotation = false)
+        => (CosmosVectorType?)property.SetOrRemoveAnnotation(
+            CosmosAnnotationNames.VectorType,
+            vectorType,
+            fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Gets the <see cref="ConfigurationSource" /> for the definition of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>
+    ///     The <see cref="ConfigurationSource" /> for the definition of the vector stored in this property.
+    /// </returns>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public static ConfigurationSource? GetVectorTypeConfigurationSource(this IConventionProperty property)
+        => property.FindAnnotation(CosmosAnnotationNames.VectorType)?.GetConfigurationSource();
 }

--- a/src/EFCore.Cosmos/Extensions/DistanceFunction.cs
+++ b/src/EFCore.Cosmos/Extensions/DistanceFunction.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.Cosmos;
+
+/// <summary>
+///     Defines the distance function for a vector index specification in the Azure Cosmos DB service.
+///     Warning: this type will be replaced by the type from the Cosmos SDK, when it is available.
+/// </summary>
+/// <seealso cref="T:Microsoft.Azure.Cosmos.Embedding" />
+/// for usage.
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public enum DistanceFunction
+{
+    /// <summary>
+    ///     Represents the Euclidean distance function.
+    /// </summary>
+    [EnumMember(Value = "euclidean")]
+    Euclidean,
+
+    /// <summary>
+    ///     Represents the cosine distance function.
+    /// </summary>
+    [EnumMember(Value = "cosine")]
+    Cosine,
+
+    /// <summary>
+    ///     Represents the dot product distance function.
+    /// </summary>
+    [EnumMember(Value = "dotproduct")]
+    DotProduct,
+}

--- a/src/EFCore.Cosmos/Extensions/Embedding.cs
+++ b/src/EFCore.Cosmos/Extensions/Embedding.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.Cosmos;
+
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+internal class Embedding : IEquatable<Embedding>
+{
+    public string? Path { get; set; }
+    public VectorDataType DataType { get; set; }
+    public int Dimensions { get; set; }
+    public DistanceFunction DistanceFunction { get; set; }
+    public bool Equals(Embedding? that)
+        => Equals(Path, that?.Path) && Equals(DataType, that?.DataType) && Equals(Dimensions, that.Dimensions);
+}

--- a/src/EFCore.Cosmos/Extensions/VectorDataType.cs
+++ b/src/EFCore.Cosmos/Extensions/VectorDataType.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.Cosmos;
+
+/// <summary>
+///     Defines the target data type of a vector index specification in the Azure Cosmos DB service.
+///     Warning: this type will be replaced by the type from the Cosmos SDK, when it is available.
+/// </summary>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public enum VectorDataType
+{
+    /// <summary>
+    ///     Represents a 16-bit floating point data type.
+    /// </summary>
+    [EnumMember(Value = "float16")]
+    Float16,
+
+    /// <summary>
+    ///     Represents a 32-bit floating point data type.
+    /// </summary>
+    [EnumMember(Value = "float32")]
+    Float32,
+
+    /// <summary>
+    ///     Represents an unsigned 8-bit binary data type.
+    /// </summary>
+    [EnumMember(Value = "uint8")]
+    Uint8,
+
+    /// <summary>
+    ///     Represents a signed 8-bit binary data type.
+    /// </summary>
+    [EnumMember(Value = "int8")]
+    Int8,
+}

--- a/src/EFCore.Cosmos/Extensions/VectorIndexPath.cs
+++ b/src/EFCore.Cosmos/Extensions/VectorIndexPath.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.Cosmos;
+
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+internal sealed class VectorIndexPath
+{
+    public string? Path { get; set; }
+    public VectorIndexType Type { get; set; }
+}

--- a/src/EFCore.Cosmos/Extensions/VectorIndexType.cs
+++ b/src/EFCore.Cosmos/Extensions/VectorIndexType.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.Cosmos;
+
+/// <summary>
+///     Defines the target index type of the vector index path specification in the Azure Cosmos DB service.
+///     Warning: this type will be replaced by the type from the Cosmos SDK, when it is available.
+/// </summary>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public enum VectorIndexType
+{
+    /// <summary>
+    ///     Represents a flat vector index type.
+    /// </summary>
+    [EnumMember(Value = "flat")]
+    Flat,
+
+    /// <summary>
+    ///     Represents a Disk ANN vector index type.
+    /// </summary>
+    [EnumMember(Value = "diskANN")]
+    // ReSharper disable once InconsistentNaming
+    DiskANN,
+
+    /// <summary>
+    ///     Represents a quantized flat vector index type.
+    /// </summary>
+    [EnumMember(Value = "quantizedFlat")]
+    QuantizedFlat,
+}

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
@@ -120,14 +121,18 @@ public class CosmosModelValidator : ModelValidator
             {
                 throw new InvalidOperationException(
                     CosmosStrings.OwnedTypeDifferentContainer(
-                        entityType.DisplayName(), ownership.PrincipalEntityType.DisplayName(), container));
+                        entityType.DisplayName(),
+                        ownership.PrincipalEntityType.DisplayName(),
+                        container));
             }
 
             if (entityType.GetContainingPropertyName() != null)
             {
                 throw new InvalidOperationException(
                     CosmosStrings.ContainerContainingPropertyConflict(
-                        entityType.DisplayName(), container, entityType.GetContainingPropertyName()));
+                        entityType.DisplayName(),
+                        container,
+                        entityType.GetContainingPropertyName()));
             }
 
             if (!containers.TryGetValue(container, out var mappedTypes))
@@ -196,8 +201,12 @@ public class CosmosModelValidator : ModelValidator
                     {
                         throw new InvalidOperationException(
                             CosmosStrings.PartitionKeyStoreNameMismatch(
-                                firstEntityType.GetPartitionKeyPropertyNames()[i], firstEntityType.DisplayName(), partitionKeyStoreNames[i],
-                                entityType.GetPartitionKeyPropertyNames()[i], entityType.DisplayName(), storeNames[i]));
+                                firstEntityType.GetPartitionKeyPropertyNames()[i],
+                                firstEntityType.DisplayName(),
+                                partitionKeyStoreNames[i],
+                                entityType.GetPartitionKeyPropertyNames()[i],
+                                entityType.DisplayName(),
+                                storeNames[i]));
                     }
                 }
             }
@@ -212,22 +221,23 @@ public class CosmosModelValidator : ModelValidator
             {
                 if (entityType.FindDiscriminatorProperty() == null)
                 {
-                    throw new InvalidOperationException(
-                        CosmosStrings.NoDiscriminatorProperty(entityType.DisplayName(), container));
+                    throw new InvalidOperationException(CosmosStrings.NoDiscriminatorProperty(entityType.DisplayName(), container));
                 }
 
                 var discriminatorValue = entityType.GetDiscriminatorValue();
                 if (discriminatorValue == null)
                 {
-                    throw new InvalidOperationException(
-                        CosmosStrings.NoDiscriminatorValue(entityType.DisplayName(), container));
+                    throw new InvalidOperationException(CosmosStrings.NoDiscriminatorValue(entityType.DisplayName(), container));
                 }
 
                 if (discriminatorValues.TryGetValue(discriminatorValue, out var duplicateEntityType))
                 {
                     throw new InvalidOperationException(
                         CosmosStrings.DuplicateDiscriminatorValue(
-                            entityType.DisplayName(), discriminatorValue, duplicateEntityType.DisplayName(), container));
+                            entityType.DisplayName(),
+                            discriminatorValue,
+                            duplicateEntityType.DisplayName(),
+                            container));
                 }
 
                 discriminatorValues[discriminatorValue] = entityType;
@@ -258,7 +268,10 @@ public class CosmosModelValidator : ModelValidator
                     var conflictingEntityType = mappedTypes.First(et => et.GetAnalyticalStoreTimeToLive() != null);
                     throw new InvalidOperationException(
                         CosmosStrings.AnalyticalTTLMismatch(
-                            analyticalTtl, conflictingEntityType.DisplayName(), entityType.DisplayName(), currentAnalyticalTtl,
+                            analyticalTtl,
+                            conflictingEntityType.DisplayName(),
+                            entityType.DisplayName(),
+                            currentAnalyticalTtl,
                             container));
                 }
             }
@@ -275,7 +288,11 @@ public class CosmosModelValidator : ModelValidator
                     var conflictingEntityType = mappedTypes.First(et => et.GetDefaultTimeToLive() != null);
                     throw new InvalidOperationException(
                         CosmosStrings.DefaultTTLMismatch(
-                            defaultTtl, conflictingEntityType.DisplayName(), entityType.DisplayName(), currentDefaultTtl, container));
+                            defaultTtl,
+                            conflictingEntityType.DisplayName(),
+                            entityType.DisplayName(),
+                            currentDefaultTtl,
+                            container));
                 }
             }
 
@@ -292,8 +309,10 @@ public class CosmosModelValidator : ModelValidator
                     var conflictingEntityType = mappedTypes.First(et => et.GetThroughput() != null);
                     throw new InvalidOperationException(
                         CosmosStrings.ThroughputMismatch(
-                            throughput.AutoscaleMaxThroughput ?? throughput.Throughput, conflictingEntityType.DisplayName(),
-                            entityType.DisplayName(), currentThroughput.AutoscaleMaxThroughput ?? currentThroughput.Throughput,
+                            throughput.AutoscaleMaxThroughput ?? throughput.Throughput,
+                            conflictingEntityType.DisplayName(),
+                            entityType.DisplayName(),
+                            currentThroughput.AutoscaleMaxThroughput ?? currentThroughput.Throughput,
                             container));
                 }
                 else if ((throughput.AutoscaleMaxThroughput == null)
@@ -308,8 +327,7 @@ public class CosmosModelValidator : ModelValidator
                         : conflictingEntityType;
 
                     throw new InvalidOperationException(
-                        CosmosStrings.ThroughputTypeMismatch(
-                            manualType.DisplayName(), autoscaleType.DisplayName(), container));
+                        CosmosStrings.ThroughputTypeMismatch(manualType.DisplayName(), autoscaleType.DisplayName(), container));
                 }
             }
         }
@@ -334,16 +352,14 @@ public class CosmosModelValidator : ModelValidator
                     var storeName = property.GetJsonPropertyName();
                     if (storeName != "_etag")
                     {
-                        throw new InvalidOperationException(
-                            CosmosStrings.NonETagConcurrencyToken(entityType.DisplayName(), storeName));
+                        throw new InvalidOperationException(CosmosStrings.NonETagConcurrencyToken(entityType.DisplayName(), storeName));
                     }
 
                     var etagType = property.GetTypeMapping().Converter?.ProviderClrType ?? property.ClrType;
                     if (etagType != typeof(string))
                     {
                         throw new InvalidOperationException(
-                            CosmosStrings.ETagNonStringStoreType(
-                                property.Name, entityType.DisplayName(), etagType.ShortDisplayName()));
+                            CosmosStrings.ETagNonStringStoreType(property.Name, entityType.DisplayName(), etagType.ShortDisplayName()));
                     }
                 }
             }
@@ -381,8 +397,7 @@ public class CosmosModelValidator : ModelValidator
             if (idType != typeof(string))
             {
                 throw new InvalidOperationException(
-                    CosmosStrings.IdNonStringStoreType(
-                        idProperty.Name, entityType.DisplayName(), idType.ShortDisplayName()));
+                    CosmosStrings.IdNonStringStoreType(idProperty.Name, entityType.DisplayName(), idType.ShortDisplayName()));
             }
 
             var partitionKeyPropertyNames = entityType.GetPartitionKeyPropertyNames();
@@ -416,7 +431,9 @@ public class CosmosModelValidator : ModelValidator
                     {
                         throw new InvalidOperationException(
                             CosmosStrings.PartitionKeyBadStoreType(
-                                partitionKeyPropertyName, entityType.DisplayName(), partitionKeyType.ShortDisplayName()));
+                                partitionKeyPropertyName,
+                                entityType.DisplayName(),
+                                partitionKeyType.ShortDisplayName()));
                     }
                 }
             }
@@ -535,10 +552,58 @@ public class CosmosModelValidator : ModelValidator
         {
             foreach (var index in entityType.GetDeclaredIndexes())
             {
-                throw new InvalidOperationException(
-                    CosmosStrings.IndexesExist(
-                        entityType.DisplayName(),
-                        string.Join(",", index.Properties.Select(e => e.Name))));
+                if (index.FindAnnotation(CosmosAnnotationNames.VectorIndexType) != null)
+                {
+                    if (index.Properties.Count > 1)
+                    {
+                        throw new InvalidOperationException(
+                            CosmosStrings.CompositeVectorIndex(
+                                entityType.DisplayName(),
+                                string.Join(",", index.Properties.Select(e => e.Name))));
+                    }
+
+                    if (index.Properties[0].FindAnnotation(CosmosAnnotationNames.VectorType) == null)
+                    {
+                        throw new InvalidOperationException(
+                            CosmosStrings.VectorIndexOnNonVector(
+                                entityType.DisplayName(),
+                                index.Properties[0].Name));
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        CosmosStrings.IndexesExist(
+                            entityType.DisplayName(),
+                            string.Join(",", index.Properties.Select(e => e.Name))));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    protected override void ValidatePropertyMapping(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        base.ValidatePropertyMapping(model, logger);
+
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetDeclaredProperties())
+            {
+                var cosmosVectorType = property.GetVectorType();
+                if (cosmosVectorType is not null)
+                {
+                    // Will throw if the data type is not set and cannot be inferred.
+                    CosmosVectorType.CreateDefaultVectorDataType(property.ClrType);
+                }
             }
         }
     }

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 /// <summary>
@@ -42,6 +44,24 @@ public static class CosmosAnnotationNames
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public const string PartitionKeyNames = Prefix + "PartitionKeyNames";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public const string VectorIndexType = Prefix + "VectorIndexType";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+    public const string VectorType = Prefix + "VectorType";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
@@ -23,7 +23,9 @@ public sealed record class CosmosVectorType(DistanceFunction DistanceFunction, i
     /// </summary>
     public static VectorDataType CreateDefaultVectorDataType(Type clrType)
     {
-        var elementType = clrType.TryGetElementType(typeof(ReadOnlyMemory<>))?.UnwrapNullableType();
+        var elementType = clrType.TryGetElementType(typeof(ReadOnlyMemory<>))?.UnwrapNullableType()
+            ?? clrType.TryGetElementType(typeof(IEnumerable<>))?.UnwrapNullableType();
+
         return elementType == typeof(sbyte)
             ? VectorDataType.Int8
             : elementType == typeof(byte)

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public sealed record class CosmosVectorType(DistanceFunction DistanceFunction, int Dimensions)
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static VectorDataType CreateDefaultVectorDataType(Type clrType)
+    {
+        var elementType = clrType.TryGetElementType(typeof(ReadOnlyMemory<>))?.UnwrapNullableType();
+        return elementType == typeof(sbyte)
+            ? VectorDataType.Int8
+            : elementType == typeof(byte)
+                ? VectorDataType.Uint8
+                : elementType == typeof(float)
+                    ? VectorDataType.Float32
+                    : throw new InvalidOperationException(CosmosStrings.BadVectorDataType(clrType.ShortDisplayName()));
+    }
+}

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -48,10 +48,26 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 givenType, dictionaryType);
 
         /// <summary>
+        ///     The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, and ReadOnlyMemory&lt;float&gt; are supported.
+        /// </summary>
+        public static string BadVectorDataType(object? clrType)
+            => string.Format(
+                GetString("BadVectorDataType", nameof(clrType)),
+                clrType);
+
+        /// <summary>
         ///     The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.
         /// </summary>
         public static string CanConnectNotSupported
             => GetString("CanConnectNotSupported");
+
+        /// <summary>
+        ///     A vector index on '{entityType}' is defined over properties `{properties}`. A vector index can only target a single property.
+        /// </summary>
+        public static string CompositeVectorIndex(object? entityType, object? properties)
+            => string.Format(
+                GetString("CompositeVectorIndex", nameof(entityType), nameof(properties)),
+                entityType, properties);
 
         /// <summary>
         ///     Complex projections in subqueries are currently unsupported.
@@ -298,6 +314,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("NoSubqueryPushdown");
 
         /// <summary>
+        ///     Container configuration for embeddings is not yet supported by the Cosmos SDK. Instead, configure the container manually. See https://aka.ms/ef-cosmos-vectors for more information.
+        /// </summary>
+        public static string NoVectorContainerConfig
+            => GetString("NoVectorContainerConfig");
+
+        /// <summary>
         ///     The expression '{sqlExpression}' in the SQL tree does not have a type mapping assigned.
         /// </summary>
         public static string NullTypeMappingInSqlTree(object? sqlExpression)
@@ -468,6 +490,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("UpdateStoreException", nameof(itemId)),
                 itemId);
+
+        /// <summary>
+        ///     A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.
+        /// </summary>
+        public static string VectorIndexOnNonVector(object? entityType, object? property)
+            => string.Format(
+                GetString("VectorIndexOnNonVector", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
+        ///     The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.
+        /// </summary>
+        public static string VectorSearchRequiresVector
+            => GetString("VectorSearchRequiresVector");
 
         /// <summary>
         ///     'VisitChildren' must be overridden in the class deriving from 'SqlExpression'.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 givenType, dictionaryType);
 
         /// <summary>
-        ///     The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, and ReadOnlyMemory&lt;float&gt; are supported.
+        ///     The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, ReadOnlyMemory&lt;float&gt;, byte[], sbyte[], and float[] are supported.
         /// </summary>
         public static string BadVectorDataType(object? clrType)
             => string.Format(

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -127,7 +127,7 @@
     <value>The type '{givenType}' cannot be mapped as a dictionary because it does not implement '{dictionaryType}'.</value>
   </data>
   <data name="BadVectorDataType" xml:space="preserve">
-    <value>The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, and ReadOnlyMemory&lt;float&gt; are supported.</value>
+    <value>The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, ReadOnlyMemory&lt;float&gt;, byte[], sbyte[], and float[] are supported.</value>
   </data>
   <data name="CanConnectNotSupported" xml:space="preserve">
     <value>The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.</value>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -126,11 +126,17 @@
   <data name="BadDictionaryType" xml:space="preserve">
     <value>The type '{givenType}' cannot be mapped as a dictionary because it does not implement '{dictionaryType}'.</value>
   </data>
+  <data name="BadVectorDataType" xml:space="preserve">
+    <value>The type '{clrType}' is being used as a vector, but the vector data type cannot be inferred. Only 'ReadOnlyMemory&lt;byte&gt;, ReadOnlyMemory&lt;sbyte&gt;, and ReadOnlyMemory&lt;float&gt; are supported.</value>
+  </data>
   <data name="CanConnectNotSupported" xml:space="preserve">
     <value>The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.</value>
   </data>
   <data name="ComplexProjectionInSubqueryNotSupported" xml:space="preserve">
     <value>Complex projections in subqueries are currently unsupported.</value>
+  </data>
+  <data name="CompositeVectorIndex" xml:space="preserve">
+    <value>A vector index on '{entityType}' is defined over properties `{properties}`. A vector index can only target a single property.</value>
   </data>
   <data name="ConnectionInfoMissing" xml:space="preserve">
     <value>None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.</value>
@@ -268,6 +274,9 @@
   <data name="NoSubqueryPushdown" xml:space="preserve">
     <value>Azure Cosmos DB does not have an appropriate subquery for this translation.</value>
   </data>
+  <data name="NoVectorContainerConfig" xml:space="preserve">
+    <value>Container configuration for embeddings is not yet supported by the Cosmos SDK. Instead, configure the container manually. See https://aka.ms/ef-cosmos-vectors for more information.</value>
+  </data>
   <data name="NullTypeMappingInSqlTree" xml:space="preserve">
     <value>The expression '{sqlExpression}' in the SQL tree does not have a type mapping assigned.</value>
   </data>
@@ -339,6 +348,12 @@
   </data>
   <data name="UpdateStoreException" xml:space="preserve">
     <value>An error occurred while saving the item with id '{itemId}'. See the inner exception for details.</value>
+  </data>
+  <data name="VectorIndexOnNonVector" xml:space="preserve">
+    <value>A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.</value>
+  </data>
+  <data name="VectorSearchRequiresVector" xml:space="preserve">
+    <value>The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.</value>
   </data>
   <data name="VisitChildrenMustBeOverridden" xml:space="preserve">
     <value>'VisitChildren' must be overridden in the class deriving from 'SqlExpression'.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -22,6 +22,7 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
     /// </summary>
     public CosmosMethodCallTranslatorProvider(
         ISqlExpressionFactory sqlExpressionFactory,
+        ITypeMappingSource typeMappingSource,
         IEnumerable<IMethodCallTranslatorPlugin> plugins)
     {
         _plugins.AddRange(plugins.SelectMany(p => p.Translators));
@@ -34,7 +35,8 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
             new CosmosRandomTranslator(sqlExpressionFactory),
             new CosmosRegexTranslator(sqlExpressionFactory),
             new CosmosStringMethodTranslator(sqlExpressionFactory),
-            new CosmosTypeCheckingTranslator(sqlExpressionFactory)
+            new CosmosTypeCheckingTranslator(sqlExpressionFactory),
+            new CosmosVectorSearchTranslator(sqlExpressionFactory, typeMappingSource)
             //new LikeTranslator(sqlExpressionFactory),
             //new EnumHasFlagTranslator(sqlExpressionFactory),
             //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
@@ -632,6 +632,19 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override Expression VisitFragment(FragmentExpression fragmentExpression)
+    {
+        _sqlBuilder.Append(fragmentExpression.Fragment);
+
+        return fragmentExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override Expression VisitSqlConditional(SqlConditionalExpression sqlConditionalExpression)
     {
         _sqlBuilder.Append('(');
@@ -657,11 +670,13 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
 
         if (_sqlParameters.All(sp => sp.Name != parameterName))
         {
-            Check.DebugAssert(sqlParameterExpression.TypeMapping is not null, "SqlParameterExpression without a type mapping");
-            var jToken = ((CosmosTypeMapping)sqlParameterExpression.TypeMapping)
-                .GenerateJToken(_parameterValues[sqlParameterExpression.Name]);
+            Check.DebugAssert(sqlParameterExpression.TypeMapping is not null, "SqlParameterExpression without a type mapping.");
 
-            _sqlParameters.Add(new SqlParameter(parameterName, jToken));
+            _sqlParameters.Add(
+                new SqlParameter(
+                    parameterName,
+                    ((CosmosTypeMapping)sqlParameterExpression.TypeMapping)
+                    .GenerateJToken(_parameterValues[sqlParameterExpression.Name])));
         }
 
         _sqlBuilder.Append(parameterName);

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/FragmentExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/FragmentExpression.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     An expression that represents a fragment that will be inserted verbatim into the query.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class FragmentExpression(string fragment) : Expression, IPrintableExpression
+{
+    /// <summary>
+    ///     The fragment.
+    /// </summary>
+    public virtual string Fragment { get; } = fragment;
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+
+    /// <inheritdoc />
+    public virtual void Print(ExpressionPrinter expressionPrinter)
+        => expressionPrinter.Append(Fragment);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual bool Equals(FragmentExpression other)
+        => base.Equals(other)
+            && Fragment == other.Fragment;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => !ReferenceEquals(null, obj)
+            && (ReferenceEquals(this, obj)
+                || obj.GetType() == GetType()
+                && Equals((FragmentExpression)obj));
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Fragment);
+}

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -34,6 +34,7 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             SqlBinaryExpression sqlBinaryExpression => VisitSqlBinary(sqlBinaryExpression),
             ObjectBinaryExpression objectBinaryExpression => VisitObjectBinary(objectBinaryExpression),
             SqlConstantExpression sqlConstantExpression => VisitSqlConstant(sqlConstantExpression),
+            FragmentExpression jsonFragmentExpression => VisitFragment(jsonFragmentExpression),
             SqlUnaryExpression sqlUnaryExpression => VisitSqlUnary(sqlUnaryExpression),
             SqlConditionalExpression sqlConditionalExpression => VisitSqlConditional(sqlConditionalExpression),
             SqlParameterExpression sqlParameterExpression => VisitSqlParameter(sqlParameterExpression),
@@ -171,6 +172,14 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected abstract Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitFragment(FragmentExpression fragmentExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosVectorSearchTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosVectorSearchTranslator.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CosmosVectorSearchTranslator(ISqlExpressionFactory sqlExpressionFactory, ITypeMappingSource typeMappingSource)
+    : IMethodCallTranslator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType != typeof(CosmosDbFunctionsExtensions)
+            && method.Name != nameof(CosmosDbFunctionsExtensions.VectorDistance))
+        {
+            return null;
+        }
+
+        var vectorMapping = arguments[1].TypeMapping as CosmosVectorTypeMapping
+            ?? arguments[2].TypeMapping as CosmosVectorTypeMapping
+            ?? throw new InvalidOperationException(CosmosStrings.VectorSearchRequiresVector);
+
+        Check.DebugAssert(arguments.Count is 3 or 4 or 5, "Did you add a parameter?");
+
+        SqlConstantExpression bruteForce;
+        if (arguments.Count >= 4)
+        {
+            if (arguments[3] is not SqlConstantExpression { Value: bool })
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ArgumentNotConstant("useBruteForce", nameof(CosmosDbFunctionsExtensions.VectorDistance)));
+            }
+
+            bruteForce = (SqlConstantExpression)arguments[3];
+        }
+        else
+        {
+            bruteForce = (SqlConstantExpression)sqlExpressionFactory.Constant(false);
+        }
+
+        var vectorType = vectorMapping.VectorType;
+        if (arguments.Count == 5)
+        {
+            if (arguments[4] is not SqlConstantExpression { Value: DistanceFunction distanceFunction })
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ArgumentNotConstant("distanceFunction", nameof(CosmosDbFunctionsExtensions.VectorDistance)));
+            }
+
+            vectorType = vectorType with { DistanceFunction = distanceFunction };
+        }
+
+        var dataType = CosmosVectorType.CreateDefaultVectorDataType(vectorMapping.ClrType);
+
+        return sqlExpressionFactory.Function(
+            "VectorDistance",
+            [
+                sqlExpressionFactory.ApplyTypeMapping(arguments[1], vectorMapping),
+                sqlExpressionFactory.ApplyTypeMapping(arguments[2], vectorMapping),
+                bruteForce,
+                new FragmentExpression(
+                    $"{{'distanceFunction':'{vectorType.DistanceFunction.ToString().ToLower()}', 'dataType':'{dataType.ToString().ToLower()}'}}")
+            ],
+            typeof(double),
+            typeMappingSource.FindMapping(typeof(double))!);
+    }
+}

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -47,19 +47,15 @@ public class CosmosTypeMappingSource : TypeMappingSource
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override CoreTypeMapping? FindMapping(IProperty property)
-    {
         // A provider should typically not override this because using the property directly causes problems with Migrations where
         // the property does not exist. However, since the Cosmos provider doesn't have Migrations, it should be okay to use the property
         // directly.
-        var mapping = (CosmosTypeMapping?)base.FindMapping(property);
-        if (mapping is not null
-            && property.FindAnnotation(CosmosAnnotationNames.VectorType)?.Value is CosmosVectorType vectorType)
+        => base.FindMapping(property) switch
         {
-            mapping = new CosmosVectorTypeMapping(mapping, vectorType);
-        }
-
-        return mapping;
-    }
+            CosmosTypeMapping mapping when property.FindAnnotation(CosmosAnnotationNames.VectorType)?.Value is CosmosVectorType vectorType
+                => new CosmosVectorTypeMapping(mapping, vectorType),
+            var other => other
+        };
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Cosmos.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using Newtonsoft.Json.Linq;
@@ -39,6 +39,28 @@ public class CosmosTypeMappingSource : TypeMappingSource
             };
     }
 
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override CoreTypeMapping? FindMapping(IProperty property)
+    {
+        // A provider should typically not override this because using the property directly causes problems with Migrations where
+        // the property does not exist. However, since the Cosmos provider doesn't have Migrations, it should be okay to use the property
+        // directly.
+        var mapping = (CosmosTypeMapping?)base.FindMapping(property);
+        if (mapping is not null
+            && property.FindAnnotation(CosmosAnnotationNames.VectorType)?.Value is CosmosVectorType vectorType)
+        {
+            mapping = new CosmosVectorTypeMapping(mapping, vectorType);
+        }
+
+        return mapping;
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -60,6 +82,15 @@ public class CosmosTypeMappingSource : TypeMappingSource
     private CoreTypeMapping? FindPrimitiveMapping(in TypeMappingInfo mappingInfo)
     {
         var clrType = mappingInfo.ClrType!;
+
+        var memoryType = clrType.TryGetElementType(typeof(ReadOnlyMemory<>));
+        if (memoryType != null)
+        {
+            return new CosmosTypeMapping(clrType)
+                .WithComposedConverter(
+                    (ValueConverter)Activator.CreateInstance(typeof(ReadOnlyMemoryConverter<>).MakeGenericType(memoryType))!,
+                    (ValueComparer)Activator.CreateInstance(typeof(ReadOnlyMemoryComparer<>).MakeGenericType(memoryType))!);
+        }
 
         return clrType.IsNumeric()
             || clrType == typeof(bool)
@@ -87,12 +118,19 @@ public class CosmosTypeMappingSource : TypeMappingSource
 
         // First attempt to resolve this as a primitive collection (e.g. List<int>). This does not handle Dictionary.
         if (TryFindJsonCollectionMapping(
-                mappingInfo, clrType, providerClrType: null, ref elementMapping, out var elementComparer,
+                mappingInfo,
+                clrType,
+                providerClrType: null,
+                ref elementMapping,
+                out var elementComparer,
                 out var collectionReaderWriter)
             && elementMapping is not null)
         {
             return new CosmosTypeMapping(
-                clrType, elementComparer, elementMapping: elementMapping, jsonValueReaderWriter: collectionReaderWriter);
+                clrType,
+                elementComparer,
+                elementMapping: elementMapping,
+                jsonValueReaderWriter: collectionReaderWriter);
         }
 
         // Next, attempt to resolve this as a dictionary (e.g. Dictionary<string, int>).

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
+public class CosmosVectorTypeMapping : CosmosTypeMapping
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static new CosmosVectorTypeMapping Default { get; }
+        // Note that this default is not valid because dimensions cannot be zero. But since there is no reasonable
+        // default dimensions size for a vector type, this is intentionally not valid rather than just being wrong.
+        // The fundamental problem here is that type mappings are "required" to have some default now.
+        = new(typeof(byte[]), new CosmosVectorType(DistanceFunction.Cosine, 0));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public CosmosVectorTypeMapping(
+        Type clrType,
+        CosmosVectorType vectorType,
+        ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
+        CoreTypeMapping? elementMapping = null,
+        JsonValueReaderWriter? jsonValueReaderWriter = null)
+        : this(
+            new CoreTypeMappingParameters(
+                clrType,
+                converter: null,
+                comparer,
+                keyComparer,
+                elementMapping: elementMapping,
+                jsonValueReaderWriter: jsonValueReaderWriter),
+            vectorType)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public CosmosVectorTypeMapping(CosmosTypeMapping mapping, CosmosVectorType vectorType)
+        : this(
+            new CoreTypeMappingParameters(
+                mapping.ClrType,
+                converter: mapping.Converter,
+                mapping.Comparer,
+                mapping.KeyComparer,
+                elementMapping: mapping.ElementTypeMapping,
+                jsonValueReaderWriter: mapping.JsonValueReaderWriter),
+            vectorType)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected CosmosVectorTypeMapping(CoreTypeMappingParameters parameters, CosmosVectorType vectorType)
+        : base(parameters)
+    {
+        VectorType = vectorType;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual CosmosVectorType VectorType { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override CoreTypeMapping WithComposedConverter(
+        ValueConverter? converter,
+        ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
+        CoreTypeMapping? elementMapping = null,
+        JsonValueReaderWriter? jsonValueReaderWriter = null)
+        => new CosmosVectorTypeMapping(
+            Parameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter),
+            VectorType);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override CoreTypeMapping Clone(CoreTypeMappingParameters parameters)
+        => new CosmosVectorTypeMapping(parameters, VectorType);
+}

--- a/src/EFCore.Cosmos/Storage/Internal/ReadOnlyMemoryComparer.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/ReadOnlyMemoryComparer.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
-
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 
 /// <summary>
@@ -11,11 +9,4 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public readonly record struct ContainerProperties(
-    string Id,
-    IReadOnlyList<string> PartitionKeyStoreNames,
-    int? AnalyticalStoreTimeToLiveInSeconds,
-    int? DefaultTimeToLive,
-    ThroughputProperties? Throughput,
-    IReadOnlyList<IIndex> Indexes,
-    IReadOnlyList<(IProperty Property, CosmosVectorType VectorType)> Vectors);
+public class ReadOnlyMemoryComparer<T>() : ValueComparer<ReadOnlyMemory<T>>(false);

--- a/src/EFCore.Cosmos/Storage/Internal/ReadOnlyMemoryConverter.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/ReadOnlyMemoryConverter.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class ReadOnlyMemoryConverter<T> : ValueConverter<ReadOnlyMemory<T>, T[]>
+{
+    private static readonly ConverterMappingHints DefaultHints = new();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ReadOnlyMemoryConverter()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ReadOnlyMemoryConverter(ConverterMappingHints? mappingHints)
+        : base(
+            v => ToArray(v),
+            v => ToMemory(v),
+            DefaultHints.With(mappingHints))
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static T[] ToArray(ReadOnlyMemory<T> memory)
+        => memory.ToArray();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static ReadOnlyMemory<T> ToMemory(T[] array)
+        // If the array is empty, then return the default ReadOnlyMemory instance because this will compare the same as other empty
+        // ReadOnlyMemory instances, while the instance created with an empty array is considered not equal to the default.
+        => array.Length == 0 ? default : new(array);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static ValueConverterInfo DefaultInfo { get; }
+        = new(typeof(ReadOnlyMemory<T>), typeof(T[]), i => new ReadOnlyMemoryConverter<T>(i.MappingHints), DefaultHints);
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -115,6 +115,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 annotation, annotatable);
 
         /// <summary>
+        ///     The '{parameter}' value passed to '{methodName}' must be a constant.
+        /// </summary>
+        public static string ArgumentNotConstant(object? parameter, object? methodName)
+            => string.Format(
+                GetString("ArgumentNotConstant", nameof(parameter), nameof(methodName)),
+                parameter, methodName);
+
+        /// <summary>
         ///     The property '{property}' of the argument '{argument}' cannot be null.
         /// </summary>
         public static string ArgumentPropertyNull(object? property, object? argument)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -150,6 +150,9 @@
   <data name="AnnotationNotFound" xml:space="preserve">
     <value>The annotation '{annotation}' was not found. Ensure that the annotation has been added to the object {annotatable}</value>
   </data>
+  <data name="ArgumentNotConstant" xml:space="preserve">
+    <value>The '{parameter}' value passed to '{methodName}' must be a constant.</value>
+  </data>
   <data name="ArgumentPropertyNull" xml:space="preserve">
     <value>The property '{property}' of the argument '{argument}' cannot be null.</value>
   </data>

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/Basic_cosmos_model/DataEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/Basic_cosmos_model/DataEntityType.cs
@@ -33,7 +33,7 @@ namespace TestNamespace
                 "Microsoft.EntityFrameworkCore.Scaffolding.CompiledModelTestBase+Data",
                 typeof(CompiledModelTestBase.Data),
                 baseEntityType,
-                propertyCount: 8,
+                propertyCount: 9,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -162,20 +162,53 @@ namespace TestNamespace
                         byte[] (string v) => Convert.FromBase64String(v))));
             blob.AddAnnotation("Cosmos:PropertyName", "JsonBlob");
 
+            var bytes = runtimeEntityType.AddProperty(
+                "Bytes",
+                typeof(ReadOnlyMemory<byte>));
+            bytes.SetAccessors(
+                ReadOnlyMemory<byte> (InternalEntityEntry entry) => entry.ReadShadowValue<ReadOnlyMemory<byte>>(2),
+                ReadOnlyMemory<byte> (InternalEntityEntry entry) => entry.ReadShadowValue<ReadOnlyMemory<byte>>(2),
+                ReadOnlyMemory<byte> (InternalEntityEntry entry) => entry.ReadOriginalValue<ReadOnlyMemory<byte>>(bytes, 3),
+                ReadOnlyMemory<byte> (InternalEntityEntry entry) => entry.GetCurrentValue<ReadOnlyMemory<byte>>(bytes),
+                object (ValueBuffer valueBuffer) => valueBuffer[3]);
+            bytes.SetPropertyIndexes(
+                index: 3,
+                originalValueIndex: 3,
+                shadowIndex: 2,
+                relationshipIndex: -1,
+                storeGenerationIndex: -1);
+            bytes.TypeMapping = CosmosTypeMapping.Default.Clone(
+                comparer: new ValueComparer<ReadOnlyMemory<byte>>(
+                    bool (ReadOnlyMemory<byte> v1, ReadOnlyMemory<byte> v2) => v1.Equals(v2),
+                    int (ReadOnlyMemory<byte> v) => ((object)v).GetHashCode(),
+                    ReadOnlyMemory<byte> (ReadOnlyMemory<byte> v) => v),
+                keyComparer: new ValueComparer<ReadOnlyMemory<byte>>(
+                    bool (ReadOnlyMemory<byte> v1, ReadOnlyMemory<byte> v2) => v1.Equals(v2),
+                    int (ReadOnlyMemory<byte> v) => ((object)v).GetHashCode(),
+                    ReadOnlyMemory<byte> (ReadOnlyMemory<byte> v) => v),
+                providerValueComparer: new ValueComparer<byte[]>(
+                    bool (byte[] v1, byte[] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
+                    int (byte[] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
+                    byte[] (byte[] source) => source.ToArray()),
+                converter: new ValueConverter<ReadOnlyMemory<byte>, byte[]>(
+                    byte[] (ReadOnlyMemory<byte> v) => ReadOnlyMemoryConverter<byte>.ToArray(v),
+                    ReadOnlyMemory<byte> (byte[] v) => ReadOnlyMemoryConverter<byte>.ToMemory(v)));
+            bytes.SetSentinelFromProviderValue(new byte[0]);
+
             var list = runtimeEntityType.AddProperty(
                 "List",
                 typeof(List<Dictionary<string, int>>),
                 nullable: true);
             list.SetAccessors(
-                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadShadowValue<List<Dictionary<string, int>>>(2),
-                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadShadowValue<List<Dictionary<string, int>>>(2),
-                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadOriginalValue<List<Dictionary<string, int>>>(list, 3),
+                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadShadowValue<List<Dictionary<string, int>>>(3),
+                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadShadowValue<List<Dictionary<string, int>>>(3),
+                List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.ReadOriginalValue<List<Dictionary<string, int>>>(list, 4),
                 List<Dictionary<string, int>> (InternalEntityEntry entry) => entry.GetCurrentValue<List<Dictionary<string, int>>>(list),
-                object (ValueBuffer valueBuffer) => valueBuffer[3]);
+                object (ValueBuffer valueBuffer) => valueBuffer[4]);
             list.SetPropertyIndexes(
-                index: 3,
-                originalValueIndex: 3,
-                shadowIndex: 2,
+                index: 4,
+                originalValueIndex: 4,
+                shadowIndex: 3,
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             list.TypeMapping = CosmosTypeMapping.Default.Clone(
@@ -217,15 +250,15 @@ namespace TestNamespace
                 typeof(Dictionary<string, string[]>),
                 nullable: true);
             map.SetAccessors(
-                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadShadowValue<Dictionary<string, string[]>>(3),
-                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadShadowValue<Dictionary<string, string[]>>(3),
-                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadOriginalValue<Dictionary<string, string[]>>(map, 4),
+                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadShadowValue<Dictionary<string, string[]>>(4),
+                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadShadowValue<Dictionary<string, string[]>>(4),
+                Dictionary<string, string[]> (InternalEntityEntry entry) => entry.ReadOriginalValue<Dictionary<string, string[]>>(map, 5),
                 Dictionary<string, string[]> (InternalEntityEntry entry) => entry.GetCurrentValue<Dictionary<string, string[]>>(map),
-                object (ValueBuffer valueBuffer) => valueBuffer[4]);
+                object (ValueBuffer valueBuffer) => valueBuffer[5]);
             map.SetPropertyIndexes(
-                index: 4,
-                originalValueIndex: 4,
-                shadowIndex: 3,
+                index: 5,
+                originalValueIndex: 5,
+                shadowIndex: 4,
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             map.TypeMapping = CosmosTypeMapping.Default.Clone(
@@ -252,15 +285,15 @@ namespace TestNamespace
                 afterSaveBehavior: PropertySaveBehavior.Throw,
                 valueGeneratorFactory: new IdValueGeneratorFactory().Create);
             __id.SetAccessors(
-                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(4),
-                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(4),
-                string (InternalEntityEntry entry) => entry.ReadOriginalValue<string>(__id, 5),
+                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(5),
+                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(5),
+                string (InternalEntityEntry entry) => entry.ReadOriginalValue<string>(__id, 6),
                 string (InternalEntityEntry entry) => entry.GetCurrentValue<string>(__id),
-                object (ValueBuffer valueBuffer) => valueBuffer[5]);
+                object (ValueBuffer valueBuffer) => valueBuffer[6]);
             __id.SetPropertyIndexes(
-                index: 5,
-                originalValueIndex: 5,
-                shadowIndex: 4,
+                index: 6,
+                originalValueIndex: 6,
+                shadowIndex: 5,
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             __id.TypeMapping = CosmosTypeMapping.Default.Clone(
@@ -288,15 +321,15 @@ namespace TestNamespace
                 beforeSaveBehavior: PropertySaveBehavior.Ignore,
                 afterSaveBehavior: PropertySaveBehavior.Ignore);
             __jObject.SetAccessors(
-                JObject (InternalEntityEntry entry) => (entry.FlaggedAsStoreGenerated(6) ? entry.ReadStoreGeneratedValue<JObject>(0) : (entry.FlaggedAsTemporary(6) && entry.ReadShadowValue<JObject>(5) == null ? entry.ReadTemporaryValue<JObject>(0) : entry.ReadShadowValue<JObject>(5))),
-                JObject (InternalEntityEntry entry) => entry.ReadShadowValue<JObject>(5),
-                JObject (InternalEntityEntry entry) => entry.ReadOriginalValue<JObject>(__jObject, 6),
+                JObject (InternalEntityEntry entry) => (entry.FlaggedAsStoreGenerated(7) ? entry.ReadStoreGeneratedValue<JObject>(0) : (entry.FlaggedAsTemporary(7) && entry.ReadShadowValue<JObject>(6) == null ? entry.ReadTemporaryValue<JObject>(0) : entry.ReadShadowValue<JObject>(6))),
+                JObject (InternalEntityEntry entry) => entry.ReadShadowValue<JObject>(6),
+                JObject (InternalEntityEntry entry) => entry.ReadOriginalValue<JObject>(__jObject, 7),
                 JObject (InternalEntityEntry entry) => entry.GetCurrentValue<JObject>(__jObject),
-                object (ValueBuffer valueBuffer) => valueBuffer[6]);
+                object (ValueBuffer valueBuffer) => valueBuffer[7]);
             __jObject.SetPropertyIndexes(
-                index: 6,
-                originalValueIndex: 6,
-                shadowIndex: 5,
+                index: 7,
+                originalValueIndex: 7,
+                shadowIndex: 6,
                 relationshipIndex: -1,
                 storeGenerationIndex: 0);
             __jObject.TypeMapping = CosmosTypeMapping.Default.Clone(
@@ -324,15 +357,15 @@ namespace TestNamespace
                 beforeSaveBehavior: PropertySaveBehavior.Ignore,
                 afterSaveBehavior: PropertySaveBehavior.Ignore);
             _etag.SetAccessors(
-                string (InternalEntityEntry entry) => (entry.FlaggedAsStoreGenerated(7) ? entry.ReadStoreGeneratedValue<string>(1) : (entry.FlaggedAsTemporary(7) && entry.ReadShadowValue<string>(6) == null ? entry.ReadTemporaryValue<string>(1) : entry.ReadShadowValue<string>(6))),
-                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(6),
-                string (InternalEntityEntry entry) => entry.ReadOriginalValue<string>(_etag, 7),
+                string (InternalEntityEntry entry) => (entry.FlaggedAsStoreGenerated(8) ? entry.ReadStoreGeneratedValue<string>(1) : (entry.FlaggedAsTemporary(8) && entry.ReadShadowValue<string>(7) == null ? entry.ReadTemporaryValue<string>(1) : entry.ReadShadowValue<string>(7))),
+                string (InternalEntityEntry entry) => entry.ReadShadowValue<string>(7),
+                string (InternalEntityEntry entry) => entry.ReadOriginalValue<string>(_etag, 8),
                 string (InternalEntityEntry entry) => entry.GetCurrentValue<string>(_etag),
-                object (ValueBuffer valueBuffer) => valueBuffer[7]);
+                object (ValueBuffer valueBuffer) => valueBuffer[8]);
             _etag.SetPropertyIndexes(
-                index: 7,
-                originalValueIndex: 7,
-                shadowIndex: 6,
+                index: 8,
+                originalValueIndex: 8,
+                shadowIndex: 7,
                 relationshipIndex: -1,
                 storeGenerationIndex: 1);
             _etag.TypeMapping = CosmosTypeMapping.Default.Clone(
@@ -363,6 +396,7 @@ namespace TestNamespace
             var id = runtimeEntityType.FindProperty("Id")!;
             var partitionId = runtimeEntityType.FindProperty("PartitionId")!;
             var blob = runtimeEntityType.FindProperty("Blob")!;
+            var bytes = runtimeEntityType.FindProperty("Bytes")!;
             var list = runtimeEntityType.FindProperty("List")!;
             var map = runtimeEntityType.FindProperty("Map")!;
             var __id = runtimeEntityType.FindProperty("__id")!;
@@ -375,16 +409,16 @@ namespace TestNamespace
                 ISnapshot (InternalEntityEntry source) =>
                 {
                     var entity = ((CompiledModelTestBase.Data)(source.Entity));
-                    return ((ISnapshot)(new Snapshot<int, long?, byte[], List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>(((ValueComparer<int>)(((IProperty)id).GetValueComparer())).Snapshot(source.GetCurrentValue<int>(id)), (source.GetCurrentValue<long?>(partitionId) == null ? null : ((ValueComparer<long?>)(((IProperty)partitionId).GetValueComparer())).Snapshot(source.GetCurrentValue<long?>(partitionId))), (source.GetCurrentValue<byte[]>(blob) == null ? null : ((ValueComparer<byte[]>)(((IProperty)blob).GetValueComparer())).Snapshot(source.GetCurrentValue<byte[]>(blob))), (((object)(source.GetCurrentValue<List<Dictionary<string, int>>>(list))) == null ? null : ((List<Dictionary<string, int>>)(((ValueComparer<object>)(((IProperty)list).GetValueComparer())).Snapshot(((object)(source.GetCurrentValue<List<Dictionary<string, int>>>(list))))))), (((object)(source.GetCurrentValue<Dictionary<string, string[]>>(map))) == null ? null : ((Dictionary<string, string[]>)(((ValueComparer<object>)(((IProperty)map).GetValueComparer())).Snapshot(((object)(source.GetCurrentValue<Dictionary<string, string[]>>(map))))))), (source.GetCurrentValue<string>(__id) == null ? null : ((ValueComparer<string>)(((IProperty)__id).GetValueComparer())).Snapshot(source.GetCurrentValue<string>(__id))), (source.GetCurrentValue<JObject>(__jObject) == null ? null : ((ValueComparer<JObject>)(((IProperty)__jObject).GetValueComparer())).Snapshot(source.GetCurrentValue<JObject>(__jObject))), (source.GetCurrentValue<string>(_etag) == null ? null : ((ValueComparer<string>)(((IProperty)_etag).GetValueComparer())).Snapshot(source.GetCurrentValue<string>(_etag))))));
+                    return ((ISnapshot)(new Snapshot<int, long?, byte[], ReadOnlyMemory<byte>, List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>(((ValueComparer<int>)(((IProperty)id).GetValueComparer())).Snapshot(source.GetCurrentValue<int>(id)), (source.GetCurrentValue<long?>(partitionId) == null ? null : ((ValueComparer<long?>)(((IProperty)partitionId).GetValueComparer())).Snapshot(source.GetCurrentValue<long?>(partitionId))), (source.GetCurrentValue<byte[]>(blob) == null ? null : ((ValueComparer<byte[]>)(((IProperty)blob).GetValueComparer())).Snapshot(source.GetCurrentValue<byte[]>(blob))), ((ValueComparer<ReadOnlyMemory<byte>>)(((IProperty)bytes).GetValueComparer())).Snapshot(source.GetCurrentValue<ReadOnlyMemory<byte>>(bytes)), (((object)(source.GetCurrentValue<List<Dictionary<string, int>>>(list))) == null ? null : ((List<Dictionary<string, int>>)(((ValueComparer<object>)(((IProperty)list).GetValueComparer())).Snapshot(((object)(source.GetCurrentValue<List<Dictionary<string, int>>>(list))))))), (((object)(source.GetCurrentValue<Dictionary<string, string[]>>(map))) == null ? null : ((Dictionary<string, string[]>)(((ValueComparer<object>)(((IProperty)map).GetValueComparer())).Snapshot(((object)(source.GetCurrentValue<Dictionary<string, string[]>>(map))))))), (source.GetCurrentValue<string>(__id) == null ? null : ((ValueComparer<string>)(((IProperty)__id).GetValueComparer())).Snapshot(source.GetCurrentValue<string>(__id))), (source.GetCurrentValue<JObject>(__jObject) == null ? null : ((ValueComparer<JObject>)(((IProperty)__jObject).GetValueComparer())).Snapshot(source.GetCurrentValue<JObject>(__jObject))), (source.GetCurrentValue<string>(_etag) == null ? null : ((ValueComparer<string>)(((IProperty)_etag).GetValueComparer())).Snapshot(source.GetCurrentValue<string>(_etag))))));
                 });
             runtimeEntityType.SetStoreGeneratedValuesFactory(
                 ISnapshot () => ((ISnapshot)(new Snapshot<JObject, string>((default(JObject) == null ? null : ((ValueComparer<JObject>)(((IProperty)__jObject).GetValueComparer())).Snapshot(default(JObject))), (default(string) == null ? null : ((ValueComparer<string>)(((IProperty)_etag).GetValueComparer())).Snapshot(default(string)))))));
             runtimeEntityType.SetTemporaryValuesFactory(
                 ISnapshot (InternalEntityEntry source) => ((ISnapshot)(new Snapshot<JObject, string>(default(JObject), default(string)))));
             runtimeEntityType.SetShadowValuesFactory(
-                ISnapshot (IDictionary<string, object> source) => ((ISnapshot)(new Snapshot<int, long?, List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>((source.ContainsKey("Id") ? ((int)(source["Id"])) : 0), (source.ContainsKey("PartitionId") ? ((long? )(source["PartitionId"])) : null), (source.ContainsKey("List") ? ((List<Dictionary<string, int>>)(source["List"])) : null), (source.ContainsKey("Map") ? ((Dictionary<string, string[]>)(source["Map"])) : null), (source.ContainsKey("__id") ? ((string)(source["__id"])) : null), (source.ContainsKey("__jObject") ? ((JObject)(source["__jObject"])) : null), (source.ContainsKey("_etag") ? ((string)(source["_etag"])) : null)))));
+                ISnapshot (IDictionary<string, object> source) => ((ISnapshot)(new Snapshot<int, long?, ReadOnlyMemory<byte>, List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>((source.ContainsKey("Id") ? ((int)(source["Id"])) : 0), (source.ContainsKey("PartitionId") ? ((long? )(source["PartitionId"])) : null), (source.ContainsKey("Bytes") ? ((ReadOnlyMemory<byte>)(source["Bytes"])) : default(ReadOnlyMemory<byte>)), (source.ContainsKey("List") ? ((List<Dictionary<string, int>>)(source["List"])) : null), (source.ContainsKey("Map") ? ((Dictionary<string, string[]>)(source["Map"])) : null), (source.ContainsKey("__id") ? ((string)(source["__id"])) : null), (source.ContainsKey("__jObject") ? ((JObject)(source["__jObject"])) : null), (source.ContainsKey("_etag") ? ((string)(source["_etag"])) : null)))));
             runtimeEntityType.SetEmptyShadowValuesFactory(
-                ISnapshot () => ((ISnapshot)(new Snapshot<int, long?, List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>(default(int), default(long? ), default(List<Dictionary<string, int>>), default(Dictionary<string, string[]>), default(string), default(JObject), default(string)))));
+                ISnapshot () => ((ISnapshot)(new Snapshot<int, long?, ReadOnlyMemory<byte>, List<Dictionary<string, int>>, Dictionary<string, string[]>, string, JObject, string>(default(int), default(long? ), default(ReadOnlyMemory<byte>), default(List<Dictionary<string, int>>), default(Dictionary<string, string[]>), default(string), default(JObject), default(string)))));
             runtimeEntityType.SetRelationshipSnapshotFactory(
                 ISnapshot (InternalEntityEntry source) =>
                 {
@@ -392,11 +426,11 @@ namespace TestNamespace
                     return ((ISnapshot)(new Snapshot<int, long?>(((ValueComparer<int>)(((IProperty)id).GetKeyValueComparer())).Snapshot(source.GetCurrentValue<int>(id)), (source.GetCurrentValue<long?>(partitionId) == null ? null : ((ValueComparer<long?>)(((IProperty)partitionId).GetKeyValueComparer())).Snapshot(source.GetCurrentValue<long?>(partitionId))))));
                 });
             runtimeEntityType.Counts = new PropertyCounts(
-                propertyCount: 8,
+                propertyCount: 9,
                 navigationCount: 0,
                 complexPropertyCount: 0,
-                originalValueCount: 8,
-                shadowCount: 7,
+                originalValueCount: 9,
+                shadowCount: 8,
                 relationshipCount: 2,
                 storeGeneratedCount: 2);
             runtimeEntityType.AddAnnotation("Cosmos:ContainerName", "DataContainer");

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
@@ -31,6 +31,7 @@ public class CompiledModelCosmosTest : CompiledModelTestBase
                         eb.ToContainer("DataContainer");
                         eb.Property<Dictionary<string, string[]>>("Map");
                         eb.Property<List<Dictionary<string, int>>>("List");
+                        eb.Property<ReadOnlyMemory<byte>>("Bytes");
                         eb.UseETagConcurrency();
                         eb.HasNoDiscriminator();
                         eb.Property(d => d.Blob).ToJsonProperty("JsonBlob");
@@ -128,6 +129,22 @@ public class CompiledModelCosmosTest : CompiledModelTestBase
                 Assert.NotNull(list.GetValueComparer());
                 Assert.NotNull(list.GetKeyValueComparer());
 
+                var bytes = dataEntity.FindProperty("Bytes")!;
+                Assert.Equal(typeof(ReadOnlyMemory<byte>), bytes.ClrType);
+                Assert.Null(bytes.PropertyInfo);
+                Assert.Null(bytes.FieldInfo);
+                Assert.False(bytes.IsNullable);
+                Assert.False(bytes.IsConcurrencyToken);
+                Assert.False(bytes.IsPrimitiveCollection);
+                Assert.Equal(ValueGenerated.Never, bytes.ValueGenerated);
+                Assert.Equal(PropertySaveBehavior.Save, bytes.GetAfterSaveBehavior());
+                Assert.Equal(PropertySaveBehavior.Save, bytes.GetBeforeSaveBehavior());
+                Assert.Equal("Bytes", CosmosPropertyExtensions.GetJsonPropertyName(bytes));
+                Assert.Null(bytes.GetValueGeneratorFactory());
+                Assert.Null(bytes.GetValueConverter());
+                Assert.NotNull(bytes.GetValueComparer());
+                Assert.NotNull(bytes.GetKeyValueComparer());
+
                 var eTag = dataEntity.FindProperty("_etag")!;
                 Assert.Equal(typeof(string), eTag.ClrType);
                 Assert.Null(eTag.PropertyInfo);
@@ -177,7 +194,7 @@ public class CompiledModelCosmosTest : CompiledModelTestBase
 
                 Assert.Equal(1, dataEntity.GetKeys().Count());
 
-                Assert.Equal([id, partitionId, blob, list, map, storeId, jObject, eTag], dataEntity.GetProperties());
+                Assert.Equal([id, partitionId, blob, bytes, list, map, storeId, jObject, eTag], dataEntity.GetProperties());
             });
 
     protected override void BuildBigModel(ModelBuilder modelBuilder, bool jsonColumns)

--- a/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
@@ -1,0 +1,359 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
+namespace Microsoft.EntityFrameworkCore;
+
+#pragma warning disable EF9103
+
+// These tests are skipped for now because we cannot create a compatible test container until the SDK supports it.
+internal class VectorSearchCosmosTest : IClassFixture<VectorSearchCosmosTest.VectorSearchFixture>
+{
+    public VectorSearchCosmosTest(VectorSearchFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        Fixture = fixture;
+        _testOutputHelper = testOutputHelper;
+        fixture.TestSqlLoggerFactory.Clear();
+    }
+
+    protected VectorSearchFixture Fixture { get; }
+
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    [ConditionalFact]
+    public virtual async Task Query_for_vector_distance_sbytes()
+    {
+        await using var context = CreateContext();
+        var inputVector = new ReadOnlyMemory<sbyte>([2, -1, 4, 3, 5, -2, 5, -7, 3, 1]);
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .Select(e => EF.Functions.VectorDistance(e.SBytes, inputVector))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+        Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
+
+        AssertSql(
+            """
+@__inputVector_1='[2,-1,4,3,5,-2,5,-7,3,1]'
+
+SELECT VALUE VectorDistance(c["SBytes"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
+FROM root c
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Query_for_vector_distance_bytes()
+    {
+        await using var context = CreateContext();
+        var inputVector = new ReadOnlyMemory<byte>([2, 1, 4, 3, 5, 2, 5, 7, 3, 1]);
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .Select(e => EF.Functions.VectorDistance(e.Bytes, inputVector))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+        Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
+
+        AssertSql(
+            """
+@__inputVector_1='[2,1,4,3,5,2,5,7,3,1]'
+
+SELECT VALUE VectorDistance(c["Bytes"], @__inputVector_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+FROM root c
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Query_for_vector_distance_singles()
+    {
+        await using var context = CreateContext();
+        var inputVector = new ReadOnlyMemory<float>([0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f, 0.86f, -0.78f]);
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .Select(
+                e => EF.Functions.VectorDistance(e.Singles, inputVector, false, DistanceFunction.DotProduct))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+        Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
+
+        AssertSql(
+            """
+@__inputVector_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
+
+SELECT VALUE VectorDistance(c["Singles"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
+FROM root c
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Vector_distance_sbytes_in_OrderBy()
+    {
+        await using var context = CreateContext();
+        var inputVector = new sbyte[] { 2, 1, 4, 6, 5, 2, 5, 7, 3, 1 };
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .OrderBy(e => EF.Functions.VectorDistance(e.SBytes, inputVector, false, DistanceFunction.DotProduct))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+
+        AssertSql(
+            """
+@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+
+SELECT VALUE c
+FROM root c
+ORDER BY VectorDistance(c["SBytes"], @__p_1, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Vector_distance_bytes_in_OrderBy()
+    {
+        await using var context = CreateContext();
+        var inputVector = new byte[] { 2, 1, 4, 6, 5, 2, 5, 7, 3, 1 };
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .OrderBy(e => EF.Functions.VectorDistance(e.Bytes, inputVector))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+AssertSql(
+    """
+@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+
+SELECT VALUE c
+FROM root c
+ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Vector_distance_singles_in_OrderBy()
+    {
+        await using var context = CreateContext();
+        var inputVector = new[] { 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f };
+
+        var booksFromStore = await context
+            .Set<Book>()
+            .OrderBy(e => EF.Functions.VectorDistance(e.Singles, inputVector))
+            .ToListAsync();
+
+        Assert.Equal(3, booksFromStore.Count);
+        AssertSql(
+            """
+@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
+
+SELECT VALUE c
+FROM root c
+ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task VectorDistance_throws_when_used_on_non_vector()
+    {
+        await using var context = CreateContext();
+        var inputVector = Array.Empty<byte>();
+
+        Assert.Equal(
+            CosmosStrings.VectorSearchRequiresVector,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await context
+                    .Set<Book>()
+                    .OrderBy(e => EF.Functions.VectorDistance(e.Isbn, inputVector))
+                    .ToListAsync())).Message);
+
+        Assert.Equal(
+            CosmosStrings.VectorSearchRequiresVector,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await context
+                    .Set<Book>()
+                    .OrderBy(e => EF.Functions.VectorDistance(inputVector, e.Isbn))
+                    .ToListAsync())).Message);
+    }
+
+    [ConditionalFact]
+    public virtual async Task VectorDistance_throws_when_used_with_non_const_args()
+    {
+        await using var context = CreateContext();
+        var inputVector = new ReadOnlyMemory<float>(
+        [
+            0.33f,
+            -0.52f,
+            0.45f,
+            -0.67f,
+            0.89f,
+            -0.34f,
+            0.86f,
+            -0.78f
+        ]);
+
+        Assert.Equal(
+            CoreStrings.ArgumentNotConstant("useBruteForce", nameof(CosmosDbFunctionsExtensions.VectorDistance)),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await context
+                    .Set<Book>()
+                    .OrderBy(e => EF.Functions.VectorDistance(e.Singles, inputVector, e.IsPublished))
+                    .ToListAsync())).Message);
+
+        Assert.Equal(
+            CoreStrings.ArgumentNotConstant("distanceFunction", nameof(CosmosDbFunctionsExtensions.VectorDistance)),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await context
+                    .Set<Book>()
+                    .OrderBy(
+                        e => EF.Functions.VectorDistance(e.Singles, inputVector, false, e.DistanceFunction))
+                    .ToListAsync())).Message);
+    }
+
+    private class Book
+    {
+        public Guid Id { get; set; }
+
+        public string Publisher { get; set; } = null!;
+
+        public string Title { get; set; } = null!;
+
+        public string Author { get; set; } = null!;
+
+        public ReadOnlyMemory<byte> Isbn { get; set; } = null!;
+
+        public bool IsPublished { get; set; }
+
+        public DistanceFunction DistanceFunction { get; set; } // Not meaningful; used for exception testing.
+
+        public ReadOnlyMemory<byte> Bytes { get; set; } = null!;
+
+        public ReadOnlyMemory<sbyte> SBytes { get; set; } = null!;
+
+        public ReadOnlyMemory<float> Singles { get; set; } = null!;
+
+        public Owned1 OwnedReference { get; set; } = null!;
+        public List<Owned1> OwnedCollection { get; set; } = null!;
+    }
+
+    [Owned]
+    protected class Owned1
+    {
+        public int Prop { get; set; }
+        public Owned2 NestedOwned { get; set; } = null!;
+        public List<Owned2> NestedOwnedCollection { get; set; } = null!;
+    }
+
+    [Owned]
+    protected class Owned2
+    {
+        public string Prop { get; set; } = null!;
+    }
+
+    protected DbContext CreateContext()
+        => Fixture.CreateContext();
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    public class VectorSearchFixture : SharedStoreFixtureBase<PoolableDbContext>
+    {
+        protected override string StoreName
+            => "VectorSearchTest";
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            => modelBuilder.Entity<Book>(
+                b =>
+                {
+                    b.Property(e => e.Id).ValueGeneratedOnAdd();
+                    b.HasKey(e => e.Id);
+                    b.HasPartitionKey(e => e.Publisher);
+
+                    b.HasIndex(e => e.Bytes).ForVectors(VectorIndexType.Flat);
+                    b.HasIndex(e => e.SBytes).ForVectors(VectorIndexType.Flat);
+                    b.HasIndex(e => e.Singles).ForVectors(VectorIndexType.Flat);
+
+                    b.Property(e => e.Bytes).IsVector(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.SBytes).IsVector(DistanceFunction.DotProduct, 10);
+                    b.Property(e => e.Singles).IsVector(DistanceFunction.Cosine, 10);
+                });
+
+        protected override Task SeedAsync(PoolableDbContext context)
+        {
+            var book1 = new Book
+            {
+                Publisher = "Manning",
+                Author = "Jon P Smith",
+                Title = "Entity Framework Core in Action",
+                Isbn = new ReadOnlyMemory<byte>("978-1617298363"u8.ToArray()),
+                Bytes = new([2, 1, 4, 3, 5, 2, 5, 7, 3, 1]),
+                SBytes = new([2, -1, 4, 3, 5, -2, 5, -7, 3, 1]),
+                Singles = new([ 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f, 0.86f, -0.78f ]),
+
+                OwnedReference = new()
+                {
+                    Prop = 7,
+                    NestedOwned = new() { Prop = "7" },
+                    NestedOwnedCollection = new() { new() { Prop = "71" }, new() { Prop = "72" } }
+                },
+                OwnedCollection = new() { new() { Prop = 71 }, new() { Prop = 72 } }
+            };
+
+            var book2 = new Book
+            {
+                Publisher = "O'Reilly",
+                Author = "Julie Lerman",
+                Title = "Programming Entity Framework: DbContext",
+                Isbn = new ReadOnlyMemory<byte>("978-1449312961"u8.ToArray()),
+                Bytes = new([2, 1, 4, 3, 5, 2, 5, 7, 3, 1]),
+                SBytes = new([2, -1, 4, 3, 5, -2, 5, -7, 3, 1]),
+                Singles = new([ 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f, 0.86f, -0.78f ]),
+
+                OwnedReference = new()
+                {
+                    Prop = 7,
+                    NestedOwned = new() { Prop = "7" },
+                    NestedOwnedCollection = new() { new() { Prop = "71" }, new() { Prop = "72" } }
+                },
+                OwnedCollection = new() { new() { Prop = 71 }, new() { Prop = 72 } }
+            };
+
+            var book3 = new Book
+            {
+                Publisher = "O'Reilly",
+                Author = "Julie Lerman",
+                Title = "Programming Entity Framework",
+                Isbn = new ReadOnlyMemory<byte>("978-0596807269"u8.ToArray()),
+                Bytes = new([2, 1, 4, 3, 5, 2, 5, 7, 3, 1]),
+                SBytes = new([2, -1, 4, 3, 5, -2, 5, -7, 3, 1]),
+                Singles = new([ 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f, 0.86f, -0.78f ]),
+
+                OwnedReference = new()
+                {
+                    Prop = 7,
+                    NestedOwned = new() { Prop = "7" },
+                    NestedOwnedCollection = new() { new() { Prop = "71" }, new() { Prop = "72" } }
+                },
+                OwnedCollection = new() { new() { Prop = 71 }, new() { Prop = 72 } }
+            };
+
+            context.AddRange(book1, book2, book3);
+
+            return context.SaveChangesAsync();
+        }
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory
+            => CosmosTestStoreFactory.Instance;
+    }
+}
+#pragma warning restore EF9103

--- a/test/EFCore.Cosmos.Tests/Extensions/CosmosDbContextOptionsExtensionsTests.cs
+++ b/test/EFCore.Cosmos.Tests/Extensions/CosmosDbContextOptionsExtensionsTests.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
-using Azure.Core;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
-using Microsoft.EntityFrameworkCore.TestUtilities;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Newtonsoft.Json.Linq;
 
@@ -468,28 +469,78 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
         VerifyError(CosmosStrings.ETagNonStringStoreType("_etag", nameof(Customer), "int"), modelBuilder);
     }
 
+#pragma warning disable EF9103
+    [ConditionalFact]
+    public virtual void Detects_multi_property_vector_index()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Customer>(
+            b =>
+            {
+                b.HasIndex(e => new { e.Name, e.OtherName }).ForVectors(VectorIndexType.Flat);
+            });
+
+        VerifyError(CosmosStrings.CompositeVectorIndex(nameof(Customer), "Name,OtherName"), modelBuilder);
+    }
+
+    [ConditionalFact]
+    public virtual void Detects_vector_index_on_non_vector_property()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Customer>(
+            b =>
+            {
+                b.HasIndex(e => new { e.Name }).ForVectors(VectorIndexType.Flat);
+            });
+
+        VerifyError(CosmosStrings.VectorIndexOnNonVector(nameof(Customer), "Name"), modelBuilder);
+    }
+#pragma warning restore EF9103
+
+
+    [ConditionalFact]
+    public virtual void Detects_vector_property_with_unknown_data_type()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<NonVector>(
+            b =>
+            {
+#pragma warning disable EF9103
+                b.Property(e => e.Vector).IsVector(DistanceFunction.Cosine, dimensions: 10);
+#pragma warning restore EF9103
+            });
+
+        VerifyError(CosmosStrings.BadVectorDataType("double[]"), modelBuilder);
+    }
+
+    private class NonVector
+    {
+        public Guid Id { get; set; }
+        public double[] Vector { get; set; }
+    }
+
     [ConditionalFact]
     public virtual void Detects_unmappable_property()
     {
         var modelBuilder = CreateConventionModelBuilder();
-        modelBuilder.Entity<RememberMyName<ReadOnlyMemory<float>>>().ToContainer("Orders");
+        modelBuilder.Entity<RememberMyName<Memory<float>>>().ToContainer("Orders");
 
         VerifyError(CoreStrings.PropertyNotAdded(
-            typeof(RememberMyName<ReadOnlyMemory<float>>).ShortDisplayName(),
+            typeof(RememberMyName<Memory<float>>).ShortDisplayName(),
             nameof(RememberMyName<float>.ForgetMeNot),
-            typeof(ReadOnlyMemory<float>).ShortDisplayName()), modelBuilder);
+            typeof(Memory<float>).ShortDisplayName()), modelBuilder);
     }
 
     [ConditionalFact]
     public virtual void Detects_unmappable_list_property()
     {
         var modelBuilder = CreateConventionModelBuilder();
-        modelBuilder.Entity<RememberMyName<ReadOnlyMemory<float>[]>>().ToContainer("Orders");
+        modelBuilder.Entity<RememberMyName<Memory<float>[]>>().ToContainer("Orders");
 
         VerifyError(CoreStrings.PropertyNotAdded(
-            typeof(RememberMyName<ReadOnlyMemory<float>[]>).ShortDisplayName(),
+            typeof(RememberMyName<Memory<float>[]>).ShortDisplayName(),
             nameof(RememberMyName<float>.ForgetMeNot),
-            typeof(ReadOnlyMemory<float>[]).ShortDisplayName()), modelBuilder);
+            typeof(Memory<float>[]).ShortDisplayName()), modelBuilder);
     }
 
     private class RememberMyName<T>

--- a/test/EFCore.Cosmos.Tests/Storage/Internal/CosmosTypeMappingSourceTest.cs
+++ b/test/EFCore.Cosmos.Tests/Storage/Internal/CosmosTypeMappingSourceTest.cs
@@ -332,8 +332,6 @@ public class CosmosTypeMappingSourceTest
     {
         Assert.Null(GetTypeMapping(typeof(Memory<float>)));
         Assert.Null(GetTypeMapping(typeof(Memory<float>?)));
-        Assert.Null(GetTypeMapping(typeof(ReadOnlyMemory<float>)));
-        Assert.Null(GetTypeMapping(typeof(ReadOnlyMemory<float>?)));
     }
 
     private static Type UnwrapNullableType(Type type)


### PR DESCRIPTION
 Fixes #33783

 This PR introduces:

 - `IsVector()` to configure a property to be configured as a vector (embedding) in the document.
   - The distance function and dimensions are specified.
   - The data type can be specified, or otherwise is inferred.
 - `HasIndex().ForVectors()` to configure a vector index over a vector property.
 - `VectorDistance()` which translates to the Cosmos `VectorDistance` function
   - The distance function and data type are taken from the property mapping, or can be overridden.

 Known issues:

 - Float16 (Half) is not working in Cosmos--needs investigation
 - Exception on int array case--could be EF or Cosmos--needs investigation
 - Owned types mess up the materialization--this will be fixed by the ReadItem improvements I am working on

