### PR TITLE
Cosmos: Stop nesting results in extra JSON object

### DIFF
--- a/src/EFCore.Cosmos/Extensions/Internal/CosmosShapedQueryExpressionExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/Internal/CosmosShapedQueryExpressionExtensions.cs
@@ -214,7 +214,6 @@ public static class CosmosShapedQueryExpressionExtensions
                             Limit: null,
                             Orderings: [],
                             IsDistinct: false,
-                            UsesSingleValueProjection: true,
                             Projection: [{ Expression: var a }]
                         },
                     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQuerySqlGenerator.cs
@@ -209,7 +209,10 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitProjection(ProjectionExpression projectionExpression)
-        => VisitProjection(projectionExpression, objectProjectionStyle: false);
+    {
+        GenerateProjection(projectionExpression, objectProjectionStyle: false);
+        return projectionExpression;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -217,8 +220,17 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected virtual Expression VisitProjection(ProjectionExpression projectionExpression, bool objectProjectionStyle)
+    private void GenerateProjection(ProjectionExpression projectionExpression, bool objectProjectionStyle)
     {
+        // If the SELECT has a single projection with IsValueProjection, prepend the VALUE keyword (without VALUE, Cosmos projects a JSON
+        // object containing the value).
+        if (projectionExpression.IsValueProjection)
+        {
+            _sqlBuilder.Append("VALUE ");
+            Visit(projectionExpression.Expression);
+            return;
+        }
+
         if (objectProjectionStyle)
         {
             _sqlBuilder.Append('"').Append(projectionExpression.Alias).Append("\" : ");
@@ -232,8 +244,6 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
         {
             _sqlBuilder.Append(" AS " + projectionExpression.Alias);
         }
-
-        return projectionExpression;
     }
 
     /// <summary>
@@ -277,34 +287,28 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
             _sqlBuilder.Append("DISTINCT ");
         }
 
-        if (selectExpression.Projection is { Count: > 0 } projection)
+        if (selectExpression.Projection is { Count: > 0 } projections)
         {
-            // If the SELECT projects a single value out, we just project that with the Cosmos VALUE keyword (without VALUE,
-            // Cosmos projects a JSON object containing the value).
-            // TODO: Ideally, just always use VALUE for all single-projection SELECTs - but this like requires shaper changes.
-            if (selectExpression.UsesSingleValueProjection && projection is [var singleProjection])
-            {
-                _sqlBuilder.Append("VALUE ");
+            Check.DebugAssert(
+                projections.Count == 1 || !projections.Any(p => p.IsValueProjection),
+                "Multiple projections with IsValueProjection");
 
-                Visit(singleProjection.Expression);
-            }
-            // Otherwise, we'll project a JSON object; Cosmos has two syntaxes for doing so:
+            // If there's only one projection, we simply project it directly (SELECT VALUE c["Id"]); this happens in GenerateProjection().
+            // Otherwise, we'll project a JSON object wrapping the multiple projections. Cosmos has two syntaxes for doing so:
             // 1. Project out a JSON object as a value (SELECT VALUE { 'a': a, 'b': b }), or
             // 2. Project a set of properties with optional AS+aliases (SELECT 'a' AS a, 'b' AS b)
             // Both methods produce the exact same results; we usually prefer the 1st, but in some cases we use the 2nd.
-            else if ((projection.Count > 1
-                         // Cosmos does not support "AS Value" projections, specifically for the alias "Value"
-                         || projection is [{ Alias: string alias }] && alias.Equals("value", StringComparison.OrdinalIgnoreCase))
-                     && projection.Any(p => !string.IsNullOrEmpty(p.Alias) && p.Alias != p.Name)
-                     && !projection.Any(p => p.Expression is SqlFunctionExpression)) // Aggregates are not allowed
+            if (projections.Count > 1
+                && projections.Any(p => !string.IsNullOrEmpty(p.Alias) && p.Alias != p.Name)
+                && !projections.Any(p => p.Expression is SqlFunctionExpression)) // Aggregates are not allowed
             {
                 _sqlBuilder.AppendLine("VALUE").AppendLine("{").IncrementIndent();
-                GenerateList(projection, e => VisitProjection(e, objectProjectionStyle: true), joinAction: sql => sql.AppendLine(","));
+                GenerateList(projections, e => GenerateProjection(e, objectProjectionStyle: true), joinAction: sql => sql.AppendLine(","));
                 _sqlBuilder.AppendLine().DecrementIndent().Append("}");
             }
             else
             {
-                GenerateList(projection, e => Visit(e));
+                GenerateList(projections, e => Visit(e));
             }
         }
         else
@@ -752,7 +756,6 @@ public class CosmosQuerySqlGenerator(ITypeMappingSource typeMappingSource) : Sql
                 Limit: null,
                 Orderings: [],
                 IsDistinct: false,
-                UsesSingleValueProjection: true,
                 Projection.Count: 1
             };
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -9,9 +9,9 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 {
     private sealed class CosmosProjectionBindingRemovingExpressionVisitor(
         SelectExpression selectExpression,
-        ParameterExpression jObjectParameter,
+        ParameterExpression jTokenParameter,
         bool trackQueryResults)
-        : CosmosProjectionBindingRemovingExpressionVisitorBase(jObjectParameter, trackQueryResults)
+        : CosmosProjectionBindingRemovingExpressionVisitorBase(jTokenParameter, trackQueryResults)
     {
         protected override ProjectionExpression GetProjection(ProjectionBindingExpression projectionBindingExpression)
             => selectExpression.Projection[GetProjectionIndex(projectionBindingExpression)];

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -74,11 +74,15 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                         // Values injected by JObjectInjectingExpressionVisitor
                         var projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
 
-                        if (projectionExpression is UnaryExpression { NodeType: ExpressionType.Convert } convertExpression)
+                        if (projectionExpression is UnaryExpression
+                            {
+                                NodeType: ExpressionType.Convert,
+                                Operand: UnaryExpression operand
+                            })
                         {
                             // Unwrap EntityProjectionExpression when the root entity is not projected
                             // That is, this is handling the projection of a non-root entity type.
-                            projectionExpression = ((UnaryExpression)convertExpression.Operand).Operand;
+                            projectionExpression = operand.Operand;
                         }
 
                         switch (projectionExpression)

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
@@ -24,7 +24,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         private readonly CosmosQueryContext _cosmosQueryContext;
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
         private readonly SelectExpression _selectExpression;
-        private readonly Func<CosmosQueryContext, JObject, T> _shaper;
+        private readonly Func<CosmosQueryContext, JToken, T> _shaper;
         private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
         private readonly Type _contextType;
         private readonly string _cosmosContainer;
@@ -42,7 +42,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             ISqlExpressionFactory sqlExpressionFactory,
             IQuerySqlGeneratorFactory querySqlGeneratorFactory,
             SelectExpression selectExpression,
-            Func<CosmosQueryContext, JObject, T> shaper,
+            Func<CosmosQueryContext, JToken, T> shaper,
             Type contextType,
             IEntityType rootEntityType,
             List<Expression> partitionKeyPropertyValues,
@@ -87,7 +87,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         {
             private readonly PagingQueryingEnumerable<T> _queryingEnumerable;
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly Func<CosmosQueryContext, JObject, T> _shaper;
+            private readonly Func<CosmosQueryContext, JToken, T> _shaper;
             private readonly Type _contextType;
             private readonly string _cosmosContainer;
             private readonly PartitionKey _cosmosPartitionKey;
@@ -184,7 +184,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                         var responseMessageEnumerable = cosmosClient.GetResponseMessageEnumerable(responseMessage);
                         foreach (var resultObject in responseMessageEnumerable)
                         {
-                            results.Add(_shaper(_cosmosQueryContext, (JObject)resultObject));
+                            results.Add(_shaper(_cosmosQueryContext, resultObject));
                             maxItemCount--;
                         }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
@@ -184,7 +184,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                         var responseMessageEnumerable = cosmosClient.GetResponseMessageEnumerable(responseMessage);
                         foreach (var resultObject in responseMessageEnumerable)
                         {
-                            results.Add(_shaper(_cosmosQueryContext, resultObject));
+                            results.Add(_shaper(_cosmosQueryContext, (JObject)resultObject));
                             maxItemCount--;
                         }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -23,7 +23,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         private readonly CosmosQueryContext _cosmosQueryContext;
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
         private readonly SelectExpression _selectExpression;
-        private readonly Func<CosmosQueryContext, JObject, T> _shaper;
+        private readonly Func<CosmosQueryContext, JToken, T> _shaper;
         private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
         private readonly Type _contextType;
         private readonly string _cosmosContainer;
@@ -37,7 +37,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             ISqlExpressionFactory sqlExpressionFactory,
             IQuerySqlGeneratorFactory querySqlGeneratorFactory,
             SelectExpression selectExpression,
-            Func<CosmosQueryContext, JObject, T> shaper,
+            Func<CosmosQueryContext, JToken, T> shaper,
             Type contextType,
             IEntityType rootEntityType,
             List<Expression> partitionKeyPropertyValues,
@@ -103,7 +103,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         {
             private readonly QueryingEnumerable<T> _queryingEnumerable;
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly Func<CosmosQueryContext, JObject, T> _shaper;
+            private readonly Func<CosmosQueryContext, JToken, T> _shaper;
             private readonly Type _contextType;
             private readonly string _cosmosContainer;
             private readonly PartitionKey _cosmosPartitionKey;
@@ -112,7 +112,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             private readonly IConcurrencyDetector _concurrencyDetector;
             private readonly IExceptionDetector _exceptionDetector;
 
-            private IEnumerator<JObject> _enumerator;
+            private IEnumerator<JToken> _enumerator;
 
             public Enumerator(QueryingEnumerable<T> queryingEnumerable)
             {
@@ -192,7 +192,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
         {
             private readonly QueryingEnumerable<T> _queryingEnumerable;
             private readonly CosmosQueryContext _cosmosQueryContext;
-            private readonly Func<CosmosQueryContext, JObject, T> _shaper;
+            private readonly Func<CosmosQueryContext, JToken, T> _shaper;
             private readonly Type _contextType;
             private readonly string _cosmosContainer;
             private readonly PartitionKey _cosmosPartitionKey;
@@ -202,7 +202,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             private readonly IConcurrencyDetector _concurrencyDetector;
             private readonly IExceptionDetector _exceptionDetector;
 
-            private IAsyncEnumerator<JObject> _enumerator;
+            private IAsyncEnumerator<JToken> _enumerator;
 
             public AsyncEnumerator(QueryingEnumerable<T> queryingEnumerable, CancellationToken cancellationToken)
             {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -40,7 +40,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor(
             throw new UnreachableException("No root entity type was set during query processing.");
         }
 
-        var jObjectParameter = Parameter(typeof(JObject), "jObject");
+        var jTokenParameter = Parameter(typeof(JToken), "jToken");
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
 
@@ -69,14 +69,14 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor(
         }
 
         shaperBody = new CosmosProjectionBindingRemovingExpressionVisitor(
-                selectExpression, jObjectParameter,
+                selectExpression, jTokenParameter,
                 QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll)
             .Visit(shaperBody);
 
         var shaperLambda = Lambda(
             shaperBody,
             QueryCompilationContext.QueryContextParameter,
-            jObjectParameter);
+            jTokenParameter);
 
         var cosmosQueryContextConstant = Convert(QueryCompilationContext.QueryContextParameter, typeof(CosmosQueryContext));
         var shaperConstant = Constant(shaperLambda.Compile());

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectReferenceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ObjectReferenceExpression.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
-public class ObjectReferenceExpression(IEntityType entityType, string name) : Expression, IAccessExpression
+public class ObjectReferenceExpression(IEntityType entityType, string name) : Expression, IPrintableExpression, IAccessExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -71,6 +71,15 @@ public class ObjectReferenceExpression(IEntityType entityType, string name) : Ex
     /// </summary>
     protected override Expression VisitChildren(ExpressionVisitor visitor)
         => this;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void Print(ExpressionPrinter expressionPrinter)
+        => expressionPrinter.Append(Name);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/ProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/ProjectionExpression.cs
@@ -10,9 +10,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class ProjectionExpression(Expression expression, string alias)
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
+public class ProjectionExpression(Expression expression, string alias, bool isValueProjection)
     : Expression, IPrintableExpression
 {
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual Expression Expression { get; } = expression;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -27,7 +36,7 @@ public class ProjectionExpression(Expression expression, string alias)
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Expression { get; } = expression;
+    public virtual bool IsValueProjection { get; } = isValueProjection;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -73,7 +82,7 @@ public class ProjectionExpression(Expression expression, string alias)
     /// </summary>
     public virtual ProjectionExpression Update(Expression expression)
         => expression != Expression
-            ? new ProjectionExpression(expression, Alias)
+            ? new ProjectionExpression(expression, Alias, IsValueProjection)
             : this;
 
     /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
@@ -96,22 +96,16 @@ public sealed class SelectExpression : Expression, IPrintableExpression
             sourceExpression = new SelectExpression(
                 sources: [],
                 predicate: null,
-                [new ProjectionExpression(sourceExpression, null!)],
+                [new ProjectionExpression(sourceExpression, alias: null!, isValueProjection: true)],
                 distinct: false,
                 orderings: [],
                 offset: null,
-                limit: null)
-            {
-                UsesSingleValueProjection = true
-            };
+                limit: null);
         }
 
         var source = new SourceExpression(sourceExpression, sourceAlias, withIn: true);
 
-        return new SelectExpression(source, projection)
-        {
-            UsesSingleValueProjection = true
-        };
+        return new SelectExpression(source, projection);
     }
 
     /// <summary>
@@ -122,18 +116,6 @@ public sealed class SelectExpression : Expression, IPrintableExpression
     /// </summary>
     public IReadOnlyList<ProjectionExpression> Projection
         => _projection;
-
-    /// <summary>
-    ///     If set, indicates that the <see cref="SelectExpression" /> has a Cosmos VALUE projection, which does not get wrapped in a
-    ///     JSON object. If <see langword="true" />, <see cref="Projection" /> must contain a single item.
-    /// </summary>
-    /// <remarks>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </remarks>
-    public bool UsesSingleValueProjection { get; init; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -292,6 +274,15 @@ public sealed class SelectExpression : Expression, IPrintableExpression
     public int AddToProjection(Expression sqlExpression)
         => AddToProjection(sqlExpression, null);
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public int AddToProjection(EntityProjectionExpression entityProjection)
+        => AddToProjection(entityProjection, null);
+
     private int AddToProjection(Expression expression, string? alias)
     {
         var existingIndex = _projection.FindIndex(pe => pe.Expression.Equals(expression));
@@ -311,7 +302,14 @@ public sealed class SelectExpression : Expression, IPrintableExpression
             currentAlias = $"{baseAlias}{counter++}";
         }
 
-        _projection.Add(new ProjectionExpression(expression, currentAlias));
+        // Add the projection; if it's the only one, then it's a Cosmos VALUE projection (i.e. SELECT VALUE f).
+        // If we add a 2nd projection, go back and remove the VALUE modifier from the 1st one. This is also why we need to have a valid
+        // alias for the 1st projection, even if it's a VALUE projection (where no alias actually gets generated in SQL).
+        _projection.Add(new ProjectionExpression(expression, currentAlias, isValueProjection: _projection.Count == 0));
+        if (_projection.Count == 2)
+        {
+            _projection[0] = new ProjectionExpression(_projection[0].Expression, _projection[0].Alias, isValueProjection: false);
+        }
 
         return _projection.Count - 1;
     }
@@ -603,8 +601,7 @@ public sealed class SelectExpression : Expression, IPrintableExpression
         {
             var newSelectExpression = new SelectExpression(sources, predicate, projections, IsDistinct, orderings, offset, limit)
             {
-                _projectionMapping = projectionMapping,
-                UsesSingleValueProjection = UsesSingleValueProjection
+                _projectionMapping = projectionMapping
             };
 
             return newSelectExpression;
@@ -636,7 +633,6 @@ public sealed class SelectExpression : Expression, IPrintableExpression
         return new SelectExpression(sources, predicate, projections, IsDistinct, orderings, offset, limit)
         {
             _projectionMapping = projectionMapping,
-            UsesSingleValueProjection = UsesSingleValueProjection,
             ReadItemInfo = ReadItemInfo
         };
     }
@@ -651,7 +647,6 @@ public sealed class SelectExpression : Expression, IPrintableExpression
         => new(Sources.ToList(), Predicate, Projection.ToList(), IsDistinct, Orderings.ToList(), Offset, Limit)
         {
             _projectionMapping = _projectionMapping,
-            UsesSingleValueProjection = UsesSingleValueProjection,
             ReadItemInfo = readItemInfo
         };
 
@@ -671,8 +666,7 @@ public sealed class SelectExpression : Expression, IPrintableExpression
 
         return new SelectExpression(Sources.ToList(), Predicate, Projection.ToList(), IsDistinct, Orderings.ToList(), Offset, Limit)
         {
-            _projectionMapping = projectionMapping,
-            UsesSingleValueProjection = true
+            _projectionMapping = projectionMapping
         };
     }
 
@@ -725,18 +719,18 @@ public sealed class SelectExpression : Expression, IPrintableExpression
             expressionPrinter.Append("DISTINCT ");
         }
 
-        if (Projection.Any())
+        switch (Projection)
         {
-            if (UsesSingleValueProjection)
-            {
+            case []:
+                expressionPrinter.Append("1");
+                break;
+            case [{ IsValueProjection: true } valueProjection]:
                 expressionPrinter.Append("VALUE ");
-            }
-
-            expressionPrinter.VisitCollection(Projection);
-        }
-        else
-        {
-            expressionPrinter.Append("1");
+                expressionPrinter.Visit(valueProjection);
+                break;
+            default:
+                expressionPrinter.VisitCollection(Projection);
+                break;
         }
 
         if (Sources.Count > 0)

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -84,7 +84,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
     private CosmosClient Client
         => _singletonWrapper.Client;
 
-    private static bool DeserializeNextToken(JsonTextReader jsonReader, out JToken? token)
+    private static bool TryDeserializeNextToken(JsonTextReader jsonReader, out JToken? token)
     {
         switch (jsonReader.TokenType)
         {
@@ -973,7 +973,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         {
             while (_jsonReader.Read())
             {
-                return DeserializeNextToken(_jsonReader, out _current);
+                return TryDeserializeNextToken(_jsonReader, out _current);
             }
 
             return false;
@@ -1015,7 +1015,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         {
             while (await _jsonReader.ReadAsync().ConfigureAwait(false))
             {
-                return DeserializeNextToken(_jsonReader, out _current);
+                return TryDeserializeNextToken(_jsonReader, out _current);
             }
 
             return false;

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -76,8 +75,40 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         _enableContentResponseOnWrite = options.EnableContentResponseOnWrite;
     }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     private CosmosClient Client
         => _singletonWrapper.Client;
+
+    private static bool DeserializeNextToken(JsonTextReader jsonReader, out JToken? token)
+    {
+        switch (jsonReader.TokenType)
+        {
+            case JsonToken.StartObject:
+                token = Serializer.Deserialize<JObject>(jsonReader);
+                return true;
+            case JsonToken.StartArray:
+                token = Serializer.Deserialize<JArray>(jsonReader);
+                return true;
+            case JsonToken.Date:
+            case JsonToken.Bytes:
+            case JsonToken.Float:
+            case JsonToken.String:
+            case JsonToken.Boolean:
+            case JsonToken.Integer:
+            case JsonToken.Null:
+                token = Serializer.Deserialize<JValue>(jsonReader);
+                return true;
+            case JsonToken.EndArray:
+            default:
+                token = null;
+                return false;
+        }
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -525,7 +556,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IEnumerable<JObject> ExecuteSqlQuery(
+    public virtual IEnumerable<JToken> ExecuteSqlQuery(
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery query)
@@ -543,7 +574,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IAsyncEnumerable<JObject> ExecuteSqlQueryAsync(
+    public virtual IAsyncEnumerable<JToken> ExecuteSqlQueryAsync(
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery query)
@@ -645,9 +676,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         using var reader = new StreamReader(responseStream);
         using var jsonReader = new JsonTextReader(reader);
 
-        var jObject = Serializer.Deserialize<JObject>(jsonReader);
-
-        return new JObject(new JProperty("c", jObject));
+        return Serializer.Deserialize<JObject>(jsonReader);
     }
 
     /// <summary>
@@ -677,6 +706,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
     private static JsonTextReader CreateJsonReader(TextReader reader)
     {
         var jsonReader = new JsonTextReader(reader);
+        jsonReader.DateParseHandling = DateParseHandling.None;
 
         while (jsonReader.Read())
         {
@@ -695,55 +725,38 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         return jsonReader;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool TryReadJObject(JsonTextReader jsonReader, [NotNullWhen(true)] out JObject? jObject)
-    {
-        jObject = null;
-
-        while (jsonReader.Read())
-        {
-            if (jsonReader.TokenType == JsonToken.StartObject)
-            {
-                jObject = Serializer.Deserialize<JObject>(jsonReader);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private sealed class DocumentEnumerable(
         CosmosClientWrapper cosmosClient,
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery cosmosSqlQuery)
-        : IEnumerable<JObject>
+        : IEnumerable<JToken>
     {
         private readonly CosmosClientWrapper _cosmosClient = cosmosClient;
         private readonly string _containerId = containerId;
         private readonly PartitionKey _partitionKeyValue = partitionKeyValue;
         private readonly CosmosSqlQuery _cosmosSqlQuery = cosmosSqlQuery;
 
-        public IEnumerator<JObject> GetEnumerator()
+        public IEnumerator<JToken> GetEnumerator()
             => new Enumerator(this);
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        private sealed class Enumerator(DocumentEnumerable documentEnumerable) : IEnumerator<JObject>
+        private sealed class Enumerator(DocumentEnumerable documentEnumerable) : IEnumerator<JToken>
         {
             private readonly CosmosClientWrapper _cosmosClientWrapper = documentEnumerable._cosmosClient;
             private readonly string _containerId = documentEnumerable._containerId;
             private readonly PartitionKey _partitionKeyValue = documentEnumerable._partitionKeyValue;
             private readonly CosmosSqlQuery _cosmosSqlQuery = documentEnumerable._cosmosSqlQuery;
 
-            private JObject? _current;
+            private JToken? _current;
             private ResponseMessage? _responseMessage;
-            private IEnumerator<JObject>? _responseMessageEnumerator;
+            private IEnumerator<JToken>? _responseMessageEnumerator;
 
             private FeedIterator? _query;
 
-            public JObject Current
+            public JToken Current
                 => _current ?? throw new InvalidOperationException();
 
             object IEnumerator.Current
@@ -821,31 +834,31 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery cosmosSqlQuery)
-        : IAsyncEnumerable<JObject>
+        : IAsyncEnumerable<JToken>
     {
         private readonly CosmosClientWrapper _cosmosClient = cosmosClient;
         private readonly string _containerId = containerId;
         private readonly PartitionKey _partitionKeyValue = partitionKeyValue;
         private readonly CosmosSqlQuery _cosmosSqlQuery = cosmosSqlQuery;
 
-        public IAsyncEnumerator<JObject> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        public IAsyncEnumerator<JToken> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             => new AsyncEnumerator(this, cancellationToken);
 
         private sealed class AsyncEnumerator(DocumentAsyncEnumerable documentEnumerable, CancellationToken cancellationToken)
-            : IAsyncEnumerator<JObject>
+            : IAsyncEnumerator<JToken>
         {
             private readonly CosmosClientWrapper _cosmosClientWrapper = documentEnumerable._cosmosClient;
             private readonly string _containerId = documentEnumerable._containerId;
             private readonly PartitionKey _partitionKeyValue = documentEnumerable._partitionKeyValue;
             private readonly CosmosSqlQuery _cosmosSqlQuery = documentEnumerable._cosmosSqlQuery;
 
-            private JObject? _current;
+            private JToken? _current;
             private ResponseMessage? _responseMessage;
-            private IAsyncEnumerator<JObject>? _responseMessageEnumerator;
+            private IAsyncEnumerator<JToken>? _responseMessageEnumerator;
 
             private FeedIterator? _query;
 
-            public JObject Current
+            public JToken Current
                 => _current ?? throw new InvalidOperationException();
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -926,28 +939,28 @@ public class CosmosClientWrapper : ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IEnumerable<JObject> GetResponseMessageEnumerable(ResponseMessage responseMessage)
+    public virtual IEnumerable<JToken> GetResponseMessageEnumerable(ResponseMessage responseMessage)
         => new ResponseMessageEnumerable(responseMessage);
 
-    private sealed class ResponseMessageEnumerable(ResponseMessage responseMessage) : IEnumerable<JObject>, IAsyncEnumerable<JObject>
+    private sealed class ResponseMessageEnumerable(ResponseMessage responseMessage) : IEnumerable<JToken>, IAsyncEnumerable<JToken>
     {
-        public IEnumerator<JObject> GetEnumerator()
+        public IEnumerator<JToken> GetEnumerator()
             => new ResponseMessageEnumerator(responseMessage);
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        public IAsyncEnumerator<JObject> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        public IAsyncEnumerator<JToken> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             => new ResponseMessageAsyncEnumerator(responseMessage);
     }
 
-    private sealed class ResponseMessageEnumerator : IEnumerator<JObject>
+    private sealed class ResponseMessageEnumerator : IEnumerator<JToken>
     {
         private readonly Stream _responseStream;
         private readonly StreamReader _reader;
         private readonly JsonTextReader _jsonReader;
 
-        private JObject? _current;
+        private JToken? _current;
 
         public ResponseMessageEnumerator(ResponseMessage responseMessage)
         {
@@ -960,17 +973,13 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         {
             while (_jsonReader.Read())
             {
-                if (_jsonReader.TokenType == JsonToken.StartObject)
-                {
-                    _current = Serializer.Deserialize<JObject>(_jsonReader);
-                    return true;
-                }
+                return DeserializeNextToken(_jsonReader, out _current);
             }
 
             return false;
         }
 
-        public JObject Current
+        public JToken Current
             => _current ?? throw new InvalidOperationException();
 
         object IEnumerator.Current
@@ -987,13 +996,13 @@ public class CosmosClientWrapper : ICosmosClientWrapper
             => throw new NotSupportedException();
     }
 
-    private sealed class ResponseMessageAsyncEnumerator : IAsyncEnumerator<JObject>
+    private sealed class ResponseMessageAsyncEnumerator : IAsyncEnumerator<JToken>
     {
         private readonly Stream _responseStream;
         private readonly StreamReader _reader;
         private readonly JsonTextReader _jsonReader;
 
-        private JObject? _current;
+        private JToken? _current;
 
         public ResponseMessageAsyncEnumerator(ResponseMessage responseMessage)
         {
@@ -1006,17 +1015,13 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         {
             while (await _jsonReader.ReadAsync().ConfigureAwait(false))
             {
-                if (_jsonReader.TokenType == JsonToken.StartObject)
-                {
-                    _current = Serializer.Deserialize<JObject>(_jsonReader);
-                    return true;
-                }
+                return DeserializeNextToken(_jsonReader, out _current);
             }
 
             return false;
         }
 
-        public JObject Current
+        public JToken Current
             => _current ?? throw new InvalidOperationException();
 
         public async ValueTask DisposeAsync()

--- a/src/EFCore.Cosmos/Storage/Internal/ICosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/ICosmosClientWrapper.cs
@@ -170,7 +170,7 @@ public interface ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IEnumerable<JObject> ExecuteSqlQuery(
+    IEnumerable<JToken> ExecuteSqlQuery(
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery query);
@@ -181,7 +181,7 @@ public interface ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IAsyncEnumerable<JObject> ExecuteSqlQueryAsync(
+    IAsyncEnumerable<JToken> ExecuteSqlQueryAsync(
         string containerId,
         PartitionKey partitionKeyValue,
         CosmosSqlQuery query);
@@ -192,5 +192,5 @@ public interface ICosmosClientWrapper
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IEnumerable<JObject> GetResponseMessageEnumerable(ResponseMessage responseMessage);
+    IEnumerable<JToken> GetResponseMessageEnumerable(ResponseMessage responseMessage);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -74,7 +74,7 @@ public class CustomConvertersCosmosTest : CustomConvertersTestBase<CustomConvert
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND (c["IsVisible"] = "Y"))
 """);
@@ -87,7 +87,7 @@ WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND (c["IsVisible"] = "Y"))
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND NOT((c["IsVisible"] = "Y")))
 """);
@@ -100,7 +100,7 @@ WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND NOT((c["IsVisible"] = "Y"))
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND (c["IsVisible"] = "Y"))
 """);
@@ -113,7 +113,7 @@ WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND (c["IsVisible"] = "Y"))
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND NOT((c["IndexerVisible"] = "Aye")))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -533,7 +533,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Vehicle", "PoweredVehicle") AND (c["Name"] = "AIM-9M Sidewinder"))
 OFFSET 0 LIMIT 1

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -1342,7 +1342,7 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
                 """
 @__p_3='42'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Id"] = @__p_3)
 OFFSET 0 LIMIT 1
@@ -1487,7 +1487,7 @@ OFFSET 0 LIMIT 1
                 """
 @__p_0='42'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["id"] = @__p_0)
 OFFSET 0 LIMIT 1

--- a/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
@@ -297,7 +297,7 @@ public abstract class FindCosmosTest : FindTestBase<FindCosmosTest.FindCosmosFix
             """
 @__p_0='77'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("BaseType", "DerivedType") AND (c["Id"] = @__p_0))
 OFFSET 0 LIMIT 1
@@ -311,7 +311,7 @@ OFFSET 0 LIMIT 1
         AssertSql("""
 @__p_0='99'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("BaseType", "DerivedType") AND (c["Id"] = @__p_0))
 OFFSET 0 LIMIT 1

--- a/test/EFCore.Cosmos.FunctionalTests/HierarchicalPartitionKeyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/HierarchicalPartitionKeyTest.cs
@@ -27,7 +27,7 @@ public class HierarchicalPartitionKeyTest : IClassFixture<HierarchicalPartitionK
     {
         const string read1Sql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 ORDER BY c["PartitionKey1"]
 OFFSET 0 LIMIT 1
@@ -37,7 +37,7 @@ OFFSET 0 LIMIT 1
             """
 @__p_0='1'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 ORDER BY c["PartitionKey1"]
 OFFSET @__p_0 LIMIT 1
@@ -58,7 +58,7 @@ OFFSET @__p_0 LIMIT 1
     {
         const string readSql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 OFFSET 0 LIMIT 2
 """;
@@ -78,7 +78,7 @@ OFFSET 0 LIMIT 2
     {
         const string readSql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Id"] = 42) OR (c["Name"] = "John Snow"))
 OFFSET 0 LIMIT 2

--- a/test/EFCore.Cosmos.FunctionalTests/PartitionKeyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/PartitionKeyTest.cs
@@ -29,7 +29,7 @@ public class PartitionKeyTest : IClassFixture<PartitionKeyTest.CosmosPartitionKe
     {
         const string readSql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 ORDER BY c["PartitionKey"]
 OFFSET 0 LIMIT 1
@@ -48,7 +48,7 @@ OFFSET 0 LIMIT 1
     {
         const string readSql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 OFFSET 0 LIMIT 2
 """;
@@ -66,7 +66,7 @@ OFFSET 0 LIMIT 2
     {
         const string readSql =
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Id"] = 42) OR (c["Name"] = "John Snow"))
 OFFSET 0 LIMIT 1
@@ -120,7 +120,6 @@ OFFSET 0 LIMIT 1
             var customerFromStore = await readSingleTask(innerContext);
 
             AssertSql(readSql);
-
             Assert.Equal(42, customerFromStore.Id);
             Assert.Equal("Theon", customerFromStore.Name);
             Assert.Equal(1, customerFromStore.PartitionKey);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -40,7 +40,7 @@ public class FromSqlQueryCosmosTest : QueryTestBase<NorthwindQueryCosmosFixture<
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["ContactName"] LIKE '%z%'
 ) s
@@ -83,7 +83,7 @@ SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["Phone"], c[
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["Phone"], c["Fax"], c["CustomerID"], c["Country"], c["ContactTitle"], c["ContactName"], c["CompanyName"], c["City"], c["Address"] FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -111,7 +111,7 @@ SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["PostalCode"
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT c["id"], c["Discriminator"], c["Region"], c["PostalCode"], c["PostalCode"] AS Foo, c["Phone"], c["Fax"], c["CustomerID"], c["Country"], c["ContactTitle"], c["ContactName"], c["CompanyName"], c["City"], c["Address"] FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -141,7 +141,7 @@ FROM (
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -168,12 +168,10 @@ WHERE CONTAINS(s["ContactName"], "z")
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
 
-
-""" + "        " + """
-
+        
 
 
     SELECT
@@ -222,7 +220,7 @@ WHERE CONTAINS(s["ContactName"], "z")
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -267,7 +265,7 @@ WHERE CONTAINS(s["ContactName"], "z")
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["CustomerID"] = "CONSH"
 ) s
@@ -298,7 +296,7 @@ WHERE c["Discriminator"] = "Customer" AND c["City"] = 'London'
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT *
     FROM root c
@@ -331,7 +329,7 @@ WHERE c["Discriminator"] = "Customer"
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT *
     FROM root c
@@ -369,7 +367,7 @@ WHERE (s["City"] = "London")
 @p0='London'
 @p1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s
@@ -401,7 +399,7 @@ FROM (
 @p0='London'
 @p1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s
@@ -431,7 +429,7 @@ FROM (
                     """
 @p0=null
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Employee" AND c["ReportsTo"] = @p0 OR (IS_NULL(c["ReportsTo"]) AND IS_NULL(@p0))
 ) s
@@ -466,7 +464,7 @@ FROM (
 @p0='London'
 @__contactTitle_1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0
 ) s
@@ -503,14 +501,14 @@ WHERE (s["ContactTitle"] = @__contactTitle_1)
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = 'London'
 ) s
 """,
                     //
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = 'Seattle'
 ) s
@@ -557,7 +555,7 @@ FROM (
 @p0='London'
 @p1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s
@@ -567,7 +565,7 @@ FROM (
 @p0='Madrid'
 @p1='Accounting Manager'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer" AND c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s
@@ -595,7 +593,7 @@ FROM (
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -625,7 +623,7 @@ WHERE c["Discriminator"] = "Product" AND NOT c["Discontinued"] AND ((c["UnitsInS
 
                 AssertSql(
                     """
-SELECT s["ProductName"]
+SELECT VALUE s["ProductName"]
 FROM (
     SELECT *
     FROM root c
@@ -654,7 +652,7 @@ FROM (
 
                 AssertSql(
                     """
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["Discriminator"] = "Customer"
 ) s
@@ -748,7 +746,7 @@ FROM (
 @p0='London'
 @p1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s
@@ -772,7 +770,7 @@ FROM (
 @p0='London'
 @p1='Sales Representative'
 
-SELECT s
+SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["City"] = @p0 AND c["ContactTitle"] = @p1
 ) s

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -171,7 +171,9 @@ WHERE CONTAINS(s["ContactName"], "z")
 SELECT VALUE s
 FROM (
 
-        
+
+""" + "        " + """
+
 
 
     SELECT

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
@@ -22,21 +22,21 @@ public class InheritanceQueryCosmosTest : InheritanceQueryTestBase<InheritanceQu
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = 1)
 OFFSET 0 LIMIT 2
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = 2)
 OFFSET 0 LIMIT 2
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = 3)
 OFFSET 0 LIMIT 2
@@ -51,7 +51,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN (0, 1, 2, 3)
 """);
@@ -65,7 +65,7 @@ WHERE c["Discriminator"] IN (0, 1, 2, 3)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
@@ -80,7 +80,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
@@ -94,10 +94,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT VALUE
-{
-    "Value" : ((c["Discriminator"] = "Kiwi") ? c["FoundOn"] : 0)
-}
+SELECT VALUE ((c["Discriminator"] = "Kiwi") ? c["FoundOn"] : 0)
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -111,7 +108,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
@@ -125,7 +122,7 @@ WHERE (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ((c["Discriminator"] = "Kiwi") AND (c["CountryId"] = 1)))
 """);
@@ -139,7 +136,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ((c["Discriminator"] = "Kiwi"
 
                 AssertSql(
                     """
-SELECT (c["Discriminator"] = "Kiwi") AS c
+SELECT VALUE (c["Discriminator"] = "Kiwi")
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -153,7 +150,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
@@ -168,7 +165,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["CountryId"] = 1)) AND c["Discriminator"] IN ("Eagle", "Kiwi"))
 ORDER BY c["Species"]
@@ -183,7 +180,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c["EagleId"]
+SELECT VALUE c["EagleId"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -197,7 +194,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
@@ -213,7 +210,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
@@ -227,7 +224,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
@@ -241,7 +238,7 @@ WHERE (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Daisy", "Rose") AND (c["Discriminator"] = "Rose"))
 """);
@@ -255,7 +252,7 @@ WHERE (c["Discriminator"] IN ("Daisy", "Rose") AND (c["Discriminator"] = "Rose")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
@@ -278,7 +275,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Daisy", "Rose")
 ORDER BY c["Species"]
@@ -293,7 +290,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Name"] = "Great spotted kiwi"))
 ORDER BY c["Species"]
@@ -308,7 +305,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 ORDER BY c["Species"]
@@ -323,7 +320,7 @@ ORDER BY c["Species"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 OFFSET 0 LIMIT 2
@@ -338,7 +335,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Rose")
 OFFSET 0 LIMIT 2
@@ -369,7 +366,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["FoundOn"] = 1))
 """);
@@ -383,7 +380,7 @@ WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["FoundOn"] = 0))
 """);
@@ -397,7 +394,7 @@ WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"
 
                 AssertSql(
                     """
-SELECT c["FoundOn"]
+SELECT VALUE c["FoundOn"]
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
@@ -425,7 +422,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c["Name"] AS Predator
+SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ("Kiwi" = c["Discriminator"]))
 """);
@@ -439,7 +436,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND ("Kiwi" = c["Discriminator"])
 
                 AssertSql(
                     """
-SELECT c["FoundOn"]
+SELECT VALUE c["FoundOn"]
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
@@ -484,7 +481,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
                     """
 @__p_0='5'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 ORDER BY c["Species"]
@@ -505,7 +502,7 @@ OFFSET 0 LIMIT @__p_0
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 OFFSET 0 LIMIT 2
@@ -520,7 +517,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT (c["IsFlightless"] ? 0 : 1) AS c
+SELECT VALUE (c["IsFlightless"] ? 0 : 1)
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 """);
@@ -532,7 +529,7 @@ WHERE (c["Discriminator"] = "Kiwi")
 
         AssertSql(
             """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] = "Kiwi")
 ORDER BY c["Name"]
@@ -555,7 +552,7 @@ ORDER BY c["Name"]
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -569,7 +566,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 """);
@@ -583,7 +580,7 @@ WHERE c["Discriminator"] IN ("Eagle", "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -597,7 +594,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -611,7 +608,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Eagle"))
 """);
@@ -625,7 +622,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Eagle"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
@@ -639,7 +636,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"))
 """);
@@ -653,7 +650,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] != "Kiwi"))
 """);
@@ -667,7 +664,7 @@ WHERE (c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] != "Kiwi"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["Discriminator"] = "Eagle"))
 """);
@@ -681,7 +678,7 @@ WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] IN ("Eagle", "Kiwi") AND (c["Discriminator"] = "Kiwi")) AND (c["Discriminator"] = "Eagle"))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
@@ -13,7 +13,7 @@ public class NonSharedPrimitiveCollectionsQueryCosmosTest : NonSharedPrimitiveCo
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -29,7 +29,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -45,7 +45,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -61,7 +61,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -82,7 +82,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -98,7 +98,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -114,7 +114,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -130,7 +130,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -146,7 +146,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -162,7 +162,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -178,7 +178,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -194,7 +194,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -210,7 +210,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -226,7 +226,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -242,7 +242,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -258,7 +258,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -274,7 +274,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -291,7 +291,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -307,7 +307,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -331,7 +331,7 @@ OFFSET 0 LIMIT 2
             """
 @__ints_0='1,2,3'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"] = @__ints_0)
 OFFSET 0 LIMIT 2
@@ -359,7 +359,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -375,7 +375,7 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-SELECT c["Ints"]
+SELECT VALUE c["Ints"]
 FROM root c
 WHERE (c["Discriminator"] = "TestEntityWithOwned")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -35,7 +35,7 @@ public class NorthwindAggregateOperatorsQueryCosmosTest
 
                 AssertSql(
                     """
-SELECT AVG((c["OrderID"] - 10248)) AS c
+SELECT VALUE AVG((c["OrderID"] - 10248))
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
@@ -63,7 +63,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
                     """
 @__Select_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["CustomerID"]))
 """);
@@ -79,7 +79,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["Cust
                     """
 @__Select_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["CustomerID"]))
 """,
@@ -87,7 +87,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["Cust
                     """
 @__Select_0='["ABCDE","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["CustomerID"]))
 """);
@@ -101,19 +101,19 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Select_0, c["Cust
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """,
                     //
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """,
                     //
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -127,7 +127,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
@@ -143,7 +143,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT MAX((c["OrderID"] - 10248)) AS c
+SELECT VALUE MAX((c["OrderID"] - 10248))
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
@@ -157,7 +157,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 
                 AssertSql(
                     """
-SELECT MIN((c["OrderID"] - 10248)) AS c
+SELECT VALUE MIN((c["OrderID"] - 10248))
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 """);
@@ -171,7 +171,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10248))
 
                 AssertSql(
                     """
-SELECT SUM(c["OrderID"]) AS c
+SELECT VALUE SUM(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 """);
@@ -185,7 +185,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
@@ -202,7 +202,7 @@ OFFSET 0 LIMIT 1
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT 2
@@ -218,7 +218,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
@@ -243,7 +243,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
@@ -259,7 +259,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "WRONG"))
 """);
@@ -273,7 +273,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "WRONG
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
@@ -299,7 +299,7 @@ OFFSET 0 LIMIT 1
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT 2
@@ -315,7 +315,7 @@ OFFSET 0 LIMIT 2
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"]
@@ -352,7 +352,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT SUM(c["OrderID"]) AS c
+SELECT VALUE SUM(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -366,7 +366,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT SUM(c["OrderID"]) AS c
+SELECT VALUE SUM(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 0))
 """);
@@ -380,7 +380,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 0))
 
                 AssertSql(
                     """
-SELECT SUM((c["OrderID"] * 2)) AS c
+SELECT VALUE SUM((c["OrderID"] * 2))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -394,7 +394,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT SUM(c["OrderID"]) AS c
+SELECT VALUE SUM(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 """);
@@ -408,7 +408,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 42))
 
                 AssertSql(
                     """
-SELECT SUM(c["SupplierID"]) AS c
+SELECT VALUE SUM(c["SupplierID"])
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 """);
@@ -422,7 +422,7 @@ WHERE (c["Discriminator"] = "Product")
 
                 AssertSql(
                     """
-SELECT SUM(c["OrderID"]) AS c
+SELECT VALUE SUM(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -436,7 +436,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT SUM((c["OrderID"] + c["OrderID"])) AS c
+SELECT VALUE SUM((c["OrderID"] + c["OrderID"]))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -467,7 +467,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT SUM(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
+SELECT VALUE SUM(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0))
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
@@ -505,7 +505,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 
                 AssertSql(
                     """
-SELECT SUM(c["Discount"]) AS c
+SELECT VALUE SUM(c["Discount"])
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 """);
@@ -528,40 +528,56 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 
             AssertSql(
                 """
-SELECT AVG(c["OrderID"]) AS c
+SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
         }
     }
 
-    public override Task Average_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_no_data_nullable(a);
+    public override async Task Average_no_data_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Average_no_data_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT AVG(c["SupplierID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE AVG(c["SupplierID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
-    public override Task Average_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Average_no_data_cast_to_nullable(a);
+    public override async Task Average_no_data_cast_to_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Average_no_data_cast_to_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT AVG(c["OrderID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
     public override async Task Min_no_data(bool async)
     {
@@ -572,7 +588,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 
             AssertSql(
                 """
-SELECT MIN(c["OrderID"]) AS c
+SELECT VALUE MIN(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
@@ -588,7 +604,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 
             AssertSql(
                 """
-SELECT MAX(c["OrderID"]) AS c
+SELECT VALUE MAX(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
@@ -611,33 +627,49 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
         AssertSql();
     }
 
-    public override Task Max_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_no_data_nullable(a);
+    public override async Task Max_no_data_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_no_data_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT MAX(c["SupplierID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE MAX(c["SupplierID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
-    public override Task Max_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Max_no_data_cast_to_nullable(a);
+    public override async Task Max_no_data_cast_to_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_no_data_cast_to_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT MAX(c["OrderID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE MAX(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
     public override async Task Min_no_data_subquery(bool async)
     {
@@ -657,7 +689,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 
             AssertSql(
                 """
-SELECT AVG(c["OrderID"]) AS c
+SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -672,7 +704,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT AVG((c["OrderID"] * 2)) AS c
+SELECT VALUE AVG((c["OrderID"] * 2))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -688,7 +720,7 @@ WHERE (c["Discriminator"] = "Order")
 
             AssertSql(
                 """
-SELECT AVG(c["OrderID"]) AS c
+SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -703,7 +735,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT AVG((c["OrderID"] + c["OrderID"])) AS c
+SELECT VALUE AVG((c["OrderID"] + c["OrderID"]))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -734,7 +766,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT AVG(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
+SELECT VALUE AVG(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0))
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
@@ -772,7 +804,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 
                 AssertSql(
                     """
-SELECT AVG(c["Discount"]) AS c
+SELECT VALUE AVG(c["Discount"])
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 """);
@@ -802,7 +834,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["ProductID"] = 1))
 
                 AssertSql(
                     """
-SELECT MIN(c["OrderID"]) AS c
+SELECT VALUE MIN(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -816,39 +848,55 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT MIN(c["OrderID"]) AS c
+SELECT VALUE MIN(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
             });
 
-    public override Task Min_no_data_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_no_data_nullable(a);
+    public override async Task Min_no_data_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Min_no_data_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT MIN(c["SupplierID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE MIN(c["SupplierID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["SupplierID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
-    public override Task Min_no_data_cast_to_nullable(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Min_no_data_cast_to_nullable(a);
+    public override async Task Min_no_data_cast_to_nullable(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            await Fixture.NoSyncTest(
+                async, async a =>
+                {
+                    Assert.Equal(
+                        CoreStrings.SequenceContainsNoElements,
+                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Min_no_data_cast_to_nullable(a))).Message);
 
-                AssertSql(
-                    """
-SELECT MIN(c["OrderID"]) AS c
+                    AssertSql(
+                        """
+SELECT VALUE MIN(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 """);
-            });
+                });
+        }
+    }
 
     public override Task Min_with_coalesce(bool async)
         => Fixture.NoSyncTest(
@@ -858,7 +906,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = -1))
 
                 AssertSql(
                     """
-SELECT MIN(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
+SELECT VALUE MIN(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0))
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
@@ -896,7 +944,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 
                 AssertSql(
                     """
-SELECT MAX(c["OrderID"]) AS c
+SELECT VALUE MAX(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -910,7 +958,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT MAX(c["OrderID"]) AS c
+SELECT VALUE MAX(c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -924,7 +972,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT MAX(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)) AS c
+SELECT VALUE MAX(((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0))
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 """);
@@ -962,7 +1010,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["ProductID"] < 40))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -976,7 +1024,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -990,7 +1038,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1004,7 +1052,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1018,7 +1066,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1032,7 +1080,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1046,7 +1094,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (((c["Discriminator"] = "Order") AND (c["OrderID"] > 10)) AND (c["CustomerID"] != "ALFKI"))
 """);
@@ -1129,7 +1177,7 @@ WHERE (((c["Discriminator"] = "Order") AND (c["OrderID"] > 10)) AND (c["Customer
                 """
 @__p_0='10'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY 42
@@ -1146,7 +1194,7 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1262,7 +1310,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"] DESC
@@ -1296,7 +1344,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
@@ -1312,7 +1360,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
@@ -1328,7 +1376,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"] DESC
@@ -1344,7 +1392,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
@@ -1360,7 +1408,7 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["ContactName"] DESC
@@ -1386,7 +1434,7 @@ OFFSET 0 LIMIT 1
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """,
@@ -1394,7 +1442,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1418,7 +1466,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='[0,1]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["EmployeeID"]))
 """,
@@ -1426,7 +1474,7 @@ WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["Employe
                     """
 @__ids_0='[0]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["EmployeeID"]))
 """);
@@ -1442,7 +1490,7 @@ WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["Employe
                     """
 @__ids_0='[0,1]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["EmployeeID"]))
 """,
@@ -1450,7 +1498,7 @@ WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["Employe
                     """
 @__ids_0='[0]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["EmployeeID"]))
 """);
@@ -1464,7 +1512,7 @@ WHERE ((c["Discriminator"] = "Employee") AND ARRAY_CONTAINS(@__ids_0, c["Employe
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
@@ -1480,7 +1528,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1496,7 +1544,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1512,7 +1560,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='[null,null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1526,7 +1574,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
@@ -1542,7 +1590,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 @__p_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__p_0, c["CustomerID"]))
 """,
@@ -1550,7 +1598,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__p_0, c["CustomerI
                     """
 @__p_0='["ABCDE","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__p_0, c["CustomerID"]))
 """);
@@ -1565,7 +1613,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__p_0, c["CustomerI
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """,
@@ -1573,7 +1621,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1589,7 +1637,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1605,7 +1653,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='[]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1619,7 +1667,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
     SELECT 1
@@ -1638,7 +1686,7 @@ WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
                     """
 @__p_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
     SELECT 1
@@ -1649,7 +1697,7 @@ WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
                     """
 @__p_0='["ABCDE","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
     SELECT 1
@@ -1668,7 +1716,7 @@ WHERE ((c["Discriminator"] = "Customer") AND EXISTS (
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """,
@@ -1676,7 +1724,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1692,7 +1740,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1708,7 +1756,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='[null,null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1722,7 +1770,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
@@ -1738,7 +1786,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 @__Order_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Order_0, c["CustomerID"]))
 """,
@@ -1746,7 +1794,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Order_0, c["Custo
                     """
 @__Order_0='["ABCDE","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Order_0, c["CustomerID"]))
 """);
@@ -1762,7 +1810,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__Order_0, c["Custo
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """,
@@ -1770,7 +1818,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1786,7 +1834,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1802,7 +1850,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='[null,null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1816,7 +1864,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
 """);
@@ -1832,7 +1880,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 @__AsReadOnly_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__AsReadOnly_0, c["CustomerID"]))
 """,
@@ -1840,7 +1888,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__AsReadOnly_0, c["
                     """
 @__AsReadOnly_0='["ABCDE","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__AsReadOnly_0, c["CustomerID"]))
 """);
@@ -1856,7 +1904,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__AsReadOnly_0, c["
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """);
@@ -1872,7 +1920,7 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["Cus
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE")) AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """);
@@ -1888,7 +1936,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["CustomerID"]) OR ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE"))))
 """);
@@ -1904,7 +1952,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["Custom
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE")) OR NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))))
 """);
@@ -1920,7 +1968,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") OR (c
                     """
 @__ids_0='["ABCDE","ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["CustomerID"]) AND ((c["CustomerID"] != "ALFKI") AND (c["CustomerID"] != "ABCDE"))))
 """);
@@ -1936,7 +1984,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["Custom
                     """
 @__ids_0='["ALFKI","ABC')); GO; DROP TABLE Orders; GO; --"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["CustomerID"]) OR ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ABCDE"))))
 """);
@@ -1952,7 +2000,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__ids_0, c["Custom
                     """
 @__ids_0='[]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -1966,7 +2014,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT(false))
 """);
@@ -1986,10 +2034,10 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT(false))
                 """
 @__p_0='ALFKI'
 
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0))) AS c
+    WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__p_0)))
 """);
         }
     }
@@ -2112,7 +2160,7 @@ SELECT EXISTS (
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR"))
 """);
@@ -2126,7 +2174,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR"))
 """);
@@ -2140,7 +2188,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ALFKI", "ANATR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
@@ -2154,7 +2202,7 @@ WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 """);
@@ -2168,7 +2216,7 @@ WHERE ((c["Discriminator"] = "Order") AND c["OrderID"] IN (10248, 10249))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -2182,7 +2230,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -2198,7 +2246,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
                     """
 @__ids_0='["ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -2214,7 +2262,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ALFKI"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -2235,10 +2283,10 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                 """
 @__entity_equality_p_0_OrderID=null
 
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @__entity_equality_p_0_OrderID))) AS c
+    WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @__entity_equality_p_0_OrderID)))
 """);
         }
     }
@@ -2259,7 +2307,7 @@ SELECT EXISTS (
 
                 AssertSql(
                     """
-SELECT LEFT(c["CustomerID"], 1) AS c
+SELECT VALUE LEFT(c["CustomerID"], 1)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2273,7 +2321,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT SUM(1) AS c
+SELECT VALUE SUM(1)
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
@@ -2289,7 +2337,7 @@ WHERE (c["Discriminator"] = "Employee")
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -2303,7 +2351,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI", "ANATR"))
 """);
@@ -2319,7 +2367,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -2335,7 +2383,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__ids_0, c["Custome
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """,
@@ -2343,7 +2391,7 @@ WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND 
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND ARRAY_CONTAINS(@__ids_0, c["CustomerID"]))
 """);
@@ -2359,7 +2407,7 @@ WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND 
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """);
@@ -2373,7 +2421,7 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["Cus
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "ALFKI", "ANATR"))
 """);
@@ -2389,7 +2437,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] NOT IN ("ABCDE", "A
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """);
@@ -2405,7 +2453,7 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT(ARRAY_CONTAINS(@__ids_0, c["Cus
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """,
@@ -2413,7 +2461,7 @@ WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND 
                     """
 @__ids_0='["ABCDE","ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND NOT(ARRAY_CONTAINS(@__ids_0, c["CustomerID"])))
 """);
@@ -2427,7 +2475,7 @@ WHERE (((c["Discriminator"] = "Customer") AND (c["City"] = "México D.F.")) AND 
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2637,7 +2685,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT AVG((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1.0 : 0.0)) AS c
+SELECT VALUE AVG((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1.0 : 0.0))
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2653,7 +2701,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT SUM((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0)) AS c
+SELECT VALUE SUM((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2669,7 +2717,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City"]))
 """);
@@ -2685,7 +2733,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City"]))
 """);
@@ -2701,7 +2749,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT MAX((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0)) AS c
+SELECT VALUE MAX((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2717,7 +2765,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__cities_0='["London","Berlin"]'
 
-SELECT MIN((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0)) AS c
+SELECT VALUE MIN((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
@@ -62,7 +62,7 @@ public class NorthwindDbFunctionsQueryCosmosTest : NorthwindDbFunctionsQueryTest
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (RAND() < 1.0))
 """);
@@ -76,7 +76,7 @@ WHERE ((c["Discriminator"] = "Order") AND (RAND() < 1.0))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (RAND() >= 0.0))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -34,7 +34,7 @@ public class NorthwindFunctionsQueryCosmosTest : NorthwindFunctionsQueryTestBase
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
@@ -50,7 +50,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
                     """
 @__pattern_0='M'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], @__pattern_0))
 """);
@@ -64,7 +64,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], @__pat
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
@@ -78,7 +78,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["Con
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
@@ -92,7 +92,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["Con
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
@@ -106,7 +106,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", false))
 """);
@@ -120,7 +120,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", true))
 """);
@@ -147,7 +147,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CompanyName"], "Qu", 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "b"))
 """);
@@ -163,7 +163,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "b"))
                     """
 @__pattern_0='b'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], @__pattern_0))
 """);
@@ -177,7 +177,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], @__patte
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
@@ -191,7 +191,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["Conta
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
@@ -205,7 +205,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["Conta
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "m"))
 """);
@@ -219,7 +219,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "m"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", false))
 """);
@@ -233,7 +233,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", fa
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", true))
 """);
@@ -260,7 +260,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "DY", tr
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
 """);
@@ -273,7 +273,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
                 await base.String_Contains_Identity(a);
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], c["ContactName"]))
 """);
@@ -287,7 +287,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], c["Conta
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["CompanyName"], c["ContactName"]))
 """);
@@ -301,7 +301,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["CompanyName"], c["Conta
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", false))
 """);
@@ -315,7 +315,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", fal
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", true))
 """);
@@ -340,7 +340,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M", tru
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LEFT(c["ContactName"], 1) = "A"))
 """);
@@ -354,7 +354,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (LEFT(c["ContactName"], 1) = "A"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (RIGHT(c["ContactName"], 1) = "s"))
 """);
@@ -368,7 +368,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (RIGHT(c["ContactName"], 1) = "s"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
 """);
@@ -478,7 +478,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "M"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (ABS(c["ProductID"]) > 10))
 """);
@@ -492,7 +492,7 @@ WHERE ((c["Discriminator"] = "Product") AND (ABS(c["ProductID"]) > 10))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (ABS(c["Quantity"]) > 10))
 """);
