### PR TITLE
Some minor Cosmos cleanup

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
@@ -35,7 +35,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                         var mutableValues = new List<SqlExpression>();
                         foreach (var value in (IEnumerable)parametersValues[valuesParameter.Name])
                         {
-                            mutableValues.Add(sqlExpressionFactory.Constant(value, typeMapping));
+                            mutableValues.Add(sqlExpressionFactory.Constant(value, value?.GetType() ?? typeof(object), typeMapping));
                         }
                         values = mutableValues;
                         break;

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlConstantExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlConstantExpression.cs
@@ -15,8 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlConstantExpression(ConstantExpression constantExpression, CoreTypeMapping? typeMapping)
-    : SqlExpression(constantExpression.Type, typeMapping)
+public class SqlConstantExpression : SqlExpression
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -24,8 +23,28 @@ public class SqlConstantExpression(ConstantExpression constantExpression, CoreTy
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual object? Value
-        => constantExpression.Value;
+    public SqlConstantExpression(object? value, Type type, CoreTypeMapping? typeMapping)
+        : base(type.UnwrapNullableType(), typeMapping)
+        => Value = value;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlConstantExpression(object value, CoreTypeMapping? typeMapping)
+        : this(value, value.GetType(), typeMapping)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual object? Value { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,7 +53,7 @@ public class SqlConstantExpression(ConstantExpression constantExpression, CoreTy
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual SqlExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
-        => new SqlConstantExpression(constantExpression, typeMapping ?? TypeMapping);
+        => new SqlConstantExpression(Value, Type, typeMapping ?? TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlParameterExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlParameterExpression.cs
@@ -10,34 +10,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public sealed class SqlParameterExpression : SqlExpression
+public sealed class SqlParameterExpression(string name, Type type, CoreTypeMapping? typeMapping)
+    : SqlExpression(type, typeMapping)
 {
-    private readonly ParameterExpression _parameterExpression;
-    private readonly string _name;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public SqlParameterExpression(ParameterExpression parameterExpression, CoreTypeMapping? typeMapping)
-        : base(parameterExpression.Type, typeMapping)
-    {
-        Check.DebugAssert(parameterExpression.Name != null, "Parameter must have name.");
-
-        _parameterExpression = parameterExpression;
-        _name = parameterExpression.Name;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public string Name
-        => _name;
+    public string Name { get; } = name;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,7 +28,7 @@ public sealed class SqlParameterExpression : SqlExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public SqlExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
-        => new SqlParameterExpression(_parameterExpression, typeMapping ?? TypeMapping);
+        => new SqlParameterExpression(Name, Type, typeMapping ?? TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -64,7 +46,7 @@ public sealed class SqlParameterExpression : SqlExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override void Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append("@" + _parameterExpression.Name);
+        => expressionPrinter.Append("@" + Name);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -303,5 +303,14 @@ public interface ISqlExpressionFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    SqlConstantExpression Constant(object? value, CoreTypeMapping? typeMapping = null);
+    SqlExpression Constant(object value, CoreTypeMapping? typeMapping = null);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    SqlExpression Constant(object? value, Type type, CoreTypeMapping? typeMapping = null);
+
 }

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -514,7 +514,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual SqlBinaryExpression IsNull(SqlExpression operand)
-        => Equal(operand, Constant(null));
+        => Equal(operand, Constant(null, operand.Type));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -523,7 +523,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual SqlBinaryExpression IsNotNull(SqlExpression operand)
-        => NotEqual(operand, Constant(null));
+        => NotEqual(operand, Constant(null, operand.Type));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -627,6 +627,15 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual SqlConstantExpression Constant(object? value, CoreTypeMapping? typeMapping = null)
-        => new(Expression.Constant(value), typeMapping);
+    public virtual SqlExpression Constant(object value, CoreTypeMapping? typeMapping = null)
+        => new SqlConstantExpression(value, typeMapping);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression Constant(object? value, Type type, CoreTypeMapping? typeMapping = null)
+        => new SqlConstantExpression(value, type, typeMapping);
 }

--- a/src/EFCore/Query/EntityQueryRootExpression.cs
+++ b/src/EFCore/Query/EntityQueryRootExpression.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public class EntityQueryRootExpression : QueryRootExpression, IPrintableExpression
 {
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
@@ -71,13 +71,10 @@ OFFSET 0 LIMIT 2
 """);
     }
 
-    public override async Task Array_of_byte()
-    {
-        // TODO
-        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Array_of_byte());
-
-        AssertSql();
-    }
+    // byte[] gets mapped to base64, which isn't queryable as a regular primitive collection.
+    [ConditionalFact]
+    public override Task Array_of_byte()
+        => AssertTranslationFailed(() => TestArray((byte)1, (byte)2));
 
     public override async Task Array_of_double()
     {
@@ -289,7 +286,7 @@ OFFSET 0 LIMIT 2
 
     public override async Task Array_of_byte_array()
     {
-        // TODO
+        // TODO: primitive collection over value-converted element, #34153
         await Assert.ThrowsAsync<InvalidOperationException>(() => base.Array_of_byte_array());
 
         AssertSql(
@@ -350,8 +347,8 @@ OFFSET 0 LIMIT 2
 
     public override async Task Constant_with_inferred_value_converter()
     {
-        // TODO
-        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Constant_with_inferred_value_converter());
+        // TODO: advanced type mapping inference for inline scalar collection, #34026
+        await AssertTranslationFailed(() => base.Constant_with_inferred_value_converter());
 
         AssertSql();
     }

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -299,7 +299,6 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedMode
                 Constant(2)),
             entityParam);
 
-        // context.Set<TestEntity>().SingleAsync(m => EF.Property<int[]>(m, "SomeArray").Count(a => a == <value1>) == 2)
         var result = await context.Set<TestEntity>().SingleAsync(predicate);
         Assert.Equal(1, result.Id);
     }


### PR DESCRIPTION
* Simplify SqlConstantExpression and SqlParameterExpression, aligning to relationl
* Clean up test failures in NonSharedPrimitiveCollectionsQueryCosmosTest
