### PR TITLE
Pack of minor Cosmos changes

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 property1, property2, entityType, storeName);
 
         /// <summary>
-        ///     Skip, Take, First/FirstOrDefault and Single/SingleOrDefault aren't supported in subqueries since Cosmos doesn't support LIMIT/OFFSET in subqueries.
+        ///     The query requires use of LIMIT and OFFSET in a subquery, which is unsupported by Cosmos.
         /// </summary>
         public static string LimitOffsetNotSupportedInSubqueries
             => GetString("LimitOffsetNotSupportedInSubqueries");
@@ -376,6 +376,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("ThroughputMismatch", nameof(throughput1), nameof(entityType1), nameof(entityType2), nameof(throughput2), nameof(container)),
                 throughput1, entityType1, entityType2, throughput2, container);
+
+        /// <summary>
+        ///     'ToPageAsync' can only be used as the terminating operator of the top-level query.
+        /// </summary>
+        public static string ToPageAsyncAtTopLevelOnly
+            => GetString("ToPageAsyncAtTopLevelOnly");
 
         /// <summary>
         ///     The provisioned throughput was configured as manual on '{manualEntityType}', but on '{autoscaleEntityType}' it was configured as autoscale. All entity types mapped to the same container '{container}' must be configured with the same provisioned throughput type.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -169,7 +169,7 @@
     <value>Both properties '{property1}' and '{property2}' on entity type '{entityType}' are mapped to '{storeName}'. Map one of the properties to a different JSON property.</value>
   </data>
   <data name="LimitOffsetNotSupportedInSubqueries" xml:space="preserve">
-    <value>Skip, Take, First/FirstOrDefault and Single/SingleOrDefault aren't supported in subqueries since Cosmos doesn't support LIMIT/OFFSET in subqueries.</value>
+    <value>The query requires use of LIMIT and OFFSET in a subquery, which is unsupported by Cosmos.</value>
   </data>
   <data name="LogExecutedCreateItem" xml:space="preserve">
     <value>Executed CreateItem ({elapsed} ms, {charge} RU) ActivityId='{activityId}', Container='{container}', Id='{id}', Partition='{partitionKey}'</value>
@@ -302,6 +302,9 @@
   </data>
   <data name="ThroughputTypeMismatch" xml:space="preserve">
     <value>The provisioned throughput was configured as manual on '{manualEntityType}', but on '{autoscaleEntityType}' it was configured as autoscale. All entity types mapped to the same container '{container}' must be configured with the same provisioned throughput type.</value>
