### PR TITLE
Index convention changes for non-relational providers

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -40,6 +40,7 @@ public class CosmosModelValidator : ModelValidator
         ValidateKeys(model, logger);
         ValidateSharedContainerCompatibility(model, logger);
         ValidateOnlyETagConcurrencyToken(model, logger);
+        ValidateIndexes(model, logger);
     }
 
     /// <summary>
@@ -428,6 +429,28 @@ public class CosmosModelValidator : ModelValidator
                 }
 
                 properties[jsonName] = navigation;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual void ValidateIndexes(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            foreach (var index in entityType.GetDeclaredIndexes())
+            {
+                throw new InvalidOperationException(
+                    CosmosStrings.IndexesExist(
+                        entityType.DisplayName(),
+                        string.Join(",", index.Properties.Select(e => e.Name))));
             }
         }
     }

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -35,6 +35,7 @@ public class CosmosConventionSetBuilder : ProviderConventionSetBuilder
         conventionSet.Add(new ContextContainerConvention(Dependencies));
         conventionSet.Add(new ETagPropertyConvention());
         conventionSet.Add(new StoreKeyConvention(Dependencies));
+        conventionSet.Remove(typeof(ForeignKeyIndexConvention));
 
         conventionSet.Replace<ValueGenerationConvention>(new CosmosValueGenerationConvention(Dependencies));
         conventionSet.Replace<KeyDiscoveryConvention>(new CosmosKeyDiscoveryConvention(Dependencies));

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
-
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 idProperty, entityType, propertyType);
 
         /// <summary>
-        ///     The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core does not support index definitions.
+        ///     The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core currently does not support index definitions.
         /// </summary>
         public static string IndexesExist(object? entityType, object? properties)
             => string.Format(

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -108,6 +108,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 idProperty, entityType, propertyType);
 
         /// <summary>
+        ///     The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core does not support index definitions.
+        /// </summary>
+        public static string IndexesExist(object? entityType, object? properties)
+            => string.Format(
+                GetString("IndexesExist", nameof(entityType), nameof(properties)),
+                entityType, properties);
+
+        /// <summary>
         ///     The specified entity type '{derivedType}' is not derived from '{entityType}'.
         /// </summary>
         public static string InvalidDerivedTypeInEntityProjection(object? derivedType, object? entityType)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -153,6 +153,9 @@
   <data name="IdNonStringStoreType" xml:space="preserve">
     <value>The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.</value>
   </data>
+  <data name="IndexesExist" xml:space="preserve">
+    <value>The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core does not support index definitions.</value>
+  </data>
   <data name="InvalidDerivedTypeInEntityProjection" xml:space="preserve">
     <value>The specified entity type '{derivedType}' is not derived from '{entityType}'.</value>
   </data>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -154,7 +154,7 @@
     <value>The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.</value>
   </data>
   <data name="IndexesExist" xml:space="preserve">
-    <value>The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core does not support index definitions.</value>
+    <value>The entity type '{entityType}' has an index defined over properties '{properties}'. The Azure Cosmos DB provider for EF Core currently does not support index definitions.</value>
   </data>
   <data name="InvalidDerivedTypeInEntityProjection" xml:space="preserve">
     <value>The specified entity type '{derivedType}' is not derived from '{entityType}'.</value>

--- a/src/EFCore.InMemory/Metadata/Conventions/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/InMemoryConventionSetBuilder.cs
@@ -37,6 +37,7 @@ public class InMemoryConventionSetBuilder : ProviderConventionSetBuilder
         var conventionSet = base.CreateConventionSet();
 
         conventionSet.Add(new DefiningQueryRewritingConvention(Dependencies));
+        conventionSet.Remove(typeof(ForeignKeyIndexConvention));
 
         return conventionSet;
     }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -78,6 +78,7 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
         conventionSet.Add(new SequenceUniquificationConvention(Dependencies, RelationalDependencies));
         conventionSet.Add(new SharedTableConvention(Dependencies, RelationalDependencies));
         conventionSet.Add(new RelationalMapToJsonConvention(Dependencies, RelationalDependencies));
+        conventionSet.Add(new ForeignKeyIndexConvention(Dependencies));
 
         conventionSet.Replace<ValueGenerationConvention>(
             new RelationalValueGenerationConvention(Dependencies, RelationalDependencies));

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -78,7 +78,6 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
         conventionSet.Add(new SequenceUniquificationConvention(Dependencies, RelationalDependencies));
         conventionSet.Add(new SharedTableConvention(Dependencies, RelationalDependencies));
         conventionSet.Add(new RelationalMapToJsonConvention(Dependencies, RelationalDependencies));
-        conventionSet.Add(new ForeignKeyIndexConvention(Dependencies));
 
         conventionSet.Replace<ValueGenerationConvention>(
             new RelationalValueGenerationConvention(Dependencies, RelationalDependencies));

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -93,7 +93,6 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         conventionSet.Add(new ConstructorBindingConvention(Dependencies));
         conventionSet.Add(new KeyAttributeConvention(Dependencies));
         conventionSet.Add(new IndexAttributeConvention(Dependencies));
-        conventionSet.Add(new ForeignKeyIndexConvention(Dependencies));
         conventionSet.Add(new ForeignKeyPropertyDiscoveryConvention(Dependencies));
         conventionSet.Add(new NonNullableReferencePropertyConvention(Dependencies));
         conventionSet.Add(new NonNullableNavigationConvention(Dependencies));

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -93,6 +93,7 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         conventionSet.Add(new ConstructorBindingConvention(Dependencies));
         conventionSet.Add(new KeyAttributeConvention(Dependencies));
         conventionSet.Add(new IndexAttributeConvention(Dependencies));