@@ -506,7 +506,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (AB
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ABS(c["UnitPrice"]) > 10.0))
 """);
@@ -520,7 +520,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ABS(c
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (10 < c["ProductID"]))
 """);
@@ -542,7 +542,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (10
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (CEILING(c["UnitPrice"]) > 10.0))
 """);
@@ -556,7 +556,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (CEILI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (FLOOR(c["UnitPrice"]) > 10.0))
 """);
@@ -586,7 +586,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (FLOOR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ROUND(c["UnitPrice"]) > 10.0))
 """);
@@ -612,7 +612,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (ROUND
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
@@ -626,7 +626,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
@@ -648,7 +648,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (TRUNC(c["UnitPrice"]) > 10.0))
 """);
@@ -758,7 +758,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5)) AND (TRUNC
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIGN(c["Discount"]) > 0))
 """);
@@ -844,7 +844,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (CEILING(c["Discount"]) > 0.0))
 """);
@@ -866,7 +866,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["UnitPrice"] < 7.0)) AND (CE
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 3.0) > 0.005))
 """);
@@ -880,7 +880,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 3.0) > 0.0
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 2.0) > 0.05))
 """);
@@ -910,7 +910,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (POWER(c["Discount"], 2.0) > 0.0
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (EXP(c["Discount"]) > 1.0))
 """);
@@ -924,7 +924,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (EX
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG10(c["Discount"]) < 0.0))
 """);
