### PR TITLE
Cosmos querying over arrays of structural type

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
@@ -532,6 +532,30 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override Expression VisitObjectBinary(ObjectBinaryExpression objectBinaryExpression)
+    {
+        var op = objectBinaryExpression.OperatorType switch
+        {
+            ExpressionType.Coalesce => " ?? ",
+
+            _ => throw new UnreachableException($"Unsupported unary OperatorType: {objectBinaryExpression.OperatorType}")
+        };
+
+        _sqlBuilder.Append('(');
+        Visit(objectBinaryExpression.Left);
+        _sqlBuilder.Append(op);
+        Visit(objectBinaryExpression.Right);
+        _sqlBuilder.Append(')');
+
+        return objectBinaryExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
     {
         var op = sqlUnaryExpression.OperatorType switch

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
@@ -49,7 +49,7 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     /// </summary>
     protected override Expression VisitEntityProjection(EntityProjectionExpression entityProjectionExpression)
     {
-        Visit(entityProjectionExpression.AccessExpression);
+        Visit(entityProjectionExpression.Object);
 
         return entityProjectionExpression;
     }
@@ -80,18 +80,34 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override Expression VisitArray(ArrayExpression arrayExpression)
+    protected override Expression VisitObjectArray(ObjectArrayExpression objectArrayExpression)
+    {
+        GenerateArray(objectArrayExpression.Subquery);
+        return objectArrayExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitScalarArray(ScalarArrayExpression scalarArrayExpression)
+    {
+        GenerateArray(scalarArrayExpression.Subquery);
+        return scalarArrayExpression;
+    }
+
+    private void GenerateArray(SelectExpression subquery)
     {
         _sqlBuilder.AppendLine("ARRAY(");
 
         using (_sqlBuilder.Indent())
         {
-            Visit(arrayExpression.Subquery);
+            Visit(subquery);
         }
 
         _sqlBuilder.Append(")");
-
-        return arrayExpression;
     }
 
     /// <summary>
@@ -100,11 +116,16 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override Expression VisitObjectArrayProjection(ObjectArrayProjectionExpression objectArrayProjectionExpression)
+    protected override Expression VisitObjectArrayAccess(ObjectArrayAccessExpression objectArrayAccessExpression)
     {
-        _sqlBuilder.Append(objectArrayProjectionExpression.ToString());
+        Visit(objectArrayAccessExpression.Object);
 
-        return objectArrayProjectionExpression;
+        _sqlBuilder
+            .Append("[\"")
+            .Append(objectArrayAccessExpression.PropertyName)
+            .Append("\"]");
+
+        return objectArrayAccessExpression;
     }
 
     /// <summary>
@@ -113,11 +134,37 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override Expression VisitKeyAccess(KeyAccessExpression keyAccessExpression)
+    protected override Expression VisitObjectArrayIndex(ObjectArrayIndexExpression objectArrayIndexExpression)
     {
-        _sqlBuilder.Append(keyAccessExpression.ToString());
+        Visit(objectArrayIndexExpression.Array);
+        _sqlBuilder.Append("[");
+        Visit(objectArrayIndexExpression.Index);
+        _sqlBuilder.Append("]");
 
-        return keyAccessExpression;
+        return objectArrayIndexExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitScalarAccess(ScalarAccessExpression scalarAccessExpression)
+    {
+        Visit(scalarAccessExpression.Object);
+
+        // TODO: Remove check once __jObject is translated to the access root in a better fashion.
+        // See issue #17670 and related issue #14121.
+        if (scalarAccessExpression.PropertyName.Length > 0)
+        {
+            _sqlBuilder
+                .Append("[\"")
+                .Append(scalarAccessExpression.PropertyName)
+                .Append("\"]");
+        }
+
+        return scalarAccessExpression;
     }
 
     /// <summary>
@@ -128,7 +175,12 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     /// </summary>
     protected override Expression VisitObjectAccess(ObjectAccessExpression objectAccessExpression)
     {
-        _sqlBuilder.Append(objectAccessExpression.ToString());
+        Visit(objectAccessExpression.Object);
+
+        _sqlBuilder
+            .Append("[\"")
+            .Append(objectAccessExpression.PropertyName)
+            .Append("\"]");
 
         return objectAccessExpression;
     }
@@ -761,14 +813,30 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override Expression VisitObjectFunction(ObjectFunctionExpression objectFunctionExpression)
+    {
+        GenerateFunction(objectFunctionExpression.Name, objectFunctionExpression.Arguments);
+        return objectFunctionExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
     {
-        _sqlBuilder.Append(sqlFunctionExpression.Name);
-        _sqlBuilder.Append('(');
-        GenerateList(sqlFunctionExpression.Arguments, e => Visit(e));
-        _sqlBuilder.Append(')');
-
+        GenerateFunction(sqlFunctionExpression.Name, sqlFunctionExpression.Arguments);
         return sqlFunctionExpression;
+    }
+
+    private void GenerateFunction(string name, IReadOnlyList<Expression> arguments)
+    {
+        _sqlBuilder.Append(name);
+        _sqlBuilder.Append('(');
+        GenerateList(arguments, e => Visit(e));
+        _sqlBuilder.Append(')');
     }
 
     private sealed class ParameterNameGenerator

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryUtils.cs
@@ -61,7 +61,7 @@ public static class CosmosQueryUtils
                     return true;
 
                 // TODO: Temporary hack - need to perform proper derivation of the array type mapping from the element (e.g. for
-                // value conversion).
+                // value conversion). #34026.
                 case SqlExpression sqlExpression:
                     var arrayTypeMapping = typeMappingSource.FindMapping(arrayClrType);
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -233,6 +233,59 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     }
 
     /// <inheritdoc />
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+        if (method.DeclaringType == typeof(Queryable))
+        {
+            switch (methodCallExpression.Method.Name)
+            {
+                // The following is a bad hack to account for https://github.com/dotnet/efcore/issues/32957#issuecomment-2165864086.
+                // Basically for the query form Where(b => b.Posts.GetElementAt(0).Id == 1), nav expansion moves the property access
+                // forward, generating Where(b => b.Posts.Select(p => p.Id).GetElementAt(0)); unfortunately that means that GetElementAt()
+                // over a bare array in Cosmos doesn't get translated to a simple indexer as it should (b["Posts"][0].Id), since the
+                // reordering messes things up.
+                case nameof(Queryable.ElementAt) or nameof(Queryable.ElementAtOrDefault)
+                    when methodCallExpression.Arguments[0] is MethodCallExpression
+                    {
+                        Method: { Name: "Select", IsGenericMethod: true }
+                    } innerMethodCall
+                    && innerMethodCall.Method.GetGenericMethodDefinition() == QueryableMethods.Select:
+                {
+                    var returnDefault = method.Name.EndsWith("OrDefault", StringComparison.Ordinal);
+                    if (Visit(innerMethodCall) is ShapedQueryExpression translatedSelect
+                        && CosmosQueryUtils.TryExtractBareArray(translatedSelect, out _, out _, out _, out var boundMember)
+                        && boundMember is IAccessExpression { PropertyName: string boundPropertyName }
+                        && Visit(innerMethodCall.Arguments[0]) is ShapedQueryExpression innerSource
+                        && TranslateElementAtOrDefault(
+                            innerSource, methodCallExpression.Arguments[1], returnDefault) is ShapedQueryExpression elementAtTranslation)
+                    {
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                        var translation = _sqlTranslator.Translate(
+                            Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions.CreateEFPropertyExpression(
+                                elementAtTranslation.ShaperExpression,
+                                elementAtTranslation.ShaperExpression.Type,
+                                boundMember.Type,
+                                boundPropertyName,
+                                makeNullable: true));
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+                        if (translation is not null)
+                        {
+                            var finalShapedQuery = CreateShapedQueryExpression(new SelectExpression(translation), boundMember.Type);
+                            return finalShapedQuery.UpdateResultCardinality(
+                                returnDefault ? ResultCardinality.SingleOrDefault : ResultCardinality.Single);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+    }
+
+    /// <inheritdoc />
     protected override Expression VisitExtension(Expression extensionExpression)
     {
         switch (extensionExpression)
@@ -316,6 +369,22 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
                 false));
     }
 
+    private ShapedQueryExpression CreateShapedQueryExpression(SelectExpression select, Type elementClrType)
+    {
+        var shaperExpression = (Expression)new ProjectionBindingExpression(
+            select, new ProjectionMember(), elementClrType.MakeNullable());
+        if (shaperExpression.Type != elementClrType)
+        {
+            Check.DebugAssert(
+                elementClrType.MakeNullable() == shaperExpression.Type,
+                "expression.Type must be nullable of targetType");
+
+            shaperExpression = Expression.Convert(shaperExpression, elementClrType);
+        }
+
+        return new ShapedQueryExpression(select, shaperExpression);
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -342,6 +411,18 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
             }
 
             source = translatedSource;
+        }
+
+        // Simplify x.Array.Any() => ARRAY_LENGTH(x.Array) > 0 instead of (EXISTS(SELECT 1 FROM i IN x.Array))
+        if (CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true))
+        {
+            var simplifiedTranslation = _sqlExpressionFactory.GreaterThan(
+                _sqlExpressionFactory.Function(
+                    "ARRAY_LENGTH", new[] { array }, typeof(int), _typeMappingSource.FindMapping(typeof(int))),
+                    _sqlExpressionFactory.Constant(0));
+            var select = new SelectExpression(simplifiedTranslation);
+
+            return source.Update(select, new ProjectionBindingExpression(select, new ProjectionMember(), typeof(int)));
         }
 
         var subquery = (SelectExpression)source.QueryExpression;
@@ -418,6 +499,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     {
         // Simplify x.Array.Contains[1] => ARRAY_CONTAINS(x.Array, 1) insert of IN+subquery
         if (CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true)
+            && array is SqlExpression scalarArray // TODO: Contains over arrays of structural types
             && TranslateExpression(item) is SqlExpression translatedItem)
         {
             if (array is ArrayConstantExpression arrayConstant)
@@ -426,8 +508,8 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
                 return source.Update(new SelectExpression(inExpression), source.ShaperExpression);
             }
 
-            (translatedItem, array) = _sqlExpressionFactory.ApplyTypeMappingsOnItemAndArray(translatedItem, array);
-            var simplifiedTranslation = _sqlExpressionFactory.Function("ARRAY_CONTAINS", new[] { array, translatedItem }, typeof(bool));
+            (translatedItem, scalarArray) = _sqlExpressionFactory.ApplyTypeMappingsOnItemAndArray(translatedItem, scalarArray);
+            var simplifiedTranslation = _sqlExpressionFactory.Function("ARRAY_CONTAINS", [scalarArray, translatedItem], typeof(bool));
             return source.UpdateQueryExpression(new SelectExpression(simplifiedTranslation));
         }
 
@@ -447,45 +529,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
-    {
-        // Simplify x.Array.Count() => ARRAY_LENGTH(x.Array) instead of (SELECT COUNT(1) FROM i IN x.Array))
-        if (predicate is null
-            && CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true))
-        {
-            var simplifiedTranslation = _sqlExpressionFactory.Function("ARRAY_LENGTH", new[] { array }, typeof(int));
-            return source.UpdateQueryExpression(new SelectExpression(simplifiedTranslation));
-        }
-
-        var selectExpression = (SelectExpression)source.QueryExpression;
-        if (selectExpression.IsDistinct
-            || selectExpression.Limit != null
-            || selectExpression.Offset != null)
-        {
-            return null;
-        }
-
-        if (predicate != null)
-        {
-            if (TranslateWhere(source, predicate) is not ShapedQueryExpression translatedSource)
-            {
-                return null;
-            }
-
-            source = translatedSource;
-        }
-
-        var translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(
-            _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Constant(1) }, typeof(int)));
-
-        var projectionMapping = new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), translation } };
-
-        selectExpression.ClearOrdering();
-        selectExpression.ReplaceProjectionMapping(projectionMapping);
-        return source.UpdateShaperExpression(
-            Expression.Convert(
-                new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(int?)),
-                typeof(int)));
-    }
+        => TranslateCountLongCount(source, predicate, typeof(int));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -531,28 +575,57 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         // subquery+OFFSET (which isn't supported by Cosmos).
         // Even if the source is a full query (not a bare array), convert it to an array via the Cosmos ARRAY() operator; we do this
         // only in subqueries, because Cosmos supports OFFSET/LIMIT at the top-level but not in subqueries.