+        conventionSet.Add(new ForeignKeyIndexConvention(Dependencies));
         conventionSet.Add(new ForeignKeyPropertyDiscoveryConvention(Dependencies));
         conventionSet.Add(new NonNullableReferencePropertyConvention(Dependencies));
         conventionSet.Add(new NonNullableNavigationConvention(Dependencies));

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesDefaultInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesDefaultInMemoryTest.cs
@@ -11,6 +11,9 @@ public class AspNetIdentityCustomTypesDefaultInMemoryTest(AspNetIdentityCustomTy
     {
     }
 
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<CustomTypesIdentityContext, Task> testOperation,
         Func<CustomTypesIdentityContext, Task> nestedTestOperation1 = null,

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesIntKeyInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesIntKeyInMemoryTest.cs
@@ -7,6 +7,9 @@ public class AspNetIdentityCustomTypesIntKeyInMemoryTest(AspNetIdentityCustomTyp
     : AspNetIdentityCustomTypesIntKeyTestBase<
         AspNetIdentityCustomTypesIntKeyInMemoryTest.AspNetIdentityCustomTypesIntKeyInMemoryFixture>(fixture)
 {
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
     {
     }

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityDefaultInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityDefaultInMemoryTest.cs
@@ -8,6 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 public class AspNetIdentityDefaultInMemoryTest(AspNetIdentityDefaultInMemoryTest.AspNetDefaultIdentityInMemoryFixture fixture)
     : AspNetIdentityDefaultTestBase<AspNetIdentityDefaultInMemoryTest.AspNetDefaultIdentityInMemoryFixture>(fixture)
 {
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
     {
     }

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityIntKeyInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityIntKeyInMemoryTest.cs
@@ -9,6 +9,9 @@ namespace Microsoft.EntityFrameworkCore;
 public class AspNetIdentityIntKeyInMemoryTest(AspNetIdentityIntKeyInMemoryTest.AspNetIdentityIntKeyInMemoryFixture fixture)
     : AspNetIdentityIntKeyTestBase<AspNetIdentityIntKeyInMemoryTest.AspNetIdentityIntKeyInMemoryFixture>(fixture)
 {
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
     {
     }

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/ConfigurationDbContextInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/ConfigurationDbContextInMemoryTest.cs
@@ -8,6 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 public class ConfigurationDbContextInMemoryTest(ConfigurationDbContextInMemoryTest.ConfigurationDbContextInMemoryFixture fixture)
     : ConfigurationDbContextTestBase<ConfigurationDbContextInMemoryTest.ConfigurationDbContextInMemoryFixture>(fixture)
 {
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
     {
     }

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/GrpcInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/GrpcInMemoryTest.cs
@@ -7,6 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public class GrpcInMemoryTest(GrpcInMemoryTest.GrpcInMemoryFixture fixture) : GrpcTestBase<GrpcInMemoryTest.GrpcInMemoryFixture>(fixture)
 {
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     public class GrpcInMemoryFixture : GrpcFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
@@ -170,9 +170,9 @@ public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>
                     "Property: CustomRoleClaimString.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: CustomRoleClaimString.ClaimType (string)",
                     "Property: CustomRoleClaimString.ClaimValue (string)",
-                    "Property: CustomRoleClaimString.RoleId (string) Required FK Index",
+                    $"Property: CustomRoleClaimString.RoleId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: CustomRoleClaimString {'RoleId'} -> CustomRoleString {'Id'} Required Cascade ToDependent: RoleClaims ToPrincipal: Role",
@@ -215,9 +215,9 @@ public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>
                     "Property: CustomUserClaimString.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: CustomUserClaimString.ClaimType (string)",
                     "Property: CustomUserClaimString.ClaimValue (string)",
-                    "Property: CustomUserClaimString.UserId (string) Required FK Index",
+                    $"Property: CustomUserClaimString.UserId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: CustomUserClaimString {'UserId'} -> CustomUserString {'Id'} Required Cascade ToDependent: Claims ToPrincipal: User",
@@ -237,9 +237,9 @@ public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>
                     "Property: CustomUserLoginString.LoginProvider (string) Required PK AfterSave:Throw",
                     "Property: CustomUserLoginString.ProviderKey (string) Required PK AfterSave:Throw",
                     "Property: CustomUserLoginString.ProviderDisplayName (string)",
-                    "Property: CustomUserLoginString.UserId (string) Required FK Index",
+                    $"Property: CustomUserLoginString.UserId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: CustomUserLoginString {'UserId'} -> CustomUserString {'Id'} Required Cascade ToDependent: Logins ToPrincipal: User",
@@ -257,9 +257,9 @@ public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>
                 Properties =
                 {
                     "Property: CustomUserRoleString.UserId (string) Required PK FK AfterSave:Throw",
-                    "Property: CustomUserRoleString.RoleId (string) Required PK FK Index AfterSave:Throw",
+                    $"Property: CustomUserRoleString.RoleId (string) Required PK FK{(HasForeignKeyIndexes ? " Index" : "")} AfterSave:Throw",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: CustomUserRoleString {'RoleId'} -> CustomRoleString {'Id'} Required Cascade ToDependent: UserRoles ToPrincipal: Role",

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
@@ -58,9 +58,9 @@ public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>
                     "Property: CustomRoleClaimInt.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: CustomRoleClaimInt.ClaimType (string)",
                     "Property: CustomRoleClaimInt.ClaimValue (string)",
-                    "Property: CustomRoleClaimInt.RoleId (int) Required FK Index",
+                    $"Property: CustomRoleClaimInt.RoleId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs = { "ForeignKey: CustomRoleClaimInt {'RoleId'} -> CustomRoleInt {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -87,9 +87,9 @@ public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>
                     "Property: CustomUserClaimInt.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: CustomUserClaimInt.ClaimType (string)",
                     "Property: CustomUserClaimInt.ClaimValue (string)",
-                    "Property: CustomUserClaimInt.UserId (int) Required FK Index",
+                    $"Property: CustomUserClaimInt.UserId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: CustomUserClaimInt {'UserId'} -> CustomUserInt {'Id'} Required Cascade ToDependent: Claims", },
             },
             new EntityTypeMapping
@@ -138,9 +138,9 @@ public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>
                     "Property: CustomUserLoginInt.LoginProvider (string) Required PK AfterSave:Throw",
                     "Property: CustomUserLoginInt.ProviderKey (string) Required PK AfterSave:Throw",
                     "Property: CustomUserLoginInt.ProviderDisplayName (string)",
-                    "Property: CustomUserLoginInt.UserId (int) Required FK Index",
+                    $"Property: CustomUserLoginInt.UserId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: CustomUserLoginInt {'UserId'} -> CustomUserInt {'Id'} Required Cascade ToDependent: Logins", },
             },
             new EntityTypeMapping
@@ -151,9 +151,9 @@ public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>
                 Properties =
                 {
                     "Property: CustomUserRoleInt.UserId (int) Required PK FK AfterSave:Throw",
-                    "Property: CustomUserRoleInt.RoleId (int) Required PK FK Index AfterSave:Throw",
+                    $"Property: CustomUserRoleInt.RoleId (int) Required PK FK{(HasForeignKeyIndexes ? " Index" : "")} AfterSave:Throw",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: CustomUserRoleInt {'RoleId'} -> CustomRoleInt {'Id'} Required Cascade",

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityDefaultTestBase.cs
@@ -44,9 +44,9 @@ public abstract class AspNetIdentityDefaultTestBase<TFixture>
                     "Property: IdentityRoleClaim<string>.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: IdentityRoleClaim<string>.ClaimType (string)",
                     "Property: IdentityRoleClaim<string>.ClaimValue (string)",
-                    "Property: IdentityRoleClaim<string>.RoleId (string) Required FK Index",
+                    $"Property: IdentityRoleClaim<string>.RoleId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs = { "ForeignKey: IdentityRoleClaim<string> {'RoleId'} -> IdentityRole {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -87,9 +87,9 @@ public abstract class AspNetIdentityDefaultTestBase<TFixture>
                     "Property: IdentityUserClaim<string>.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: IdentityUserClaim<string>.ClaimType (string)",
                     "Property: IdentityUserClaim<string>.ClaimValue (string)",
-                    "Property: IdentityUserClaim<string>.UserId (string) Required FK Index",
+                    $"Property: IdentityUserClaim<string>.UserId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: IdentityUserClaim<string> {'UserId'} -> IdentityUser {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -102,9 +102,9 @@ public abstract class AspNetIdentityDefaultTestBase<TFixture>
                     "Property: IdentityUserLogin<string>.LoginProvider (string) Required PK AfterSave:Throw",
                     "Property: IdentityUserLogin<string>.ProviderKey (string) Required PK AfterSave:Throw",
                     "Property: IdentityUserLogin<string>.ProviderDisplayName (string)",
-                    "Property: IdentityUserLogin<string>.UserId (string) Required FK Index",
+                    $"Property: IdentityUserLogin<string>.UserId (string) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: IdentityUserLogin<string> {'UserId'} -> IdentityUser {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -115,9 +115,9 @@ public abstract class AspNetIdentityDefaultTestBase<TFixture>
                 Properties =
                 {
                     "Property: IdentityUserRole<string>.UserId (string) Required PK FK AfterSave:Throw",
-                    "Property: IdentityUserRole<string>.RoleId (string) Required PK FK Index AfterSave:Throw",
+                    $"Property: IdentityUserRole<string>.RoleId (string) Required PK FK{(HasForeignKeyIndexes ? " Index" : "")} AfterSave:Throw",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: IdentityUserRole<string> {'RoleId'} -> IdentityRole {'Id'} Required Cascade",

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityIntKeyTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityIntKeyTestBase.cs
@@ -46,9 +46,9 @@ public abstract class AspNetIdentityIntKeyTestBase<TFixture>
                     "Property: IdentityRoleClaim<int>.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: IdentityRoleClaim<int>.ClaimType (string)",
                     "Property: IdentityRoleClaim<int>.ClaimValue (string)",
-                    "Property: IdentityRoleClaim<int>.RoleId (int) Required FK Index",
+                    $"Property: IdentityRoleClaim<int>.RoleId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs = { "ForeignKey: IdentityRoleClaim<int> {'RoleId'} -> IdentityRole<int> {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -89,9 +89,9 @@ public abstract class AspNetIdentityIntKeyTestBase<TFixture>
                     "Property: IdentityUserClaim<int>.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: IdentityUserClaim<int>.ClaimType (string)",
                     "Property: IdentityUserClaim<int>.ClaimValue (string)",
-                    "Property: IdentityUserClaim<int>.UserId (int) Required FK Index",
+                    $"Property: IdentityUserClaim<int>.UserId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: IdentityUserClaim<int> {'UserId'} -> IdentityUser<int> {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -104,9 +104,9 @@ public abstract class AspNetIdentityIntKeyTestBase<TFixture>
                     "Property: IdentityUserLogin<int>.LoginProvider (string) Required PK AfterSave:Throw",
                     "Property: IdentityUserLogin<int>.ProviderKey (string) Required PK AfterSave:Throw",
                     "Property: IdentityUserLogin<int>.ProviderDisplayName (string)",
-                    "Property: IdentityUserLogin<int>.UserId (int) Required FK Index",
+                    $"Property: IdentityUserLogin<int>.UserId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                 },
-                Indexes = { "{'UserId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'UserId'} "] : [],
                 FKs = { "ForeignKey: IdentityUserLogin<int> {'UserId'} -> IdentityUser<int> {'Id'} Required Cascade", },
             },
             new EntityTypeMapping
@@ -117,9 +117,9 @@ public abstract class AspNetIdentityIntKeyTestBase<TFixture>
                 Properties =
                 {
                     "Property: IdentityUserRole<int>.UserId (int) Required PK FK AfterSave:Throw",
-                    "Property: IdentityUserRole<int>.RoleId (int) Required PK FK Index AfterSave:Throw",
+                    $"Property: IdentityUserRole<int>.RoleId (int) Required PK FK{(HasForeignKeyIndexes ? " Index" : "")} AfterSave:Throw",
                 },
-                Indexes = { "{'RoleId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'RoleId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: IdentityUserRole<int> {'RoleId'} -> IdentityRole<int> {'Id'} Required Cascade",

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
@@ -27,6 +27,9 @@ public abstract class
         Fixture = fixture;
     }
 
+    protected virtual bool HasForeignKeyIndexes
+        => true;
+
     [ConditionalFact]
     public void Can_build_identity_model()
     {

--- a/test/EFCore.AspNet.Specification.Tests/ConfigurationDbContextTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/ConfigurationDbContextTestBase.cs
@@ -18,6 +18,9 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
 
     protected ConfigurationDbContextFixtureBase Fixture { get; }
 
+    protected virtual bool HasForeignKeyIndexes
+        => true;
+
     [ConditionalFact(
         Skip =
             "VerificationException : Method System.Linq.Enumerable.MaxFloat: type argument 'System.Char' violates the constraint of type parameter 'T'.")]
@@ -283,10 +286,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ApiResourceClaim.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ApiResourceClaim.ApiResourceId (int) Required FK Index",
+                    $"Property: ApiResourceClaim.ApiResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiResourceClaim.Type (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'ApiResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ApiResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiResourceClaim {'ApiResourceId'} -> ApiResource {'Id'} Required Cascade ToDependent: UserClaims ToPrincipal: ApiResource",
@@ -301,11 +304,11 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ApiResourceProperty.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ApiResourceProperty.ApiResourceId (int) Required FK Index",
+                    $"Property: ApiResourceProperty.ApiResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiResourceProperty.Key (string) Required MaxLength(250)",
                     "Property: ApiResourceProperty.Value (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'ApiResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ApiResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiResourceProperty {'ApiResourceId'} -> ApiResource {'Id'} Required Cascade ToDependent: Properties ToPrincipal: ApiResource",
@@ -320,10 +323,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ApiResourceScope.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ApiResourceScope.ApiResourceId (int) Required FK Index",
+                    $"Property: ApiResourceScope.ApiResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiResourceScope.Scope (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'ApiResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ApiResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiResourceScope {'ApiResourceId'} -> ApiResource {'Id'} Required Cascade ToDependent: Scopes ToPrincipal: ApiResource",
@@ -338,14 +341,14 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ApiResourceSecret.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ApiResourceSecret.ApiResourceId (int) Required FK Index",
+                    $"Property: ApiResourceSecret.ApiResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiResourceSecret.Created (DateTime) Required",
                     "Property: ApiResourceSecret.Description (string) MaxLength(1000)",
                     "Property: ApiResourceSecret.Expiration (DateTime?)",
                     "Property: ApiResourceSecret.Type (string) Required MaxLength(250)",
                     "Property: ApiResourceSecret.Value (string) Required MaxLength(4000)",
                 },
-                Indexes = { "{'ApiResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ApiResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiResourceSecret {'ApiResourceId'} -> ApiResource {'Id'} Required Cascade ToDependent: Secrets ToPrincipal: ApiResource",
@@ -383,10 +386,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ApiScopeClaim.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ApiScopeClaim.ScopeId (int) Required FK Index",
+                    $"Property: ApiScopeClaim.ScopeId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiScopeClaim.Type (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'ScopeId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ScopeId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiScopeClaim {'ScopeId'} -> ApiScope {'Id'} Required Cascade ToDependent: UserClaims ToPrincipal: Scope",
@@ -402,10 +405,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 {
                     "Property: ApiScopeProperty.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
                     "Property: ApiScopeProperty.Key (string) Required MaxLength(250)",
-                    "Property: ApiScopeProperty.ScopeId (int) Required FK Index",
+                    $"Property: ApiScopeProperty.ScopeId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ApiScopeProperty.Value (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'ScopeId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ScopeId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ApiScopeProperty {'ScopeId'} -> ApiScope {'Id'} Required Cascade ToDependent: Properties ToPrincipal: Scope",
@@ -486,11 +489,11 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientClaim.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientClaim.ClientId (int) Required FK Index",
+                    $"Property: ClientClaim.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientClaim.Type (string) Required MaxLength(250)",
                     "Property: ClientClaim.Value (string) Required MaxLength(250)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs = { "ForeignKey: ClientClaim {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: Claims ToPrincipal: Client", },
                 Navigations = { "Navigation: ClientClaim.Client (Client) ToPrincipal Client Inverse: Claims", },
             },
@@ -502,10 +505,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientCorsOrigin.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientCorsOrigin.ClientId (int) Required FK Index",
+                    $"Property: ClientCorsOrigin.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientCorsOrigin.Origin (string) Required MaxLength(150)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientCorsOrigin {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: AllowedCorsOrigins ToPrincipal: Client",
@@ -520,10 +523,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientGrantType.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientGrantType.ClientId (int) Required FK Index",
+                    $"Property: ClientGrantType.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientGrantType.GrantType (string) Required MaxLength(250)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientGrantType {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: AllowedGrantTypes ToPrincipal: Client",
@@ -538,10 +541,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientIdPRestriction.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientIdPRestriction.ClientId (int) Required FK Index",
+                    $"Property: ClientIdPRestriction.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientIdPRestriction.Provider (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientIdPRestriction {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: IdentityProviderRestrictions ToPrincipal: Client",
@@ -559,10 +562,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientPostLogoutRedirectUri.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientPostLogoutRedirectUri.ClientId (int) Required FK Index",
+                    $"Property: ClientPostLogoutRedirectUri.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientPostLogoutRedirectUri.PostLogoutRedirectUri (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientPostLogoutRedirectUri {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: PostLogoutRedirectUris ToPrincipal: Client",
@@ -580,11 +583,11 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientProperty.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientProperty.ClientId (int) Required FK Index",
+                    $"Property: ClientProperty.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientProperty.Key (string) Required MaxLength(250)",
                     "Property: ClientProperty.Value (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientProperty {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: Properties ToPrincipal: Client",
@@ -599,10 +602,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientRedirectUri.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientRedirectUri.ClientId (int) Required FK Index",
+                    $"Property: ClientRedirectUri.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientRedirectUri.RedirectUri (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientRedirectUri {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: RedirectUris ToPrincipal: Client",
@@ -617,10 +620,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientScope.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientScope.ClientId (int) Required FK Index",
+                    $"Property: ClientScope.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientScope.Scope (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientScope {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: AllowedScopes ToPrincipal: Client",
@@ -635,14 +638,14 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: ClientSecret.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: ClientSecret.ClientId (int) Required FK Index",
+                    $"Property: ClientSecret.ClientId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: ClientSecret.Created (DateTime) Required",
                     "Property: ClientSecret.Description (string) MaxLength(2000)",
                     "Property: ClientSecret.Expiration (DateTime?)",
                     "Property: ClientSecret.Type (string) Required MaxLength(250)",
                     "Property: ClientSecret.Value (string) Required MaxLength(4000)",
                 },
-                Indexes = { "{'ClientId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'ClientId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: ClientSecret {'ClientId'} -> Client {'Id'} Required Cascade ToDependent: ClientSecrets ToPrincipal: Client",
@@ -683,10 +686,10 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: IdentityResourceClaim.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: IdentityResourceClaim.IdentityResourceId (int) Required FK Index",
+                    $"Property: IdentityResourceClaim.IdentityResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: IdentityResourceClaim.Type (string) Required MaxLength(200)",
                 },
-                Indexes = { "{'IdentityResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'IdentityResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: IdentityResourceClaim {'IdentityResourceId'} -> IdentityResource {'Id'} Required Cascade ToDependent: UserClaims ToPrincipal: IdentityResource",
@@ -704,11 +707,11 @@ public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<T
                 Properties =
                 {
                     "Property: IdentityResourceProperty.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: IdentityResourceProperty.IdentityResourceId (int) Required FK Index",
+                    $"Property: IdentityResourceProperty.IdentityResourceId (int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: IdentityResourceProperty.Key (string) Required MaxLength(250)",
                     "Property: IdentityResourceProperty.Value (string) Required MaxLength(2000)",
                 },
-                Indexes = { "{'IdentityResourceId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'IdentityResourceId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: IdentityResourceProperty {'IdentityResourceId'} -> IdentityResource {'Id'} Required Cascade ToDependent: Properties ToPrincipal: IdentityResource",

--- a/test/EFCore.AspNet.Specification.Tests/GrpcTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/GrpcTestBase.cs
@@ -18,6 +18,9 @@ public abstract class GrpcTestBase<TFixture> : IClassFixture<TFixture>
 
     protected TFixture Fixture { get; }
 
+    protected virtual bool HasForeignKeyIndexes
+        => true;
+
     protected List<EntityTypeMapping> ExpectedMappings
         => new()
         {
@@ -30,9 +33,9 @@ public abstract class GrpcTestBase<TFixture> : IClassFixture<TFixture>
                 Properties =
                 {
                     "Property: PostTag (Dictionary<string, object>).PostsInTagDataPostId (no field, int) Indexer Required PK FK AfterSave:Throw",
-                    "Property: PostTag (Dictionary<string, object>).TagsInPostDataTagId (no field, int) Indexer Required PK FK Index AfterSave:Throw",
+                    $"Property: PostTag (Dictionary<string, object>).TagsInPostDataTagId (no field, int) Indexer Required PK FK{(HasForeignKeyIndexes ? " Index" : "")} AfterSave:Throw",
                 },
-                Indexes = { "{'TagsInPostDataTagId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'TagsInPostDataTagId'} "] : [],
                 FKs =
                 {
                     "ForeignKey: PostTag (Dictionary<string, object>) {'PostsInTagDataPostId'} -> Post {'PostId'} Required Cascade",
@@ -59,12 +62,12 @@ public abstract class GrpcTestBase<TFixture> : IClassFixture<TFixture>
                 Properties =
                 {
                     "Property: Post.PostId (postId_, int) Required PK AfterSave:Throw ValueGenerated.OnAdd",
-                    "Property: Post.AuthorId (authorId_, int) Required FK Index",
+                    $"Property: Post.AuthorId (authorId_, int) Required FK{(HasForeignKeyIndexes ? " Index" : "")}",
                     "Property: Post.DateCreated (dateCreated_, Timestamp)",
                     "Property: Post.PostStat (postStat_, PostStatus) Required",
                     "Property: Post.Title (title_, string)",
                 },
-                Indexes = { "{'AuthorId'} ", },
+                Indexes = HasForeignKeyIndexes ? ["{'AuthorId'} "] : [],
                 FKs = { "ForeignKey: Post {'AuthorId'} -> Author {'AuthorId'} Required Cascade ToPrincipal: PostAuthor", },
                 Navigations = { "Navigation: Post.PostAuthor (postAuthor_, Author) ToPrincipal Author", },
                 SkipNavigations =

--- a/test/EFCore.AspNet.Specification.Tests/TestUtilities/EntityTypeMapping.cs
+++ b/test/EFCore.AspNet.Specification.Tests/TestUtilities/EntityTypeMapping.cs
@@ -36,7 +36,7 @@ public class EntityTypeMapping
     public string TableName { get; set; }
     public string PrimaryKey { get; set; }
     public List<string> Properties { get; } = [];
-    public List<string> Indexes { get; } = [];
+    public List<string> Indexes { get; set; } = [];
     public List<string> FKs { get; } = [];
     public List<string> Navigations { get; } = [];
     public List<string> SkipNavigations { get; } = [];

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -190,6 +190,9 @@ WHERE (c["Discriminator"] IN ("Blog", "RssBlog") AND NOT((c["IndexerVisible"] = 
             nullableShadowJObject.SetConfigurationSource(ConfigurationSource.Convention);
 
             modelBuilder.Entity<SimpleCounter>(b => b.ToContainer("SimpleCounters"));
+
+            modelBuilder.Entity<Person>().Metadata.RemoveIndex(
+                modelBuilder.Entity<Person>().Property(e => e.SSN).Metadata.GetContainingIndexes().Single());
         }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -11,6 +11,42 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
 {
     public class CosmosGenericNonRelationship(CosmosModelBuilderFixture fixture) : NonRelationshipTestBase(fixture), IClassFixture<CosmosModelBuilderFixture>
     {
+        public override void Can_add_contained_indexes()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Customer), "Id"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_add_contained_indexes).Message);
+
+        public override void Can_add_index()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Customer), "Name"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_add_index).Message);
+
+        public override void Can_add_index_when_no_clr_property()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Customer), "Index"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_add_index_when_no_clr_property).Message);
+
+        public override void Can_add_multiple_indexes()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Customer), "Id"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_add_multiple_indexes).Message);
+
+        public override void Can_set_composite_index_on_an_entity_with_fields()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(EntityWithFields), "TenantId,CompanyId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_set_composite_index_on_an_entity_with_fields).Message);
+
+        public override void Can_set_index_on_an_entity_with_fields()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(EntityWithFields), "CompanyId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_set_index_on_an_entity_with_fields).Message);
+
         public override void Properties_can_set_row_version()
             => Assert.Equal(
                 CosmosStrings.NonETagConcurrencyToken(nameof(Quarks), "Charm"),
@@ -564,6 +600,12 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
 
     public class CosmosGenericOneToMany(CosmosModelBuilderFixture fixture) : OneToManyTestBase(fixture), IClassFixture<CosmosModelBuilderFixture>
     {
+        public override void Creates_overlapping_foreign_keys_with_different_nullability()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Product), "Id,OrderId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Creates_overlapping_foreign_keys_with_different_nullability).Message);
+
         public override void Navigation_to_shared_type_is_not_discovered_by_convention()
         {
             var modelBuilder = CreateModelBuilder();
@@ -921,6 +963,48 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
                 "No exception was thrown",
                 Assert.Throws<ThrowsException>(base.Deriving_from_owned_type_throws).Message);
 
+        public override void Can_configure_one_to_many_owned_type_with_fields()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(OneToManyOwnedWithField), "OneToManyOwnerId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_one_to_many_owned_type_with_fields).Message);
+
+        public override void Can_configure_one_to_one_owned_type_with_fields()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(OneToOneOwnedWithField), "OneToOneOwnerId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_one_to_one_owned_type_with_fields).Message);
+
+        public override void Can_configure_owned_type()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(CustomerDetails), "CustomerId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_owned_type).Message);
+
+        public override void Can_configure_owned_type_collection()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Order), "foo"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_owned_type_collection).Message);
+
+        public override void Can_configure_owned_type_collection_using_nested_closure()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist(nameof(Order), "AnotherCustomerId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_owned_type_collection_using_nested_closure).Message);
+
+        public override void Can_configure_chained_ownerships()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist("Book.Label#BookLabel.AnotherBookLabel#AnotherBookLabel.SpecialBookLabel#SpecialBookLabel", "BookId"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Can_configure_chained_ownerships).Message);
+
+        public override void Shared_type_entity_types_with_FK_to_another_entity_works()
+            => Assert.Equal(
+                CosmosStrings.IndexesExist("BillingOwner.Bill1#BillingDetail", "Country"),
+                Assert.Throws<InvalidOperationException>(
+                    base.Shared_type_entity_types_with_FK_to_another_entity_works).Message);
+
         [ConditionalFact]
         public virtual void Reference_type_is_discovered_as_owned()
         {
@@ -957,5 +1041,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
     public class CosmosModelBuilderFixture : ModelBuilderFixtureBase
     {
         public override TestHelpers TestHelpers => CosmosTestHelpers.Instance;
+        public override bool ForeignKeysHaveIndexes
+            => false;
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
@@ -51,5 +51,23 @@ public class NorthwindQueryCosmosFixture<TModelCustomizer> : NorthwindQueryFixtu
         modelBuilder
             .Entity<CustomerQueryWithQueryFilter>()
             .HasDiscriminator<string>("Discriminator").HasValue("Customer");
+
+        modelBuilder.Entity<Customer>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Customer>().Property(e => e.City).Metadata.GetContainingIndexes().Single());
+
+        modelBuilder.Entity<Customer>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Customer>().Property(e => e.CompanyName).Metadata.GetContainingIndexes().Single());
+
+        modelBuilder.Entity<Customer>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Customer>().Property(e => e.PostalCode).Metadata.GetContainingIndexes().Single());
+
+        modelBuilder.Entity<Customer>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Customer>().Property(e => e.Region).Metadata.GetContainingIndexes().Single());
+
+        modelBuilder.Entity<Order>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Order>().Property(e => e.OrderDate).Metadata.GetContainingIndexes().Single());
+
+        modelBuilder.Entity<Product>().Metadata.RemoveIndex(
+            modelBuilder.Entity<Product>().Property(e => e.ProductName).Metadata.GetContainingIndexes().Single());
     }
 }

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -349,6 +349,19 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
     }
 
     [ConditionalFact]