@@ -938,7 +938,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG(c["Discount"]) < 0.0))
 """);
@@ -952,7 +952,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c["Discount"] > 0.0))) AND (LOG(c["Discount"], 7.0) < -1.0))
 """);
@@ -966,7 +966,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = 11077) AND (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SQRT(c["Discount"]) > 0.0))
 """);
@@ -980,7 +980,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SQ
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ACOS(c["Discount"]) > 1.0))
 """);
@@ -994,7 +994,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (AC
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ASIN(c["Discount"]) > 0.0))
 """);
@@ -1008,7 +1008,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (AS
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ATAN(c["Discount"]) > 0.0))
 """);
@@ -1022,7 +1022,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (AT
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (ATN2(c["Discount"], 1.0) > 0.0))
 """);
@@ -1036,7 +1036,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (AT
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (COS(c["Discount"]) > 0.0))
 """);
@@ -1050,7 +1050,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (CO
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIN(c["Discount"]) > 0.0))
 """);
@@ -1064,7 +1064,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (TAN(c["Discount"]) > 0.0))
 """);
@@ -1078,7 +1078,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (TA
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SIGN(c["Discount"]) > 0))
 """);
@@ -1092,7 +1092,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (DEGREES(c["Discount"]) > 0.0))
 """);
@@ -1106,7 +1106,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (DE
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (RADIANS(c["Discount"]) > 0.0))
 """);
@@ -1128,7 +1128,7 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (RA
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (UPPER(c["CustomerID"]) = "ALFKI"))
 """);