-        var array = CosmosQueryUtils.TryExtractBareArray(source, out var a, out var projectedScalarReference)
+        var array = CosmosQueryUtils.TryExtractBareArray(
+            source, out var a, out var projection, out var projectedStructuralTypeShaper, out _)
             ? a
-            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projectedScalarReference)
+            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projection)
                 ? a
                 : null;
 
         // Simplify x.Array[1] => x.Array[1] (using the Cosmos array subscript operator) instead of a subquery with LIMIT/OFFSET
-        if (array is SqlExpression scalarArray) // TODO: ElementAt over arrays of structural types
+        switch (array)
         {
-            SqlExpression translation = _sqlExpressionFactory.ArrayIndex(
-                array, translatedIndex, projectedScalarReference!.Type, projectedScalarReference.TypeMapping);
-
-            if (returnDefault)
+            // ElementAtOrDefault over an array of scalars
+            case SqlExpression scalarArray when projection is SqlExpression element:
             {
-                translation = _sqlExpressionFactory.CoalesceUndefined(
-                    translation, TranslateExpression(translation.Type.GetDefaultValueConstant())!);
+                SqlExpression translation = _sqlExpressionFactory.ArrayIndex(
+                    scalarArray, translatedIndex, element.Type, element.TypeMapping);
+
+                if (returnDefault)
+                {
+                    translation = _sqlExpressionFactory.CoalesceUndefined(
+                        translation, TranslateExpression(translation.Type.GetDefaultValueConstant())!);
+                }
+
+                var translatedSelect = new SelectExpression(translation);
+                return source.Update(
+                    translatedSelect,
+                    new ProjectionBindingExpression(translatedSelect, new ProjectionMember(), element.Type));
             }
 
-            return source.UpdateQueryExpression(new SelectExpression(translation));
+            // ElementAtOrDefault over an array os structural types
+            case not null when projectedStructuralTypeShaper is not null:
+            {
+                var translation = new ObjectArrayIndexExpression(array, translatedIndex, projectedStructuralTypeShaper.Type);
+
+                if (returnDefault)
+                {
+                    // TODO
+                    throw new InvalidOperationException("ElementAtOrDefault over array of entity types is not supported.");
+                }
+
+                var translatedSelect =
+                    new SelectExpression(new EntityProjectionExpression(translation, (IEntityType)projectedStructuralTypeShaper.StructuralType));
+                return source.Update(
+                    translatedSelect,
+                    new StructuralTypeShaperExpression(
+                        projectedStructuralTypeShaper.StructuralType,
+                        new ProjectionBindingExpression(translatedSelect, new ProjectionMember(), typeof(ValueBuffer)),
+                        nullable: true));
+            }
         }
 
-        // Translate using OFFSET/LIMIT, except in subqueries where it isn't supported
+        // Simplification to indexing failed, translate using OFFSET/LIMIT, except in subqueries where it isn't supported.
         if (_subquery)
         {
             AddTranslationErrorDetails(CosmosStrings.LimitOffsetNotSupportedInSubqueries);
@@ -731,36 +804,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateLongCount(ShapedQueryExpression source, LambdaExpression? predicate)
-    {
-        var selectExpression = (SelectExpression)source.QueryExpression;
-        if (selectExpression.IsDistinct
-            || selectExpression.Limit != null
-            || selectExpression.Offset != null)
-        {
-            return null;
-        }
-
-        if (predicate != null)
-        {
-            if (TranslateWhere(source, predicate) is not ShapedQueryExpression translatedSource)
-            {
-                return null;
-            }
-
-            source = translatedSource;
-        }
-
-        var translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(
-            _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Constant(1) }, typeof(long)));
-        var projectionMapping = new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), translation } };
-
-        selectExpression.ClearOrdering();
-        selectExpression.ReplaceProjectionMapping(projectionMapping);
-        return source.UpdateShaperExpression(
-            Expression.Convert(
-                new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(long?)),
-                typeof(long)));
-    }
+        => TranslateCountLongCount(source, predicate, typeof(long));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1021,23 +1065,47 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         // subquery+OFFSET (which isn't supported by Cosmos).
         // Even if the source is a full query (not a bare array), convert it to an array via the Cosmos ARRAY() operator; we do this
         // only in subqueries, because Cosmos supports OFFSET/LIMIT at the top-level but not in subqueries.
-        var array = CosmosQueryUtils.TryExtractBareArray(source, out var a, out var projectedScalarReference)
+        var array = CosmosQueryUtils.TryExtractBareArray(
+            source, out var a, out var projection, out var projectedStructuralTypeShaper, out _)
             ? a
-            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projectedScalarReference)
+            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projection)
                 ? a
                 : null;
 
-        if (array is SqlExpression scalarArray) // TODO: Take over arrays of structural types
+        switch (array)
         {
-            var slice = _sqlExpressionFactory.Function(
-                "ARRAY_SLICE", [scalarArray, translatedCount], scalarArray.Type, scalarArray.TypeMapping);
+            // ElementAtOrDefault over an array of scalars
+            case SqlExpression scalarArray when projection is SqlExpression element:
+            {
+                var slice = _sqlExpressionFactory.Function(
+                    "ARRAY_SLICE", [scalarArray, translatedCount], scalarArray.Type, scalarArray.TypeMapping);
 
-            // TODO: Proper alias management (#33894). Ideally reach into the source of the original SelectExpression and use that alias.
-            select = SelectExpression.CreateForPrimitiveCollection(
-                new SourceExpression(slice, "i", withIn: true),
-                projectedScalarReference!.Type,
-                projectedScalarReference.TypeMapping!);
-            return source.UpdateQueryExpression(select);
+                // TODO: Proper alias management (#33894). Ideally reach into the source of the original SelectExpression and use that alias.
+                var translatedSelect = SelectExpression.CreateForCollection(
+                    slice,
+                    "i",
+                    new ScalarReferenceExpression("i", element.Type, element.TypeMapping));
+                return source.UpdateQueryExpression(translatedSelect);
+            }
+
+            // ElementAtOrDefault over an array os structural types
+            case not null when projectedStructuralTypeShaper is not null:
+            {
+                // TODO: Proper alias management (#33894).
+                var slice = new ObjectFunctionExpression("ARRAY_SLICE", [array, translatedCount], projectedStructuralTypeShaper.Type);
+                var translatedSelect = SelectExpression.CreateForCollection(
+                    slice,
+                    "i",
+                    new EntityProjectionExpression(
+                        new ObjectReferenceExpression((IEntityType)projectedStructuralTypeShaper.StructuralType, "i"),
+                        (IEntityType)projectedStructuralTypeShaper.StructuralType));
+                return source.Update(
+                    translatedSelect,
+                    new StructuralTypeShaperExpression(
+                        projectedStructuralTypeShaper.StructuralType,
+                        new ProjectionBindingExpression(translatedSelect, new ProjectionMember(), typeof(ValueBuffer)),
+                        nullable: true));
+            }
         }
 
         // Translate using OFFSET/LIMIT, except in subqueries where it isn't supported
@@ -1118,27 +1186,56 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         // subquery+LIMIT (which isn't supported by Cosmos).
         // Even if the source is a full query (not a bare array), convert it to an array via the Cosmos ARRAY() operator; we do this
         // only in subqueries, because Cosmos supports OFFSET/LIMIT at the top-level but not in subqueries.
-        var array = CosmosQueryUtils.TryExtractBareArray(source, out var a, out var projectedScalarReference)
+        var array = CosmosQueryUtils.TryExtractBareArray(
+            source, out var a, out var projection, out var projectedStructuralTypeShaper, out _)
             ? a
-            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projectedScalarReference)
+            : _subquery && CosmosQueryUtils.TryConvertToArray(source, _typeMappingSource, out a, out projection)
                 ? a
                 : null;
 
-        if (array is SqlExpression scalarArray) // TODO: Take over arrays of structural types
+        switch (array)
         {
-            // Take() is composed over Skip(), combine the two together to a single ARRAY_SLICE()
-            var slice = array is SqlFunctionExpression { Name: "ARRAY_SLICE", Arguments: [var nestedArray, var skipCount] } previousSlice
-                ? previousSlice.Update([nestedArray, skipCount, translatedCount])
-                : _sqlExpressionFactory.Function(
-                    "ARRAY_SLICE", [scalarArray, TranslateExpression(Expression.Constant(0))!, translatedCount], scalarArray.Type,
-                    scalarArray.TypeMapping);
+            // ElementAtOrDefault over an array of scalars
+            case SqlExpression scalarArray when projection is SqlExpression element:
+            {
+                // Take() is composed over Skip(), combine the two together to a single ARRAY_SLICE()
+                var slice = array is SqlFunctionExpression { Name: "ARRAY_SLICE", Arguments: [var nestedArray, var skipCount] } previousSlice
+                    ? previousSlice.Update([nestedArray, skipCount, translatedCount])
+                    : _sqlExpressionFactory.Function(
+                        "ARRAY_SLICE", [scalarArray, TranslateExpression(Expression.Constant(0))!, translatedCount], scalarArray.Type,
+                        scalarArray.TypeMapping);
 
-            // TODO: Proper alias management (#33894). Ideally reach into the source of the original SelectExpression and use that alias.
-            select = SelectExpression.CreateForPrimitiveCollection(
-                new SourceExpression(slice, "i", withIn: true),
-                projectedScalarReference!.Type,
-                projectedScalarReference.TypeMapping!);
-            return source.UpdateQueryExpression(select);
+                // TODO: Proper alias management (#33894). Ideally reach into the source of the original SelectExpression and use that alias.
+                select = SelectExpression.CreateForCollection(
+                    slice,
+                    "i",
+                    new ScalarReferenceExpression("i", element.Type, element.TypeMapping));
+                return source.UpdateQueryExpression(select);
+            }
+
+            // ElementAtOrDefault over an array os structural types
+            case not null when projectedStructuralTypeShaper is not null:
+            {
+                // TODO: Proper alias management (#33894).
+                // Take() is composed over Skip(), combine the two together to a single ARRAY_SLICE()
+                var slice = array is ObjectFunctionExpression { Name: "ARRAY_SLICE", Arguments: [var nestedArray, var skipCount] } previousSlice
+                    ? previousSlice.Update([nestedArray, skipCount, translatedCount])
+                    : new ObjectFunctionExpression(
+                        "ARRAY_SLICE", [array, TranslateExpression(Expression.Constant(0))!, translatedCount], projectedStructuralTypeShaper.Type);
+
+                var translatedSelect = SelectExpression.CreateForCollection(
+                    slice,
+                    "i",
+                    new EntityProjectionExpression(
+                        new ObjectReferenceExpression((IEntityType)projectedStructuralTypeShaper.StructuralType, "i"),
+                        (IEntityType)projectedStructuralTypeShaper.StructuralType));
+                return source.Update(
+                    translatedSelect,
+                    new StructuralTypeShaperExpression(
+                        projectedStructuralTypeShaper.StructuralType,
+                        new ProjectionBindingExpression(translatedSelect, new ProjectionMember(), typeof(ValueBuffer)),
+                        nullable: true));
+            }
         }
 
         // Translate using OFFSET/LIMIT, except in subqueries where it isn't supported