+    public virtual void Detects_index()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Customer>(
+            b =>
+            {
+                b.HasIndex(e => new { e.Name, e.OtherName });
+            });
+
+        VerifyError(CosmosStrings.IndexesExist(nameof(Customer), "Name,OtherName"), modelBuilder);
+    }
+
+    [ConditionalFact]
     public virtual void Detects_missing_discriminator()
     {
         var modelBuilder = CreateConventionModelBuilder();

--- a/test/EFCore.InMemory.FunctionalTests/DataAnnotationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DataAnnotationInMemoryTest.cs
@@ -9,6 +9,9 @@ public class DataAnnotationInMemoryTest(DataAnnotationInMemoryTest.DataAnnotatio
     protected override TestHelpers TestHelpers
         => InMemoryTestHelpers.Instance;
 
+    protected override bool HasForeignKeyIndexes
+        => false;
+
     public override Task ConcurrencyCheckAttribute_throws_if_value_in_database_changed()
     {
         using var context = CreateContext();

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderTest.cs
@@ -27,5 +27,8 @@ public class InMemoryModelBuilderTest : ModelBuilderTest
     public class InMemoryModelBuilderFixture : ModelBuilderFixtureBase
     {
         public override TestHelpers TestHelpers => InMemoryTestHelpers.Instance;
+
+        public override bool ForeignKeysHaveIndexes
+            => false;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/ComplexTypes/PrincipalBaseEntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/ComplexTypes/PrincipalBaseEntityType.cs
@@ -38,7 +38,6 @@ namespace TestNamespace
                 complexPropertyCount: 1,
                 navigationCount: 1,
                 foreignKeyCount: 1,
-                unnamedIndexCount: 1,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -855,9 +854,6 @@ namespace TestNamespace
             var key = runtimeEntityType.AddKey(
                 new[] { id });
             runtimeEntityType.SetPrimaryKey(key);
-
-            var index = runtimeEntityType.AddIndex(
-                new[] { principalBaseId });
 
             return runtimeEntityType;
         }

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Lazy_loading_manual/LazyProxiesEntity4EntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Lazy_loading_manual/LazyProxiesEntity4EntityType.cs
@@ -32,7 +32,6 @@ namespace TestNamespace
                 navigationCount: 1,
                 servicePropertyCount: 1,
                 foreignKeyCount: 1,
-                unnamedIndexCount: 1,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -216,9 +215,6 @@ namespace TestNamespace
             var key = runtimeEntityType.AddKey(
                 new[] { id });
             runtimeEntityType.SetPrimaryKey(key);
-
-            var index = runtimeEntityType.AddIndex(
-                new[] { referenceNavigationId });
 
             return runtimeEntityType;
         }

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Lazy_loading_proxies/LazyProxiesEntity1EntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Lazy_loading_proxies/LazyProxiesEntity1EntityType.cs
@@ -33,7 +33,6 @@ namespace TestNamespace
                 navigationCount: 1,
                 servicePropertyCount: 1,
                 foreignKeyCount: 1,
-                unnamedIndexCount: 1,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -132,9 +131,6 @@ namespace TestNamespace
             var key = runtimeEntityType.AddKey(
                 new[] { id });
             runtimeEntityType.SetPrimaryKey(key);
-
-            var index = runtimeEntityType.AddIndex(
-                new[] { referenceNavigationId });
 
             return runtimeEntityType;
         }

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Manual_lazy_loading/LazyPropertyDelegateEntityEntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Manual_lazy_loading/LazyPropertyDelegateEntityEntityType.cs
@@ -32,7 +32,6 @@ namespace TestNamespace
                 navigationCount: 1,
                 servicePropertyCount: 2,
                 foreignKeyCount: 1,
-                unnamedIndexCount: 1,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -152,10 +151,6 @@ namespace TestNamespace
             var key = runtimeEntityType.AddKey(
                 new[] { id });
             runtimeEntityType.SetPrimaryKey(key);
-
-            var index = runtimeEntityType.AddIndex(
-                new[] { lazyConstructorEntityId },
-                unique: true);
 
             return runtimeEntityType;
         }

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Manual_lazy_loading/LazyPropertyEntityEntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/Manual_lazy_loading/LazyPropertyEntityEntityType.cs
@@ -32,7 +32,6 @@ namespace TestNamespace
                 navigationCount: 1,
                 servicePropertyCount: 1,
                 foreignKeyCount: 1,