@@ -1142,7 +1142,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (UPPER(c["CustomerID"]) = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LOWER(c["CustomerID"]) = "alfki"))
 """);
@@ -1228,7 +1228,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (LOWER(c["CustomerID"]) = "alfki"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["Region"], "") = 0))
 """);
@@ -1242,7 +1242,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["Region"], "") = 0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a") = 1))
 """);
@@ -1258,7 +1258,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a") = 
                     """
 @__pattern_0='a'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], @__pattern_0) = 1))
 """);
@@ -1272,7 +1272,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], @__patt
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", 2) = 4))
 """);
@@ -1288,7 +1288,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", 2)
                     """
 @__start_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", @__start_0) = 4))
 """);
@@ -1302,7 +1302,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["ContactName"], "a", @_
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], "ia", "") = "Mar Anders"))
 """);
@@ -1316,7 +1316,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], "ia", ""
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], c["ContactName"], c["CustomerID"]) = c["CustomerID"]))
 """);
@@ -1330,7 +1330,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["ContactName"], c["Conta
 
                 AssertSql(
                     """
-SELECT c["ContactName"]
+SELECT VALUE c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 0, LENGTH(c["CustomerID"])) = "ALFKI"))
 """);
@@ -1344,7 +1344,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 0, LENG
 
                 AssertSql(
                     """
-SELECT c["ContactName"]
+SELECT VALUE c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 1, LENGTH(c["CustomerID"])) = "LFKI"))
 """);
@@ -1360,7 +1360,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], 1, LENG
                     """
 @__start_0='2'
 
-SELECT c["ContactName"]
+SELECT VALUE c["ContactName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], @__start_0, LENGTH(c["CustomerID"])) = "FKI"))
 """);
@@ -1374,7 +1374,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["CustomerID"], @__star
 
                 AssertSql(
                     """
-SELECT LEFT(c["ContactName"], 3) AS c
+SELECT VALUE LEFT(c["ContactName"], 3)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1388,7 +1388,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT SUBSTRING(c["ContactName"], 2, 0) AS c
+SELECT VALUE SUBSTRING(c["ContactName"], 2, 0)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1402,7 +1402,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT SUBSTRING(c["ContactName"], 1, 3) AS c
+SELECT VALUE SUBSTRING(c["ContactName"], 1, 3)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1418,7 +1418,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
                     """
 @__start_0='2'
 
-SELECT SUBSTRING(c["ContactName"], @__start_0, 3) AS c
+SELECT VALUE SUBSTRING(c["ContactName"], @__start_0, 3)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1432,7 +1432,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT SUBSTRING(c["ContactName"], INDEX_OF(c["ContactName"], "a"), 3) AS c
+SELECT VALUE SUBSTRING(c["ContactName"], INDEX_OF(c["ContactName"], "a"), 3)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1506,7 +1506,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LTRIM(c["ContactTitle"]) = "Owner"))
 """);
@@ -1536,7 +1536,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (LTRIM(c["ContactTitle"]) = "Owner"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (RTRIM(c["ContactTitle"]) = "Owner"))
 """);
@@ -1566,7 +1566,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (RTRIM(c["ContactTitle"]) = "Owner"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (TRIM(c["ContactTitle"]) = "Owner"))
 """);
@@ -1598,7 +1598,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (TRIM(c["ContactTitle"]) = "Owner")
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY LENGTH(c["CustomerID"]), c["CustomerID"]
@@ -1634,7 +1634,7 @@ ORDER BY LENGTH(c["CustomerID"]), c["CustomerID"]
                     """
 @__arg_0='1996-07-04T00:00:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] = @__arg_0))
 """);
@@ -1648,7 +1648,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] = @__arg_0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1710,7 +1710,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 """);
@@ -1724,7 +1724,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch("ALFKI", c["CustomerID"]))
 """);
@@ -1742,7 +1742,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch("ALFKI", c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 """);
@@ -1760,7 +1760,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "i"))
 """);
@@ -1778,7 +1778,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "m"))
 """);
@@ -1796,7 +1796,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "s"))
 """);
@@ -1814,7 +1814,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "x"))
 """);
@@ -1833,7 +1833,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "ix"))
 """);
@@ -1868,7 +1868,7 @@ WHERE ((c["Discriminator"] = "Customer") AND RegexMatch(c["CustomerID"], "^T", "
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFkI", true))
 """);
@@ -1886,7 +1886,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFk
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFkI", true))
 """);
@@ -1904,7 +1904,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "alFk
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFKI"))
 """);
@@ -1922,7 +1922,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFK
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFKI"))
 """);
@@ -1944,7 +1944,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["CustomerID"], "ALFK
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "     "))
 """);
@@ -1960,7 +1960,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], "     ")
                     """
 @__pattern_0='     '
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], @__pattern_0))
 """);
@@ -1974,7 +1974,7 @@ WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["ContactName"], @__patte
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 """);
@@ -1988,7 +1988,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10250))
 
                 AssertSql(
                     """
-SELECT c["UnitPrice"]
+SELECT VALUE c["UnitPrice"]
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 """);
@@ -2002,7 +2002,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 
                 AssertSql(
                     """
-SELECT c["UnitPrice"]
+SELECT VALUE c["UnitPrice"]
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 """);
@@ -2016,7 +2016,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND (c["Quantity"] < 5))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT(CONTAINS(c["CompanyName"], c["ContactName"])))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
@@ -31,7 +31,7 @@ public class NorthwindKeylessEntitiesQueryCosmosTest : NorthwindKeylessEntitiesQ
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -45,7 +45,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -62,7 +62,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "ProductView")
 """);
@@ -87,7 +87,7 @@ WHERE (c["Discriminator"] = "ProductView")
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["OrderCount"] > 0))
 """);
@@ -118,7 +118,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["OrderCount"] > 0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -180,7 +180,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -194,7 +194,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -5377,21 +5377,21 @@ WHERE (c["Discriminator"] = "Customer")
 """,
             //
             """
-SELECT VALUE c
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """,
             //
             """
-SELECT VALUE c
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """,
             //
             """
-SELECT VALUE c
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -39,7 +39,7 @@ public class NorthwindMiscellaneousQueryCosmosTest : NorthwindMiscellaneousQuery
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -53,13 +53,13 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """,
                     //
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -98,7 +98,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = c["CustomerID"]))
 """);
@@ -114,7 +114,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = c["CustomerID"])
                     """
 @__entity_equality_local_0_CustomerID='ANATR'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_local_0_CustomerID))
 """);
@@ -145,7 +145,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equali
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ANATR"))
 """);
@@ -168,7 +168,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ANATR"))
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
@@ -182,7 +182,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] != null))
 """);
@@ -476,7 +476,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] != null))
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY (c["EmployeeID"] - c["EmployeeID"])
@@ -495,7 +495,7 @@ ORDER BY (c["EmployeeID"] - c["EmployeeID"])
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY (c["UnitsInStock"] > 0), c["ProductID"]
@@ -514,7 +514,7 @@ ORDER BY (c["UnitsInStock"] > 0), c["ProductID"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitsInStock"] > 10) ? (c["ProductID"] > 40) : (c["ProductID"] <= 40)), c["ProductID"]
@@ -561,7 +561,7 @@ ORDER BY ((c["UnitsInStock"] > 10) ? (c["ProductID"] > 40) : (c["ProductID"] <= 
 @__p_0='5'
 @__p_1='10'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
@@ -652,7 +652,7 @@ OFFSET @__p_0 LIMIT @__p_1
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -666,7 +666,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -680,7 +680,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -696,7 +696,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__p_0='91'
 
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT @__p_0
@@ -713,7 +713,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='91'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 OFFSET 0 LIMIT @__p_0
@@ -730,7 +730,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='10'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -748,7 +748,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='10'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -766,7 +766,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='10'
 
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -784,7 +784,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='2'
 
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -821,10 +821,10 @@ OFFSET 0 LIMIT @__p_0
 
             AssertSql(
                 """
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE (c["Discriminator"] = "Customer")) AS c
+    WHERE (c["Discriminator"] = "Customer"))
 """);
         }
     }
@@ -841,10 +841,10 @@ SELECT EXISTS (
 
             AssertSql(
                 """
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "A"))) AS c
+    WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "A")))
 """);
         }
     }
@@ -1290,7 +1290,7 @@ SELECT EXISTS (
 @__p_0='5'
 @__p_1='10'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactName"]
@@ -1313,12 +1313,12 @@ OFFSET @__p_0 LIMIT @__p_1
 @__p_0='5'
 @__p_1='10'
 
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
     WHERE (c["Discriminator"] = "Customer")
     ORDER BY c["ContactName"]
-    OFFSET @__p_0 LIMIT @__p_1) AS c
+    OFFSET @__p_0 LIMIT @__p_1)
 """);
         }
     }
@@ -1354,12 +1354,12 @@ SELECT EXISTS (
 @__p_0='5'
 @__p_1='7'
 
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
     WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "C"))
     ORDER BY c["CustomerID"]
-    OFFSET @__p_0 LIMIT @__p_1) AS c
+    OFFSET @__p_0 LIMIT @__p_1)
 """);
         }
     }
@@ -1378,12 +1378,12 @@ SELECT EXISTS (
                 """
 @__p_0='5'
 
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
     WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "B"))
     ORDER BY c["CustomerID"]
-    OFFSET 0 LIMIT @__p_0) AS c
+    OFFSET 0 LIMIT @__p_0)
 """);
         }
     }
@@ -1396,7 +1396,7 @@ SELECT EXISTS (
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1414,7 +1414,7 @@ ORDER BY c["CustomerID"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY true
@@ -1433,7 +1433,7 @@ ORDER BY true
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY 3
@@ -1454,7 +1454,7 @@ ORDER BY 3
                 """
 @__param_0='5'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY @__param_0
@@ -1470,7 +1470,7 @@ ORDER BY @__param_0
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1485,7 +1485,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1516,7 +1516,7 @@ ORDER BY c["CustomerID"]
                     """
 @__p_0='5'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 ORDER BY c["OrderID"]
@@ -1553,7 +1553,7 @@ OFFSET 0 LIMIT @__p_0
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["Title"], c["EmployeeID"]
@@ -1572,7 +1572,7 @@ ORDER BY c["Title"], c["EmployeeID"]
 
             AssertSql(
                 """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["Country"], c["City"]
@@ -1592,10 +1592,10 @@ ORDER BY c["Country"], c["City"]
 
             AssertSql(
                 """
-SELECT EXISTS (
+SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE (c["Discriminator"] = "Customer")) AS c
+    WHERE (c["Discriminator"] = "Customer"))
 """);
         }
     }
@@ -1694,7 +1694,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 
                 AssertSql(
                     """
-SELECT DISTINCT c["CustomerID"]
+SELECT DISTINCT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 """);
@@ -1810,7 +1810,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10300))
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ"), c["CustomerID"]
@@ -1853,7 +1853,7 @@ ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ"), c["CustomerID"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] = null) ? "ZZ" : c["Region"]), c["CustomerID"]
@@ -1869,7 +1869,7 @@ ORDER BY ((c["Region"] = null) ? "ZZ" : c["Region"]), c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["City"]
@@ -1887,7 +1887,7 @@ ORDER BY c["City"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["Region"] = "ASK")
@@ -1922,7 +1922,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["ContactName"] != null) ? c["ContactName"] : c["CompanyName"]) = "Liz Nixon"))
 """);
@@ -2002,7 +2002,7 @@ OFFSET 0 LIMIT @__p_0
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ")
@@ -2018,7 +2018,7 @@ ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 """);
@@ -2034,7 +2034,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00
                     """
 @__Parse_0='1998-01-01T12:00:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__Parse_0))
 """);
@@ -2048,7 +2048,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__Parse_0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 """);
@@ -2064,7 +2064,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00
                     """
 @__p_0='1998-01-01T12:00:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
 """,
@@ -2072,7 +2072,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
                     """
 @__p_0='1998-01-01T11:00:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
 """);
@@ -2138,7 +2138,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] > @__p_0))
                     """
 '
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND CONTAINS(c["CustomerID"], @__NewLine_0))
 """,
@@ -2259,7 +2259,7 @@ ORDER BY c["CustomerID"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")))
 """);
@@ -2274,7 +2274,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) AND (c["CustomerID"] = "ANTON")))
 """);
@@ -2290,7 +2290,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c[
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")) AND (c["Country"] = "Germany")))
 """);
@@ -2305,7 +2305,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") | (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")))
 """);
@@ -2321,7 +2321,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ALFKI") & (c[
                     """
 @__negatedId_0='-10249'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = @__negatedId_0))
 """);
@@ -2335,7 +2335,7 @@ WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = @__negatedId_0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] & 10248) = 10248))
 """);
@@ -2349,7 +2349,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] & 10248) = 10248))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] | 10248) = 10248))
 """);
@@ -2363,7 +2363,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] | 10248) = 10248))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] ^ 1) = 10249))
 """);
