### PR TITLE
Translation of TimeOnly.FromTimeSpan on SQL Server no-op

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
@@ -62,7 +62,8 @@ public class SqlServerTimeOnlyMethodTranslator : IMethodCallTranslator
 
         if ((method == FromDateTime || method == FromTimeSpan)
             && instance is null
-            && arguments.Count == 1)
+            && arguments.Count == 1
+            && arguments[0].Type != typeof(TimeSpan))
         {
             return _sqlExpressionFactory.Convert(arguments[0], typeof(TimeOnly));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -9352,7 +9352,7 @@ WHERE CAST(DATEADD(hour, CAST(CAST(CAST(LEN([t].[Note]) AS int) AS float) AS int
 """
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Duration] AS time) < [m].[Time]
+WHERE [m].[Duration] < [m].[Time]
 """);
     }
 
@@ -9366,7 +9366,7 @@ WHERE CAST([m].[Duration] AS time) < [m].[Time]
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Duration] AS time) = @__time_0
+WHERE [m].[Duration] = @__time_0
 """);
     }
 
@@ -9378,7 +9378,7 @@ WHERE CAST([m].[Duration] AS time) = @__time_0
 """
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-ORDER BY CAST([m].[Duration] AS time)
+ORDER BY [m].[Duration]
 """);
     }
 


### PR DESCRIPTION
fix #34025

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