-                unnamedIndexCount: 1,
                 keyCount: 1);
 
             var id = runtimeEntityType.AddProperty(
@@ -141,10 +140,6 @@ namespace TestNamespace
             var key = runtimeEntityType.AddKey(
                 new[] { id });
             runtimeEntityType.SetPrimaryKey(key);
-
-            var index = runtimeEntityType.AddIndex(
-                new[] { lazyConstructorEntityId },
-                unique: true);
 
             return runtimeEntityType;
         }

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -22,6 +22,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected TFixture Fixture { get; }
 
+    protected virtual bool HasForeignKeyIndexes
+        => true;
+
     protected DbContext CreateContext()
         => Fixture.CreateContext();
 
@@ -1653,17 +1656,25 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var fk1 = entityType.GetForeignKeys().Single(fk => fk.Properties.Single().Name == nameof(Comment.ParentCommentID));
         Assert.Equal(nameof(Comment.ParentComment), fk1.DependentToPrincipal.Name);
         Assert.Null(fk1.PrincipalToDependent);
-        var index1 = entityType.FindIndex(fk1.Properties);
-        Assert.False(index1.IsUnique);
+
+        if (HasForeignKeyIndexes)
+        {
+            var index1 = entityType.FindIndex(fk1.Properties);
+            Assert.False(index1.IsUnique);
+        }
 
         var fk2 = entityType.GetForeignKeys().Single(fk => fk.Properties.Single().Name == nameof(Comment.ReplyCommentID));
         Assert.Equal(nameof(Comment.ReplyComment), fk2.DependentToPrincipal.Name);
         Assert.Null(fk2.PrincipalToDependent);