@@ -2433,13 +2433,13 @@ ORDER BY c["CustomerID"]
 @__dateFilter_Value_Month_0='7'
 @__dateFilter_Value_Year_1='1996'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10400))
 """);
@@ -2457,13 +2457,13 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10400))
 @__dateFilter_Value_Month_0='7'
 @__dateFilter_Value_Year_1='1996'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -2481,13 +2481,13 @@ WHERE false
 @__dateFilter_Value_Month_0='7'
 @__dateFilter_Value_Year_1='1996'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] < 10400) OR (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2517,7 +2517,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2531,7 +2531,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2545,13 +2545,13 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """,
                     //
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2565,7 +2565,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2579,7 +2579,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("yyyy", 1, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("yyyy", 1, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2593,7 +2593,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("mm", 1, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("mm", 1, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2607,7 +2607,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("hh", 1.0, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("hh", 1.0, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2621,7 +2621,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("mi", 1.0, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("mi", 1.0, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2635,7 +2635,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("ss", 1.0, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("ss", 1.0, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2649,7 +2649,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("ms", 1000000000000.0, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("ms", 1000000000000.0, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2663,7 +2663,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT DateTimeAdd("ms", -1000000000000.0, c["OrderDate"]) AS c
+SELECT VALUE DateTimeAdd("ms", -1000000000000.0, c["OrderDate"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -2691,7 +2691,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
                 AssertSql(
                     """
-SELECT (c["OrderID"] % 25) AS c
+SELECT VALUE (c["OrderID"] % 25)
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] < 10500))
 ORDER BY c["OrderID"]
@@ -2708,7 +2708,7 @@ ORDER BY c["OrderID"]
                     """
 @__nextYear_0='2017'
 
-SELECT DISTINCT DateTimePart("yyyy", c["OrderDate"]) AS c
+SELECT DISTINCT VALUE DateTimePart("yyyy", c["OrderDate"])
 FROM root c
 WHERE (((c["Discriminator"] = "Order") AND (c["OrderDate"] != null)) AND (DateTimePart("yyyy", c["OrderDate"]) < @__nextYear_0))
 """);
@@ -2768,7 +2768,7 @@ WHERE (((c["Discriminator"] = "Order") AND (c["OrderDate"] != null)) AND (DateTi
 @__p_0='5'
 @__p_1='8'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactTitle"], c["ContactName"]
@@ -2827,7 +2827,7 @@ OFFSET @__p_0 LIMIT @__p_1
 @__p_0='5'
 @__p_1='15'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["ContactTitle"], c["ContactName"]
@@ -2849,7 +2849,7 @@ OFFSET @__p_0 LIMIT @__p_1
                 """
 @__p_0='15'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)
@@ -2872,7 +2872,7 @@ OFFSET 0 LIMIT @__p_0
 @__p_0='5'
 @__p_1='15'
 
-SELECT DISTINCT c
+SELECT DISTINCT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Product")
 ORDER BY ((c["UnitPrice"] != null) ? c["UnitPrice"] : 0.0)
@@ -2977,7 +2977,7 @@ OFFSET @__p_0 LIMIT @__p_1
 
                 AssertSql(
                     """
-SELECT DISTINCT c["CustomerID"]
+SELECT DISTINCT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -3009,7 +3009,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT DISTINCT (c["CustomerID"] || c["City"]) AS A
+SELECT DISTINCT VALUE (c["CustomerID"] || c["City"])
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "ALFKIBerlin"))
 """);
@@ -3043,7 +3043,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "
 
             AssertSql(
                 """
-SELECT (c["CustomerID"] || c["City"]) AS A
+SELECT VALUE (c["CustomerID"] || c["City"])
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["CustomerID"] || c["City"])
@@ -3067,7 +3067,7 @@ ORDER BY (c["CustomerID"] || c["City"])
 
                 AssertSql(
                     """
-SELECT DISTINCT c["CustomerID"] AS Property
+SELECT DISTINCT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -3099,7 +3099,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT DISTINCT (c["CustomerID"] || c["City"]) AS Property
+SELECT DISTINCT VALUE (c["CustomerID"] || c["City"])
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "ALFKIBerlin"))
 """);
@@ -3134,7 +3134,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || c["City"]) = "
 
             AssertSql(
                 """
-SELECT (c["CustomerID"] || c["City"]) AS Property
+SELECT VALUE (c["CustomerID"] || c["City"])
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY (c["CustomerID"] || c["City"])
@@ -3374,7 +3374,7 @@ ORDER BY (c["CustomerID"] || c["City"])
                     """
 @__prefix_0='A'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], @__prefix_0))
 """);
@@ -3404,7 +3404,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], @__pref
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND NOT((c["CustomerID"] = null)))
 ORDER BY c["CustomerID"]
@@ -3451,7 +3451,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
@@ -3473,7 +3473,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND (c["CustomerID"] = c["CustomerID"]))
 """);
@@ -3511,7 +3511,7 @@ WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) 
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
@@ -3526,7 +3526,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"] DESC
@@ -3562,7 +3562,7 @@ ORDER BY c["CustomerID"] DESC
 @__p_0='5'
 @__p_1='10'
 
-SELECT c["CustomerID"] AS Id
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -3590,7 +3590,7 @@ OFFSET @__p_0 LIMIT @__p_1
                 """
 @__list_0='[]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY ARRAY_CONTAINS(@__list_0, c["CustomerID"])
@@ -3610,7 +3610,7 @@ ORDER BY ARRAY_CONTAINS(@__list_0, c["CustomerID"])
                 """
 @__list_0='[]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY NOT(ARRAY_CONTAINS(@__list_0, c["CustomerID"]))
@@ -3712,13 +3712,13 @@ ORDER BY NOT(ARRAY_CONTAINS(@__list_0, c["CustomerID"]))
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """,
                     //
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """);
@@ -3735,7 +3735,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "OrderDetail")
 ORDER BY c["OrderID"] DESC, c["ProductID"] DESC
@@ -3778,7 +3778,7 @@ ORDER BY c["OrderID"] DESC, c["ProductID"] DESC
 
             AssertSql(
                 """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC, c["Country"]
@@ -3797,7 +3797,7 @@ ORDER BY c["CustomerID"] DESC, c["Country"]
 
             AssertSql(
                 """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC, c["Country"] DESC
@@ -3824,7 +3824,7 @@ ORDER BY c["CustomerID"] DESC, c["Country"] DESC
 
             AssertSql(
                 """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"], c["Country"]
@@ -3843,7 +3843,7 @@ ORDER BY c["CustomerID"], c["Country"]
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 ORDER BY c["City"], c["CustomerID"]
@@ -3924,7 +3924,7 @@ ORDER BY c["City"], c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["Title"]
+SELECT VALUE c["Title"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
@@ -3950,7 +3950,7 @@ WHERE (c["Discriminator"] = "Employee")
                     """
 @__value_0='Sales Representative'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
 """);
@@ -4154,7 +4154,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((((c["Quantity"] + 1) = 5) AND ((c["Quantity"] - 1) = 3)) AND ((c["Quantity"] * 1) = c["Quantity"])))
 ORDER BY c["OrderID"]
@@ -4169,7 +4169,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT MAX(c["Quantity"]) AS c
+SELECT VALUE MAX(c["Quantity"])
 FROM root c
 WHERE (c["Discriminator"] = "OrderDetail")
 """);
@@ -4192,7 +4192,7 @@ WHERE (c["Discriminator"] = "OrderDetail")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN (null, "ALFKI"))
 """);
@@ -4395,7 +4395,7 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN (null, "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4410,7 +4410,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -4424,7 +4424,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4438,7 +4438,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT false AS Result
+SELECT VALUE false
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4466,7 +4466,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 """);
@@ -4481,7 +4481,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderDate"] != null))
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4496,7 +4496,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """);
@@ -4510,7 +4510,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -4524,7 +4524,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
@@ -4548,7 +4548,7 @@ ORDER BY c["EmployeeID"]
 
                 AssertSql(
                     """
-SELECT c["ContactName"]
+SELECT VALUE c["ContactName"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4574,11 +4574,14 @@ WHERE (c["Discriminator"] = "Order")
         // Always throws for sync.
         if (async)
         {
-            await base.Non_nullable_property_through_optional_navigation(async);
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>().Select(e => new { e.Region.Length })));
 
             AssertSql(
                 """
-SELECT LENGTH(c["Region"]) AS Length
+SELECT VALUE LENGTH(c["Region"])
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4593,7 +4596,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4608,7 +4611,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] != null) AND (c["ProductID"] != null)))
 """);
@@ -4629,7 +4632,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] != null) AND (c["
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
@@ -4661,7 +4664,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4676,7 +4679,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4701,7 +4704,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__value_0='Sales Representative'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
 """,
@@ -4709,7 +4712,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = @__value_0))
                     """
 @__value_0='Steven'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["FirstName"] = @__value_0))
 """);
@@ -4725,7 +4728,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["FirstName"] = @__value_0))
                     """
 @__entity_equality_local_0_CustomerID='ANATR'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__entity_equality_local_0_CustomerID) AND (@__entity_equality_local_0_CustomerID = c["CustomerID"])))
 """);
@@ -4739,7 +4742,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__entity_equal
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4754,7 +4757,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
@@ -4768,7 +4771,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = null) OR (c["ProductID"] = null)))
 """);
@@ -4782,7 +4785,7 @@ WHERE ((c["Discriminator"] = "OrderDetail") AND ((c["OrderID"] = null) OR (c["Pr
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -4801,7 +4804,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
@@ -4816,7 +4819,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4831,7 +4834,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -4845,7 +4848,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT true AS Data1
+SELECT VALUE true
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -4859,13 +4862,13 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -4879,7 +4882,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"] DESC
@@ -4894,7 +4897,7 @@ ORDER BY c["CustomerID"] DESC
 
                 AssertSql(
                     """
-SELECT c["Title"]
+SELECT VALUE c["Title"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
@@ -4910,7 +4913,7 @@ WHERE (c["Discriminator"] = "Employee")
                     """
 @__p_0='0'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -4920,7 +4923,7 @@ OFFSET @__p_0 LIMIT @__p_0
                     """
 @__p_0='1'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -5183,7 +5186,7 @@ OFFSET @__p_0 LIMIT @__p_0
                     """
 @__data_0='["ALFKIAlfreds Futterkiste","ANATRAna Trujillo Emparedados y helados"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_0, (c["CustomerID"] || c["CompanyName"])))
 """);
@@ -5199,7 +5202,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_0, (c["Custo
                     """
 @__data_0='["ALFKISomeConstant","ANATRSomeConstant","ALFKIX"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_0, (c["CustomerID"] || "SomeConstant")))
 """);
@@ -5224,7 +5227,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_0, (c["Custo
 @__data_1='["ALFKISomeVariable","ANATRSomeVariable","ALFKIX"]'
 @__someVariable_0='SomeVariable'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_1, (c["CustomerID"] || @__someVariable_0)))
 """);
@@ -5240,7 +5243,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__data_1, (c["Custo
                     """
 @__Contains_0='true'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND @__Contains_0)
 """);
@@ -5257,7 +5260,7 @@ WHERE ((c["Discriminator"] = "Customer") AND @__Contains_0)
 @__customerId_0='ALFKI'
 @__details_City_1='Berlin'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__customerId_0) AND (c["City"] = @__details_City_1)))
 """);
@@ -5271,6 +5274,8 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__customerId_0
 
                 AssertSql("ReadItem(None, Customer|ALFKI)");
             });
+
+    #region ToPageAsync
 
     [ConditionalFact]
     public virtual async Task ToPageAsync()
@@ -5304,27 +5309,89 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = @__customerId_0
 
         AssertSql(
             """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """,
             //
             """
-SELECT c
-FROM root c
-WHERE (c["Discriminator"] = "Customer")
-ORDER BY c["CustomerID"]
-""",
-            //
-            """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """,
             //
             """
-SELECT c
+SELECT VALUE c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+ORDER BY c["CustomerID"]
+""",
+            //
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+ORDER BY c["CustomerID"]
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task ToPageAsync_with_scalar()
+    {
+        await using var context = CreateContext();
+
+        var totalCustomers = await context.Set<Customer>().CountAsync();
+
+        var page1 = await context.Set<Customer>()
+            .Select(c => c.CustomerID)
+            .OrderBy(id => id)
+            .ToPageAsync(pageSize: 1, continuationToken: null);
+
+        var id1 = Assert.Single(page1.Values);
+        Assert.Equal("ALFKI", id1);
+
+        var page2 = await context.Set<Customer>()
+            .Select(c => c.CustomerID)
+            .OrderBy(id => id)
+            .ToPageAsync(pageSize: 2, page1.ContinuationToken);
+
+        Assert.Collection(
+            page2.Values,
+            id => Assert.Equal("ANATR", id),
+            id => Assert.Equal("ANTON", id));
+
+        var page3 = await context.Set<Customer>()
+            .Select(c => c.CustomerID)
+            .OrderBy(id => id)
+            .ToPageAsync(pageSize: totalCustomers, page2.ContinuationToken);
+
+        Assert.Equal(totalCustomers - 3, page3.Values.Count);
+        Assert.Null(page3.ContinuationToken);
+
+        AssertSql(
+            """
+SELECT VALUE COUNT(1)
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""",
+            //
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+ORDER BY c["CustomerID"]
+""",
+            //
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+ORDER BY c["CustomerID"]
+""",
+            //
+            """
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -5348,13 +5415,13 @@ ORDER BY c["CustomerID"]
 
         AssertSql(
             """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """,
             //
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -5375,7 +5442,7 @@ ORDER BY c["CustomerID"]
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -5388,6 +5455,8 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
                 async: true,
                 ss => ss.Set<Customer>().Where(c => c.Orders.AsQueryable().ToPageAsync(1, null, null, default) == default)),
             CosmosStrings.ToPageAsyncAtTopLevelOnly);
+
+    #endregion ToPageAsync
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4574,10 +4574,10 @@ WHERE (c["Discriminator"] = "Order")
         // Always throws for sync.
         if (async)
         {
-            await Assert.ThrowsAsync<NullReferenceException>(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Select(e => new { e.Region.Length })));
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Select(e => new { e.Region.Length }),
+                ss => ss.Set<Customer>().Where(e => e.Region != null).Select(e => new { e.Region.Length }));
 
             AssertSql(
                 """

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1943,20 +1943,22 @@ WHERE (c["Discriminator"] = "Order")
 """);
             });
 
-    public override Task Select_with_complex_expression_that_can_be_funcletized(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await Assert.ThrowsAsync<EqualException>(
-                    () => base.Select_with_complex_expression_that_can_be_funcletized(a));
+    public override async Task Select_with_complex_expression_that_can_be_funcletized(bool async)
+    {
+        // Always throws for sync.
+        if (async)
+        {
+            await Assert.ThrowsAsync<EqualException>(
+                () => base.Select_with_complex_expression_that_can_be_funcletized(true));
 
-                AssertSql(
-                    """
+            AssertSql(
+                """
 SELECT VALUE INDEX_OF(c["Region"], "")
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
-            });
+        }
+    }
 
     public override Task Select_datetime_Ticks_component(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -31,16 +31,13 @@ public class NorthwindSelectQueryCosmosTest : NorthwindSelectQueryTestBase<North
             async, async a =>
             {
                 await AssertQuery(
-                    async,
+                    a,
                     ss => ss.Set<Order>().Select(o => new { Value = o.OrderID }),
                     e => e.Value);
 
                 AssertSql(
                     """
-SELECT VALUE
-{
-    "Value" : c["OrderID"]
-}
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -111,7 +108,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["Region"]
+SELECT VALUE c["Region"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -147,7 +144,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
@@ -170,7 +167,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -185,7 +182,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT [c["EmployeeID"], c["ReportsTo"]] AS c
+SELECT VALUE [c["EmployeeID"], c["ReportsTo"]]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """);
@@ -211,7 +208,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
                 """
 @__boolean_0='false'
 
-SELECT @__boolean_0 AS c
+SELECT VALUE @__boolean_0
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY @__boolean_0
@@ -227,7 +224,7 @@ ORDER BY @__boolean_0
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -241,7 +238,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -351,7 +348,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT 0 AS c
+SELECT VALUE 0
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -365,7 +362,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT null AS c
+SELECT VALUE null
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -381,7 +378,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__x_0='10'
 
-SELECT @__x_0 AS c
+SELECT VALUE @__x_0
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -397,7 +394,7 @@ WHERE (c["Discriminator"] = "Customer")
                     """
 @__p_0='9'
 
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 OFFSET 0 LIMIT @__p_0
@@ -412,7 +409,7 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT c["CompanyName"]
+SELECT VALUE c["CompanyName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -426,7 +423,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
                 AssertSql(
                     """
-SELECT c["City"]
+SELECT VALUE c["City"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -518,7 +515,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -533,7 +530,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -548,7 +545,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -563,7 +560,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -578,7 +575,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT (c["OrderID"] + c["OrderID"]) AS c
+SELECT VALUE (c["OrderID"] + c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -594,7 +591,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -609,7 +606,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT -(c["OrderID"]) AS c
+SELECT VALUE -(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -624,7 +621,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -639,7 +636,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT LENGTH(c["CustomerID"]) AS c
+SELECT VALUE LENGTH(c["CustomerID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -654,7 +651,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT ABS(c["OrderID"]) AS c
+SELECT VALUE ABS(c["OrderID"])
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -669,7 +666,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 ORDER BY c["OrderID"]
@@ -695,7 +692,7 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-SELECT ((c["CustomerID"] = null) ? true : (c["OrderID"] < 100)) AS c
+SELECT VALUE ((c["CustomerID"] = null) ? true : (c["OrderID"] < 100))
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -813,7 +810,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT DateTimePart("yyyy", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("yyyy", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -827,7 +824,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("mm", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("mm", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -842,7 +839,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -856,7 +853,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("dd", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("dd", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -870,7 +867,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("hh", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("hh", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -884,7 +881,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("mi", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("mi", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -898,7 +895,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("ss", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("ss", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -912,7 +909,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT DateTimePart("ms", c["OrderDate"]) AS c
+SELECT VALUE DateTimePart("ms", c["OrderDate"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -926,7 +923,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT ((c["CustomerID"] = "ALFKI") ? 1 : 2) AS c
+SELECT VALUE ((c["CustomerID"] = "ALFKI") ? 1 : 2)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -940,7 +937,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT ((c["CustomerID"] = "ALFKI") ? 1 : 2) AS c
+SELECT VALUE ((c["CustomerID"] = "ALFKI") ? 1 : 2)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -954,7 +951,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT ((c["CustomerID"] = "ALFKI") ? true : false) AS c
+SELECT VALUE ((c["CustomerID"] = "ALFKI") ? true : false)
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -968,7 +965,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -982,7 +979,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["CustomerID"] AS A
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1005,7 +1002,7 @@ ORDER BY c["CustomerID"]
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1027,7 +1024,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
@@ -1041,7 +1038,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
@@ -1265,7 +1262,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10250))
 
                 AssertSql(
                     """
-SELECT ((c["EmployeeID"] != null) ? c["EmployeeID"] : 0) AS c
+SELECT VALUE ((c["EmployeeID"] != null) ? c["EmployeeID"] : 0)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1295,7 +1292,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"] DESC
@@ -1310,7 +1307,7 @@ ORDER BY c["EmployeeID"] DESC
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
@@ -1333,7 +1330,7 @@ ORDER BY c["EmployeeID"]
 
                 AssertSql(
                     """
-SELECT (c["City"] = "Seattle") AS c
+SELECT VALUE (c["City"] = "Seattle")
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1434,7 +1431,7 @@ ORDER BY c["CustomerID"]
                     """
 @__p_0='10'
 
-SELECT ((c["CustomerID"] || " ") || c["City"]) AS Aggregate
+SELECT VALUE ((c["CustomerID"] || " ") || c["City"])
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
@@ -1452,7 +1449,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='10'
 
-SELECT ((c["CustomerID"] || " ") || c["City"]) AS Aggregate
+SELECT VALUE ((c["CustomerID"] || " ") || c["City"])
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
@@ -1703,7 +1700,7 @@ ORDER BY c["OrderID"]
 
             AssertSql(
                 """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"] DESC, c["City"]
@@ -1767,7 +1764,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1781,7 +1778,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 ORDER BY c["EmployeeID"]
@@ -1827,7 +1824,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1841,7 +1838,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1869,7 +1866,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["OrderID"]
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1897,7 +1894,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE (c["Discriminator"] = "Employee")
 """);
@@ -1911,7 +1908,7 @@ WHERE (c["Discriminator"] = "Employee")
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1939,12 +1936,13 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
             });
 
+    [ConditionalTheory(Skip = "`undefined` result is filtered out")]
     public override Task Select_with_complex_expression_that_can_be_funcletized(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -1953,7 +1951,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT INDEX_OF(c["Region"], "") AS c
+SELECT VALUE ((c["Region"] = null) ? null : INDEX_OF(c["Region"], ""))
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);
@@ -1967,7 +1965,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -1981,7 +1979,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT 10 AS X
+SELECT VALUE 10
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1995,7 +1993,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2009,7 +2007,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT ((c["CustomerID"] = "1") ? "01" : ((c["CustomerID"] = "2") ? "02" : ((c["CustomerID"] = "3") ? "03" : ((c["CustomerID"] = "4") ? "04" : ((c["CustomerID"] = "5") ? "05" : ((c["CustomerID"] = "6") ? "06" : ((c["CustomerID"] = "7") ? "07" : ((c["CustomerID"] = "8") ? "08" : ((c["CustomerID"] = "9") ? "09" : ((c["CustomerID"] = "10") ? "10" : ((c["CustomerID"] = "11") ? "11" : null))))))))))) AS c
+SELECT VALUE ((c["CustomerID"] = "1") ? "01" : ((c["CustomerID"] = "2") ? "02" : ((c["CustomerID"] = "3") ? "03" : ((c["CustomerID"] = "4") ? "04" : ((c["CustomerID"] = "5") ? "05" : ((c["CustomerID"] = "6") ? "06" : ((c["CustomerID"] = "7") ? "07" : ((c["CustomerID"] = "8") ? "08" : ((c["CustomerID"] = "9") ? "09" : ((c["CustomerID"] = "10") ? "10" : ((c["CustomerID"] = "11") ? "11" : null)))))))))))
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2023,7 +2021,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT (((c["OrderID"] % 2) = 0) ? c["OrderID"] : -(c["OrderID"])) AS c
+SELECT VALUE (((c["OrderID"] % 2) = 0) ? c["OrderID"] : -(c["OrderID"]))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2037,7 +2035,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT (((c["OrderID"] % 2) = 0) ? c["OrderID"] : 0) AS c
+SELECT VALUE (((c["OrderID"] % 2) = 0) ? c["OrderID"] : 0)
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2051,7 +2049,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT (((c["OrderID"] % 2) = 0) ? (((c["OrderID"] % 5) = 0) ? -(c["OrderID"]) : c["OrderID"]) : c["OrderID"]) AS c
+SELECT VALUE (((c["OrderID"] % 2) = 0) ? (((c["OrderID"] % 5) = 0) ? -(c["OrderID"]) : c["OrderID"]) : c["OrderID"])
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2065,7 +2063,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT ((((c["OrderID"] % 2) = 0) ? false : true) ? c["OrderID"] : -(c["OrderID"])) AS c
+SELECT VALUE ((((c["OrderID"] % 2) = 0) ? false : true) ? c["OrderID"] : -(c["OrderID"]))
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2079,7 +2077,7 @@ WHERE (c["Discriminator"] = "Order")
 
                 AssertSql(
                     """
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "F"))
 """);
@@ -2105,7 +2103,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "F"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -1942,16 +1943,16 @@ WHERE (c["Discriminator"] = "Order")
 """);
             });
 
-    [ConditionalTheory(Skip = "`undefined` result is filtered out")]
     public override Task Select_with_complex_expression_that_can_be_funcletized(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
             {
-                await base.Select_with_complex_expression_that_can_be_funcletized(a);
+                await Assert.ThrowsAsync<EqualException>(
+                    () => base.Select_with_complex_expression_that_can_be_funcletized(a));
 
                 AssertSql(
                     """
-SELECT VALUE ((c["Region"] = null) ? null : INDEX_OF(c["Region"], ""))
+SELECT VALUE INDEX_OF(c["Region"], "")
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = "ALFKI"))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -37,7 +37,7 @@ public class NorthwindWhereQueryCosmosTest : NorthwindWhereQueryTestBase<Northwi
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] + 10) = 10258))
 """);
@@ -55,7 +55,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] + 10) = 10258))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] - 10) = 10238))
 """);
@@ -73,7 +73,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] - 10) = 10238))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] * 1) = 10248))
 """);
@@ -91,7 +91,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] * 1) = 10248))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] / 1) = 10248))
 """);
@@ -109,7 +109,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] / 1) = 10248))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] % 10248) = 0))
 """);
@@ -128,7 +128,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] % 10248) = 0))
 
                     AssertSql(
                         """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") | (c["CustomerID"] = "ANATR")))
 """);
