### PR TITLE
Update Microsoft.CodeAnalysis version to 4.10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,8 +37,8 @@
     <MicrosoftBuildTasksCoreVersion>17.9.5</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>17.9.5</MicrosoftBuildUtilitiesCoreVersion>
     <!-- NB: This version affects Visual Studio compatibility. See https://learn.microsoft.com/visualstudio/extensibility/roslyn-version-support -->
-    <MicrosoftCodeAnalysisVersion>4.8.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.24121.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisVersion>4.10.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.24352.1</MicrosoftCodeAnalysisTestingVersion>
     <AzureIdentityVersion>1.11.3</AzureIdentityVersion>
     <AzureResourceManagerCosmosDBVersion>1.3.2</AzureResourceManagerCosmosDBVersion>
     <OpenTelemetryExporterInMemoryVersion>1.8.1</OpenTelemetryExporterInMemoryVersion>

--- a/test/EFCore.Analyzers.Tests/TestUtilities/CSharpAnalyzerVerifier.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/CSharpAnalyzerVerifier.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Model;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Extensions.DependencyModel;
 using CompilationOptions = Microsoft.CodeAnalysis.CompilationOptions;
 
@@ -18,7 +17,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
@@ -27,7 +26,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
         return test.RunAsync();
     }
 
-    public class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+    public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     {
         protected override CompilationOptions CreateCompilationOptions()
         {

--- a/test/EFCore.Analyzers.Tests/TestUtilities/CSharpCodeFixVerifier.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/CSharpCodeFixVerifier.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Model;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
@@ -18,7 +17,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TCodeFix : CodeFixProvider, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
@@ -34,7 +33,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         await test.RunAsync();
     }
 
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
         protected override async Task<Project> CreateProjectImplAsync(
             EvaluatedProjectState primaryProject,

--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
   </ItemGroup>

--- a/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -50,9 +50,9 @@
 
   <ItemGroup>
     <!-- Newer version of Roslyn used in tests for testing interceptors -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0-2.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0-2.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisVersion)" />
 
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>


### PR DESCRIPTION
This should help avoid warnings due to the transitive System.Drawing.Common 4.7.0 dependency that has a "critical" CVE for an RCE vulnerability. https://github.com/advisories/GHSA-rxg9-xrhp-64gj.

Right now, System.Drawing.Common is transitively referenced via Microsoft.CodeAnalysis.Workspaces.MSBuild 4.8.0 -> Microsoft.Build.Framework 16.10.0 -> System.Security.Permissions 4.7.0 -> System.Windows.Extensions 4.7.0 -> System.Drawing.Common 4.7.0.

I think updating the Microsoft.CodeAnalysis.Workspaces.MSBuild dependency from 4.8.0 to 4.10.0 should remove the transitive System.Drawing.Common dependency entirely.