@@ -1364,21 +1461,50 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     /// </summary>
     protected override ShapedQueryExpression? TranslateMemberAccess(Expression source, MemberIdentity member)
     {
-        // TODO: the below immediately wraps the JSON array property in a subquery (SELECT VALUE i FROM i IN c.Array).
-        // TODO: This isn't strictly necessary, as c.Array can be referenced directly; however, that would mean producing a
-        // TODO: ShapedQueryExpression that doesn't wrap a SelectExpression, but rather a KeyAccessExpression directly; this isn't currently
-        // TODO: supported.
-
         // Attempt to translate access into a primitive collection property
-        if (_sqlTranslator.TryBindMember(_sqlTranslator.Visit(source), member, out var translatedExpression, out var property)
-            && property is IProperty { IsPrimitiveCollection: true }
-            && translatedExpression is SqlExpression sqlExpression
-            && WrapPrimitiveCollectionAsShapedQuery(
-                sqlExpression,
-                sqlExpression.Type.GetSequenceType(),
-                sqlExpression.TypeMapping!.ElementTypeMapping!) is { } primitiveCollectionTranslation)
+        if (_sqlTranslator.TryBindMember(
+                _sqlTranslator.Visit(source),
+                member,
+                out var translatedExpression,
+                out var property,
+                wrapResultExpressionInReferenceExpression: false))
         {
-            return primitiveCollectionTranslation;
+            // TODO: TryBindMember returns EntityReferenceExpression, which is internal to SqlTranslatingEV.
+            // Maybe have it return the StructuralTypeShaperExpression instead, and only when binding from within SqlTranslatingEV,
+            // wrap with ERE?
+            // Check: how is this currently working in relational?
+            switch (translatedExpression)
+            {
+                case StructuralTypeShaperExpression shaper when property is INavigation { IsCollection: true }:
+                {
+                    // TODO: Alias management #33894
+                    var targetEntityType = (IEntityType)shaper.StructuralType;
+                    var sourceAlias = "t";
+                    var projection = new EntityProjectionExpression(
+                        new ObjectReferenceExpression(targetEntityType, sourceAlias), targetEntityType);
+                    var select = SelectExpression.CreateForCollection(
+                        shaper.ValueBufferExpression,
+                        sourceAlias,
+                        projection);
+                    return CreateShapedQueryExpression(targetEntityType, select);
+                }
+
+                // TODO: Collection of complex type (#31253)
+
+                // Note that non-collection navigations/complex types are handled in CosmosSqlTranslatingExpressionVisitor
+                // (no collection -> no queryable operators)
+
+                case SqlExpression sqlExpression when property is IProperty { IsPrimitiveCollection: true }:
+                {
+                    var elementClrType = sqlExpression.Type.GetSequenceType();
+                    // TODO: Do proper alias management: #33894
+                    var select = SelectExpression.CreateForCollection(
+                        sqlExpression,
+                        "i",
+                        new ScalarReferenceExpression("i", elementClrType, sqlExpression.TypeMapping!.ElementTypeMapping!));
+                    return CreateShapedQueryExpression(select, elementClrType);
+                }
+            }
         }
 
         return null;
@@ -1416,17 +1542,12 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         var arrayTypeMapping = _typeMappingSource.FindMapping(elementClrType.MakeArrayType()); // TODO: IEnumerable?
         var inlineArray = new ArrayConstantExpression(elementClrType, translatedItems, arrayTypeMapping);
 
-        // Unfortunately, Cosmos doesn't support selecting directly from an inline array: SELECT i FROM i IN [1,2,3] (syntax error)
-        // We must wrap the inline array in a subquery: SELECT VALUE i FROM (SELECT VALUE [1,2,3])
-        var innerSelect = new SelectExpression(
-            [new ProjectionExpression(inlineArray, null!)],
-            sources: [],
-            orderings: [])
-        {
-            UsesSingleValueProjection = true
-        };
-
-        return WrapPrimitiveCollectionAsShapedQuery(innerSelect, elementClrType, elementTypeMapping);
+        // TODO: Do proper alias management: #33894
+        var select = SelectExpression.CreateForCollection(
+            inlineArray,
+            "i",
+            new ScalarReferenceExpression("i", elementClrType, elementTypeMapping));
+        return CreateShapedQueryExpression(select, elementClrType);
     }
 
     /// <summary>
@@ -1452,44 +1573,61 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         var elementTypeMapping = _typeMappingSource.FindMapping(elementClrType)!;
         var sqlParameterExpression = new SqlParameterExpression(parameterQueryRootExpression.ParameterExpression, arrayTypeMapping);
 
-        // Unfortunately, Cosmos doesn't support selecting directly from an inline array: SELECT i FROM i IN [1,2,3] (syntax error)
-        // We must wrap the inline array in a subquery: SELECT VALUE i FROM (SELECT VALUE [1,2,3])
-        var innerSelect = new SelectExpression(
-            [new ProjectionExpression(sqlParameterExpression, null!)],
-            sources: [],
-            orderings: [])
-        {
-            UsesSingleValueProjection = true
-        };
-
-        return WrapPrimitiveCollectionAsShapedQuery(innerSelect, elementClrType, elementTypeMapping);
-    }
-
-    private ShapedQueryExpression WrapPrimitiveCollectionAsShapedQuery(
-        Expression array,
-        Type elementClrType,
-        CoreTypeMapping elementTypeMapping)
-    {
         // TODO: Do proper alias management: #33894
-        var select = SelectExpression.CreateForPrimitiveCollection(
-            new SourceExpression(array, "i", withIn: true),
-            elementClrType,
-            elementTypeMapping);
-        var shaperExpression = (Expression)new ProjectionBindingExpression(
-            select, new ProjectionMember(), elementClrType.MakeNullable());
-        if (shaperExpression.Type != elementClrType)
-        {
-            Check.DebugAssert(
-                elementClrType.MakeNullable() == shaperExpression.Type,
-                "expression.Type must be nullable of targetType");
-
-            shaperExpression = Expression.Convert(shaperExpression, elementClrType);
-        }
-
-        return new ShapedQueryExpression(select, shaperExpression);
+        var select = SelectExpression.CreateForCollection(
+            sqlParameterExpression,
+            "i",
+            new ScalarReferenceExpression("i", elementClrType, elementTypeMapping));
+        return CreateShapedQueryExpression(select, elementClrType);
     }
 
     #endregion Queryable collection support
+
+    private ShapedQueryExpression? TranslateCountLongCount(ShapedQueryExpression source, LambdaExpression? predicate, Type returnType)
+    {
+        // Simplify x.Array.Count() => ARRAY_LENGTH(x.Array) instead of (SELECT COUNT(1) FROM i IN x.Array))
+        if (predicate is null
+            && CosmosQueryUtils.TryExtractBareArray(source, out var array, ignoreOrderings: true))
+        {
+            var simplifiedTranslation = _sqlExpressionFactory.Function(
+                "ARRAY_LENGTH", new[] { array }, typeof(int), _typeMappingSource.FindMapping(typeof(int)));
+            var select = new SelectExpression(simplifiedTranslation);
+
+            return source.Update(select, new ProjectionBindingExpression(select, new ProjectionMember(), typeof(int)));
+        }
+
+        var selectExpression = (SelectExpression)source.QueryExpression;
+
+        // TODO: Subquery pushdown, #33968
+        if (selectExpression.IsDistinct
+            || selectExpression.Limit != null
+            || selectExpression.Offset != null)
+        {
+            return null;
+        }
+
+        if (predicate != null)
+        {
+            if (TranslateWhere(source, predicate) is not ShapedQueryExpression translatedSource)
+            {
+                return null;
+            }
+
+            source = translatedSource;
+        }
+
+        var translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(
+            _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Constant(1) }, typeof(int)));
+
+        var projectionMapping = new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), translation } };
+
+        selectExpression.ClearOrdering();
+        selectExpression.ReplaceProjectionMapping(projectionMapping);
+        return source.UpdateShaperExpression(
+            Expression.Convert(
+                new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), returnType.MakeNullable()),
+                returnType));
+    }
 
     private ShapedQueryExpression? TranslateSetOperation(
         ShapedQueryExpression source1,
@@ -1499,18 +1637,33 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     {
         if (CosmosQueryUtils.TryConvertToArray(source1, _typeMappingSource, out var array1, out var projection1, ignoreOrderings)
             && CosmosQueryUtils.TryConvertToArray(source2, _typeMappingSource, out var array2, out var projection2, ignoreOrderings)
-            && projection1.Type == projection2.Type
-            && (projection1.TypeMapping ?? projection2.TypeMapping) is CoreTypeMapping typeMapping)
+            && projection1.Type == projection2.Type)
         {
-            var translation = _sqlExpressionFactory.Function(functionName, [array1, array2], projection1.Type, typeMapping);
-            var select = SelectExpression.CreateForPrimitiveCollection(
-                new SourceExpression(translation, "i", withIn: true),
-                projection1.Type,
-                typeMapping);
-            return source1.UpdateQueryExpression(select);
+            // Set operation over arrays of scalars
+            if (projection1 is SqlExpression sqlProjection1
+                && projection2 is SqlExpression sqlProjection2
+                && (sqlProjection1.TypeMapping ?? sqlProjection2.TypeMapping) is CoreTypeMapping typeMapping)
+            {
+                // TODO: Proper alias management (#33894).
+                var translation = _sqlExpressionFactory.Function(functionName, [array1, array2], projection1.Type, typeMapping);
+                var select = SelectExpression.CreateForCollection(
+                    translation, "i", new ScalarReferenceExpression("i", projection1.Type, typeMapping));
+                return source1.UpdateQueryExpression(select);
+            }
+
+            // Set operation over arrays of structural types
+            if (source1.ShaperExpression is StructuralTypeShaperExpression { StructuralType: var structuralType1 }
+                && source2.ShaperExpression is StructuralTypeShaperExpression { StructuralType: var structuralType2 }
+                && structuralType1 == structuralType2)
+            {
+                // TODO: Proper alias management (#33894).
+                var translation = new ObjectFunctionExpression(functionName, [array1, array2], projection1.Type);
+                var select = SelectExpression.CreateForCollection(
+                    translation, "i", new ObjectReferenceExpression((IEntityType)structuralType1, "i"));
+                return CreateShapedQueryExpression(select, structuralType1.ClrType);
+            }
         }
 
-        // TODO: can also handle subqueries via ARRAY()
         return null;
     }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -250,9 +250,11 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
                     {
                         Method: { Name: "Select", IsGenericMethod: true }
                     } innerMethodCall
+                    && method.GetGenericMethodDefinition() is var genericDefinition
+                    && (genericDefinition == QueryableMethods.ElementAt || genericDefinition == QueryableMethods.ElementAtOrDefault)
                     && innerMethodCall.Method.GetGenericMethodDefinition() == QueryableMethods.Select:
                 {
-                    var returnDefault = method.Name.EndsWith("OrDefault", StringComparison.Ordinal);
+                    var returnDefault = method.Name == nameof(Queryable.ElementAtOrDefault);
                     if (Visit(innerMethodCall) is ShapedQueryExpression translatedSelect
                         && CosmosQueryUtils.TryExtractBareArray(translatedSelect, out _, out _, out _, out var boundMember)
                         && boundMember is IAccessExpression { PropertyName: string boundPropertyName }
@@ -277,6 +279,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
                                 returnDefault ? ResultCardinality.SingleOrDefault : ResultCardinality.Single);
                         }
                     }
+
                     break;
                 }
             }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