@@ -144,7 +144,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") | (c["
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") & (c["CustomerID"] = "ANATR")))
 """);
@@ -160,7 +160,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") & (c["
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") != true))
 """);
@@ -178,7 +178,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") != tru
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] << 1) = 20496))
 """);
@@ -196,7 +196,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] << 1) = 20496))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] >> 1) = 5124))
 """);
@@ -214,7 +214,7 @@ WHERE ((c["Discriminator"] = "Order") AND ((c["OrderID"] >> 1) = 5124))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["City"] = "Seattle") AND (c["ContactTitle"] = "Owner")))
 """);
@@ -232,7 +232,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["City"] = "Seattle") AND (c["Co
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ANATR")))
 """);
@@ -250,7 +250,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] = "ALFKI") OR (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND NOT((c["City"] != "Seattle")))
 """);
@@ -268,7 +268,7 @@ WHERE ((c["Discriminator"] = "Customer") AND NOT((c["City"] != "Seattle")))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 """);
@@ -286,7 +286,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] != 2))
 """);
@@ -304,7 +304,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] != 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] > 2))
 """);
@@ -322,7 +322,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] > 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] >= 2))
 """);
@@ -340,7 +340,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] >= 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] < 3))
 """);
@@ -358,7 +358,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] < 3))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] <= 2))
 """);
@@ -376,7 +376,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] <= 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || "END") = "ALFKIEND"))
 """);
@@ -394,7 +394,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] || "END") = "ALFK
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (-(c["OrderID"]) = -10248))
 """);
@@ -412,7 +412,7 @@ WHERE ((c["Discriminator"] = "Order") AND (-(c["OrderID"]) = -10248))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = -10249))
 """);
@@ -432,7 +432,7 @@ WHERE ((c["Discriminator"] = "Order") AND (~(c["OrderID"]) = -10249))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region"] : "SP") = "BC"))
 """);
@@ -450,7 +450,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region"] : "SP") = "BC"))
 """);
@@ -464,7 +464,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] != null) ? c["Region
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -491,7 +491,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
                     """
 @__city_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """);
@@ -510,7 +510,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
                     """
 @__p_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__p_0))
 """);
@@ -526,7 +526,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__p_0))
                     """
 @__get_Item_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__get_Item_0))
 """);
@@ -542,7 +542,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__get_Item_0))
                     """
 @__predicateTuple_Item2_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item2_0))
 """);
@@ -558,7 +558,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item
                     """
 @__predicateTuple_Item2_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item2_0))
 """);
@@ -574,7 +574,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__predicateTuple_Item
                     """
 @__predicate_0='true'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND @__predicate_0)
 """);
@@ -590,7 +590,7 @@ WHERE ((c["Discriminator"] = "Customer") AND @__predicate_0)
                     """
 @__city_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """,
@@ -598,7 +598,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
                     """
 @__city_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """);
@@ -630,7 +630,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
                     """
 @__GetCity_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
 """,
@@ -638,7 +638,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
                     """
 @__GetCity_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
 """);
@@ -654,7 +654,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__GetCity_0))
                     """
 @__city_InstanceFieldValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldValue_0))
 """,
@@ -662,7 +662,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldV
                     """
 @__city_InstanceFieldValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldValue_0))
 """);
@@ -678,7 +678,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceFieldV
                     """
 @__city_InstancePropertyValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstancePropertyValue_0))
 """,
@@ -686,7 +686,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceProper
                     """
 @__city_InstancePropertyValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstancePropertyValue_0))
 """);
@@ -702,7 +702,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_InstanceProper
                     """
 @__StaticFieldValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0))
 """,
@@ -710,7 +710,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0)
                     """
 @__StaticFieldValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0))
 """);
@@ -726,7 +726,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticFieldValue_0)
                     """
 @__StaticPropertyValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue_0))
 """,
@@ -734,7 +734,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue
                     """
 @__StaticPropertyValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue_0))
 """);
@@ -750,7 +750,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__StaticPropertyValue
                     """
 @__city_Nested_InstanceFieldValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstanceFieldValue_0))
 """,
@@ -758,7 +758,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_Instanc
                     """
 @__city_Nested_InstanceFieldValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstanceFieldValue_0))
 """);
@@ -774,7 +774,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_Instanc
                     """
 @__city_Nested_InstancePropertyValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstancePropertyValue_0))
 """,
@@ -782,7 +782,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_Instanc
                     """
 @__city_Nested_InstancePropertyValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_InstancePropertyValue_0))
 """);
@@ -798,7 +798,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_Nested_Instanc
                     """
 @__InstanceFieldValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """,
@@ -806,7 +806,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_
                     """
 @__InstanceFieldValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """);
@@ -822,7 +822,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_
                     """
 @__InstanceFieldValue_0='London'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """,
@@ -830,7 +830,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_
                     """
 @__InstanceFieldValue_0='Seattle'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_0))
 """);
@@ -864,7 +864,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__InstanceFieldValue_
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
@@ -878,7 +878,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative
 
                 AssertSql(
                     """
-SELECT c["Title"]
+SELECT VALUE c["Title"]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 """);
@@ -898,7 +898,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative
                         """
 @__p_0='5'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative"))
 ORDER BY c["EmployeeID"]
@@ -974,7 +974,7 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -988,7 +988,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["City"], "London", true))
 """);
@@ -1011,7 +1011,7 @@ WHERE ((c["Discriminator"] = "Customer") AND STRINGEQUALS(c["City"], "London", t
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1034,13 +1034,13 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1054,13 +1054,13 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1076,7 +1076,7 @@ WHERE false
                     """
 @__intPrm_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__intPrm_0))
 """,
@@ -1084,7 +1084,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__intPrm_0))
                     """
 @__intPrm_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__intPrm_0 = c["ReportsTo"]))
 """);
@@ -1100,7 +1100,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (@__intPrm_0 = c["ReportsTo"]))
                     """
 @__nullableIntPrm_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo"]))
 """,
@@ -1108,7 +1108,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo
                     """
 @__nullableIntPrm_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm_0))
 """);
@@ -1124,7 +1124,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm
                     """
 @__nullableIntPrm_0=null
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo"]))
 """,
@@ -1132,7 +1132,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (@__nullableIntPrm_0 = c["ReportsTo
                     """
 @__nullableIntPrm_0=null
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm_0))
 """);
@@ -1146,7 +1146,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = @__nullableIntPrm
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 """);
@@ -1160,7 +1160,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = 2))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = null))
 """);
@@ -1174,7 +1174,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["ReportsTo"] = null))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (LENGTH(c["City"]) = 6))
 """);
@@ -1188,7 +1188,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (LENGTH(c["City"]) = 6))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["City"], "Sea") != -1))
 """);
@@ -1202,7 +1202,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (INDEX_OF(c["City"], "Sea") != -1))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["City"], "Sea", "Rea") = "Reattle"))
 """);
@@ -1216,7 +1216,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (REPLACE(c["City"], "Sea", "Rea") =
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["City"], 1, 2) = "ea"))
 """);
@@ -1240,7 +1240,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (SUBSTRING(c["City"], 1, 2) = "ea")
                     """
 @__myDatetime_0='2015-04-10T00:00:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatetime_0))
 """);
@@ -1256,7 +1256,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatet
                     """
 @__myDatetimeOffset_0='2015-04-10T00:00:00-08:00'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatetimeOffset_0))
 """);
@@ -1286,7 +1286,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (GetCurrentDateTime() != @__myDatet
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", DateTimeAdd("yyyy", -1, c["OrderDate"])) = 1997))
 """);
@@ -1300,7 +1300,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", DateTimeAdd("yyy
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", c["OrderDate"]) = 1998))
 """);
@@ -1314,7 +1314,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("yyyy", c["OrderDate"]) 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mm", c["OrderDate"]) = 4))
 """);
@@ -1336,7 +1336,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mm", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("dd", c["OrderDate"]) = 4))
 """);
@@ -1350,7 +1350,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("dd", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("hh", c["OrderDate"]) = 0))
 """);
@@ -1364,7 +1364,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("hh", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mi", c["OrderDate"]) = 0))
 """);
@@ -1378,7 +1378,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("mi", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ss", c["OrderDate"]) = 0))
 """);
@@ -1392,7 +1392,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ss", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ms", c["OrderDate"]) = 0))
 """);
@@ -1422,7 +1422,7 @@ WHERE ((c["Discriminator"] = "Order") AND (DateTimePart("ms", c["OrderDate"]) = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ("London" = c["City"]))
 """);
@@ -1436,7 +1436,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ("London" = c["City"]))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
@@ -1450,7 +1450,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1464,7 +1464,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1478,7 +1478,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 """);
@@ -1492,7 +1492,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] != null))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1506,7 +1506,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1520,7 +1520,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = c["City"]))
 """);
@@ -1584,7 +1584,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = c["City"]))
                     """
 @__p_0='9'
 
-SELECT c["EmployeeID"]
+SELECT VALUE c["EmployeeID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
@@ -1599,7 +1599,7 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 """);
@@ -1613,7 +1613,7 @@ WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 """);
@@ -1635,7 +1635,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(NOT((c["Discontinued"] = true))))
 """);
@@ -1649,7 +1649,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT(NOT((c["Discontinued"] = true)))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 """);
@@ -1663,7 +1663,7 @@ WHERE ((c["Discriminator"] = "Product") AND c["Discontinued"])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 """);
@@ -1677,7 +1677,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT(c["Discontinued"]))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = true))
 """);
@@ -1691,7 +1691,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = true))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (((c["ProductID"] > 100) AND c["Discontinued"]) OR (c["Discontinued"] = true)))
 """);
@@ -1705,7 +1705,7 @@ WHERE ((c["Discriminator"] = "Product") AND (((c["ProductID"] > 100) AND c["Disc
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = (c["ProductID"] > 50)))
 """);
@@ -1719,7 +1719,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = (c["ProductID"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = NOT(c["Discontinued"])))
 """);
@@ -1733,7 +1733,7 @@ WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = NOT(c["Dis
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT((c["ProductID"] > 50)) = NOT((c["ProductID"] > 20))))
 """);
@@ -1747,7 +1747,7 @@ WHERE ((c["Discriminator"] = "Product") AND (NOT((c["ProductID"] > 50)) = NOT((c
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = (c["ProductID"] > 50)))
 """);
@@ -1763,7 +1763,7 @@ WHERE ((c["Discriminator"] = "Product") AND (NOT(c["Discontinued"]) = (c["Produc
                     """
 @__prm_0='true'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND @__prm_0)
 """);
@@ -1779,7 +1779,7 @@ WHERE ((c["Discriminator"] = "Product") AND @__prm_0)
                     """
 @__prm_0='true'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] > 50) != @__prm_0))
 """);
@@ -1795,7 +1795,7 @@ WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] > 50) != @__prm_0))
                     """
 @__prm_0='true'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = ((c["ProductID"] > 50) != @__prm_0)))
 """);
@@ -1809,7 +1809,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["Discontinued"] = ((c["ProductID"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] OR (c["ProductID"] < 20))))
 """);
@@ -1823,7 +1823,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] OR (c["Produc
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] AND (c["ProductID"] < 20))))
 """);
@@ -1837,7 +1837,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT((c["Discontinued"] AND (c["Produ
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT((NOT((NOT(c["Discontinued"]) AND (c["ProductID"] < 60))) OR NOT((c["ProductID"] > 30)))))
 """);
@@ -1851,7 +1851,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT((NOT((NOT(c["Discontinued"]) AND
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] > 10))
 """);
@@ -1865,7 +1865,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] > 10))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ENDSWITH(c["CustomerID"], "KI") = true))
 """);
@@ -1879,7 +1879,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ENDSWITH(c["CustomerID"], "KI") = 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1893,7 +1893,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -1907,7 +1907,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """,
@@ -1917,7 +1917,7 @@ WHERE false
                     "ReadItem(None, Customer|ALFKI)",
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -1931,7 +1931,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Fax"] = null))
 """);
@@ -2005,7 +2005,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["Fax"] = null))
                     """
 @__i_0='A'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AAROUT"))
 """);
@@ -2022,7 +2022,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AAR
 @__i_0='A'
 @__j_1='B'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || c["CustomerID"])) = "ABANATR"))
 """);
@@ -2040,7 +2040,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || c["CustomerI
 @__j_1='B'
 @__k_2='C'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || (@__k_2 || c["CustomerID"]))) = "ABCANTON"))
 """);