-        var index2 = entityType.FindIndex(fk2.Properties);
-        Assert.False(index2.IsUnique);
+
+        if (HasForeignKeyIndexes)
+        {
+            var index2 = entityType.FindIndex(fk2.Properties);
+            Assert.False(index2.IsUnique);
+        }
 
         Assert.Equal(2, entityType.GetForeignKeys().Count());
-        Assert.Equal(2, entityType.GetIndexes().Count());
+        Assert.Equal(HasForeignKeyIndexes ? 2 : 0, entityType.GetIndexes().Count());
     }
 
     private class Comment

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Inheritance.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Inheritance.cs
@@ -158,8 +158,8 @@ public abstract partial class ModelBuilderTest
                     return true;
                 });
             Fixture.TestHelpers.ModelAsserter.AssertEqual(
-                initialIndexes.Single().Properties,
-                pickle.GetIndexes().Single().Properties);
+                initialIndexes.SingleOrDefault()?.Properties ?? Array.Empty<IReadOnlyProperty>(),
+                pickle.GetIndexes().SingleOrDefault()?.Properties ?? Array.Empty<IMutableProperty>());
             Fixture.TestHelpers.ModelAsserter.AssertEqual(
                 initialForeignKeys.Single().Properties,
                 pickle.GetForeignKeys().Single().Properties);
