### PR TITLE
Enable `Max_in_multi_level_nested_subquery` test on Sqlite

### DIFF
--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -69,8 +69,4 @@ public class ComplexNavigationsQuerySqliteTest(ComplexNavigationsQuerySqliteFixt
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Single_select_many_in_projection_with_take(async))).Message);
-
-    [ConditionalTheory(Skip = "issue #32559")]
-    public override Task Max_in_multi_level_nested_subquery(bool async)
-        => base.Max_in_multi_level_nested_subquery(async);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
@@ -70,8 +70,4 @@ public class ComplexNavigationsSharedTypeQuerySqliteTest(ComplexNavigationsShare
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Single_select_many_in_projection_with_take(async))).Message);
-
-    [ConditionalTheory(Skip = "issue #32559")]
-    public override Task Max_in_multi_level_nested_subquery(bool async)
-        => base.Max_in_multi_level_nested_subquery(async);
 }


### PR DESCRIPTION
Fixed by #33060.

Fixes #32559.