@@ -2054,7 +2054,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || (@__j_1 || (@__k_2 || c
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 """);
@@ -2068,7 +2068,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] < 20))
 """);
@@ -2084,7 +2084,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] < 20))
                     """
 @__productId_0='15'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] < @__productId_0) AND (c["UnitsInStock"] >= 20)))
 """);
@@ -2098,7 +2098,7 @@ WHERE ((c["Discriminator"] = "Product") AND ((c["ProductID"] < @__productId_0) A
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 """);
@@ -2112,7 +2112,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] >= 20))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -2126,7 +2126,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND NOT(((c["UnitsInStock"] >= 20) ? false : true)))
 """);
@@ -2212,7 +2212,7 @@ WHERE ((c["Discriminator"] = "Product") AND NOT(((c["UnitsInStock"] >= 20) ? fal
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((c["Region"] = null) AND (c["Country"] = "UK")))
 """);
@@ -2226,7 +2226,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["Region"] = null) AND (c["Count
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2240,7 +2240,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "QUICK")) AND (c["OrderDate"] > "1998-01-01T00:00:00"))
 """);
@@ -2316,7 +2316,7 @@ WHERE (((c["Discriminator"] = "Order") AND (c["CustomerID"] = "QUICK")) AND (c["
 
                 AssertSql(
                     """
-SELECT c["OrderDate"]
+SELECT VALUE c["OrderDate"]
 FROM root c
 WHERE (c["Discriminator"] = "Order")
 """);
@@ -2332,7 +2332,7 @@ WHERE (c["Discriminator"] = "Order")
                     """
 @__p_0='false'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND @__p_0)
 """);
@@ -2354,7 +2354,7 @@ WHERE ((c["Discriminator"] = "Order") AND @__p_0)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
 """);
@@ -2538,7 +2538,7 @@ WHERE ((c["Discriminator"] = "Product") AND (true ? false : true))
                     """
 @__orderIds_0='[10248,10249]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 """);
@@ -2554,7 +2554,7 @@ WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["Order
                     """
 @__orderIds_0='[10248,10249]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 """);
@@ -2716,7 +2716,7 @@ WHERE ((c["Discriminator"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["Order
                     """
 @__customerIds_0='["ALFKI","FISSA","WHITC"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c["CustomerID"]) AND (c["City"] = "Seattle")))
 """);
@@ -2732,7 +2732,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c
                     """
 @__customerIds_0='["ALFKI","FISSA"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c["CustomerID"]) OR (c["City"] = "Seattle")))
 """);
@@ -2760,7 +2760,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__customerIds_0, c
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2774,7 +2774,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -2788,7 +2788,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -2802,7 +2802,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """);
@@ -2816,7 +2816,7 @@ WHERE (c["Discriminator"] = "Customer")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] = null) ? "OR" : c["Region"]) = "OR"))
 """);
@@ -2830,7 +2830,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["Region"] = null) ? "OR" : c["
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
@@ -2844,7 +2844,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -2858,7 +2858,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 
                 AssertSql(
                     """
-SELECT c["CompanyName"]
+SELECT VALUE c["CompanyName"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """);
@@ -2904,7 +2904,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
                     """
 @__cities_0='["Seattle"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City"]))
 """);
@@ -2918,7 +2918,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ARRAY_CONTAINS(@__cities_0, c["City
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["CustomerID"] = "ALFKI") OR (c["CustomerID"] = "ANATR")) OR (c["CustomerID"] = "ANTON")) OR (c["CustomerID"] = "ANATR")))
 """);
@@ -2932,7 +2932,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((((c["CustomerID"] = "ALFKI") OR (
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = null)) OR (c["Region"] = "BC")))
 """);
@@ -2946,7 +2946,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Regi
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR (c["CustomerID"] = "ANTON")))
 """);
@@ -2960,7 +2960,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANAT
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ANTON") OR c["CustomerID"] IN ("ALFKI", "ANATR")) OR (c["CustomerID"] = "ALFKI")))
 """);
@@ -2974,7 +2974,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = "ANTON") OR c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") OR c["CustomerID"] IN ("ALFKI", "ANTON")))
 """);
@@ -2988,7 +2988,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANAT
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] NOT IN ("ALFKI", "ANATR") AND c["CustomerID"] NOT IN ("ALFKI", "ANTON")))
 """);
@@ -3006,7 +3006,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] NOT IN ("ALFKI", "
 @__prm2_1='ANATR'
 @__prm3_2='ANTON'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] != @__prm1_0) AND (c["CustomerID"] != @__prm2_1)) AND (c["CustomerID"] != @__prm3_2)))
 """);
@@ -3023,7 +3023,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] != @__prm1_0) AN
 @__prm1_0='ALFKI'
 @__prm2_1='ANATR'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN (@__prm1_0, @__prm2_1) OR (c["CustomerID"] = "ANTON")))
 """);
@@ -3039,7 +3039,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN (@__prm1_0, @__
                     """
 @__prm_0=null
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = @__prm_0)) OR (c["Region"] = "BC")))
 """);
@@ -3055,7 +3055,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] = "WA") OR (c["Regi
                     """
 @__array_0='["ALFKI","ANATR"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__array_0, c["CustomerID"]) OR (c["CustomerID"] = "ANTON")))
 """);
@@ -3073,7 +3073,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (ARRAY_CONTAINS(@__array_0, c["Cust
 @__array_1='["ALFKI","ANATR"]'
 @__prm2_2='ALFKI'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = @__prm1_0) OR ARRAY_CONTAINS(@__array_1, c["CustomerID"])) OR (c["CustomerID"] = @__prm2_2)))
 """);
@@ -3087,7 +3087,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] = @__prm1_0) OR 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANATR") AND ((c["CustomerID"] = "ANATR") OR (c["CustomerID"] = "ANTON"))))
 """);
@@ -3101,7 +3101,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] IN ("ALFKI", "ANAT
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] != "WA") AND (c["Region"] != "OR")) AND (c["Region"] != null)) OR ((c["Region"] != "WA") AND (c["Region"] != null))))
 """);
@@ -3115,7 +3115,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((((c["Region"] != "WA") AND (c["Re
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["Region"] = null))
 """);
@@ -3163,7 +3163,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["Title"] = "Sales Representative
                     """
 @__p_0='9'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
@@ -3180,7 +3180,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='9'
 
-SELECT c AS e
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 5))
 OFFSET 0 LIMIT @__p_0
@@ -3197,7 +3197,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__entity_equality_customer_0_CustomerID='ALFKI'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_customer_0_CustomerID))
 """,
@@ -3205,7 +3205,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equali
                     """
 @__entity_equality_customer_0_CustomerID='ANATR'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equality_customer_0_CustomerID))
 """);
@@ -3221,7 +3221,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = @__entity_equali
                     """
 @__i_0='A'
 
-SELECT c["CustomerID"]
+SELECT VALUE c["CustomerID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AALFKI"))
 """);
@@ -3253,7 +3253,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((@__i_0 || c["CustomerID"]) = "AAL
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = ("ALF" || "KI")))
 """);
@@ -3294,7 +3294,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = ("ALF" || "KI"))
                     """
 @__id_0='ALF'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = (@__id_0 || "KI")))
 """);
@@ -3315,7 +3315,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = (@__id_0 || "KI"
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
 """,
@@ -3323,7 +3323,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
                     """
 @__prm_Value_0='1337'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__prm_Value_0))
 """,
@@ -3331,7 +3331,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__prm_Value_0))
                     """
 @__ToString_0='1337'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__ToString_0))
 """,
@@ -3339,13 +3339,13 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__ToString_0))
                     """
 @__p_0='1337'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = @__p_0))
 """,
                     //
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
 """);
@@ -3361,25 +3361,25 @@ WHERE ((c["Discriminator"] = "Order") AND (c["CustomerID"] = "1337"))
                     """
 @__id_0='10252'
 
-SELECT c["OrderID"] AS Id
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = @__id_0))
 """,
                     //
                     """
-SELECT c["OrderID"] AS Id
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
                     //
                     """
-SELECT c["OrderID"] AS Id
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """,
                     //
                     """
-SELECT c["OrderID"] AS Id
+SELECT VALUE c["OrderID"]
 FROM root c
 WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10252))
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -46,7 +46,7 @@ public class OwnedQueryCosmosTest : OwnedQueryTestBase<OwnedQueryCosmosTest.Owne
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) > 0))
 ORDER BY c["Id"]
@@ -65,10 +65,10 @@ ORDER BY c["Id"]
 
             AssertSql(
                 """
-SELECT (ARRAY(
+SELECT VALUE (ARRAY(
     SELECT VALUE (o["Id"] != 42)
     FROM o IN c["Orders"]
-    ORDER BY o["Id"])[0] ?? false) AS c
+    ORDER BY o["Id"])[0] ?? false)
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -97,7 +97,7 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["Country"]["Name"] = "USA"))
 """);
@@ -111,7 +111,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c["PersonAddress"]["Country"]["Name"]
+SELECT VALUE c["PersonAddress"]["Country"]["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["Country"]["Name"] = "USA"))
 """);
@@ -125,7 +125,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -139,7 +139,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Branch", "LeafA")
 """);
@@ -153,7 +153,7 @@ WHERE c["Discriminator"] IN ("Branch", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("Branch", "LeafA")
 """);
@@ -167,7 +167,7 @@ WHERE c["Discriminator"] IN ("Branch", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "LeafA")
 """);
@@ -301,7 +301,7 @@ WHERE (c["Discriminator"] = "LeafA")
 
                 AssertSql(
                     """
-SELECT o AS o0
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
@@ -366,7 +366,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Discriminator"] = "LeafA"))
 """);
@@ -385,7 +385,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
                 // TODO: The following should project out c["PersonAddress"], not c: #34067
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -410,7 +410,7 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT COUNT(1) AS c
+SELECT VALUE COUNT(1)
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -448,10 +448,9 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
 
-                // TODO: The following should project out a["Details"], not a: #34067
                 AssertSql(
                     """
-SELECT o["Details"]
+SELECT VALUE o["Details"]
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -475,10 +474,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count() == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-
-                AssertSql(
-                    """
-SELECT o AS o0
+AssertSql(
+    """
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -502,10 +500,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count() == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-
-                AssertSql(
-                    """
-SELECT o AS o0
+AssertSql(
+    """
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -529,10 +526,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-
-                AssertSql(
-                    """
-SELECT o["Details"]
+AssertSql(
+    """
+SELECT VALUE o["Details"]
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -556,10 +552,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Length == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-
-                AssertSql(
-                    """
-SELECT o AS o0
+AssertSql(
+    """
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -579,7 +574,7 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Name"] = "Mona Cy"))
 """);
@@ -593,7 +588,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
@@ -607,7 +602,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Name"] = "Mona Cy"))
 """);
@@ -621,7 +616,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -635,7 +630,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c["PersonAddress"]["AddressLine"]
+SELECT VALUE c["PersonAddress"]["AddressLine"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -649,7 +644,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -668,7 +663,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Name"], c["Id"]
@@ -689,7 +684,7 @@ ORDER BY c["Name"], c["Id"]
 
             AssertSql(
                 """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Name"], c["Id"]
@@ -710,7 +705,7 @@ ORDER BY c["Name"], c["Id"]
 
             AssertSql(
                 """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
@@ -731,7 +726,7 @@ ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
 
             AssertSql(
                 """
-SELECT c["Name"]
+SELECT VALUE c["Name"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
@@ -767,7 +762,7 @@ ORDER BY c["PersonAddress"]["ZipCode"], c["Id"]
 
                 AssertSql(
                     """
-SELECT c["PersonAddress"]["ZipCode"] AS Nation
+SELECT VALUE c["PersonAddress"]["ZipCode"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -781,7 +776,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c["PersonAddress"]["ZipCode"] AS Nation
+SELECT VALUE c["PersonAddress"]["ZipCode"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -797,10 +792,9 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
             async, async a =>
             {
                 await base.Can_query_indexer_property_on_owned_collection(a);
-
-                AssertSql(
-                    """
-SELECT c["Name"]
+AssertSql(
+    """
+SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((
     SELECT VALUE COUNT(1)
@@ -844,7 +838,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["PersonAddress"]["PlaceType"], c["Id"]
@@ -860,7 +854,7 @@ ORDER BY c["PersonAddress"]["PlaceType"], c["Id"]
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Id"] = 1))
 OFFSET 0 LIMIT 2
@@ -869,7 +863,7 @@ OFFSET 0 LIMIT 2
                     """
 @__p_0='1'
 
-SELECT o AS o0
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o["ClientId"] = @__p_0))
@@ -917,7 +911,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
@@ -931,7 +925,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["PersonAddress"]["ZipCode"] = 38654))
 """);
@@ -949,7 +943,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
 
                 AssertSql(
                     """
-SELECT c["PersonAddress"]["AddressLine"]
+SELECT VALUE c["PersonAddress"]["AddressLine"]
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -963,7 +957,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("HeliumBalloon", "HydrogenBalloon")
 """);
@@ -980,7 +974,7 @@ WHERE c["Discriminator"] IN ("HeliumBalloon", "HydrogenBalloon")
 @__p_0='1'
 @__p_1='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -999,7 +993,7 @@ OFFSET @__p_0 LIMIT @__p_1
 @__p_0='1'
 @__p_1='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -1015,11 +1009,14 @@ OFFSET @__p_0 LIMIT @__p_1
             await CosmosTestHelpers.Instance.NoSyncTest(
                 async, async a =>
                 {
-                    await base.Non_nullable_property_through_optional_navigation(a);
+                    await Assert.ThrowsAsync<NullReferenceException>(
+                        () => AssertQuery(
+                            async,
+                            ss => ss.Set<Barton>().Select(e => new { e.Throned.Value })));
 
                     AssertSql(
                         """
-SELECT c["Throned"]["Value"]
+SELECT VALUE c["Throned"]["Value"]
 FROM root c
 WHERE (c["Discriminator"] = "Barton")
 """);
@@ -1035,7 +1032,7 @@ WHERE (c["Discriminator"] = "Barton")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -1049,7 +1046,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Star")
 """);
@@ -1063,7 +1060,7 @@ WHERE (c["Discriminator"] = "Star")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
@@ -1077,7 +1074,7 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Id"] = 1))
 """);
@@ -1093,7 +1090,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
                     """
 @__p_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -1113,7 +1110,7 @@ OFFSET 0 LIMIT @__p_0
                     """
 @__p_0='2'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
@@ -1131,7 +1128,7 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) = 2))
 """);
@@ -1147,7 +1144,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (AR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(c["Orders"]) > 0))
 """);
@@ -1163,7 +1160,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (AR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS (
     SELECT 1
@@ -1182,7 +1179,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS (
     SELECT 1
@@ -1201,7 +1198,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXI
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Orders"][1]["Id"] = -11))
 """);
@@ -1214,10 +1211,9 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
             async, async a =>
             {
                 await base.ElementAtOrDefault_over_owned_collection(a);
-
-                AssertSql(
-                    """
-SELECT c
+AssertSql(
+    """
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c["Orders"][10] ?? null)["Id"] = -11))
 """);
@@ -1233,10 +1229,9 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c
             var exception = await Assert.ThrowsAsync<CosmosException>(() => base.OrderBy_ElementAt_over_owned_collection(async));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
-SELECT c
+AssertSql(
+    """
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY(
     SELECT VALUE o["Id"]
@@ -1256,7 +1251,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (AR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(ARRAY_SLICE(c["Orders"], 1, 1)) = 1))
 """);
@@ -1272,7 +1267,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (AR
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (DateTimePart("yyyy", (ARRAY(
     SELECT VALUE o["OrderDate"]
@@ -1305,7 +1300,7 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (Da
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(SetUnion(ARRAY(
     SELECT VALUE o

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -474,8 +474,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count() == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
@@ -500,8 +501,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count() == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
@@ -526,8 +528,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Count == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE o["Details"]
 FROM root c
 JOIN o IN c["Orders"]
@@ -552,8 +555,9 @@ ORDER BY c["Id"]
                         .Where(e => e.Length == 1),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a));
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
@@ -792,8 +796,9 @@ WHERE c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
             async, async a =>
             {
                 await base.Can_query_indexer_property_on_owned_collection(a);
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE c["Name"]
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((
@@ -1211,8 +1216,9 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c[
             async, async a =>
             {
                 await base.ElementAtOrDefault_over_owned_collection(a);
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c["Orders"][10] ?? null)["Id"] = -11))
@@ -1229,8 +1235,9 @@ WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c
             var exception = await Assert.ThrowsAsync<CosmosException>(() => base.OrderBy_ElementAt_over_owned_collection(async));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-AssertSql(
-    """
+
+            AssertSql(
+                """
 SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -1915,8 +1915,9 @@ WHERE IS_DEFINED(c["Ints"][2])
                     a,
                     ss => ss.Set<PrimitiveCollectionsEntity>().Where(e => EF.Functions.CoalesceUndefined(e.Ints[2], 999) == 999),
                     ss => ss.Set<PrimitiveCollectionsEntity>().Where(e => e.Ints.Length < 3));
-AssertSql(
-    """
+
+                AssertSql(
+                    """
 SELECT VALUE c
 FROM root c
 WHERE ((c["Ints"][2] ?? 999) = 999)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -27,7 +27,7 @@ public class PrimitiveCollectionsQueryCosmosTest : PrimitiveCollectionsQueryTest
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Int"] IN (10, 999)
 """);
@@ -41,7 +41,7 @@ WHERE c["Int"] IN (10, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["NullableInt"] IN (10, 999)
 """);
@@ -55,7 +55,7 @@ WHERE c["NullableInt"] IN (10, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["NullableInt"] IN (null, 999)
 """);
@@ -69,7 +69,7 @@ WHERE c["NullableInt"] IN (null, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -86,7 +86,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -103,7 +103,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -120,7 +120,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -137,7 +137,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE false
 """);
@@ -160,7 +160,7 @@ WHERE false
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (2, 999)
 """);
@@ -174,7 +174,7 @@ WHERE c["Id"] IN (2, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (2, 999, 1000)
 """);
@@ -188,7 +188,7 @@ WHERE c["Id"] IN (2, 999, 1000)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (2, 999, 1000)
 """);
@@ -205,7 +205,7 @@ WHERE c["Id"] IN (2, 999, 1000)
 @__i_0='2'
 @__j_1='999'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (@__i_0, @__j_1)
 """);
@@ -221,7 +221,7 @@ WHERE c["Id"] IN (@__i_0, @__j_1)
                     """
 @__j_0='999'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (2, @__j_0)
 """);
@@ -237,7 +237,7 @@ WHERE c["Id"] IN (2, @__j_0)
                     """
 @__i_0='11'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
 """);
@@ -253,7 +253,7 @@ WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
                     """
 @__i_0='11'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
 """);
@@ -267,7 +267,7 @@ WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] IN (2, 999)
 """);
@@ -281,7 +281,7 @@ WHERE c["Id"] IN (2, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE c["Id"] NOT IN (2, 999)
 """);
@@ -295,7 +295,7 @@ WHERE c["Id"] NOT IN (2, 999)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
@@ -311,7 +311,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
@@ -327,7 +327,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
@@ -343,7 +343,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
@@ -361,7 +361,7 @@ WHERE ((
                     """
 @__i_0='25'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
@@ -379,7 +379,7 @@ WHERE ((
                     """
 @__i_0='25'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
@@ -397,7 +397,7 @@ WHERE ((
             """
 @__i_0='35'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
@@ -415,7 +415,7 @@ WHERE ((
                     """
 @__i_0='35'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
@@ -433,7 +433,7 @@ WHERE ((
                     """
 @__ids_0='[2,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -452,7 +452,7 @@ WHERE ((
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
 """,
@@ -460,7 +460,7 @@ WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
 """);
@@ -476,7 +476,7 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
 """,
@@ -484,7 +484,7 @@ WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
 """);
@@ -500,7 +500,7 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__ints_0, c["NullableInt"])
 """,
@@ -508,7 +508,7 @@ WHERE ARRAY_CONTAINS(@__ints_0, c["NullableInt"])
                     """
 @__ints_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["NullableInt"]))
 """);
@@ -524,7 +524,7 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["NullableInt"]))
                     """
 @__nullableInts_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__nullableInts_0, c["Int"])
 """,
@@ -532,7 +532,7 @@ WHERE ARRAY_CONTAINS(@__nullableInts_0, c["Int"])
                     """
 @__nullableInts_0='[10,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["Int"]))
 """);
@@ -548,7 +548,7 @@ WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["Int"]))
                     """
 @__nullableInts_0='[null,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"])
 """,
@@ -556,7 +556,7 @@ WHERE ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"])
                     """
 @__nullableInts_0='[null,999]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"]))
 """);
@@ -572,7 +572,7 @@ WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"]))
                     """
 @__strings_0='["10","999"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
 """,
@@ -580,7 +580,7 @@ WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
                     """
 @__strings_0='["10","999"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
 """);
@@ -596,7 +596,7 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
                     """
 @__strings_0='["10","999"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
 """,
@@ -604,7 +604,7 @@ WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
                     """
 @__strings_0='["10","999"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
 """);
@@ -620,7 +620,7 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
                     """
 @__strings_0='["10",null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
 """,
@@ -628,7 +628,7 @@ WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
                     """
 @__strings_0='["10",null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
 """);
@@ -644,7 +644,7 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
                     """
 @__strings_0='["999",null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
 """,
@@ -652,7 +652,7 @@ WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
                     """
 @__strings_0='["999",null]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
 """);
@@ -668,7 +668,7 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
                     """
 @__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__dateTimes_0, c["DateTime"])
 """);
@@ -684,7 +684,7 @@ WHERE ARRAY_CONTAINS(@__dateTimes_0, c["DateTime"])
                     """
 @__bools_0='[true]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__bools_0, c["Bool"])
 """);
@@ -700,7 +700,7 @@ WHERE ARRAY_CONTAINS(@__bools_0, c["Bool"])
                     """
 @__enums_0='[0,3]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__enums_0, c["Enum"])
 """);
@@ -716,7 +716,7 @@ WHERE ARRAY_CONTAINS(@__enums_0, c["Enum"])
                     """
 @__ints_0=null
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
 """);
@@ -730,7 +730,7 @@ WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["Ints"], 10)
 """);
@@ -744,7 +744,7 @@ WHERE ARRAY_CONTAINS(c["Ints"], 10)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["NullableInts"], 10)
 """);
@@ -758,7 +758,7 @@ WHERE ARRAY_CONTAINS(c["NullableInts"], 10)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["NullableInts"], null)
 """);
@@ -772,7 +772,7 @@ WHERE ARRAY_CONTAINS(c["NullableInts"], null)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["Strings"], null)
 """);