@@ -189,8 +189,8 @@ public abstract partial class ModelBuilderTest
                     return true;
                 });
             Fixture.TestHelpers.ModelAsserter.AssertEqual(
-                initialIndexes.Single().Properties,
-                ingredient.GetIndexes().Single().Properties);
+                initialIndexes.SingleOrDefault()?.Properties ?? Array.Empty<IReadOnlyProperty>(),
+                ingredient.GetIndexes().SingleOrDefault()?.Properties ?? Array.Empty<IMutableProperty>());
             Fixture.TestHelpers.ModelAsserter.AssertEqual(
                 initialForeignKeys.Single().Properties,
                 ingredient.GetForeignKeys().Single().Properties);
@@ -569,6 +569,11 @@ public abstract partial class ModelBuilderTest
         [ConditionalFact]
         public virtual void Index_removed_when_covered_by_an_inherited_foreign_key()
         {
+            if (!Fixture.ForeignKeysHaveIndexes)
+            {
+                return;
+            }
+
             var modelBuilder = CreateModelBuilder();
             modelBuilder.Ignore<CustomerDetails>();
             modelBuilder.Ignore<OrderDetails>();
@@ -653,6 +658,11 @@ public abstract partial class ModelBuilderTest
         [ConditionalFact]
         public virtual void Index_removed_when_covered_by_an_inherited_index()
         {
+            if (!Fixture.ForeignKeysHaveIndexes)
+            {
+                return;
+            }
+
             var modelBuilder = CreateModelBuilder();
             modelBuilder.Ignore<CustomerDetails>();
             modelBuilder.Ignore<OrderDetails>();

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToOne.cs
@@ -44,8 +44,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -103,8 +112,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -137,8 +155,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -174,8 +201,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -209,8 +245,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -248,8 +293,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -281,8 +335,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -313,8 +376,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -350,8 +422,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -391,8 +472,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -428,8 +518,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -466,8 +565,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -500,8 +608,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -536,8 +653,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -573,8 +699,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk!.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -610,8 +745,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -644,8 +788,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Pickle.BigMak), dependentType.GetNavigations().Single().Name);
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -678,8 +831,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -714,8 +876,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(dependentType.GetNavigations().Where(nav => nav.ForeignKey != fk));
             Assert.Empty(principalType.GetNavigations().Where(nav => nav.ForeignKey != fk));
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk!.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -748,8 +919,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -784,8 +964,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -839,8 +1028,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -892,8 +1090,16 @@ public abstract partial class ModelBuilderTest
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -934,8 +1140,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -976,8 +1191,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1023,8 +1247,16 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1070,8 +1302,16 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1117,8 +1357,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1164,8 +1412,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1246,8 +1502,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1289,8 +1554,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1345,8 +1619,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1401,8 +1683,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1442,8 +1732,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1483,8 +1782,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk!.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1531,8 +1839,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1572,10 +1889,19 @@ public abstract partial class ModelBuilderTest
 
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.NotSame(principalKey, fk.PrincipalKey);
-            Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties).IsUnique);
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties)!.IsUnique);
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(principalType.GetIndexes());
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship(
@@ -1621,8 +1947,16 @@ public abstract partial class ModelBuilderTest
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.NotSame(principalKey, fk.PrincipalKey);
             Assert.Empty(principalType.GetIndexes());
-            Assert.Single(dependentType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(dependentType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonRelationship.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonRelationship.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Dynamic;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 // ReSharper disable InconsistentNaming

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToMany.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToMany.cs
@@ -47,8 +47,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -106,8 +115,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -140,8 +158,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -175,8 +202,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Customer.Orders), newFk.PrincipalToDependent.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -213,8 +249,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -252,8 +297,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -283,8 +337,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -315,8 +378,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -353,8 +425,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -394,8 +475,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -432,8 +522,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -470,8 +569,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -505,8 +613,17 @@ public abstract partial class ModelBuilderTest
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -538,8 +655,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -575,8 +701,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -614,8 +749,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -649,8 +793,17 @@ public abstract partial class ModelBuilderTest
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -685,8 +838,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -722,8 +884,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetNavigations().Where(nav => nav.ForeignKey != existingFk));
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -758,8 +929,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -798,8 +978,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -856,8 +1045,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -904,8 +1102,17 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1006,8 +1213,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1050,8 +1266,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1097,8 +1322,16 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1144,8 +1377,16 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1193,8 +1434,17 @@ public abstract partial class ModelBuilderTest
             Assert.False(fkProperty.IsNullable);
             expectedDependentProperties.Add(fkProperty);
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1238,8 +1488,17 @@ public abstract partial class ModelBuilderTest
             Assert.False(fkProperty.IsNullable);
             expectedDependentProperties.Add(fkProperty);
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1285,8 +1544,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1332,8 +1599,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1377,8 +1652,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1423,8 +1706,16 @@ public abstract partial class ModelBuilderTest
 
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1463,8 +1754,16 @@ public abstract partial class ModelBuilderTest
             var newKeyProperty = principalType.FindProperty(nameof(BigMak.AlternateKey));
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1501,8 +1800,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1544,8 +1851,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1597,8 +1912,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1650,8 +1973,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1694,8 +2025,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1731,8 +2070,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1773,8 +2120,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1813,9 +2168,17 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(principalKey, fk.PrincipalKey);
             Assert.NotEqual(existingFk.Properties, fk.Properties);
             Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties).IsUnique);
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties)!.IsUnique);
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship(
@@ -1858,8 +2221,16 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(principalKey, fk.PrincipalKey);
             Assert.Equal(existingFk.Properties, fk.Properties);
             Assert.Empty(principalType.GetIndexes());
-            Assert.Single(dependentType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(dependentType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2004,8 +2375,16 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Nob.Hob), otherFk.DependentToPrincipal.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
@@ -149,8 +149,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -212,8 +221,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Single(dependentType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(dependentType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -240,8 +258,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Customer.Details), principalType.GetNavigations().Single().Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -302,8 +329,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -365,11 +401,19 @@ public abstract partial class ModelBuilderTest
             var fk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.True(fk.IsUnique);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -393,8 +437,17 @@ public abstract partial class ModelBuilderTest
             Assert.True(fk.IsUnique);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -425,8 +478,17 @@ public abstract partial class ModelBuilderTest
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
         }
 
@@ -462,8 +524,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -533,8 +604,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -569,8 +649,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -602,8 +691,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(BigMak.Bun), principalType.GetNavigations().Single().Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -637,11 +735,19 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.True(fk.IsUnique);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -675,8 +781,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(expectedDependentProperties, dependentType.GetProperties());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -711,8 +826,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -789,8 +913,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -891,10 +1024,18 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -926,10 +1067,18 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.Empty(dependentType.GetIndexes());
-            Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(principalType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -960,7 +1109,16 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -992,10 +1150,18 @@ public abstract partial class ModelBuilderTest
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count() - 1, dependentType.GetIndexes().Count());
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -1034,9 +1200,17 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.Empty(dependentType.GetIndexes());
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(principalType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -1107,8 +1281,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1147,8 +1330,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1193,8 +1384,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1239,8 +1439,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1284,8 +1493,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1329,8 +1546,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1401,8 +1626,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Single(dependentType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(dependentType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1442,8 +1676,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1524,8 +1767,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1565,8 +1817,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1879,8 +2140,17 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Customer.Details), fk.PrincipalToDependent.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -1910,8 +2180,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.True(fk.IsUnique);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -1939,9 +2217,16 @@ public abstract partial class ModelBuilderTest
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
-            Assert.Equal(principalType.GetForeignKeys().Count(), principalType.GetIndexes().Count());
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -1970,8 +2255,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2012,8 +2306,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2049,8 +2352,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2088,8 +2400,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2128,8 +2449,17 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2182,8 +2512,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2236,8 +2574,16 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2403,8 +2749,17 @@ public abstract partial class ModelBuilderTest
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -2443,11 +2798,19 @@ public abstract partial class ModelBuilderTest
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
             Assert.True(fk.IsUnique);
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2485,11 +2848,19 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetNavigations().Where(nav => nav.ForeignKey == fk));
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
-            Assert.True(
-                principalType.GetForeignKeys()
-                    .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.True(
+                    principalType.GetForeignKeys()
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2518,8 +2889,15 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(navigationToDependent.Name, fk.DependentToPrincipal.Name);
             Assert.True(fk.IsRequired);
 
-            Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
 
             modelBuilder.FinalizeModel();
         }
@@ -2548,8 +2926,16 @@ public abstract partial class ModelBuilderTest
             Assert.Null(fk.PrincipalToDependent);
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.DependentToPrincipal?.Name);
             Assert.Equal(2, entityType.GetNavigations().Count());
-            Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2576,8 +2962,16 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.PrincipalToDependent?.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Equal(2, entityType.GetNavigations().Count());
-            Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2636,8 +3030,15 @@ public abstract partial class ModelBuilderTest
             Assert.True(fk.IsRequired);
             Assert.False(fk.IsRequiredDependent);
 
-            Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2669,8 +3070,15 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(navigationToDependent.Name, newFk.DependentToPrincipal.Name);
             Assert.True(newFk.IsUnique);
 
-            Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(fk.DeclaringEntityType.GetForeignKeys().Count(), fk.DeclaringEntityType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2703,8 +3111,16 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(SelfRef.SelfRef2), fk.PrincipalToDependent?.Name);
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.DependentToPrincipal?.Name);
             Assert.Equal(2, entityType.GetNavigations().Count());
-            Assert.Single(fk.DeclaringEntityType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(fk.DeclaringEntityType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -2724,8 +3140,16 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.PrincipalToDependent?.Name);
             Assert.Equal(nameof(SelfRef.SelfRef2), fk.DependentToPrincipal?.Name);
             Assert.Equal(2, entityType.GetNavigations().Count());
-            Assert.Single(fk.DeclaringEntityType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(fk.DeclaringEntityType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
         }
 
         [ConditionalFact]
@@ -3096,9 +3520,18 @@ public abstract partial class ModelBuilderTest
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.NotSame(principalKey, fk.PrincipalKey);
             Assert.Empty(principalType.GetIndexes());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.False(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties).IsUnique);
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(existingFk.DeclaringEntityType.FindIndex(existingFk.Properties)!.IsUnique);
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(fk.DeclaringEntityType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -3140,8 +3573,17 @@ public abstract partial class ModelBuilderTest
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.NotSame(principalKey, fk.PrincipalKey);
             Assert.Empty(principalType.GetIndexes());
-            Assert.Single(dependentType.GetIndexes());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Single(dependentType.GetIndexes());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 
@@ -3171,12 +3613,28 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.Empty(principalType.GetIndexes());
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
 
             modelBuilder.Entity<Tomato>().Ignore(t => t.BurgerId2);
 
-            Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-            Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+            }
+            else
+            {
+                Assert.Empty(dependentType.GetIndexes());
+            }
+
             Assert.Empty(principalType.GetIndexes());
         }
 

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
@@ -417,8 +417,16 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(nameof(Order.CustomerId), chainedOwnership.Properties.Single().Name);
             Assert.Equal(nameof(Order.OrderId), chainedOwned.FindPrimaryKey().Properties.Single().Name);
             Assert.Single(chainedOwned.GetForeignKeys());
-            Assert.Equal(nameof(Order.CustomerId), chainedOwned.GetIndexes().Single().Properties.Single().Name);
-            Assert.Same(entityBuilder.OwnedEntityType, chainedOwned);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(nameof(Order.CustomerId), chainedOwned.GetIndexes().Single().Properties.Single().Name);
+                Assert.Same(entityBuilder.OwnedEntityType, chainedOwned);
+            }
+            else
+            {
+                Assert.Empty(chainedOwned.GetIndexes());
+            }
 
             Assert.Equal(3, model.GetEntityTypes().Count());
         }
