### PR TITLE
Enable JSON tests on SQLite without Spatialite

### DIFF
--- a/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-[SpatialiteRequired]
 public class JsonTypesSqliteTest : JsonTypesRelationalTestBase
 {
     public override Task Can_read_write_array_of_list_of_GUID_JSON_values(string expected)


### PR DESCRIPTION
They use NTS on the "client side", but they do not depend on the presence of Spatialite module in SQLite.