@@ -84,7 +84,7 @@ public class CosmosValueConverterCompensatingExpressionVisitor(ISqlExpressionFac
     private SqlExpression? TryCompensateForBoolWithValueConverter(SqlExpression? sqlExpression)
         => sqlExpression switch
         {
-            KeyAccessExpression keyAccessExpression
+            ScalarAccessExpression keyAccessExpression
                 when keyAccessExpression.TypeMapping!.ClrType == typeof(bool) && keyAccessExpression.TypeMapping!.Converter != null
                 => sqlExpressionFactory.Equal(sqlExpression, sqlExpressionFactory.Constant(true, sqlExpression.TypeMapping)),
 

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/IAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/IAccessExpression.cs
@@ -18,5 +18,5 @@ public interface IAccessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    string? Name { get; }
+    string? PropertyName { get; }
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectBinaryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectBinaryExpression.cs
@@ -1,0 +1,176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class ObjectBinaryExpression : Expression, IPrintableExpression
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ObjectBinaryExpression(ExpressionType operatorType, Expression left, Expression right, Type type)
+    {
+        if (!IsValidOperator(operatorType))
+        {
+            throw new InvalidOperationException(
+                CosmosStrings.UnsupportedOperatorForSqlExpression(
+                    operatorType, typeof(SqlBinaryExpression).ShortDisplayName()));
+        }
+
+        Type = type;
+        OperatorType = operatorType;
+        Left = left;
+        Right = right;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Type Type { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ExpressionType OperatorType { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual Expression Left { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual Expression Right { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var left = (Expression)visitor.Visit(Left);
+        var right = (Expression)visitor.Visit(Right);
+
+        return Update(left, right);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ObjectBinaryExpression Update(Expression left, Expression right)
+        => left != Left || right != Right
+            ? new ObjectBinaryExpression(OperatorType, left, right, Type)
+            : this;
+
+    internal static bool IsValidOperator(ExpressionType operatorType)
+        => operatorType is ExpressionType.Coalesce;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void Print(ExpressionPrinter expressionPrinter)
+    {
+        var requiresBrackets = RequiresBrackets(Left);
+
+        if (requiresBrackets)
+        {
+            expressionPrinter.Append("(");
+        }
+
+        expressionPrinter.Visit(Left);
+
+        if (requiresBrackets)
+        {
+            expressionPrinter.Append(")");
+        }
+
+        expressionPrinter.Append(expressionPrinter.GenerateBinaryOperator(OperatorType));
+
+        requiresBrackets = RequiresBrackets(Right);
+
+        if (requiresBrackets)
+        {
+            expressionPrinter.Append("(");
+        }
+
+        expressionPrinter.Visit(Right);
+
+        if (requiresBrackets)
+        {
+            expressionPrinter.Append(")");
+        }
+
+        static bool RequiresBrackets(Expression expression)
+            => expression is ObjectBinaryExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override bool Equals(object? obj)
+        => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is ObjectBinaryExpression other
+                && Equals(other));
+
+    private bool Equals(ObjectBinaryExpression other)
+        => Type == other.Type
+            && OperatorType == other.OperatorType
+            && Left.Equals(other.Left)
+            && Right.Equals(other.Right);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override int GetHashCode()
+        => HashCode.Combine(Type, OperatorType, Left, Right);
+}

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectFunctionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectFunctionExpression.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable once CheckNamespace
@@ -10,8 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KeyAccessExpression(IProperty property, Expression accessExpression)
-    : SqlExpression(property.ClrType, property.GetTypeMapping()), IAccessExpression
+public class ObjectFunctionExpression(string name, IEnumerable<Expression> arguments, Type type)
+    : Expression, IPrintableExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,7 +19,8 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Name { get; } = property.GetJsonPropertyName();
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,7 +28,7 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public new virtual IProperty Property { get; } = property;
+    public override Type Type { get; } = type;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -35,7 +36,15 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression AccessExpression { get; } = accessExpression;
+    public virtual string Name { get; } = name;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IReadOnlyList<Expression> Arguments { get; } = arguments.ToList();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -44,18 +53,19 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitChildren(ExpressionVisitor visitor)
-        => Update(visitor.Visit(AccessExpression));
+    {
+        var changed = false;
+        var arguments = new Expression[Arguments.Count];
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            arguments[i] = visitor.Visit(Arguments[i]);
+            changed |= arguments[i] != Arguments[i];
+        }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual KeyAccessExpression Update(Expression outerExpression)
-        => outerExpression != AccessExpression
-            ? new KeyAccessExpression(Property, outerExpression)
+        return changed
+            ? new ObjectFunctionExpression(Name, arguments, Type)
             : this;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -63,8 +73,10 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override void Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append(ToString());
+    public virtual ObjectFunctionExpression Update(IReadOnlyList<Expression> arguments)
+        => arguments.SequenceEqual(Arguments)
+            ? this
+            : new ObjectFunctionExpression(Name, arguments, Type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -72,12 +84,13 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override string ToString()
-        => Name?.Length > 0
-            ? $"{AccessExpression}[\"{Name}\"]"
-            // TODO: Remove once __jObject is translated to the access root in a better fashion.
-            // See issue #17670 and related issue #14121.
-            : $"{AccessExpression}";
+    public void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append(Name);
+        expressionPrinter.Append("(");
+        expressionPrinter.VisitCollection(Arguments);
+        expressionPrinter.Append(")");
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -88,13 +101,12 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     public override bool Equals(object? obj)
         => obj != null
             && (ReferenceEquals(this, obj)
-                || obj is KeyAccessExpression keyAccessExpression
-                && Equals(keyAccessExpression));
+                || obj is ObjectFunctionExpression objectFunctionExpression
+                && Equals(objectFunctionExpression));
 
-    private bool Equals(KeyAccessExpression keyAccessExpression)
-        => base.Equals(keyAccessExpression)
-            && Name == keyAccessExpression.Name
-            && AccessExpression.Equals(keyAccessExpression.AccessExpression);
+    private bool Equals(ObjectFunctionExpression objectFunctionExpression)
+        => Name == objectFunctionExpression.Name
+            && Arguments.SequenceEqual(objectFunctionExpression.Arguments);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -103,5 +115,15 @@ public class KeyAccessExpression(IProperty property, Expression accessExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override int GetHashCode()
-        => HashCode.Combine(base.GetHashCode(), Name, AccessExpression);
+    {
+        var hash = new HashCode();
+        hash.Add(base.GetHashCode());
+        hash.Add(Name);
+        for (var i = 0; i < Arguments.Count; i++)
+        {
+            hash.Add(Arguments[i]);
+        }
+
+        return hash.ToHashCode();
+    }
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectReferenceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectReferenceExpression.cs
@@ -60,7 +60,7 @@ public class ObjectReferenceExpression(IEntityType entityType, string name) : Ex
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    string IAccessExpression.Name
+    string IAccessExpression.PropertyName
         => Name;
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ProjectionExpression.cs
@@ -36,7 +36,7 @@ public class ProjectionExpression(Expression expression, string alias)
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual string? Name
-        => (Expression as IAccessExpression)?.Name;
+        => (Expression as IAccessExpression)?.PropertyName;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarAccessExpression.cs
@@ -1,13 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
-///     Represents a property access on a CosmosJSON object, which returns a JSON object (structural type) (e.g. <c>c.Address</c>).
+///     Represents a property access on a CosmosJSON object, which returns a scalar (e.g. <c>c.Name</c>).
 /// </summary>
 /// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -15,7 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
-public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessExpression
+public class ScalarAccessExpression(Expression @object, string propertyName, Type clrType, CoreTypeMapping? typeMapping)
+    : SqlExpression(clrType, typeMapping), IAccessExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,16 +22,7 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public ObjectAccessExpression(Expression @object, INavigation navigation)
-    {
-        PropertyName = navigation.TargetEntityType.GetContainingPropertyName()
-            ?? throw new InvalidOperationException(
-                CosmosStrings.NavigationPropertyIsNotAnEmbeddedEntity(
-                    navigation.DeclaringEntityType.DisplayName(), navigation.Name));
-
-        Navigation = navigation;
-        Object = @object;
-    }
+    public virtual Expression Object { get; } = @object;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -40,41 +30,7 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override ExpressionType NodeType
-        => ExpressionType.Extension;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override Type Type
-        => Navigation.ClrType;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual Expression Object { get; }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual string PropertyName { get; }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual INavigation Navigation { get; }
+    public virtual string PropertyName { get; } = propertyName;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -91,10 +47,10 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual ObjectAccessExpression Update(Expression outerExpression)
-        => outerExpression != Object
-            ? new ObjectAccessExpression(outerExpression, Navigation)
-            : this;
+    public virtual ScalarAccessExpression Update(Expression @object)
+        => ReferenceEquals(@object, Object)
+            ? this
+            : new ScalarAccessExpression(@object, PropertyName, Type, TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -102,17 +58,14 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append(ToString());
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override string ToString()
-        => $"{Object}[\"{PropertyName}\"]";
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Visit(Object);
+        expressionPrinter
+            .Append("[\"")
+            .Append(PropertyName)
+            .Append("\"]");
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -123,12 +76,13 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     public override bool Equals(object? obj)
         => obj != null
             && (ReferenceEquals(this, obj)
-                || obj is ObjectAccessExpression objectAccessExpression
-                && Equals(objectAccessExpression));
+                || obj is ScalarAccessExpression keyAccessExpression
+                && Equals(keyAccessExpression));
 
-    private bool Equals(ObjectAccessExpression objectAccessExpression)
-        => Navigation == objectAccessExpression.Navigation
-            && Object.Equals(objectAccessExpression.Object);
+    private bool Equals(ScalarAccessExpression scalarAccessExpression)
+        => base.Equals(scalarAccessExpression)
+            && PropertyName == scalarAccessExpression.PropertyName
+            && Object.Equals(scalarAccessExpression.Object);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -137,5 +91,5 @@ public class ObjectAccessExpression : Expression, IPrintableExpression, IAccessE
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override int GetHashCode()
-        => HashCode.Combine(Navigation, Object);
+        => HashCode.Combine(base.GetHashCode(), PropertyName, Object);
 }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarArrayExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarArrayExpression.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
 [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
-public class ArrayExpression(SelectExpression subquery, Type arrayClrType, CoreTypeMapping? arrayTypeMapping = null)
+public class ScalarArrayExpression(SelectExpression subquery, Type arrayClrType, CoreTypeMapping? arrayTypeMapping = null)
     : SqlExpression(arrayClrType, arrayTypeMapping)
 {
     /// <summary>
@@ -35,11 +35,11 @@ public class ArrayExpression(SelectExpression subquery, Type arrayClrType, CoreT
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override ArrayExpression VisitChildren(ExpressionVisitor visitor)
+    protected override ScalarArrayExpression VisitChildren(ExpressionVisitor visitor)
         => visitor.Visit(Subquery) is var newQuery
             && ReferenceEquals(newQuery, Subquery)
                 ? this
-                : new ArrayExpression((SelectExpression)newQuery, Type, TypeMapping);
+                : new ScalarArrayExpression((SelectExpression)newQuery, Type, TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -56,9 +56,9 @@ public class ArrayExpression(SelectExpression subquery, Type arrayClrType, CoreT
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
-        => obj is ArrayExpression other && Equals(other);
+        => obj is ScalarArrayExpression other && Equals(other);
 
-    private bool Equals(ArrayExpression? other)
+    private bool Equals(ScalarArrayExpression? other)
         => ReferenceEquals(this, other) || (base.Equals(other) && Subquery.Equals(other.Subquery));
 
     /// <inheritdoc />

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarReferenceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarReferenceExpression.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
-///     Represents a reference to a JSON value in the Cosmos SQL query, e.g. the first <c>i</c> in <c>SELECT i FROM i IN x.y</c>.
+///     Represents a reference to a JSON scalar value in the Cosmos SQL query, e.g. the first <c>i</c> in <c>SELECT i FROM i IN x.y</c>.
 ///     When referencing a non-scalar, <see cref="ObjectReferenceExpression" /> is used instead.
 /// </summary>
 /// <remarks>
@@ -31,7 +31,7 @@ public class ScalarReferenceExpression(string name, Type clrType, CoreTypeMappin
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    string IAccessExpression.Name
+    string IAccessExpression.PropertyName
         => Name;
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarSubqueryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ScalarSubqueryExpression.cs
@@ -30,7 +30,7 @@ public class ScalarSubqueryExpression : SqlExpression
             subquery,
             subquery.Projection[0].Expression is SqlExpression sqlExpression
                 ? sqlExpression.TypeMapping
-                : throw new UnreachableException("Can't construct scalar subquery over SelectExpresison with non-SqlExpression projection"))
+                : throw new UnreachableException("Can't construct scalar subquery over SelectExpression with non-SqlExpression projection"))
     {
         Subquery = subquery;
     }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SourceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SourceExpression.cs
@@ -66,7 +66,7 @@ public class SourceExpression(Expression containerExpression, string alias, bool
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    string IAccessExpression.Name
+    string IAccessExpression.PropertyName
         => Alias;
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
@@ -10,12 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlFunctionExpression(
-        string name,
-        IEnumerable<SqlExpression> arguments,
-        Type type,
-        CoreTypeMapping? typeMapping)
-    : SqlExpression(type, typeMapping)
+public class SqlFunctionExpression : SqlExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,7 +18,16 @@ public class SqlFunctionExpression(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Name { get; } = name;
+    public SqlFunctionExpression(
+        string name,
+        IEnumerable<Expression> arguments,
+        Type type,
+        CoreTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Name = name;
+        Arguments = arguments.ToList();
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,7 +35,15 @@ public class SqlFunctionExpression(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<SqlExpression> Arguments { get; } = arguments.ToList();
+    public virtual string Name { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IReadOnlyList<Expression> Arguments { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -42,19 +54,15 @@ public class SqlFunctionExpression(
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
         var changed = false;
-        var arguments = new SqlExpression[Arguments.Count];
+        var arguments = new Expression[Arguments.Count];
         for (var i = 0; i < arguments.Length; i++)
         {
-            arguments[i] = (SqlExpression)visitor.Visit(Arguments[i]);
+            arguments[i] = visitor.Visit(Arguments[i]);
             changed |= arguments[i] != Arguments[i];
         }
 
         return changed
-            ? new SqlFunctionExpression(
-                Name,
-                arguments,
-                Type,
-                TypeMapping)
+            ? new SqlFunctionExpression(Name, arguments, Type, TypeMapping)
             : this;
     }
 
@@ -73,10 +81,10 @@ public class SqlFunctionExpression(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SqlFunctionExpression Update(IReadOnlyList<SqlExpression> arguments)
-        => !arguments.SequenceEqual(Arguments)
-            ? new SqlFunctionExpression(Name, arguments, Type, TypeMapping)
-            : this;
+    public virtual SqlFunctionExpression Update(IReadOnlyList<Expression> arguments)
+        => arguments.SequenceEqual(Arguments)
+            ? this
+            : new SqlFunctionExpression(Name, arguments, Type, TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -266,7 +266,7 @@ public interface ISqlExpressionFactory
     /// </summary>
     SqlFunctionExpression Function(
         string functionName,
-        IEnumerable<SqlExpression> arguments,
+        IEnumerable<Expression> arguments,
         Type returnType,
         CoreTypeMapping? typeMapping = null);
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -163,7 +163,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
             case ExpressionType.ArrayIndex:
             {
                 // TODO: This infers based on the CLR type; need to properly infer based on the element type mapping
-                // TODO: being applied here (e.g. WHERE @p[1] = c.PropertyWithValueConverter)
+                // TODO: being applied here (e.g. WHERE @p[1] = c.PropertyWithValueConverter). #34026
                 var arrayTypeMapping = left.TypeMapping
                     ?? (typeMapping is null ? null : typeMappingSource.FindMapping(typeMapping.ClrType.MakeArrayType()));
                 return new SqlBinaryExpression(

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -568,15 +568,15 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     /// </summary>
     public virtual SqlFunctionExpression Function(
         string functionName,
-        IEnumerable<SqlExpression> arguments,
+        IEnumerable<Expression> arguments,
         Type returnType,
         CoreTypeMapping? typeMapping = null)
     {
-        var typeMappedArguments = new List<SqlExpression>();
+        var typeMappedArguments = new List<Expression>();
 
         foreach (var argument in arguments)
         {
-            typeMappedArguments.Add(ApplyDefaultTypeMapping(argument));
+            typeMappedArguments.Add(argument is SqlExpression sqlArgument ? ApplyDefaultTypeMapping(sqlArgument) : argument);
         }
 
         return new SqlFunctionExpression(

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -25,10 +25,10 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             SelectExpression selectExpression => VisitSelect(selectExpression),
             ProjectionExpression projectionExpression => VisitProjection(projectionExpression),
             EntityProjectionExpression entityProjectionExpression => VisitEntityProjection(entityProjectionExpression),
-            ObjectArrayProjectionExpression arrayProjectionExpression => VisitObjectArrayProjection(arrayProjectionExpression),
+            ObjectArrayAccessExpression arrayProjectionExpression => VisitObjectArrayAccess(arrayProjectionExpression),
             FromSqlExpression fromSqlExpression => VisitFromSql(fromSqlExpression),
             ObjectReferenceExpression objectReferenceExpression => VisitObjectReference(objectReferenceExpression),
-            KeyAccessExpression keyAccessExpression => VisitKeyAccess(keyAccessExpression),
+            ScalarAccessExpression keyAccessExpression => VisitScalarAccess(keyAccessExpression),
             ObjectAccessExpression objectAccessExpression => VisitObjectAccess(objectAccessExpression),
             ScalarSubqueryExpression scalarSubqueryExpression => VisitScalarSubquery(scalarSubqueryExpression),
             SqlBinaryExpression sqlBinaryExpression => VisitSqlBinary(sqlBinaryExpression),
@@ -39,11 +39,14 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             InExpression inExpression => VisitIn(inExpression),
             ArrayConstantExpression inlineArrayExpression => VisitArrayConstant(inlineArrayExpression),
             SourceExpression sourceExpression => VisitSource(sourceExpression),
+            ObjectFunctionExpression objectFunctionExpression => VisitObjectFunction(objectFunctionExpression),
             SqlFunctionExpression sqlFunctionExpression => VisitSqlFunction(sqlFunctionExpression),
             OrderingExpression orderingExpression => VisitOrdering(orderingExpression),
             ScalarReferenceExpression valueReferenceExpression => VisitValueReference(valueReferenceExpression),
             ExistsExpression existsExpression => VisitExists(existsExpression),
-            ArrayExpression arrayExpression => VisitArray(arrayExpression),
+            ObjectArrayExpression arrayExpression => VisitObjectArray(arrayExpression),
+            ScalarArrayExpression arrayExpression => VisitScalarArray(arrayExpression),
+            ObjectArrayIndexExpression objectArrayIndexExpression => VisitObjectArrayIndex(objectArrayIndexExpression),
 
             _ => base.VisitExtension(extensionExpression)
         };
@@ -62,7 +65,23 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract Expression VisitArray(ArrayExpression arrayExpression);
+    protected abstract Expression VisitObjectArray(ObjectArrayExpression objectArrayExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitScalarArray(ScalarArrayExpression scalarArrayExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitObjectArrayIndex(ObjectArrayIndexExpression objectArrayIndexExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -79,6 +98,14 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected abstract Expression VisitOrdering(OrderingExpression orderingExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitObjectFunction(ObjectFunctionExpression objectFunctionExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -158,7 +185,7 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract Expression VisitKeyAccess(KeyAccessExpression keyAccessExpression);
+    protected abstract Expression VisitScalarAccess(ScalarAccessExpression scalarAccessExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -198,7 +225,7 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract Expression VisitObjectArrayProjection(ObjectArrayProjectionExpression objectArrayProjectionExpression);
+    protected abstract Expression VisitObjectArrayAccess(ObjectArrayAccessExpression objectArrayAccessExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -32,6 +32,7 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             ObjectAccessExpression objectAccessExpression => VisitObjectAccess(objectAccessExpression),
             ScalarSubqueryExpression scalarSubqueryExpression => VisitScalarSubquery(scalarSubqueryExpression),
             SqlBinaryExpression sqlBinaryExpression => VisitSqlBinary(sqlBinaryExpression),
+            ObjectBinaryExpression objectBinaryExpression => VisitObjectBinary(objectBinaryExpression),
             SqlConstantExpression sqlConstantExpression => VisitSqlConstant(sqlConstantExpression),
             SqlUnaryExpression sqlUnaryExpression => VisitSqlUnary(sqlUnaryExpression),
             SqlConditionalExpression sqlConditionalExpression => VisitSqlConditional(sqlConditionalExpression),
@@ -178,6 +179,14 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected abstract Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract Expression VisitObjectBinary(ObjectBinaryExpression objectBinaryExpression);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
@@ -36,8 +36,8 @@ public class StructuralTypeProjectionExpression : Expression
         : this(
             type,
             propertyExpressionMap,
-            [],
-            null,
+            ownedNavigationMap: [],
+            complexPropertyCache: null,
             tableMap,
             nullable,
             discriminatorExpression)
@@ -61,7 +61,7 @@ public class StructuralTypeProjectionExpression : Expression
         : this(
             type,
             propertyExpressionMap,
-            [],
+            ownedNavigationMap: [],
             complexPropertyCache,
             tableMap,
             nullable,
@@ -423,10 +423,7 @@ public class StructuralTypeProjectionExpression : Expression
             : null;
     }
 
-    /// <summary>
-    ///     Creates a <see cref="string"/> representation of the Expression.
-    /// </summary>
-    /// <returns>A <see cref="string"/> representation of the Expression.</returns>
+    /// <inheritdoc />
     public override string ToString()
-        => $"EntityProjectionExpression: {StructuralType.ShortName()}";
+        => $"StructuralTypeProjectionExpression: {StructuralType.ShortName()}";
 }

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -367,7 +367,14 @@ public static class ExpressionExtensions
         bool makeNullable = true) // No shadow entities in runtime
         => CreateEFPropertyExpression(target, property.DeclaringType.ClrType, property.ClrType, property.Name, makeNullable);
 
-    private static Expression CreateEFPropertyExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static Expression CreateEFPropertyExpression(
         Expression target,
         Type propertyDeclaringType,
         Type propertyType,

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -87,7 +87,7 @@ public class ExpressionPrinter : ExpressionVisitor
     /// </summary>
     /// <param name="value">The string to append.</param>
     /// <returns>This printer so additional calls can be chained.</returns>
-    public virtual ExpressionVisitor AppendLine(string value)
+    public virtual ExpressionPrinter AppendLine(string value)
     {
         _stringBuilder.AppendLine(value);
         return this;

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public class IncludeExpression : Expression, IPrintableExpression
 {
     /// <summary>
@@ -108,15 +109,17 @@ public class IncludeExpression : Expression, IPrintableExpression
     /// <inheritdoc />
     void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
     {
-        expressionPrinter.AppendLine("IncludeExpression(");
+        expressionPrinter.AppendLine("Include(");
         using (expressionPrinter.Indent())
         {
-            expressionPrinter.AppendLine("EntityExpression:");
+            expressionPrinter.Append("Entity: ");
             expressionPrinter.Visit(EntityExpression);
             expressionPrinter.AppendLine(", ");
-            expressionPrinter.AppendLine("NavigationExpression:");
+            expressionPrinter
+                .Append("Navigation: ")
+                .Append(Navigation.Name)
+                .Append(", ");
             expressionPrinter.Visit(NavigationExpression);
-            expressionPrinter.AppendLine($", {Navigation.Name})");
         }
     }
 }

--- a/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public class MaterializeCollectionNavigationExpression : Expression, IPrintableExpression
 {
     /// <summary>
@@ -69,7 +70,7 @@ public class MaterializeCollectionNavigationExpression : Expression, IPrintableE
         using (expressionPrinter.Indent())
         {
             expressionPrinter.AppendLine($"Navigation: {Navigation.DeclaringEntityType.DisplayName()}.{Navigation.Name},");
-            expressionPrinter.Append("subquery: ");
+            expressionPrinter.Append("Subquery: ");
             expressionPrinter.Visit(Subquery);
             expressionPrinter.Append(")");
         }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -289,13 +289,17 @@ public class QueryCompilationContext
     private static readonly MethodInfo QueryContextAddParameterMethodInfo
         = typeof(QueryContext).GetTypeInfo().GetDeclaredMethod(nameof(QueryContext.AddParameter))!;
 
-    private sealed class NotTranslatedExpressionType : Expression
+    [DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+    private sealed class NotTranslatedExpressionType : Expression, IPrintableExpression
     {
         public override Type Type
             => typeof(object);
 
         public override ExpressionType NodeType
             => ExpressionType.Extension;
+
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
+            => expressionPrinter.Append("!!! NotTranslated !!!");
     }
 
     private sealed class RuntimeParameterConstantLifter(ILiftableConstantFactory liftableConstantFactory) : ExpressionVisitor

--- a/src/EFCore/Query/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/ShapedQueryExpression.cs
@@ -91,11 +91,11 @@ public class ShapedQueryExpression : Expression, IPrintableExpression
     /// <param name="queryExpression">The <see cref="QueryExpression" /> property of the result.</param>
     /// <returns>This expression if shaper expression did not change, or an expression with the updated shaper expression.</returns>
     public virtual ShapedQueryExpression UpdateQueryExpression(Expression queryExpression)
-        => !ReferenceEquals(queryExpression, QueryExpression)
-            ? new ShapedQueryExpression(
+        => ReferenceEquals(queryExpression, QueryExpression)
+            ? this
+            : new ShapedQueryExpression(
                 queryExpression,
-                ReplacingExpressionVisitor.Replace(QueryExpression, queryExpression, ShaperExpression), ResultCardinality)
-            : this;
+                ReplacingExpressionVisitor.Replace(QueryExpression, queryExpression, ShaperExpression), ResultCardinality);
 
     /// <summary>
     ///     Creates a new expression that is like this one, but using the supplied shaper expression. If shaper expression is the same, it will

--- a/src/EFCore/Query/StructuralTypeShaperExpression.cs
+++ b/src/EFCore/Query/StructuralTypeShaperExpression.cs
@@ -273,19 +273,21 @@ public class StructuralTypeShaperExpression : Expression, IPrintableExpression
     /// <inheritdoc />
     void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
     {
-        expressionPrinter.AppendLine(nameof(StructuralTypeShaperExpression) + ": ");
+        expressionPrinter.AppendLine(nameof(StructuralTypeShaperExpression) + "(");
         using (expressionPrinter.Indent())
         {
-            expressionPrinter.AppendLine(StructuralType.Name);
-            expressionPrinter.AppendLine(nameof(ValueBufferExpression) + ": ");
-            using (expressionPrinter.Indent())
-            {
-                expressionPrinter.Visit(ValueBufferExpression);
-                expressionPrinter.AppendLine();
-            }
+            expressionPrinter
+                .Append(nameof(StructuralType) + ": ")
+                .AppendLine(StructuralType.Name);
 
-            expressionPrinter.Append(nameof(IsNullable) + ": ");
-            expressionPrinter.AppendLine(IsNullable.ToString());
+            expressionPrinter.Append(nameof(ValueBufferExpression) + ": ");
+            expressionPrinter.Visit(ValueBufferExpression);
+            expressionPrinter.AppendLine();
+
+            expressionPrinter
+                .Append(nameof(IsNullable) + ": ")
+                .Append(IsNullable.ToString())
+                .Append(")");
         }
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
@@ -11,18 +14,18 @@ public class OwnedQueryCosmosTest : OwnedQueryTestBase<OwnedQueryCosmosTest.Owne
         : base(fixture)
     {
         ClearLog();
-        //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Query_loads_reference_nav_automatically_in_projection(bool async)
-        => base.Query_loads_reference_nav_automatically_in_projection(async);
+        => AssertTranslationFailed(() => base.Query_loads_reference_nav_automatically_in_projection(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task Query_with_owned_entity_equality_operator(bool async)
-        => base.Query_with_owned_entity_equality_operator(async);
+        => AssertTranslationFailed(() => base.Query_with_owned_entity_equality_operator(async));
 
-    [ConditionalTheory(Skip = "Count #16146")]
+    [ConditionalTheory]
     public override Task Navigation_rewrite_on_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -33,29 +36,46 @@ public class OwnedQueryCosmosTest : OwnedQueryTestBase<OwnedQueryCosmosTest.Owne
                     """
 SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""LeafB"") OR ((c[""Discriminator""] = ""LeafA"") OR ((c[""Discriminator""] = ""Branch"") OR (c[""Discriminator""] = ""OwnedPerson""))))
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) > 0))
+ORDER BY c["Id"]
 """);
             });
 
-    [ConditionalTheory(Skip = "Issue#16926")]
-    public override Task Navigation_rewrite_on_owned_collection_with_composition(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_collection_with_composition(a);
+    [ConditionalTheory]
+    public override async Task Navigation_rewrite_on_owned_collection_with_composition(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Navigation_rewrite_on_owned_collection_with_composition(async));
 
-                AssertSql(" ");
-            });
+            Assert.Contains("'ORDER BY' is not supported in subqueries.", exception.Message);
 
-    [ConditionalTheory(Skip = "Issue#16926")]
-    public override Task Navigation_rewrite_on_owned_collection_with_composition_complex(bool async)
-        => CosmosTestHelpers.Instance.NoSyncTest(
-            async, async a =>
-            {
-                await base.Navigation_rewrite_on_owned_collection_with_composition_complex(a);
+            AssertSql(
+                """
+SELECT (ARRAY(
+    SELECT VALUE (t["Id"] != 42)
+    FROM t IN c["Orders"]
+    ORDER BY t["Id"])[0] ?? false) AS c
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["Id"]
+""");
+        }
+    }
 
-                AssertSql(" ");
-            });
+    public override async Task Navigation_rewrite_on_owned_collection_with_composition_complex(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // TODO: #33995
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Navigation_rewrite_on_owned_collection_with_composition_complex(async));
+
+            AssertSql();
+        }
+    }
 
     public override Task Navigation_rewrite_on_owned_reference_projecting_entity(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -141,71 +161,87 @@ WHERE (c["Discriminator"] = "LeafA")
 """);
             });
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(bool async)
-        => base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(async);
+        => AssertTranslationFailed(
+            () => base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    public override async Task Set_throws_for_owned_type(bool async)
+    {
+        await base.Set_throws_for_owned_type(async);
+
+        AssertSql();
+    }
+
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_and_scalar(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_and_scalar(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_and_scalar(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(async);
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
-    public override Task
-        Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_in_predicate_and_projection(bool async)
-        => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_in_predicate_and_projection(
-            async);
+    // TODO: Fake LeftJoin, #33969
+    public override Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_in_predicate_and_projection(bool async)
+        => AssertTranslationFailed(
+            () => base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_in_predicate_and_projection(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Project_multiple_owned_navigations(bool async)
-        => base.Project_multiple_owned_navigations(async);
+        => AssertTranslationFailed(
+            () => base.Project_multiple_owned_navigations(async));
 
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
+    // TODO: Fake LeftJoin, #33969
     public override Task Project_multiple_owned_navigations_with_expansion_on_owned_collections(bool async)
-        => base.Project_multiple_owned_navigations_with_expansion_on_owned_collections(async);
+        => AssertTranslationFailed(
+            () => base.Project_multiple_owned_navigations_with_expansion_on_owned_collections(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task SelectMany_on_owned_collection(bool async)
-        => base.SelectMany_on_owned_collection(async);
+        => AssertTranslationFailed(() => base.SelectMany_on_owned_collection(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task SelectMany_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
-        => base.SelectMany_on_owned_reference_followed_by_regular_entity_and_collection(async);
+        => AssertTranslationFailed(() => base.SelectMany_on_owned_reference_followed_by_regular_entity_and_collection(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task SelectMany_on_owned_reference_with_entity_in_between_ending_in_owned_collection(bool async)
-        => base.SelectMany_on_owned_reference_with_entity_in_between_ending_in_owned_collection(async);
+        => AssertTranslationFailed(() => base.SelectMany_on_owned_reference_with_entity_in_between_ending_in_owned_collection(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task Query_with_owned_entity_equality_method(bool async)
-        => base.Query_with_owned_entity_equality_method(async);
+        => AssertTranslationFailed(() => base.Query_with_owned_entity_equality_method(async));
 
-    [ConditionalTheory(Skip = "SelectMany #17246")]
+    // TODO: SelectMany, #17246
     public override Task Query_with_owned_entity_equality_object_method(bool async)
-        => base.Query_with_owned_entity_equality_object_method(async);
+        => AssertTranslationFailed(() => base.Query_with_owned_entity_equality_object_method(async));
 
     public override Task Query_with_OfType_eagerly_loads_correct_owned_navigations(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -221,45 +257,62 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 """);
             });
 
-    [ConditionalTheory(Skip = "Distinct ordering #16156")]
+    // TODO: Subquery pushdown, #33968
     public override Task Query_when_subquery(bool async)
-        => base.Query_when_subquery(async);
+        => AssertTranslationFailed(() => base.Query_when_subquery(async));
 
-    [ConditionalTheory(Skip = "Count #16146")]
     public override Task No_ignored_include_warning_when_implicit_load(bool async)
-        => base.No_ignored_include_warning_when_implicit_load(async);
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.No_ignored_include_warning_when_implicit_load(a);
 
-    [ConditionalTheory(Skip = "Skip withouth Take #18923")]
-    public override Task Client_method_skip_loads_owned_navigations(bool async)
-        => base.Client_method_skip_loads_owned_navigations(async);
+                AssertSql(
+                    """
+SELECT COUNT(1) AS c
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+""");
+            });
 
-    [ConditionalTheory(Skip = "Skip withouth Take #18923")]
-    public override Task Client_method_skip_loads_owned_navigations_variation_2(bool async)
-        => base.Client_method_skip_loads_owned_navigations_variation_2(async);
+    public override async Task Client_method_skip_loads_owned_navigations(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Client_method_skip_loads_owned_navigations(async));
 
-    [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+    }
+
+    public override async Task Client_method_skip_loads_owned_navigations_variation_2(bool async)
+    {
+        var exception =
+            await Assert.ThrowsAsync<InvalidOperationException>(() => base.Client_method_skip_loads_owned_navigations_variation_2(async));
+
+        Assert.Equal(CosmosStrings.OffsetRequiresLimit, exception.Message);
+    }
+
+    // TODO: SelectMany, #17246
     public override Task Where_owned_collection_navigation_ToList_Count(bool async)
-        => base.Where_owned_collection_navigation_ToList_Count(async);
+        => AssertTranslationFailed(() => base.Where_owned_collection_navigation_ToList_Count(async));
 
-    [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+    // TODO: SelectMany, #17246
     public override Task Where_collection_navigation_ToArray_Count(bool async)
-        => base.Where_collection_navigation_ToArray_Count(async);
+        => AssertTranslationFailed(() => base.Where_collection_navigation_ToArray_Count(async));
 
-    [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+    // TODO: SelectMany, #17246
     public override Task Where_collection_navigation_AsEnumerable_Count(bool async)
-        => base.Where_collection_navigation_AsEnumerable_Count(async);
+        => AssertTranslationFailed(() => base.Where_collection_navigation_AsEnumerable_Count(async));
 
-    [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+    // TODO: SelectMany, #17246
     public override Task Where_collection_navigation_ToList_Count_member(bool async)
-        => base.Where_collection_navigation_ToList_Count_member(async);
+        => AssertTranslationFailed(() => base.Where_collection_navigation_ToList_Count_member(async));
 
-    [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+    // TODO: SelectMany, #17246
     public override Task Where_collection_navigation_ToArray_Length_member(bool async)
-        => base.Where_collection_navigation_ToArray_Length_member(async);
+        => AssertTranslationFailed(() => base.Where_collection_navigation_ToArray_Length_member(async));
 
-    [ConditionalTheory(Skip = "Issue #16146")]
+    // TODO: GroupBy, #17313
     public override Task GroupBy_with_multiple_aggregates_on_owned_navigation_properties(bool async)
-        => base.GroupBy_with_multiple_aggregates_on_owned_navigation_properties(async);
+        => AssertTranslationFailed(() => base.GroupBy_with_multiple_aggregates_on_owned_navigation_properties(async));
 
     public override Task Can_query_on_indexer_properties(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -345,77 +398,109 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
             });
 
-    [ConditionalTheory(Skip = "OrderBy requires composite index #17246")]
     public override async Task Can_OrderBy_indexer_properties(bool async)
     {
-        await base.Can_OrderBy_indexer_properties(async);
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Can_OrderBy_indexer_properties(async));
 
-        AssertSql(" ");
+            Assert.Contains(
+                "The order by query does not have a corresponding composite index that it can be served from.",
+                exception.Message);
+
+            AssertSql(
+                """
+SELECT c
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["Name"], c["Id"]
+""");
+        }
     }
 
-    [ConditionalTheory(Skip = "OrderBy requires composite index #17246")]
     public override async Task Can_OrderBy_indexer_properties_converted(bool async)
     {
-        await base.Can_OrderBy_indexer_properties_converted(async);
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Can_OrderBy_indexer_properties_converted(async));
 
-        AssertSql(" ");
+            Assert.Contains(
+                "The order by query does not have a corresponding composite index that it can be served from.",
+                exception.Message);
+
+            AssertSql(
+                """
+SELECT c["Name"]
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["Name"], c["Id"]
+""");
+        }
     }
 
-    [ConditionalTheory(Skip = "OrderBy requires composite index #17246")]
     public override async Task Can_OrderBy_owned_indexer_properties(bool async)
     {
-        await base.Can_OrderBy_owned_indexer_properties(async);
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Can_OrderBy_owned_indexer_properties(async));
 
-        AssertSql(" ");
+            Assert.Contains(
+                "The order by query does not have a corresponding composite index that it can be served from.",
+                exception.Message);
+
+            AssertSql(
+                """
+SELECT c["Name"]
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
+""");
+        }
     }
 
-    [ConditionalTheory(Skip = "OrderBy requires composite index #17246")]
-    public override async Task Can_OrderBy_owened_indexer_properties_converted(bool async)
+    public override async Task Can_OrderBy_owned_indexer_properties_converted(bool async)
     {
-        await base.Can_OrderBy_owened_indexer_properties_converted(async);
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Can_OrderBy_owned_indexer_properties_converted(async));
 
-        AssertSql(" ");
+            Assert.Contains(
+                "The order by query does not have a corresponding composite index that it can be served from.",
+                exception.Message);
+
+            AssertSql(
+                """
+SELECT c["Name"]
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
+""");
+        }
     }
 
-    [ConditionalTheory(Skip = "GroupBy #17246")]
-    public override async Task Can_group_by_indexer_property(bool isAsync)
-    {
-        await base.Can_group_by_indexer_property(isAsync);
+    // TODO: GroupBy, #17313
+    public override Task Can_group_by_indexer_property(bool async)
+        => AssertTranslationFailed(() => base.Can_group_by_indexer_property(async));
 
-        AssertSql(" ");
-    }
+    // TODO: GroupBy, #17313
+    public override Task Can_group_by_converted_indexer_property(bool async)
+        => AssertTranslationFailed(() => base.Can_group_by_converted_indexer_property(async));
 
-    [ConditionalTheory(Skip = "GroupBy #17246")]
-    public override async Task Can_group_by_converted_indexer_property(bool isAsync)
-    {
-        await base.Can_group_by_converted_indexer_property(isAsync);
+    // TODO: GroupBy, #17313
+    public override Task Can_group_by_owned_indexer_property(bool async)
+        => AssertTranslationFailed(() => base.Can_group_by_owned_indexer_property(async));
 
-        AssertSql(" ");
-    }
+    // TODO: GroupBy, #17313
+    public override Task Can_group_by_converted_owned_indexer_property(bool async)
+        => AssertTranslationFailed(() => base.Can_group_by_converted_owned_indexer_property(async));
 
-    [ConditionalTheory(Skip = "GroupBy #17246")]
-    public override async Task Can_group_by_owned_indexer_property(bool isAsync)
-    {
-        await base.Can_group_by_owned_indexer_property(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "GroupBy #17246")]
-    public override async Task Can_group_by_converted_owned_indexer_property(bool isAsync)
-    {
-        await base.Can_group_by_converted_owned_indexer_property(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "Join #17246")]
-    public override async Task Can_join_on_indexer_property_on_query(bool async)
-    {
-        await base.Can_join_on_indexer_property_on_query(async);
-
-        AssertSql(" ");
-    }
+    // Uncorrelated JOINS aren't supported by Cosmos
+    public override Task Can_join_on_indexer_property_on_query(bool async)
+        => AssertTranslationFailed(() => base.Can_group_by_converted_owned_indexer_property(async));
 
     public override Task Projecting_indexer_property_ignores_include(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -445,76 +530,93 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
             });
 
-    [ConditionalTheory(Skip = "Subquery #17246")]
-    public override async Task Indexer_property_is_pushdown_into_subquery(bool isAsync)
+    public override Task Indexer_property_is_pushdown_into_subquery(bool async)
+        => AssertTranslationFailedWithDetails(
+            () => base.Indexer_property_is_pushdown_into_subquery(async),
+            CosmosStrings.NonCorrelatedSubqueriesNotSupported);
+
+    public override Task Can_query_indexer_property_on_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Can_query_indexer_property_on_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c["Name"]
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((
+    SELECT VALUE COUNT(1)
+    FROM t IN c["Orders"]
+    WHERE (DateTimePart("yyyy", t["OrderDate"]) = 2018)) = 1))
+""");
+            });
+
+    public override async Task NoTracking_Include_with_cycles_throws(bool async)
     {
-        await base.Indexer_property_is_pushdown_into_subquery(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "Composition over owned collection #17246")]
-    public override async Task Can_query_indexer_property_on_owned_collection(bool isAsync)
-    {
-        await base.Can_query_indexer_property_on_owned_collection(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "No SelectMany, No Ability to Include navigation back to owner #17246")]
-    public override Task NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(
-        bool async,
-        bool useAsTracking)
-        => base.NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(async, useAsTracking);
-
-    [ConditionalTheory(Skip = "No Composite index to process custom ordering #17246")]
-    public override async Task Ordering_by_identifying_projection(bool async)
-    {
-        await base.Ordering_by_identifying_projection(async);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "Composition over owned collection #17246")]
-    public override async Task Query_on_collection_entry_works_for_owned_collection(bool isAsync)
-    {
-        await base.Query_on_collection_entry_works_for_owned_collection(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "issue #17246")]
-    public override async Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(
-        bool isAsync)
-    {
-        await base.Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(isAsync);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
-    public override async Task Left_join_on_entity_with_owned_navigations(bool async)
-    {
-        await base.Left_join_on_entity_with_owned_navigations(async);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "LeftJoin #17314")]
-    public override async Task Left_join_on_entity_with_owned_navigations_complex(bool async)
-    {
-        await base.Left_join_on_entity_with_owned_navigations_complex(async);
-
-        AssertSql(" ");
-    }
-
-    [ConditionalTheory(Skip = "GroupBy #17314")]
-    public override async Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
-    {
-        await base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async);
+        await base.NoTracking_Include_with_cycles_throws(async);
 
         AssertSql();
     }
+
+    // TODO: SelectMany, #17246
+    public override Task NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(
+        bool async,
+        bool useAsTracking)
+        => AssertTranslationFailed(
+            () => base.NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(async, useAsTracking));
+
+    public override async Task Trying_to_access_non_existent_indexer_property_throws_meaningful_exception(bool async)
+    {
+        await base.Trying_to_access_non_existent_indexer_property_throws_meaningful_exception(async);
+
+        AssertSql();
+    }
+
+    public override async Task Ordering_by_identifying_projection(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Ordering_by_identifying_projection(async));
+
+            Assert.Contains(
+                "The order by query does not have a corresponding composite index that it can be served from.",
+                exception.Message);
+
+            AssertSql(
+                """
+SELECT c
+FROM root c
+WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
+ORDER BY c["PersonAddress"]["PlaceType"], c["Id"]
+""");
+        }
+    }
+
+    // TODO: SelectMany, #17246
+    public override Task Query_on_collection_entry_works_for_owned_collection(bool async)
+        => AssertTranslationFailed(() => base.Query_on_collection_entry_works_for_owned_collection(async));
+
+    // Non-correlated queries not supported by Cosmos
+    public override Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(
+        bool async)
+        => AssertTranslationFailed(
+            () => base.Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(async));
+
+    // Non-correlated queries not supported by Cosmos
+    public override Task Left_join_on_entity_with_owned_navigations(bool async)
+        => AssertTranslationFailed(
+            () => base.Left_join_on_entity_with_owned_navigations(async));
+
+    // Non-correlated queries not supported by Cosmos
+    public override Task Left_join_on_entity_with_owned_navigations_complex(bool async)
+        => AssertTranslationFailed(
+            () => base.Left_join_on_entity_with_owned_navigations_complex(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async));
 
     public override Task Filter_on_indexer_using_closure(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -544,6 +646,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 """);
             });
 
+    // Non-correlated queries not supported by Cosmos
     public override Task Preserve_includes_when_applying_skip_take_after_anonymous_type_select(bool async)
         => AssertTranslationFailed(() => base.Preserve_includes_when_applying_skip_take_after_anonymous_type_select(async));
 
@@ -726,6 +829,190 @@ ORDER BY c["Id"]
 OFFSET 0 LIMIT @__p_0
 """);
             });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Count_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Count_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) = 2))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Any_without_predicate_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Any_without_predicate_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) > 0))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Any_with_predicate_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Any_with_predicate_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS (
+    SELECT 1
+    FROM t IN c["Orders"]
+    WHERE (t["Id"] = -30)))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Contains_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Contains_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS (
+    SELECT 1
+    FROM t IN c["Orders"]
+    WHERE (t["Id"] = -30)))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task ElementAt_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.ElementAt_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Orders"][1]["Id"] = -11))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override async Task OrderBy_ElementAt_over_owned_collection(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.OrderBy_ElementAt_over_owned_collection(async));
+
+            Assert.Contains("'ORDER BY' is not supported in subqueries.", exception.Message);
+
+            AssertSql(
+                """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY(
+    SELECT VALUE t["Id"]
+    FROM t IN c["Orders"]
+    ORDER BY t["Id"])[1] = -10))
+""");
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Skip_Take_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Skip_Take_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(ARRAY_SLICE(c["Orders"], 1, 1)) = 1))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task FirstOrDefault_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.FirstOrDefault_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (DateTimePart("yyyy", (ARRAY(
+    SELECT VALUE t["OrderDate"]
+    FROM t IN c["Orders"]
+    WHERE (t["Id"] > -20))[0] ?? "0001-01-01T00:00:00")) = 2018))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override async Task Distinct_over_owned_collection(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            // TODO: Subquery pushdown, #33968
+            await AssertTranslationFailed(() => base.Distinct_over_owned_collection(async));
+
+            AssertSql();
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Union_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Union_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(SetUnion(ARRAY(
+    SELECT VALUE t
+    FROM t IN c["Orders"]
+    WHERE (t["Id"] = -10)), ARRAY(
+    SELECT VALUE t
+    FROM t IN c["Orders"]
+    WHERE (t["Id"] = -11)))) = 2))
+""");
+            });
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -918,6 +918,22 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public override Task ElementAtOrDefault_over_owned_collection(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.ElementAtOrDefault_over_owned_collection(a);
+
+                AssertSql(
+                    """
+SELECT c
+FROM root c
+WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c["Orders"][10] ?? null)["Id"] = -11))
+""");
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public override async Task OrderBy_ElementAt_over_owned_collection(bool async)
     {
         // Always throws for sync.

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -955,9 +955,7 @@ WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (c["NullableStrin
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (EXISTS (
-    SELECT 1
-    FROM i IN c["Strings"]) AND (c["Strings"][1] = c["NullableString"])))
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND ((ARRAY_LENGTH(c["Strings"]) > 0) AND (c["Strings"][1] = c["NullableString"])))
 """);
             });
 
@@ -1289,15 +1287,13 @@ WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY(
                     """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND EXISTS (
-    SELECT 1
-    FROM i IN c["Ints"]))
+WHERE ((c["Discriminator"] = "PrimitiveCollectionsEntity") AND (ARRAY_LENGTH(c["Ints"]) > 0))
 """);
             });
 
     public override async Task Column_collection_Distinct(bool async)
     {
-        // TODO: Count after Distinct requires subquery pushdown
+        // TODO: Subquery pushdown, #33968
         await AssertTranslationFailed(() => base.Column_collection_Distinct(async));
 
         AssertSql();

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
@@ -12,6 +12,9 @@ public class OwnedQueryInMemoryTest(OwnedQueryInMemoryTest.OwnedQueryInMemoryFix
     public override Task ElementAt_over_owned_collection(bool async)
         => AssertTranslationFailed(() => base.ElementAt_over_owned_collection(async));
 
+    public override Task ElementAtOrDefault_over_owned_collection(bool async)
+        => AssertTranslationFailed(() => base.ElementAt_over_owned_collection(async));
+
     public override Task FirstOrDefault_over_owned_collection(bool async)
         => Assert.ThrowsAsync<NullReferenceException>(() => base.FirstOrDefault_over_owned_collection(async));
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
@@ -6,6 +6,18 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public class OwnedQueryInMemoryTest(OwnedQueryInMemoryTest.OwnedQueryInMemoryFixture fixture)
     : OwnedQueryTestBase<OwnedQueryInMemoryTest.OwnedQueryInMemoryFixture>(fixture)
 {
+    public override Task Contains_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_owned_collection(async));
+
+    public override Task ElementAt_over_owned_collection(bool async)
+        => AssertTranslationFailed(() => base.ElementAt_over_owned_collection(async));
+
+    public override Task FirstOrDefault_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<NullReferenceException>(() => base.FirstOrDefault_over_owned_collection(async));
+
+    public override Task OrderBy_ElementAt_over_owned_collection(bool async)
+        => AssertTranslationFailed(() => base.OrderBy_ElementAt_over_owned_collection(async));
+
     public class OwnedQueryInMemoryFixture : OwnedQueryFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
@@ -12,6 +14,22 @@ public abstract class OwnedQueryRelationalTestBase<TFixture> : OwnedQueryTestBas
         : base(fixture)
     {
     }
+
+    public override Task Contains_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_owned_collection(async));
+
+    // The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator.
+    public override Task ElementAt_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.ElementAt_over_owned_collection(async));
+
+    // The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator.
+    public override Task Skip_Take_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Skip_Take_over_owned_collection(async));
+
+    // This test is non-deterministic on relational, since FirstOrDefault is used without an ordering.
+    // Since this is FirstOrDefault with a filter, we don't issue our usual "missing ordering" warning (see #33997).
+    public override Task FirstOrDefault_over_owned_collection(bool async)
+        => Task.CompletedTask;
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
@@ -23,6 +23,10 @@ public abstract class OwnedQueryRelationalTestBase<TFixture> : OwnedQueryTestBas
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.ElementAt_over_owned_collection(async));
 
     // The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator.
+    public override Task ElementAtOrDefault_over_owned_collection(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.ElementAtOrDefault_over_owned_collection(async));
+
+    // The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator.
     public override Task Skip_Take_over_owned_collection(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Skip_Take_over_owned_collection(async));
 

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -596,7 +596,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Can_OrderBy_owened_indexer_properties_converted(bool async)
+    public virtual Task Can_OrderBy_owned_indexer_properties_converted(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OwnedPerson>().OrderBy(c => (int)c.PersonAddress["ZipCode"]).ThenBy(c => c.Id).Select(c => (string)c["Name"]),
@@ -762,7 +762,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         using var context = CreateContext();
 
-        var ownedPerson = context.Set<OwnedPerson>().AsTracking().Single(e => e.Id == 1);
+        var ownedPerson = await context.Set<OwnedPerson>().AsTracking().SingleAsync(e => e.Id == 1);
         var collectionQuery = context.Entry(ownedPerson).Collection(e => e.Orders).Query().AsNoTracking();
 
         var actualOrders = async
@@ -899,6 +899,81 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 AssertEqual(e.Key, a.Key);
                 AssertEqual(e.Sum, a.Sum);
             });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Count_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count == 2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Any_without_predicate_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Any()));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Any_with_predicate_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Any(i => i.Id == -30)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Contains(new Order { Id = -30 })),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Any(o => o.Id == -30)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task ElementAt_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.ElementAt(1).Id == -11),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 2 && p.Orders.ElementAt(1).Id == -11));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task OrderBy_ElementAt_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.OrderBy(o => o.Id).ElementAt(1).Id == -10),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 2 && p.Orders.OrderBy(o => o.Id).ElementAt(1).Id == -10));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Skip_Take_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Skip(1).Take(1).Count() == 1));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task FirstOrDefault_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)["OrderDate"]).Year == 2018),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.FirstOrDefault(o => o.Id > -20) != null && ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)["OrderDate"]).Year == 2018));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Distinct_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Distinct().Count() == 2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .Where(p => p.Orders.Where(o => o.Id == -10).Union(p.Orders.Where(o => o.Id == -11)).Count() == 2));
 
     protected virtual DbContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -921,6 +921,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Any(i => i.Id == -30)));
 
+    // TODO: proper owned entity containment, #34027
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Contains_over_owned_collection(bool async)
@@ -931,11 +932,31 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_over_owned_collection_with_parameter_item(bool async)
+    {
+        var order = new Order { Id = -30 };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Contains(order)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task ElementAt_over_owned_collection(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OwnedPerson>().Where(p => p.Orders.ElementAt(1).Id == -11),
             ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 2 && p.Orders.ElementAt(1).Id == -11));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task ElementAtOrDefault_over_owned_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.ElementAtOrDefault(10).Id == -11),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 11 && p.Orders.ElementAtOrDefault(1).Id == -11),
+            assertEmpty: true);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -932,17 +932,6 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Contains_over_owned_collection_with_parameter_item(bool async)
-    {
-        var order = new Order { Id = -30 };
-
-        return AssertQuery(
-            async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Contains(order)));
-    }
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task ElementAt_over_owned_collection(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1554,6 +1554,13 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
         AssertSql();
     }
 
+    public override async Task ElementAtOrDefault_over_owned_collection(bool async)
+    {
+        await base.ElementAtOrDefault_over_owned_collection(async);
+
+        AssertSql();
+    }
+
     public override async Task OrderBy_ElementAt_over_owned_collection(bool async)
     {
         await base.OrderBy_ElementAt_over_owned_collection(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -902,9 +902,9 @@ ORDER BY [o].[PersonAddress_ZipCode], [o].[Id]
 """);
     }
 
-    public override async Task Can_OrderBy_owened_indexer_properties_converted(bool async)
+    public override async Task Can_OrderBy_owned_indexer_properties_converted(bool async)
     {
-        await base.Can_OrderBy_owened_indexer_properties_converted(async);
+        await base.Can_OrderBy_owned_indexer_properties_converted(async);
 
         AssertSql(
             """
@@ -1474,6 +1474,172 @@ SELECT [o].[Id] AS [Key], (
     WHERE [o].[Id] = [o0].[Id]) AS [Sum]
 FROM [OwnedPerson] AS [o]
 GROUP BY [o].[Id]
+""");
+    }
+
+    public override async Task Count_over_owned_collection(bool async)
+    {
+        await base.Count_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o1].[ClientId], [o1].[Id], [o1].[OrderDate], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id] AS [Id0], [o2].[Detail]
+    FROM [Order] AS [o1]
+    LEFT JOIN [OrderDetail] AS [o2] ON [o1].[ClientId] = [o2].[OrderClientId] AND [o1].[Id] = [o2].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Order] AS [o0]
+    WHERE [o].[Id] = [o0].[ClientId]) = 2
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
+""");
+    }
+
+    public override async Task Any_without_predicate_over_owned_collection(bool async)
+    {
+        await base.Any_without_predicate_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o1].[ClientId], [o1].[Id], [o1].[OrderDate], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id] AS [Id0], [o2].[Detail]
+    FROM [Order] AS [o1]
+    LEFT JOIN [OrderDetail] AS [o2] ON [o1].[ClientId] = [o2].[OrderClientId] AND [o1].[Id] = [o2].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Order] AS [o0]
+    WHERE [o].[Id] = [o0].[ClientId])
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
+""");
+    }
+
+    public override async Task Any_with_predicate_over_owned_collection(bool async)
+    {
+        await base.Any_with_predicate_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o1].[ClientId], [o1].[Id], [o1].[OrderDate], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id] AS [Id0], [o2].[Detail]
+    FROM [Order] AS [o1]
+    LEFT JOIN [OrderDetail] AS [o2] ON [o1].[ClientId] = [o2].[OrderClientId] AND [o1].[Id] = [o2].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Order] AS [o0]
+    WHERE [o].[Id] = [o0].[ClientId] AND [o0].[Id] = -30)
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
+""");
+    }
+
+    public override async Task Contains_over_owned_collection(bool async)
+    {
+        await base.Contains_over_owned_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task ElementAt_over_owned_collection(bool async)
+    {
+        await base.ElementAt_over_owned_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task OrderBy_ElementAt_over_owned_collection(bool async)
+    {
+        await base.OrderBy_ElementAt_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o1].[ClientId], [o1].[Id], [o1].[OrderDate], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id] AS [Id0], [o2].[Detail]
+    FROM [Order] AS [o1]
+    LEFT JOIN [OrderDetail] AS [o2] ON [o1].[ClientId] = [o2].[OrderClientId] AND [o1].[Id] = [o2].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE (
+    SELECT [o0].[Id]
+    FROM [Order] AS [o0]
+    WHERE [o].[Id] = [o0].[ClientId]
+    ORDER BY [o0].[Id]
+    OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY) = -10
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
+""");
+    }
+
+    public override async Task Skip_Take_over_owned_collection(bool async)
+    {
+        await base.Skip_Take_over_owned_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task FirstOrDefault_over_owned_collection(bool async)
+    {
+        await base.FirstOrDefault_over_owned_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Distinct_over_owned_collection(bool async)
+    {
+        await base.Distinct_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o2].[ClientId], [o2].[Id], [o2].[OrderDate], [o3].[OrderClientId], [o3].[OrderId], [o3].[Id] AS [Id0], [o3].[Detail]
+    FROM [Order] AS [o2]
+    LEFT JOIN [OrderDetail] AS [o3] ON [o2].[ClientId] = [o3].[OrderClientId] AND [o2].[Id] = [o3].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT DISTINCT [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
+        FROM [Order] AS [o0]
+        WHERE [o].[Id] = [o0].[ClientId]
+    ) AS [o1]) = 2
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
+""");
+    }
+
+    public override async Task Union_over_owned_collection(bool async)
+    {
+        await base.Union_over_owned_collection(async);
+
+        AssertSql(
+            """
+SELECT [o].[Id], [o].[Discriminator], [o].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN (
+    SELECT [o2].[ClientId], [o2].[Id], [o2].[OrderDate], [o3].[OrderClientId], [o3].[OrderId], [o3].[Id] AS [Id0], [o3].[Detail]
+    FROM [Order] AS [o2]
+    LEFT JOIN [OrderDetail] AS [o3] ON [o2].[ClientId] = [o3].[OrderClientId] AND [o2].[Id] = [o3].[OrderId]
+) AS [s] ON [o].[Id] = [s].[ClientId]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
+        FROM [Order] AS [o0]
+        WHERE [o].[Id] = [o0].[ClientId] AND [o0].[Id] = -10
+        UNION
+        SELECT [o1].[ClientId], [o1].[Id], [o1].[OrderDate]
+        FROM [Order] AS [o1]
+        WHERE [o].[Id] = [o1].[ClientId] AND [o1].[Id] = -11
+    ) AS [u]) = 2
+ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -916,9 +916,9 @@ ORDER BY [o].[PersonAddress_ZipCode], [o].[Id]
 """);
     }
 
-    public override async Task Can_OrderBy_owened_indexer_properties_converted(bool async)
+    public override async Task Can_OrderBy_owned_indexer_properties_converted(bool async)
     {
-        await base.Can_OrderBy_owened_indexer_properties_converted(async);
+        await base.Can_OrderBy_owned_indexer_properties_converted(async);
 
         AssertSql(
             """


### PR DESCRIPTION
This PR adds general support for querying over arrays of structural types in Cosmos. Most translations work, various problems and edge cases are tracked separately.

Note that this PR introduces a bit of expression type explosion, with many types representing the same NoSQL syntax (but returning different things, i.e. scalar vs. structural type). See #33999 for more information, hopefully we clean this up at some point.

Closes #16926
Closes #20441
Closes #25700
Closes #25701
Closes #33032