@@ -453,8 +461,17 @@ public abstract partial class ModelBuilderTest
 
             Assert.Null(owner.FindProperty("foo"));
             Assert.Equal(nameof(Order.AnotherCustomerId), owned.FindPrimaryKey().Properties.Single().Name);
-            Assert.Equal(2, owned.GetIndexes().Count());
-            Assert.Equal("CustomerAlternateKey", owned.GetIndexes().First().Properties.Single().Name);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(2, owned.GetIndexes().Count());
+                Assert.Equal("CustomerAlternateKey", owned.GetIndexes().First().Properties.Single().Name);
+            }
+            else
+            {
+                Assert.Single(owned.GetIndexes());
+            }
+
             Assert.Equal("foo", owned.GetIndexes().Last().Properties.Single().Name);
             Assert.Equal(PropertyAccessMode.FieldDuringConstruction, owned.GetPropertyAccessMode());
             Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, owned.GetChangeTrackingStrategy());
@@ -496,9 +513,18 @@ public abstract partial class ModelBuilderTest
             Assert.Equal("bar", owned.FindAnnotation("foo").Value);
             Assert.Single(owned.GetForeignKeys());
             Assert.Equal("Id", owned.FindPrimaryKey().Properties.Single().Name);
-            Assert.Equal(2, owned.GetIndexes().Count());
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(2, owned.GetIndexes().Count());
+                Assert.Equal("DifferentCustomerId", owned.GetIndexes().Last().Properties.Single().Name);
+            }
+            else
+            {
+                Assert.Single(owned.GetIndexes());
+            }
+
             Assert.Equal(nameof(Order.AnotherCustomerId), owned.GetIndexes().First().Properties.Single().Name);
-            Assert.Equal("DifferentCustomerId", owned.GetIndexes().Last().Properties.Single().Name);
             Assert.False(owned.FindProperty(nameof(Order.AnotherCustomerId)).IsNullable);
             Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
         }
@@ -672,9 +698,18 @@ public abstract partial class ModelBuilderTest
             Assert.False(chainedOwnership.IsUnique);
             Assert.Equal("OrderId", chainedOwnership.Properties.Single().Name);
             Assert.Equal(nameof(Product.Id), chainedOwned.FindPrimaryKey().Properties.Single().Name);
-            Assert.Equal(
-                "OrderId",
-                chainedOwned.GetIndexes().Single().Properties.Single().Name);
+
+            if (Fixture.ForeignKeysHaveIndexes)
+            {
+                Assert.Equal(
+                    "OrderId",
+                    chainedOwned.GetIndexes().Single().Properties.Single().Name);
+            }
+            else
+            {
+                Assert.Empty(chainedOwned.GetIndexes());
+            }
+
             Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal.Name);
 
             Assert.Equal(4, model.GetEntityTypes().Count());
@@ -1805,7 +1840,7 @@ public abstract partial class ModelBuilderTest
 
             var bill2 = owner.FindNavigation(nameof(BillingOwner.Bill2)).TargetEntityType;
             Assert.Equal(2, bill2.GetForeignKeys().Count());
-            Assert.Single(bill2.GetIndexes());
+            Assert.Equal(Fixture.ForeignKeysHaveIndexes ? 1 : 0, bill2.GetIndexes().Count());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
@@ -51,6 +51,9 @@ public abstract partial class ModelBuilderTest
         public abstract TestHelpers TestHelpers { get; }
         public virtual DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder) => builder;
         public virtual IServiceCollection AddServices(IServiceCollection services) => services;
+
+        public virtual bool ForeignKeysHaveIndexes
+            => true;
     }
 
     public abstract class TestModelBuilder : IInfrastructure<ModelBuilder>

--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
@@ -1305,32 +1305,47 @@ public abstract partial class ModelBuilding101TestBase
                 => Set<Post>();
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<Blog>()
+            {
+                modelBuilder.Entity<Blog>()
                     .HasMany(e => e.Posts)
                     .WithOne(e => e.Blog)
                     .HasPrincipalKey(e => e.AlternateId);
+
+                modelBuilder.Entity<Post>()
+                    .HasIndex(e => e.BlogId);
+            }
         }
 
         public class Context1 : Context0
         {
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<Blog>()
+            {
+                modelBuilder.Entity<Blog>()
                     .HasMany(e => e.Posts)
                     .WithOne(e => e.Blog)
                     .HasPrincipalKey(e => e.AlternateId)
                     .HasForeignKey(e => e.BlogId)
                     .IsRequired();
+
+                modelBuilder.Entity<Post>()
+                    .HasIndex(e => e.BlogId);
+            }
         }
 
         public class Context2 : Context0
         {
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<Post>()
+            {
+                modelBuilder.Entity<Post>()
                     .HasOne(e => e.Blog)
                     .WithMany(e => e.Posts)
                     .HasPrincipalKey(e => e.AlternateId)
                     .HasForeignKey(e => e.BlogId)
                     .IsRequired();
+
+                modelBuilder.Entity<Post>()
+                    .HasIndex(e => e.BlogId);
+            }
         }
 
         public class ContextAnnotated0 : Context101
