### PR TITLE
Fix build regression from #34002

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerStringMethodTranslator.cs
@@ -384,7 +384,7 @@ public class SqlServerStringMethodTranslator : IMethodCallTranslator
 
     private SqlExpression? ProcessTrimStartEnd(SqlExpression instance, IReadOnlyList<SqlExpression> arguments, string functionName)
     {
-        SqlConstantExpression? charactersToTrim = null;
+        SqlExpression? charactersToTrim = null;
         if (arguments.Count > 0 && arguments[0] is SqlConstantExpression { Value: var charactersToTrimValue })
         {
             charactersToTrim = charactersToTrimValue switch


### PR DESCRIPTION
#33715 and #34002 were developed concurrently.
Their merge does not build because of some changes in the types returned by `ISqlExpressionFactory`.
