### PR TITLE
Fix for #34117, Improve Hash Code Distribution for RelationalCommandCache Keys

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
@@ -154,6 +155,6 @@ public class RelationalCommandCache : IPrintableExpression
         }
 
         public override int GetHashCode()
-            => _queryExpression.GetHashCode();
+            => RuntimeHelpers.GetHashCode(_queryExpression);
     }
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -154,6 +154,6 @@ public class RelationalCommandCache : IPrintableExpression
         }
 
         public override int GetHashCode()
-            => 0;
+            => _queryExpression.GetHashCode();
     }
 }


### PR DESCRIPTION
This PR addresses a performance issue in the RelationalCommandCache class where the CommandCacheKey struct uses a hard-coded GetHashCode implementation that returns 0. This implementation leads to all instances being placed in the same bucket within the MemoryCache's internal ConcurrentDictionary, causing linear search times and negating the performance benefits of the hash-based collection.

See Issue https://github.com/dotnet/efcore/issues/34117

Changes

- Modified the GetHashCode implementation in the CommandCacheKey struct to use RuntimeHelpers.GetHashCode(_queryExpression).

- Ensured that the new implementation maintains the contract with the overridden Equals method, which first checks for reference equality.