@@ -786,7 +786,7 @@ WHERE ARRAY_CONTAINS(c["Strings"], null)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["NullableStrings"], null)
 """);
@@ -800,7 +800,7 @@ WHERE ARRAY_CONTAINS(c["NullableStrings"], null)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(c["Bools"], true)
 """);
@@ -814,7 +814,7 @@ WHERE ARRAY_CONTAINS(c["Bools"], true)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(c["Ints"]) = 2)
 """);
@@ -828,7 +828,7 @@ WHERE (ARRAY_LENGTH(c["Ints"]) = 2)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(c["Ints"]) = 2)
 """);
@@ -842,7 +842,7 @@ WHERE (ARRAY_LENGTH(c["Ints"]) = 2)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -859,7 +859,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
@@ -876,7 +876,7 @@ WHERE ((
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"][1] = 10)
 """);
@@ -890,7 +890,7 @@ WHERE (c["Ints"][1] = 10)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Strings"][1] = "10")
 """);
@@ -904,7 +904,7 @@ WHERE (c["Strings"][1] = "10")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["DateTimes"][1] = "2020-01-10T12:30:00Z")
 """);
@@ -918,7 +918,7 @@ WHERE (c["DateTimes"][1] = "2020-01-10T12:30:00Z")
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"][999] = 10)
 """);
@@ -933,7 +933,7 @@ WHERE (c["Ints"][999] = 10)
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["NullableStrings"][2] = c["NullableString"])
 """);
@@ -948,7 +948,7 @@ WHERE (c["NullableStrings"][2] = c["NullableString"])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((ARRAY_LENGTH(c["Strings"]) > 0) AND (c["Strings"][1] = c["NullableString"]))
 """);
@@ -966,7 +966,7 @@ WHERE ((ARRAY_LENGTH(c["Strings"]) > 0) AND (c["Strings"][1] = c["NullableString
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ([1, 2, 3][c["Int"]] = 1)
 """);
@@ -985,7 +985,7 @@ WHERE ([1, 2, 3][c["Int"]] = 1)
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ([1, c["Int"], 3][c["Int"]] = 1)
 """);
@@ -1004,7 +1004,7 @@ WHERE ([1, c["Int"], 3][c["Int"]] = 1)
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ([1, c["Int"], 3][c["Int"]] = 1)
 """);
@@ -1025,7 +1025,7 @@ WHERE ([1, c["Int"], 3][c["Int"]] = 1)
                 """
 @__ints_0='[0,2,3]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (@__ints_0[c["Int"]] = c["Int"])
 """);
@@ -1046,7 +1046,7 @@ WHERE (@__ints_0[c["Int"]] = c["Int"])
                 """
 @__ints_0='[1,2,3]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (@__ints_0[c["Int"]] = 1)
 """);
@@ -1061,7 +1061,7 @@ WHERE (@__ints_0[c["Int"]] = 1)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"][1] = 10)
 """);
@@ -1075,7 +1075,7 @@ WHERE (c["Ints"][1] = 10)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"][0] = 1)
 """);
@@ -1089,7 +1089,7 @@ WHERE (c["Ints"][0] = 1)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Ints"][0] ?? 0) = 1)
 """);
@@ -1103,7 +1103,7 @@ WHERE ((c["Ints"][0] ?? 0) = 1)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"][0] = 1)
 """);
@@ -1117,7 +1117,7 @@ WHERE (c["Ints"][0] = 1)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Ints"][0] ?? 0) = 1)
 """);
@@ -1131,7 +1131,7 @@ WHERE ((c["Ints"][0] ?? 0) = 1)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(ARRAY_SLICE(c["Ints"], 1)) = 2)
 """);
@@ -1145,7 +1145,7 @@ WHERE (ARRAY_LENGTH(ARRAY_SLICE(c["Ints"], 1)) = 2)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(ARRAY_SLICE(c["Ints"], 0, 2), 11)
 """);
@@ -1159,7 +1159,7 @@ WHERE ARRAY_CONTAINS(ARRAY_SLICE(c["Ints"], 0, 2), 11)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(ARRAY_SLICE(c["Ints"], 1, 2), 11)
 """);
@@ -1173,7 +1173,7 @@ WHERE ARRAY_CONTAINS(ARRAY_SLICE(c["Ints"], 1, 2), 11)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
     SELECT VALUE i
@@ -1190,7 +1190,7 @@ WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
     SELECT VALUE i
@@ -1207,7 +1207,7 @@ WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
     SELECT VALUE i
@@ -1224,7 +1224,7 @@ WHERE (ARRAY_LENGTH(ARRAY_SLICE(ARRAY(
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE EXISTS (
     SELECT 1
@@ -1245,7 +1245,7 @@ WHERE EXISTS (
 
             AssertSql(
                 """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY(
     SELECT VALUE i
@@ -1263,7 +1263,7 @@ WHERE (ARRAY(
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY(
     SELECT VALUE i
@@ -1280,7 +1280,7 @@ WHERE (ARRAY(
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(c["Ints"]) > 0)
 """);
@@ -1302,7 +1302,7 @@ WHERE (ARRAY_LENGTH(c["Ints"]) > 0)
 
                 AssertSql(
                     """
-SELECT i AS i0
+SELECT VALUE i
 FROM root c
 JOIN i IN c["Ints"]
 """);
@@ -1316,7 +1316,7 @@ JOIN i IN c["Ints"]
 
                 AssertSql(
                     """
-SELECT j
+SELECT VALUE j
 FROM root c
 JOIN (
     SELECT VALUE i
@@ -1346,7 +1346,7 @@ JOIN (
 
                 AssertSql(
                     """
-SELECT c["Ints"]
+SELECT VALUE c["Ints"]
 FROM root c
 ORDER BY c["Id"]
 """);
@@ -1378,7 +1378,7 @@ ORDER BY c["Id"]
                     """
 @__ints_0='[11,111]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(ARRAY_CONCAT(@__ints_0, c["Ints"])) = 2)
 """);
@@ -1394,7 +1394,7 @@ WHERE (ARRAY_LENGTH(ARRAY_CONCAT(@__ints_0, c["Ints"])) = 2)
                     """
 @__ints_0='[11,111]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(SetUnion(c["Ints"], @__ints_0)) = 2)
 """);
@@ -1408,7 +1408,7 @@ WHERE (ARRAY_LENGTH(SetUnion(c["Ints"], @__ints_0)) = 2)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(SetIntersect(c["Ints"], [11, 111])) = 2)
 """);
@@ -1431,7 +1431,7 @@ WHERE (ARRAY_LENGTH(SetIntersect(c["Ints"], [11, 111])) = 2)
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(SetUnion(ARRAY(
     SELECT VALUE i
@@ -1450,7 +1450,7 @@ WHERE (ARRAY_LENGTH(SetUnion(ARRAY(
                     """
 @__ints_0='[1,10]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"] = @__ints_0)
 """);
@@ -1466,7 +1466,7 @@ WHERE (c["Ints"] = @__ints_0)
                     """
 @__ints_0='[1,10]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_CONCAT(c["Ints"], @__ints_0) = [1,11,111,1,10])
 """);
@@ -1480,7 +1480,7 @@ WHERE (ARRAY_CONCAT(c["Ints"], @__ints_0) = [1,11,111,1,10])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"] = [1,10])
 """);
@@ -1497,7 +1497,7 @@ WHERE (c["Ints"] = [1,10])
 @__i_0='1'
 @__j_1='10'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Ints"] = [@__i_0, @__j_1])
 """);
@@ -1511,7 +1511,7 @@ WHERE (c["Ints"] = [@__i_0, @__j_1])
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY(
     SELECT VALUE i
@@ -1542,7 +1542,7 @@ WHERE (ARRAY(
                     """
 @__Skip_0='[111]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (ARRAY_LENGTH(SetUnion(@__Skip_0, c["Ints"])) = 3)
 """);
@@ -1609,7 +1609,7 @@ WHERE (ARRAY_LENGTH(SetUnion(@__Skip_0, c["Ints"])) = 3)
 
                 AssertSql(
                     """
-SELECT c["Ints"]
+SELECT VALUE c["Ints"]
 FROM root c
 ORDER BY c["Id"]
 """);
@@ -1627,10 +1627,10 @@ ORDER BY c["Id"]
 
             AssertSql(
                 """
-SELECT ARRAY(
+SELECT VALUE ARRAY(
     SELECT VALUE i
     FROM i IN c["Ints"]
-    ORDER BY i DESC) AS c
+    ORDER BY i DESC)
 FROM root c
 ORDER BY c["Id"]
 """);
@@ -1645,10 +1645,10 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT ARRAY(
+SELECT VALUE ARRAY(
     SELECT VALUE d
     FROM d IN c["DateTimes"]
-    WHERE (DateTimePart("dd", d) != 1)) AS c
+    WHERE (DateTimePart("dd", d) != 1))
 FROM root c
 ORDER BY c["Id"]
 """);
@@ -1698,9 +1698,9 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT ARRAY(
+SELECT VALUE ARRAY(
     SELECT DISTINCT VALUE i
-    FROM i IN c["Ints"]) AS c
+    FROM i IN c["Ints"])
 FROM root c
 ORDER BY c["Id"]
 """);
@@ -1726,12 +1726,11 @@ WHERE (c["Discriminator"] = "PrimitiveCollectionsEntity")
             {
                 await base.Project_collection_of_ints_with_ToList_and_FirstOrDefault(a);
 
-                // TODO: Improve SQL, #34081
                 AssertSql(
                     """
-SELECT ARRAY(
+SELECT VALUE ARRAY(
     SELECT VALUE i
-    FROM i IN c["Ints"]) AS c
+    FROM i IN c["Ints"])
 FROM root c
 ORDER BY c["Id"]
 OFFSET 0 LIMIT 1
@@ -1771,7 +1770,6 @@ ORDER BY c["Id"]
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
 
-            // TODO: Improve SQL, #34081
             AssertSql(
                 """
 SELECT VALUE
@@ -1827,7 +1825,7 @@ ORDER BY c["Id"]
                 // The following should be SELECT VALUE [c["String"], "foo"], #33779
                 AssertSql(
                     """
-SELECT [c["String"], "foo"] AS c
+SELECT VALUE [c["String"], "foo"]
 FROM root c
 """);
             });
@@ -1863,7 +1861,7 @@ FROM root c
 @__strings_1='["one","two","three"]'
 @__ints_0='[1,2,3]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two"))
 """);
@@ -1880,7 +1878,7 @@ WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" 
 @__strings_1='["one","two","three"]'
 @__ints_0='[1,2,3]'
 
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two"))
 """);
@@ -1901,7 +1899,7 @@ WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" 
 
                 AssertSql(
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE IS_DEFINED(c["Ints"][2])
 """);
@@ -1917,10 +1915,9 @@ WHERE IS_DEFINED(c["Ints"][2])
                     a,
                     ss => ss.Set<PrimitiveCollectionsEntity>().Where(e => EF.Functions.CoalesceUndefined(e.Ints[2], 999) == 999),
                     ss => ss.Set<PrimitiveCollectionsEntity>().Where(e => e.Ints.Length < 3));
-
-                AssertSql(
-                    """
-SELECT c
+AssertSql(
+    """
+SELECT VALUE c
 FROM root c
 WHERE ((c["Ints"][2] ?? 999) = 999)
 """);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTestBase.cs
@@ -45,7 +45,7 @@ public abstract class QueryLoggingCosmosTestBase
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
                     "NorthwindContext", "None", "", Environment.NewLine,
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """),
@@ -57,7 +57,7 @@ WHERE (c["Discriminator"] = "Customer")
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
                     "NorthwindContext", "?", "", Environment.NewLine,
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Customer")
 """),
@@ -91,7 +91,7 @@ WHERE (c["Discriminator"] = "Customer")
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
                     "NorthwindContext", "None", "@__city_0='Redmond'", Environment.NewLine,
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """),
@@ -103,7 +103,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
                     "NorthwindContext", "?", "@__city_0=?", Environment.NewLine,
                     """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = @__city_0))
 """),

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
@@ -24,7 +24,7 @@ public class ReadItemPartitionKeyQueryTest : QueryTestBase<ReadItemPartitionKeyQ
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 """);
     }
@@ -38,7 +38,7 @@ FROM root c
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 """);
     }
@@ -53,7 +53,7 @@ FROM root c
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["PartitionKey1"] = "PK1") AND (c["PartitionKey2"] = 1))
 """);
@@ -69,7 +69,7 @@ WHERE ((c["PartitionKey1"] = "PK1") AND (c["PartitionKey2"] = 1))
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE CONTAINS(c["Payload"], "3")
 """);
@@ -88,7 +88,7 @@ WHERE CONTAINS(c["Payload"], "3")
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 """);
     }
@@ -103,7 +103,7 @@ FROM root c
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 """);
     }
@@ -132,7 +132,7 @@ FROM root c
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["PartitionKey"] = "PK2")
 """);
@@ -149,7 +149,7 @@ WHERE (c["PartitionKey"] = "PK2")
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["PartitionKey"] = "PK1")
 """);
@@ -247,7 +247,7 @@ WHERE (c["PartitionKey"] = "PK1")
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE ((c["Id"] = 1) AND (c["Id"] = 2))
 """);
@@ -272,7 +272,7 @@ WHERE ((c["Id"] = 1) AND (c["Id"] = 2))
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Id"] = 1)
 """);
@@ -328,7 +328,7 @@ WHERE (c["Id"] = 1)
 
         AssertSql(
             """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] IN ("SharedContainerEntity2", "SharedContainerEntity2Child") AND (c["Id"] = 4))
 """);


### PR DESCRIPTION
@ajcvickers as discussed offline, here's a draft PR which changes the Cosmos NoSQL we generate to add VALUE for single-projection SelectExpressions; this stops wrapping results in an additional JSON object.

The tests to look at are NorthwindSelectQueryTestBase.Select_scalar (for scalar projections) and NorthwindSelectQueryTestBase.Select_customer_identity (for structural types); I've included all the information [here and below](https://github.com/dotnet/efcore/issues/25527#issuecomment-2181561173). Note that we we also have array projections - both scalar and projections - which should work the same way; but there's a bit of extra trouble there which I'll be looking at next.

Closes #25527