+  </data>
+  <data name="ToPageAsyncAtTopLevelOnly" xml:space="preserve">
+    <value>'ToPageAsync' can only be used as the terminating operator of the top-level query.</value>
   </data>
   <data name="TransactionsNotSupported" xml:space="preserve">
     <value>The Cosmos database provider does not support transactions.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -603,7 +603,10 @@ public class CosmosSqlTranslatingExpressionVisitor(
                 return TranslateContains(argument, methodCallExpression.Object!);
 
             // For queryable methods, either we translate the whole aggregate or we go to subquery mode
-            case { Method.IsStatic: true, Arguments.Count: > 0 } when method.DeclaringType == typeof(Queryable):
+            case { Method.IsStatic: true, Arguments.Count: > 0 }
+                when method.DeclaringType == typeof(Queryable)
+                || method.DeclaringType == typeof(EntityFrameworkQueryableExtensions)
+                || method.DeclaringType == typeof(CosmosQueryableExtensions):
                 return TranslateAsSubquery(methodCallExpression);
 
             default:

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
 [DebuggerDisplay("{PrintShortSql(), nq}")]
-public class SelectExpression : Expression, IPrintableExpression
+public sealed class SelectExpression : Expression, IPrintableExpression
 {
     private IDictionary<ProjectionMember, Expression> _projectionMapping = new Dictionary<ProjectionMember, Expression>();
     private readonly List<SourceExpression> _sources = [];
@@ -29,7 +29,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual ReadItemInfo? ReadItemInfo { get; init; }
+    public ReadItemInfo? ReadItemInfo { get; init; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -108,7 +108,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<ProjectionExpression> Projection
+    public IReadOnlyList<ProjectionExpression> Projection
         => _projection;
 
     /// <summary>
@@ -121,7 +121,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </remarks>
-    public virtual bool UsesSingleValueProjection { get; init; }
+    public bool UsesSingleValueProjection { get; init; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -129,7 +129,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<SourceExpression> Sources
+    public IReadOnlyList<SourceExpression> Sources
         => _sources;
 
     /// <summary>
@@ -138,7 +138,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<OrderingExpression> Orderings
+    public IReadOnlyList<OrderingExpression> Orderings
         => _orderings;
 
     /// <summary>
@@ -147,7 +147,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SqlExpression? Predicate { get; private set; }
+    public SqlExpression? Predicate { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -155,7 +155,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SqlExpression? Limit { get; private set; }
+    public SqlExpression? Limit { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -163,7 +163,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SqlExpression? Offset { get; private set; }
+    public SqlExpression? Offset { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -171,7 +171,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsDistinct { get; private set; }
+    public bool IsDistinct { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -179,7 +179,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression GetMappedProjection(ProjectionMember projectionMember)
+    public Expression GetMappedProjection(ProjectionMember projectionMember)
         => _projectionMapping[projectionMember];
 
     /// <summary>
@@ -188,7 +188,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ClearProjection()
+    public void ClearProjection()
         => _projectionMapping.Clear();
 
     /// <summary>
@@ -197,7 +197,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void AddPartitionKey(IProperty partitionKeyProperty, Expression expression)
+    public void AddPartitionKey(IProperty partitionKeyProperty, Expression expression)
         => _partitionKeyValues.Add((expression, partitionKeyProperty));
 
     /// <summary>
@@ -206,7 +206,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual PartitionKey GetPartitionKeyValue(IReadOnlyDictionary<string, object> parameterValues)
+    public PartitionKey GetPartitionKeyValue(IReadOnlyDictionary<string, object> parameterValues)
     {
         if (!_partitionKeyValues.Any())
         {
@@ -236,7 +236,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyProjection()
+    public void ApplyProjection()
     {
         if (Projection.Any())
         {
@@ -261,7 +261,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ReplaceProjectionMapping(IDictionary<ProjectionMember, Expression> projectionMapping)
+    public void ReplaceProjectionMapping(IDictionary<ProjectionMember, Expression> projectionMapping)
     {
         _projectionMapping.Clear();
         foreach (var (projectionMember, expression) in projectionMapping)
@@ -276,7 +276,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual int AddToProjection(Expression sqlExpression)
+    public int AddToProjection(Expression sqlExpression)
         => AddToProjection(sqlExpression, null);
 
     private int AddToProjection(Expression expression, string? alias)
@@ -309,7 +309,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyDistinct()
+    public void ApplyDistinct()
         => IsDistinct = true;
 
     /// <summary>
@@ -318,7 +318,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ClearOrdering()
+    public void ClearOrdering()
         => _orderings.Clear();
 
     /// <summary>
@@ -327,7 +327,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyPredicate(SqlExpression expression)
+    public void ApplyPredicate(SqlExpression expression)
     {
         if (expression is SqlConstantExpression { Value: true })
         {
@@ -350,18 +350,8 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyLimit(SqlExpression sqlExpression)
-    {
-        if (Limit != null)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.TranslationFailedWithDetails(
-                    sqlExpression.Print(),
-                    CosmosStrings.NoSubqueryPushdown));
-        }
-
-        Limit = sqlExpression;
-    }
+    public void ApplyLimit(SqlExpression sqlExpression)
+        => Limit = sqlExpression;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -369,19 +359,8 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyOffset(SqlExpression sqlExpression)
-    {
-        if (Limit != null
-            || Offset != null)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.TranslationFailedWithDetails(
-                    sqlExpression.Print(),
-                    CosmosStrings.NoSubqueryPushdown));
-        }
-
-        Offset = sqlExpression;
-    }
+    public void ApplyOffset(SqlExpression sqlExpression)
+        => Offset = sqlExpression;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -389,18 +368,8 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ApplyOrdering(OrderingExpression orderingExpression)
+    public void ApplyOrdering(OrderingExpression orderingExpression)
     {
-        if (IsDistinct
-            || Limit != null
-            || Offset != null)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.TranslationFailedWithDetails(
-                    orderingExpression.Print(),
-                    CosmosStrings.NoSubqueryPushdown));
-        }
-
         _orderings.Clear();
         _orderings.Add(orderingExpression);
     }
@@ -411,7 +380,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void AppendOrdering(OrderingExpression orderingExpression)
+    public void AppendOrdering(OrderingExpression orderingExpression)
     {
         if (_orderings.FirstOrDefault(o => o.Expression.Equals(orderingExpression.Expression)) == null)
         {
@@ -425,7 +394,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void ReverseOrderings()
+    public void ReverseOrderings()
     {
         if (Limit != null
             || Offset != null)
@@ -452,7 +421,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression AddJoin(ShapedQueryExpression inner, Expression outerShaper, CosmosAliasManager aliasManager)
+    public Expression AddJoin(ShapedQueryExpression inner, Expression outerShaper, CosmosAliasManager aliasManager)
     {
         var (innerSelect, innerShaper) = ((SelectExpression)inner.QueryExpression, inner.ShaperExpression);
 
@@ -641,7 +610,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SelectExpression Update(
+    public SelectExpression Update(
         List<ProjectionExpression> projections,
         List<SourceExpression> sources,
         SqlExpression? predicate,
@@ -673,7 +642,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SelectExpression WithSingleValueProjection()
+    public SelectExpression WithSingleValueProjection()
     {
         var projectionMapping = new Dictionary<ProjectionMember, Expression>();
         foreach (var (projectionMember, expression) in _projectionMapping)
@@ -811,7 +780,7 @@ public class SelectExpression : Expression, IPrintableExpression
     ///     </para>
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual string DebugView
+    public string DebugView
         => this.Print();
 
     #endregion Print

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -981,7 +981,10 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
             // For queryable methods, either we translate the whole aggregate or we go to subquery mode
             // We don't try to translate component-wise it. Providers should implement in subquery translation.
-            case { Method.IsStatic: true, Arguments.Count: > 0 } when method.DeclaringType == typeof(Queryable):
+            case { Method.IsStatic: true, Arguments.Count: > 0 }
+                when method.DeclaringType == typeof(Queryable)
+                || method.DeclaringType == typeof(EntityFrameworkQueryableExtensions)
+                || method.DeclaringType == typeof(RelationalQueryableExtensions):
                 return TryTranslateAggregateMethodCall(methodCallExpression, out var translatedAggregate)
                     ? translatedAggregate
                     : TranslateAsSubquery(methodCallExpression);

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -537,7 +537,9 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
 
         return _subquery
             ? QueryCompilationContext.NotTranslatedExpression
-            : throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
+            : TranslationErrorDetails is null
+                ? throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()))
+                : throw new InvalidOperationException(CoreStrings.TranslationFailedWithDetails(methodCallExpression.Print(), TranslationErrorDetails));
     }
 
     private sealed class EntityShaperNullableMarkingExpressionVisitor : ExpressionVisitor

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -624,30 +624,27 @@ OFFSET @__p_0 LIMIT @__p_1
 
     public override async Task Take_Skip(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_Skip(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task Take_Skip_Distinct(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_Skip_Distinct(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task Take_Skip_Distinct_Caching(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_Skip_Distinct_Caching(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -826,10 +823,9 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task Take_OrderBy_Count(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_OrderBy_Count(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -1246,10 +1242,9 @@ SELECT EXISTS (
 
     public override async Task Take_with_single(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_with_single(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -1943,10 +1938,9 @@ WHERE ((c["Discriminator"] = "Customer") AND (((c["ContactName"] != null) ? c["C
 
     public override async Task Take_skip_null_coalesce_operator(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Take_skip_null_coalesce_operator(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -1980,30 +1974,27 @@ OFFSET 0 LIMIT @__p_0
 
     public override async Task Select_take_skip_null_coalesce_operator(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Select_take_skip_null_coalesce_operator(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task Select_take_skip_null_coalesce_operator2(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Select_take_skip_null_coalesce_operator2(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task Select_take_skip_null_coalesce_operator3(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.Select_take_skip_null_coalesce_operator3(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -2796,40 +2787,36 @@ OFFSET @__p_0 LIMIT @__p_1
 
     public override async Task OrderBy_skip_skip_take(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_skip_skip_take(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task OrderBy_skip_take_take(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_skip_take_take(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task OrderBy_skip_take_take_take_take(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_skip_take_take_take_take(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task OrderBy_skip_take_skip_take_skip(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_skip_take_skip_take_skip(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -2904,20 +2891,18 @@ OFFSET @__p_0 LIMIT @__p_1
 
     public override async Task OrderBy_coalesce_skip_take_distinct_take(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_coalesce_skip_take_distinct_take(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
 
     public override async Task OrderBy_skip_take_distinct_orderby_take(bool async)
     {
-        // Subquery pushdown. Issue #16156.
         await AssertTranslationFailedWithDetails(
             () => base.OrderBy_skip_take_distinct_orderby_take(async),
-            CosmosStrings.NoSubqueryPushdown);
+            CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
         AssertSql();
     }
@@ -5412,6 +5397,14 @@ WHERE (c["Discriminator"] = "Customer")
 ORDER BY c["CustomerID"]
 """);
     }
+
+    [ConditionalFact]
+    public virtual async Task ToPageAsync_in_subquery_throws()
+        => await AssertTranslationFailedWithDetails(
+            () => AssertQuery(
+                async: true,
+                ss => ss.Set<Customer>().Where(c => c.Orders.AsQueryable().ToPageAsync(1, null, null, default) == default)),
+            CosmosStrings.ToPageAsyncAtTopLevelOnly);
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
**Note: this is based on top of #34074, review last commit only**

* Refactor common point for implementation subquery pushdown, and improve error reporting when that happens.
* Move pushdown detection logic out of SelectExpression
* Detect ToPageAsync in subqueries and throw detailed message
* Make SelectExpression sealed
* Some relational syntax cleanup