### PR TITLE
Use ARM to create containers for Cosmos tests.

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
@@ -212,24 +212,11 @@ public class CosmosDatabaseCreator : IDatabaseCreator
         => throw new NotSupportedException(CosmosStrings.CanConnectNotSupported);
 
     /// <summary>
-    ///     Returns the store name of the property that is used to store the partition key.
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    /// <param name="entityType">The entity type to get the partition key property name for.</param>
-    /// <returns>The name of the partition key property.</returns>
-    [Obsolete("Use GetPartitionKeyStoreNames")]
-    private static string GetPartitionKeyStoreName(IEntityType entityType)
-    {
-        var name = entityType.GetPartitionKeyPropertyName();
-        return name != null
-            ? entityType.FindProperty(name)!.GetJsonPropertyName()
-            : CosmosClientWrapper.DefaultPartitionKey;
-    }
-
-    /// <summary>
-    ///     Returns the store names of the properties that is used to store the partition keys.
-    /// </summary>
-    /// <param name="entityType">The entity type to get the partition key property names for.</param>
-    /// <returns>The names of the partition key property.</returns>
     private static IReadOnlyList<string> GetPartitionKeyStoreNames(IEntityType entityType)
     {
         var properties = entityType.GetPartitionKeyProperties();

--- a/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
@@ -16,6 +16,22 @@ public class F1CosmosFixture<TRowVersion> : F1FixtureBase<TRowVersion>
     public override TestHelpers TestHelpers
         => CosmosTestHelpers.Instance;
 
+    public override async Task ReseedAsync()
+    {
+        await base.ReseedAsync();
+
+        using var context = CreateContext();
+        try
+        {
+            await context.Teams.SingleAsync(t => t.Id == Team.Ferrari);
+        }
+        catch (Exception)
+        {
+            // Recreating the containers without using CosmosClient causes cached metadata in CosmosClient to be out of sync
+            // and causes the first query to fail. This is a workaround for that.
+        }
+    }
+
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder).ConfigureWarnings(w => w.Ignore(CosmosEventId.NoPartitionKeyDefined));
 


### PR DESCRIPTION
The tests were passing while using Entra ID, but after local auth was disabled container operations started failing (they should have failed before).

Fixes #33993