### PR TITLE
Don't use service discovery for DbContext types if corresponding IDesignTimeDbContextFactory implementations are found.

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -497,6 +497,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 assembly);
 
         /// <summary>
+        ///     No type deriving from DbContext was found. Add [assembly: DbContext(typeof(*))] attribute for every context type used in this project.
+        /// </summary>
+        public static string NoContextsToOptimize
+            => GetString("NoContextsToOptimize");
+
+        /// <summary>
         ///     You must provide a DbContext.t4 file in order to scaffold using custom templates.
         /// </summary>
         public static string NoContextTemplate
@@ -613,6 +619,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("NotExistDatabase", nameof(name)),
                 name);
+
+        /// <summary>
+        ///     No files were generated during the DbContext optimization. Ensure that the target project has code that uses DbContext and that the supplied options are correct.
+        /// </summary>
+        public static string OptimizeNoFilesGenerated
+            => GetString("OptimizeNoFilesGenerated");
 
         /// <summary>
         ///     Changes have been made to the model since the last migration. Add a new migration.

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -312,6 +312,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="NoContext" xml:space="preserve">
     <value>No DbContext was found in assembly '{assembly}'. Ensure that you're using the correct assembly and that the type is neither abstract nor generic.</value>
   </data>
+  <data name="NoContextsToOptimize" xml:space="preserve">
+    <value>No type deriving from DbContext was found. Add [assembly: DbContext(typeof(*))] attribute for every context type used in this project.</value>
+  </data>
   <data name="NoContextTemplate" xml:space="preserve">
     <value>You must provide a DbContext.t4 file in order to scaffold using custom templates.</value>
   </data>
@@ -362,6 +365,9 @@ Change your target project to the migrations project by using the Package Manage
   </data>
   <data name="NotExistDatabase" xml:space="preserve">
     <value>Database '{name}' did not exist, no action was taken.</value>
+  </data>
+  <data name="OptimizeNoFilesGenerated" xml:space="preserve">
+    <value>No files were generated during the DbContext optimization. Ensure that the target project has code that uses DbContext and that the supplied options are correct.</value>
   </data>
   <data name="PendingModelChanges" xml:space="preserve">
     <value>Changes have been made to the model since the last migration. Add a new migration.</value>

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("ConnectionDescription");
 
         /// <summary>
-        ///     The DbContext to use.
+        ///     The DbContext to use. "*" can be used to run the command for all contexts found. This will also disable service discovery through the startup project if a corresponding IDesignTimeDbContextFactory implementation is found.
         /// </summary>
         public static string ContextDescription
             => GetString("ContextDescription");

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -133,7 +133,7 @@
     <value>The connection string to the database.</value>
   </data>
   <data name="ContextDescription" xml:space="preserve">
-    <value>The DbContext to use.</value>
+    <value>The DbContext to use. "*" can be used to run the command for all contexts found. This will also disable service discovery through the startup project if a corresponding IDesignTimeDbContextFactory implementation is found.</value>
   </data>
   <data name="ContextDirDescription" xml:space="preserve">
     <value>The directory to put the DbContext file in. Paths are relative to the project directory.</value>

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("ConnectionDescription");
 
         /// <summary>
-        ///     The DbContext to use.
+        ///     The DbContext to use. "*" can be used to run the command for all contexts found. This will also disable service discovery through the startup project if a corresponding IDesignTimeDbContextFactory implementation is found.
         /// </summary>
         public static string ContextDescription
             => GetString("ContextDescription");

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -139,7 +139,7 @@
     <value>The connection string to the database.</value>
   </data>
   <data name="ContextDescription" xml:space="preserve">
-    <value>The DbContext to use.</value>
+    <value>The DbContext to use. "*" can be used to run the command for all contexts found. This will also disable service discovery through the startup project if a corresponding IDesignTimeDbContextFactory implementation is found.</value>
   </data>
   <data name="ContextDirDescription" xml:space="preserve">
     <value>The directory to put the DbContext file in. Paths are relative to the project directory.</value>

--- a/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
@@ -22,5 +22,5 @@ public class DatabaseOperationsTest
             args: null);
     }
 
-    private class TestContext : DbContext;
+    public class TestContext : DbContext;
 }

--- a/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
@@ -5,4 +5,28 @@ using Microsoft.EntityFrameworkCore.Design.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-public class TestAppServiceProviderFactory(Assembly startupAssembly, IOperationReporter reporter = null) : AppServiceProviderFactory(startupAssembly, reporter ?? new TestOperationReporter());
+public class TestAppServiceProviderFactory : AppServiceProviderFactory
+{
+    private readonly bool _throwOnCreate;
+
+    public TestAppServiceProviderFactory(Assembly startupAssembly, bool throwOnCreate = false)
+        : this(startupAssembly, new TestOperationReporter(), throwOnCreate)
+    {
+    }
+
+    public TestAppServiceProviderFactory(Assembly startupAssembly, TestOperationReporter reporter, bool throwOnCreate = false)
+        : base(startupAssembly, reporter)
+    {
+        TestOperationReporter = reporter;
+        _throwOnCreate = throwOnCreate;
+    }
+
+    public TestOperationReporter TestOperationReporter { get; }
+
+    public override IServiceProvider Create(string[] args)
+    {
+        Assert.False(_throwOnCreate, "Service provider shouldn't be used in this case.");
+
+        return base.Create(args);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -231,8 +231,8 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedMode
         await using var context = contextFactory.CreateContext();
 
         var results = await context.Set<TestEntityWithOwned>().Select(t => t.Ints).ToListAsync();
-        Assert.True(results.Any(r => r?.SequenceEqual([1, 2]) == true));
-        Assert.True(results.Any(r => r?.SequenceEqual([3, 4]) == true));
+        Assert.Contains(results, r => r?.SequenceEqual([1, 2]) ?? false);
+        Assert.Contains(results, r => r?.SequenceEqual([3, 4]) ?? false);
     }
 
     private class TestEntityWithOwned


### PR DESCRIPTION
Throw for MSBuild-based execution if no DbContext types are found.

Fixes #27322