@@ -1344,6 +1359,7 @@ public abstract partial class ModelBuilding101TestBase
                 public ICollection<Post> Posts { get; } = new List<Post>();
             }
 
+            [Index(nameof(BlogId))]
             public class Post
             {
                 public int Id { get; set; }

--- a/test/EFCore.SqlServer.Tests/Metadata/Conventions/RelationalForeignKeyIndexConventionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/Conventions/RelationalForeignKeyIndexConventionTest.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+public class RelationalForeignKeyIndexConventionTest
+{
+    [ConditionalFact]
+    public void Removing_relationship_removes_unused_conventional_index()
+    {
+        var modelBuilder = CreateConventionalModelBuilder();
+        modelBuilder.Ignore(typeof(SpecialOrder), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var derivedPrincipalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+
+        var relationshipBuilder = dependentEntityBuilder.HasRelationship(
+            principalEntityBuilder.Metadata,
+            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
+            ConfigurationSource.DataAnnotation);
+        Assert.NotNull(relationshipBuilder);
+
+        var relationshipBuilder2 = dependentEntityBuilder.HasRelationship(
+            derivedPrincipalEntityBuilder.Metadata,
+            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
+            ConfigurationSource.DataAnnotation);
+        Assert.NotNull(relationshipBuilder2);
+        Assert.NotSame(relationshipBuilder, relationshipBuilder2);
+        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
+
+        Assert.NotNull(
+            dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
+
+        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
+        Assert.Single(dependentEntityBuilder.Metadata.GetForeignKeys());
+
+        Assert.NotNull(
+            dependentEntityBuilder.HasNoRelationship(relationshipBuilder2.Metadata, ConfigurationSource.DataAnnotation));
+
+        Assert.Empty(dependentEntityBuilder.Metadata.GetIndexes());
+        Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+    }
+
+    [ConditionalFact]
+    public void Removing_relationship_does_not_remove_conventional_index_if_in_use()
+    {
+        var modelBuilder = CreateConventionalModelBuilder();
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+
+        var relationshipBuilder = dependentEntityBuilder.HasRelationship(
+            principalEntityBuilder.Metadata,
+            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
+            ConfigurationSource.Convention);
+        Assert.NotNull(relationshipBuilder);
+        dependentEntityBuilder.HasIndex(new[] { Order.CustomerIdProperty }, ConfigurationSource.Explicit);
+
+        Assert.NotNull(dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
+
+        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
+        Assert.Equal(Order.CustomerIdProperty.Name, dependentEntityBuilder.Metadata.GetIndexes().First().Properties.First().Name);
+        Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+    }
+    private static TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions> CreateTestLogger()
+        => new() { EnabledFor = LogLevel.Warning };
+
+    private InternalModelBuilder CreateModelBuilder(Model model = null)
+        => new(model ?? new Model());
+
+    private InternalModelBuilder CreateConventionalModelBuilder()
+        => (InternalModelBuilder)SqlServerTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
+
+    public enum MemberType
+    {
+        Property,
+        ComplexProperty,
+        ServiceProperty,
+        Navigation,
+        SkipNavigation
+    }
+
+    private class Order
+    {
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId));
+        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique));
+        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer));
+        public static readonly PropertyInfo ContextProperty = typeof(Order).GetProperty(nameof(Context));
+        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
+
+        public int Id { get; set; }
+        public int CustomerId { get; set; }
+        public Guid? CustomerUnique { get; set; }
+        public Customer Customer { get; set; }
+        public DbContext Context { get; set; }
+        public ICollection<Product> Products { get; set; }
+    }
+
+    private class SpecialOrder : Order, IEnumerable<Order>
+    {
+        public static readonly PropertyInfo SpecialtyProperty = typeof(SpecialOrder).GetProperty("Specialty");
+
+        public IEnumerator<Order> GetEnumerator()
+        {
+            yield return this;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public string Specialty { get; set; }
+    }
+
+    private class ExtraSpecialOrder : SpecialOrder;
+
+    private class BackOrder : Order;
+
+    private class Customer
+    {
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
+        public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty(nameof(Unique));
+        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders));
+        public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders));
+        public static readonly PropertyInfo SpecialOrdersProperty = typeof(Customer).GetProperty(nameof(SpecialOrders));
+
+        public int Id { get; set; }
+        public Guid Unique { get; set; }
+        public ICollection<Order> Orders { get; set; }
+        public Order NotCollectionOrders { get; set; }
+        public ICollection<SpecialOrder> SpecialOrders { get; set; }
+        internal SpecialCustomer SpecialCustomer { get; set; }
+    }
+
+    private class SpecialCustomer : Customer
+    {
+        internal Customer Customer { get; set; }
+    }
+
+    private class OrderProduct
+    {
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+
+        public int OrderId { get; set; }
+        public int ProductId { get; set; }
+        public virtual Order Order { get; set; }
+        public virtual Product Product { get; set; }
+    }
+
+    private class Product
+    {
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
+
+        public int Id { get; set; }
+
+        public virtual ICollection<Order> Orders { get; set; }
+    }
+
+    private class SpecialProduct : Product;
+
+    private class ExtraSpecialProduct : SpecialProduct;
+
+    private class Splot
+    {
+        public static readonly PropertyInfo SplowedProperty = typeof(Splot).GetProperty("Splowed");
+
+        public int? Splowed { get; set; }
+    }
+
+    private class Splow : Splot;
+
+    private class Splod : Splow;
+
+    private class IndexedClass
+    {
+        public static readonly string IndexerPropertyName = "Indexer";
+
+        public object this[string name]
+        {
+            get => null;
+            set { }
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -572,63 +572,6 @@ public class InternalEntityTypeBuilderTest
     }
 
     [ConditionalFact]
-    public void Removing_relationship_removes_unused_conventional_index()
-    {
-        var modelBuilder = CreateConventionalModelBuilder();
-        modelBuilder.Ignore(typeof(SpecialOrder), ConfigurationSource.Explicit);
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var derivedPrincipalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-
-        var relationshipBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata,
-            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
-            ConfigurationSource.DataAnnotation);
-        Assert.NotNull(relationshipBuilder);
-
-        var relationshipBuilder2 = dependentEntityBuilder.HasRelationship(
-            derivedPrincipalEntityBuilder.Metadata,
-            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
-            ConfigurationSource.DataAnnotation);
-        Assert.NotNull(relationshipBuilder2);
-        Assert.NotSame(relationshipBuilder, relationshipBuilder2);
-        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
-
-        Assert.NotNull(
-            dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
-
-        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
-        Assert.Single(dependentEntityBuilder.Metadata.GetForeignKeys());
-
-        Assert.NotNull(
-            dependentEntityBuilder.HasNoRelationship(relationshipBuilder2.Metadata, ConfigurationSource.DataAnnotation));
-
-        Assert.Empty(dependentEntityBuilder.Metadata.GetIndexes());
-        Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
-    }
-
-    [ConditionalFact]
-    public void Removing_relationship_does_not_remove_conventional_index_if_in_use()
-    {
-        var modelBuilder = CreateConventionalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-
-        var relationshipBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata,
-            new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
-            ConfigurationSource.Convention);
-        Assert.NotNull(relationshipBuilder);
-        dependentEntityBuilder.HasIndex(new[] { Order.CustomerIdProperty }, ConfigurationSource.Explicit);
-
-        Assert.NotNull(dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
-
-        Assert.Single(dependentEntityBuilder.Metadata.GetIndexes());
-        Assert.Equal(Order.CustomerIdProperty.Name, dependentEntityBuilder.Metadata.GetIndexes().First().Properties.First().Name);
-        Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
-    }
-
-    [ConditionalFact]
     public void Removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere()
     {
         Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(


### PR DESCRIPTION
Block unused indexes with the Cosmos provider. Fixes #34023.

Also stop adding indexes for foreign keys by convention for non-relational providers. Fixes #34053.


