### PR TITLE
Execute migrations using the ExecutionStrategy

### DIFF
--- a/src/EFCore.Relational/Diagnostics/MigrationCommandEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigrationCommandEventData.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     The <see cref="DiagnosticSource" /> event payload for
+///     <see cref="RelationalEventId" /> events of a specific migration.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class MigrationCommandEventData : MigratorEventData
+{
+    /// <summary>
+    ///     Constructs the event payload.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="migrator">
+    ///     The <see cref="IMigrator" /> in use.
+    /// </param>
+    /// <param name="migration">
+    ///     The <see cref="Migration" /> being processed.
+    /// </param>
+    /// <param name="command">
+    ///     The <see cref="MigrationCommand" /> being processed.
+    /// </param>
+    public MigrationCommandEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        IMigrator migrator,
+        Migration migration,
+        MigrationCommand command)
+        : base(eventDefinition, messageGenerator, migrator)
+    {
+        Migration = migration;
+        MigrationCommand = command;
+    }
+
+    /// <summary>
+    ///     The <see cref="Migration" /> being processed.
+    /// </summary>
+    public virtual Migration Migration { get; }
+
+    /// <summary>
+    ///     The <see cref="MigrationCommand" /> being processed.
+    /// </summary>
+    public virtual MigrationCommand MigrationCommand { get; }
+}

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -77,6 +77,8 @@ public static class RelationalEventId
         MigrationsNotFound,
         MigrationAttributeMissingWarning,
         ColumnOrderIgnoredWarning,
+        PendingModelChangesWarning,
+        NonTransactionalMigrationOperationWarning,
 
         // Query events
         QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
@@ -720,6 +722,32 @@ public static class RelationalEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId ColumnOrderIgnoredWarning = MakeMigrationsId(Id.ColumnOrderIgnoredWarning);
+
+    /// <summary>
+    ///     The model contains changes compared to the last migration.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="DbContextTypeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId PendingModelChangesWarning = MakeMigrationsId(Id.PendingModelChangesWarning);
+
+    /// <summary>
+    ///     A migration contains a non-transactional operation.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="MigrationCommandEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId NonTransactionalMigrationOperationWarning = MakeMigrationsId(Id.NonTransactionalMigrationOperationWarning);
 
     private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
 

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -2310,6 +2310,90 @@ public static class RelationalLoggerExtensions
     }
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.PendingModelChangesWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="contextType">The <see cref="DbContext" /> type being used.</param>
+    public static void PendingModelChangesWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+        Type contextType)
+    {
+        var definition = RelationalResources.LogPendingModelChanges(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, contextType.ShortDisplayName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new DbContextTypeEventData(
+                definition,
+                PendingModelChanges,
+                contextType);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string PendingModelChanges(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string>)definition;
+        var p = (DbContextTypeEventData)payload;
+        return d.GenerateMessage(p.ContextType.ShortDisplayName());
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.NonTransactionalMigrationOperationWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="migrator">The <see cref="IMigrator" /> in use.</param>
+    /// <param name="migration">The <see cref="Migration" /> being processed.</param>
+    /// <param name="command">The <see cref="MigrationCommand" /> being processed.</param>
+    public static void NonTransactionalMigrationOperationWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+        IMigrator migrator,
+        Migration migration,
+        MigrationCommand command)
+    {
+        var definition = RelationalResources.LogNonTransactionalMigrationOperationWarning(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            var commandText = command.CommandText;
+            if (commandText.Length > 100)
+            {
+                commandText = commandText.Substring(0, 100) + "...";
+            }
+            definition.Log(diagnostics, commandText, migration.GetType().ShortDisplayName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MigrationCommandEventData(
+                definition,
+                NonTransactionalMigrationOperationWarning,
+                migrator,
+                migration,
+                command);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string NonTransactionalMigrationOperationWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string>)definition;
+        var p = (MigrationCommandEventData)payload;
+        var commandText = p.MigrationCommand.CommandText;
+        if (commandText.Length > 100)
+        {
+            commandText = commandText.Substring(0, 100) + "...";
+        }
+        return d.GenerateMessage(commandText, p.Migration.GetType().ShortDisplayName());
+    }
+
+    /// <summary>
     ///     Logs for the <see cref="RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning" /> event.
     /// </summary>
     /// <param name="diagnostics">The diagnostics logger to use.</param>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -653,6 +653,24 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogPendingModelChanges;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogNonTransactionalMigrationOperationWarning;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogExceptionDuringNonQueryOperation;
 
     /// <summary>

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -54,7 +54,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             { typeof(ISqlGenerationHelper), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IRelationalAnnotationProvider), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IMigrationsAnnotationProvider), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-            { typeof(IMigrationCommandExecutor), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IMigrationCommandExecutor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalTypeMappingSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IUpdateSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IRelationalTransactionFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -96,7 +96,8 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
                 typeof(IAggregateMethodCallTranslatorPlugin),
                 new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true)
             },
-            { typeof(IMemberTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) }
+            { typeof(IMemberTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
+            { typeof(IMigratorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) }
         };
 
     /// <summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -439,7 +439,9 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
                 .TryWithExplicit(RelationalEventId.IndexPropertiesBothMappedAndNotMappedToTable, WarningBehavior.Throw)
                 .TryWithExplicit(RelationalEventId.IndexPropertiesMappedToNonOverlappingTables, WarningBehavior.Throw)
                 .TryWithExplicit(RelationalEventId.ForeignKeyPropertiesMappedToUnrelatedTables, WarningBehavior.Throw)
-                .TryWithExplicit(RelationalEventId.StoredProcedureConcurrencyTokenNotMapped, WarningBehavior.Throw));
+                .TryWithExplicit(RelationalEventId.StoredProcedureConcurrencyTokenNotMapped, WarningBehavior.Throw)
+                .TryWithExplicit(RelationalEventId.PendingModelChangesWarning, WarningBehavior.Throw)
+                .TryWithExplicit(RelationalEventId.NonTransactionalMigrationOperationWarning, WarningBehavior.Throw));
 
     /// <summary>
     ///     Information/metadata for a <see cref="RelationalOptionsExtension" />.

--- a/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
@@ -8,9 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
-///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
-///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+///         The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
+///         <see cref="DbContext" /> instance will use its own instance of this service.
+///         The implementation may depend on other services registered with any lifetime.
+///         The implementation does not need to be thread-safe.
 ///     </para>
 ///     <para>
 ///         See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.

--- a/src/EFCore.Relational/Migrations/IMigrator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrator.cs
@@ -26,33 +26,49 @@ public interface IMigrator
     ///     Migrates the database to either a specified target migration or up to the latest
     ///     migration that exists in the <see cref="IMigrationsAssembly" />.
     /// </summary>
-    /// <remarks>
-    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
-    /// </remarks>
     /// <param name="targetMigration">
     ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
     /// </param>
+    /// <param name="seed">
+    ///     The optional seed method to run after migrating the database. It will be invoked even if no migrations were applied.
+    /// </param>
+    /// <param name="lockTimeout">
+    ///     The maximum amount of time that the migration lock should be held. Unless a catastrophic failure occurs, the
+    ///     lock is released when the migration operation completes.
+    /// </param>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
     [RequiresUnreferencedCode("Migration generation currently isn't compatible with trimming")]
     [RequiresDynamicCode("Migrations operations are not supported with NativeAOT")]
-    void Migrate(string? targetMigration = null);
+    void Migrate(string? targetMigration = null, Action<DbContext, IMigratorData>? seed = null, TimeSpan? lockTimeout = null);
 
     /// <summary>
     ///     Migrates the database to either a specified target migration or up to the latest
     ///     migration that exists in the <see cref="IMigrationsAssembly" />.
     /// </summary>
-    /// <remarks>
-    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
-    /// </remarks>
     /// <param name="targetMigration">
     ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
     /// </param>
+    /// <param name="seed">
+    ///     The optional seed method to run after migrating the database. It will be invoked even if no migrations were applied.
+    /// </param>
+    /// <param name="lockTimeout">
+    ///     The maximum amount of time that the migration lock should be held. Unless a catastrophic failure occurs, the
+    ///     lock is released when the migration operation completes.
+    /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation</returns>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     [RequiresUnreferencedCode("Migration generation currently isn't compatible with trimming")]
     [RequiresDynamicCode("Migrations operations are not supported with NativeAOT")]
     Task MigrateAsync(
         string? targetMigration = null,
+        Func<DbContext, IMigratorData, CancellationToken, Task>? seed = null,
+        TimeSpan? lockTimeout = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -78,4 +94,16 @@ public interface IMigrator
         string? fromMigration = null,
         string? toMigration = null,
         MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default);
+
+    /// <summary>
+    ///     Returns <see langword="true" /> if the model has pending changes to be applied.
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true" /> if the database model has pending changes
+    ///     and a new migration has to be added.
+    /// </returns>
+    [RequiresDynamicCode(
+        "Migrations operations are not supported with NativeAOT"
+        + " Use a migration bundle or an alternate way of executing migration operations.")]
+    bool HasPendingModelChanges();
 }

--- a/src/EFCore.Relational/Migrations/IMigratorData.cs
+++ b/src/EFCore.Relational/Migrations/IMigratorData.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+///     A class that holds the results from the last migrations application.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+/// </remarks>
+public interface IMigratorData
+{
+    /// <summary>
+    ///     The migrations that were applied to the database.
+    /// </summary>
+    public IReadOnlyList<Migration> AppliedMigrations { get; }
+
+    /// <summary>
+    ///     The migrations that were reverted from the database.
+    /// </summary>
+    public IReadOnlyList<Migration> RevertedMigrations { get; }
+
+    /// <summary>
+    ///     The target migration.
+    ///     <see langword="null" /> if all migrations were reverted or no target migration was specified.
+    /// </summary>
+    public Migration? TargetMigration { get; }
+}

--- a/src/EFCore.Relational/Migrations/IMigratorPlugin.cs
+++ b/src/EFCore.Relational/Migrations/IMigratorPlugin.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+///     <para>
+///         A service on the EF internal service provider that allows providers or extensions to execute logic
+///         after <see cref="IMigrator.Migrate(string?, Action{DbContext, IMigratorData}?, TimeSpan?)"/> is called.
+///     </para>
+///     <para>
+///         This type is typically used by providers or extensions. It is generally not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+///     is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+///     This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+/// </remarks>
+public interface IMigratorPlugin
+{
+    /// <summary>
+    ///     Called by <see cref="IMigrator.Migrate(string?, Action{DbContext, IMigratorData}?, TimeSpan?)"/> before applying the migrations.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext" /> that is being migrated.</param>
+    /// <param name="data">The <see cref="IMigratorData" /> that contains the result of the migrations application.</param>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    void Migrating(DbContext context, IMigratorData data);
+
+    /// <summary>
+    ///     Called by <see cref="IMigrator.MigrateAsync(string?, Func{DbContext, IMigratorData, CancellationToken, Task}?, TimeSpan?, CancellationToken)"/> before applying the migrations.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext" /> that is being migrated.</param>
+    /// <param name="data">The <see cref="IMigratorData" /> that contains the result of the migrations application.</param>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task MigratingAsync(
+        DbContext context,
+        IMigratorData data,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Called by <see cref="IMigrator.Migrate(string?, Action{DbContext, IMigratorData}?, TimeSpan?)"/> after applying the migrations, but before the seeding action.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext" /> that is being migrated.</param>
+    /// <param name="data">The <see cref="IMigratorData" /> that contains the result of the migrations application.</param>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    void Migrated(DbContext context, IMigratorData data);
+
+    /// <summary>
+    ///     Called by <see cref="IMigrator.MigrateAsync(string?, Func{DbContext, IMigratorData, CancellationToken, Task}?, TimeSpan?, CancellationToken)"/> after applying the migrations, but before the seeding action.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext" /> that is being migrated.</param>
+    /// <param name="data">The <see cref="IMigratorData" /> that contains the result of the migrations application.</param>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task MigratedAsync(
+        DbContext context,
+        IMigratorData data,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EFCore.Relational/Migrations/Internal/MigratorData.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigratorData.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class MigratorData(
+    IReadOnlyList<Migration> appliedMigrations,
+    IReadOnlyList<Migration> revertedMigrations,
+    Migration? targetMigration)
+    : IMigratorData
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlyList<Migration> AppliedMigrations { get; } = appliedMigrations;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlyList<Migration> RevertedMigrations { get; } = revertedMigrations;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public Migration? TargetMigration { get; } = targetMigration;
+}

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1178,7 +1178,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("JsonNodeMustBeHandledByProviderSpecificVisitor");
 
         /// <summary>
-        ///     Using parameter to access the element of a JSON collection '{entityTypeName}' is not supported when using '{asNoTrackingWithIdentityResolution}'. Use constant, or project the entire JSON entity collection instead.
+        ///     Using a parameter to access the element of a JSON collection '{entityTypeName}' is not supported when using '{asNoTrackingWithIdentityResolution}'. Use a constant, or project the entire JSON entity collection instead.
         /// </summary>
         public static string JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution(object? entityTypeName, object? asNoTrackingWithIdentityResolution)
             => string.Format(
@@ -1188,10 +1188,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     When using '{asNoTrackingWithIdentityResolution}' entities mapped to JSON must be projected in a particular order. Project entire collection of entities '{entityTypeName}' before its individual elements.
         /// </summary>
-        public static string JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(object? entityTypeName, object? asNoTrackingWithIdentityResolution)
+        public static string JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution(object? asNoTrackingWithIdentityResolution, object? entityTypeName)
             => string.Format(
-                GetString("JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution", nameof(entityTypeName), nameof(asNoTrackingWithIdentityResolution)),
-                entityTypeName, asNoTrackingWithIdentityResolution);
+                GetString("JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution", nameof(asNoTrackingWithIdentityResolution), nameof(entityTypeName)),
+                asNoTrackingWithIdentityResolution, entityTypeName);
 
         /// <summary>
         ///     Projecting queryable operations on JSON collection is not supported for '{asNoTrackingWithIdentityResolution}'.
@@ -1386,7 +1386,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NoActiveTransaction");
 
         /// <summary>
-        ///     No alias is defined on table: '{table}'
+        ///     No alias is defined on table: '{table}'.
         /// </summary>
         public static string NoAliasOnTable(object? table)
             => string.Format(
@@ -2106,7 +2106,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(
@@ -3523,6 +3523,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     The migration operation '{operation}' from migration '{migration}' cannot be executed in a transaction. If the app is terminated or an unrecoverable error occurs while this operation is being executed then the migration will be left in a partially applied state and would need to be reverted manually before it can be applied again. Create a separate migration that contains just this operation.
+        /// </summary>
+        public static EventDefinition<string, string> LogNonTransactionalMigrationOperationWarning(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNonTransactionalMigrationOperationWarning;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogNonTransactionalMigrationOperationWarning,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        RelationalEventId.NonTransactionalMigrationOperationWarning,
+                        LogLevel.Error,
+                        "RelationalEventId.NonTransactionalMigrationOperationWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            RelationalEventId.NonTransactionalMigrationOperationWarning,
+                            _resourceManager.GetString("LogNonTransactionalMigrationOperationWarning")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     Opened connection to database '{database}' on server '{server}'.
         /// </summary>
         public static EventDefinition<string, string> LogOpenedConnection(IDiagnosticsLogger logger)
@@ -3642,6 +3667,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning,
                             _resourceManager.GetString("LogOptionalDependentWithoutIdentifyingProperty")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     The model for context '{contextType}' has pending changes. Add a new migration before updating the database.
+        /// </summary>
+        public static EventDefinition<string> LogPendingModelChanges(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogPendingModelChanges;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogPendingModelChanges,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        RelationalEventId.PendingModelChangesWarning,
+                        LogLevel.Error,
+                        "RelationalEventId.PendingModelChangesWarning",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            RelationalEventId.PendingModelChangesWarning,
+                            _resourceManager.GetString("LogPendingModelChanges")!)));
             }
 
             return (EventDefinition<string>)definition;

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -2036,7 +2036,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("TransactionAssociatedWithDifferentConnection");
 
         /// <summary>
-        ///     User transaction is not supported with a TransactionSuppressed migrations.
+        ///     User transaction is not supported with a TransactionSuppressed migrations or a retrying execution strategy.
         /// </summary>
         public static string TransactionSuppressedMigrationInUserTransaction
             => GetString("TransactionSuppressedMigrationInUserTransaction");

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1209,7 +1209,7 @@
     <value>The specified transaction is not associated with the current connection. Only transactions associated with the current connection may be used.</value>
   </data>
   <data name="TransactionSuppressedMigrationInUserTransaction" xml:space="preserve">
-    <value>User transaction is not supported with a TransactionSuppressed migrations.</value>
+    <value>User transaction is not supported with a TransactionSuppressed migrations or a retrying execution strategy.</value>
   </data>
   <data name="TriggerWithMismatchedTable" xml:space="preserve">
     <value>Trigger '{trigger}' for table '{triggerTable}' is defined on entity type '{entityType}', which is mapped to table '{entityTable}'. See https://aka.ms/efcore-docs-triggers for more information on triggers.</value>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -563,7 +563,7 @@
     <value>This node should be handled by provider-specific sql generator.</value>
   </data>
   <data name="JsonProjectingCollectionElementAccessedUsingParmeterNoTrackingWithIdentityResolution" xml:space="preserve">
-    <value>Using parameter to access the element of a JSON collection '{entityTypeName}' is not supported for '{asNoTrackingWithIdentityResolution}'. Use constant, or project the entire JSON entity collection instead.</value>
+    <value>Using a parameter to access the element of a JSON collection '{entityTypeName}' is not supported when using '{asNoTrackingWithIdentityResolution}'. Use a constant, or project the entire JSON entity collection instead.</value>
   </data>
   <data name="JsonProjectingEntitiesIncorrectOrderNoTrackingWithIdentityResolution" xml:space="preserve">
     <value>When using '{asNoTrackingWithIdentityResolution}' entities mapped to JSON must be projected in a particular order. Project entire collection of entities '{entityTypeName}' before its individual elements.</value>
@@ -797,6 +797,10 @@
     <value>No migrations were found in assembly '{migrationsAssembly}'.</value>
     <comment>Debug RelationalEventId.MigrationsNotFound string</comment>
   </data>
+  <data name="LogNonTransactionalMigrationOperationWarning" xml:space="preserve">
+    <value>The migration operation '{operation}' from migration '{migration}' cannot be executed in a transaction. If the app is terminated or an unrecoverable error occurs while this operation is being executed then the migration will be left in a partially applied state and would need to be reverted manually before it can be applied again. Create a separate migration that contains just this operation.</value>
+    <comment>Error RelationalEventId.NonTransactionalMigrationOperationWarning string string</comment>
+  </data>
   <data name="LogOpenedConnection" xml:space="preserve">
     <value>Opened connection to database '{database}' on server '{server}'.</value>
     <comment>Debug RelationalEventId.ConnectionOpened string string</comment>
@@ -816,6 +820,10 @@
   <data name="LogOptionalDependentWithoutIdentifyingProperty" xml:space="preserve">
     <value>The entity type '{entityType}' is an optional dependent using table sharing without any required non shared property that could be used to identify whether the entity exists. If all nullable properties contain a null value in database then an object instance won't be created in the query. Add a required property to create instances with null values for other properties or mark the incoming navigation as required to always create an instance.</value>
     <comment>Warning RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning string</comment>
+  </data>
+  <data name="LogPendingModelChanges" xml:space="preserve">
+    <value>The model for context '{contextType}' has pending changes. Add a new migration before updating the database.</value>
+    <comment>Error RelationalEventId.PendingModelChangesWarning string</comment>
   </data>
   <data name="LogPossibleUnintendedUseOfEquals" xml:space="preserve">
     <value>Possible unintended use of method 'Equals' for arguments '{left}' and '{right}' of different types in a query. This comparison will always return false.</value>
@@ -1029,11 +1037,11 @@
   <data name="SelectExpressionNonTphWithCustomTable" xml:space="preserve">
     <value>Cannot create a 'SelectExpression' with a custom 'TableExpressionBase' since the result type '{entityType}' is part of a hierarchy and does not contain a discriminator property.</value>
   </data>
-  <data name="SetOperationOverDifferentStructuralTypes" xml:space="preserve">
-    <value>Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').</value>
-  </data>
   <data name="SelectExpressionUpdateNotSupportedWhileMutable" xml:space="preserve">
     <value>SelectExpression.Update() is not supported while the expression is in mutable state.</value>
+  </data>
+  <data name="SetOperationOverDifferentStructuralTypes" xml:space="preserve">
+    <value>Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').</value>
   </data>
   <data name="SetOperationsNotAllowedAfterClientEvaluation" xml:space="preserve">
     <value>Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.</value>

--- a/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProviderDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProviderDependencies.cs
@@ -56,7 +56,7 @@ public sealed record RelationalAggregateMethodCallTranslatorProviderDependencies
     }
 
     /// <summary>
-    ///     The expression factory..
+    ///     The expression factory.
     /// </summary>
     public ISqlExpressionFactory SqlExpressionFactory { get; init; }
 

--- a/src/EFCore.Relational/Query/RelationalMemberTranslatorProviderDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalMemberTranslatorProviderDependencies.cs
@@ -54,7 +54,7 @@ public sealed record RelationalMemberTranslatorProviderDependencies
     }
 
     /// <summary>
-    ///     The expression factory..
+    ///     The expression factory.
     /// </summary>
     public ISqlExpressionFactory SqlExpressionFactory { get; init; }
 

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1738,7 +1738,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
     }
 
     /// <summary>
-    ///     Generates a transfer from one schema to another..
+    ///     Generates a transfer from one schema to another.
     /// </summary>
     /// <param name="newSchema">The schema to transfer to.</param>
     /// <param name="schema">The schema to transfer from.</param>

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -117,9 +117,8 @@ public static class SqliteServiceCollectionExtensions
             .TryAdd<ISqlExpressionFactory, SqliteSqlExpressionFactory>()
             .TryAdd<IRelationalParameterBasedSqlProcessorFactory, SqliteParameterBasedSqlProcessorFactory>()
             .TryAddProviderSpecificServices(
-                b => b.TryAddScoped<ISqliteRelationalConnection, SqliteRelationalConnection>());
-
-        builder.TryAddCoreServices();
+                b => b.TryAddScoped<ISqliteRelationalConnection, SqliteRelationalConnection>())
+            .TryAddCoreServices();
 
         return serviceCollection;
     }

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -1033,7 +1033,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1069,7 +1069,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1157,7 +1157,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1192,7 +1192,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1280,7 +1280,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1316,7 +1316,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1404,7 +1404,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1440,7 +1440,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1528,7 +1528,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.
@@ -1564,7 +1564,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     A task that represents the asynchronous operation.
-    ///     The task result contains the sum of the projected values..
+    ///     The task result contains the sum of the projected values.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -1041,7 +1041,7 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <remarks>
     ///     <para>
     ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />,
-    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />, 
+    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />,
     ///         <see cref="AddDbContextFactory{TContext, TFactory}(IServiceCollection,Action{DbContextOptionsBuilder}?,ServiceLifetime)" /> or
     ///         <see cref="AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />
     ///         must also be called for the specified configuration to take effect.
@@ -1077,7 +1077,7 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <remarks>
     ///     <para>
     ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />,
-    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />, 
+    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />,
     ///         <see cref="AddDbContextFactory{TContext, TFactory}(IServiceCollection,Action{DbContextOptionsBuilder}?,ServiceLifetime)" /> or
     ///         <see cref="AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />
     ///         must also be called for the specified configuration to take effect.

--- a/src/EFCore/Metadata/ITypeBase.cs
+++ b/src/EFCore/Metadata/ITypeBase.cs
@@ -195,7 +195,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     new IPropertyBase? FindMember(string name);
 
     /// <summary>
-    ///     Gets the members with the given name on this type, base types or derived types..
+    ///     Gets the members with the given name on this type, base types or derived types.
     /// </summary>
     /// <returns>Type members.</returns>
     new IEnumerable<IPropertyBase> FindMembersInHierarchy(string name);

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -123,7 +123,10 @@ public class MigrationsScaffolderTest
                     services.GetRequiredService<IModelRuntimeInitializer>(),
                     services.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Migrations>>(),
                     services.GetRequiredService<IRelationalCommandDiagnosticsLogger>(),
-                    services.GetRequiredService<IDatabaseProvider>())));
+                    services.GetRequiredService<IDatabaseProvider>(),
+                    services.GetServices<IMigratorPlugin>(),
+                    services.GetRequiredService<IMigrationsModelDiffer>(),
+                    services.GetRequiredService<IDesignTimeModel>())));
     }
 
     // ReSharper disable once UnusedTypeParameter

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -91,8 +91,7 @@ public class MigrationsScaffolderTest
                     services.GetRequiredService<CommandBatchPreparerDependencies>()),
                 idGenerator,
                 new MigrationsCodeGeneratorSelector(
-                    new[]
-                    {
+                    [
                         new CSharpMigrationsGenerator(
                             new MigrationsCodeGeneratorDependencies(
                                 sqlServerTypeMappingSource,
@@ -105,7 +104,7 @@ public class MigrationsScaffolderTest
                                 new CSharpSnapshotGenerator(
                                     new CSharpSnapshotGeneratorDependencies(
                                         code, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))))
-                    }),
+                    ]),
                 historyRepository,
                 reporter,
                 new MockProvider(),

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -3,7 +3,7 @@
 
 // ReSharper disable InconsistentNaming
 
-using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations;
 
@@ -18,6 +18,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
     {
         Fixture = fixture;
         Fixture.TestStore.CloseConnection();
+        Fixture.TestSqlLoggerFactory.Clear();
     }
 
     protected string Sql { get; private set; }
@@ -70,7 +71,12 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
 
         GiveMeSomeTime(db);
 
-        db.Database.Migrate();
+        MigrationsInfrastructureFixtureBase.MigratorPlugin.ResetCounts();
+        db.Database.Migrate((c, d) =>
+        {
+            c.Add(new MigrationsInfrastructureFixtureBase.Foo { Id = 1, Bar = 10, Description = "Test" });
+            c.SaveChanges();
+        });
 
         var history = db.GetService<IHistoryRepository>();
         Assert.Collection(
@@ -82,6 +88,47 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
             x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
             x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
+
+        Assert.NotNull(db.Find<MigrationsInfrastructureFixtureBase.Foo>(1));
+
+        Assert.Equal(1, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratingCallCount);
+        Assert.Equal(1, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratedCallCount);
+        Assert.Equal(0, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratingAsyncCallCount);
+        Assert.Equal(0, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratedAsyncCallCount);
+    }
+
+    [ConditionalFact]
+    public virtual async Task Can_apply_all_migrations_async()
+    {
+        using var db = Fixture.CreateContext();
+        await db.Database.EnsureDeletedAsync();
+
+        await GiveMeSomeTimeAsync(db);
+
+        MigrationsInfrastructureFixtureBase.MigratorPlugin.ResetCounts();
+        await db.Database.MigrateAsync(async (c, d, ct) =>
+        {
+            c.Add(new MigrationsInfrastructureFixtureBase.Foo { Id = 1, Bar = 10, Description = "Test" });
+            await c.SaveChangesAsync(ct);
+        });
+
+        var history = db.GetService<IHistoryRepository>();
+        Assert.Collection(
+            await history.GetAppliedMigrationsAsync(),
+            x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+            x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
+            x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
+            x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
+            x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
+            x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
+            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
+
+        Assert.NotNull(await db.FindAsync<MigrationsInfrastructureFixtureBase.Foo>(1));
+
+        Assert.Equal(0, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratingCallCount);
+        Assert.Equal(0, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratedCallCount);
+        Assert.Equal(1, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratingAsyncCallCount);
+        Assert.Equal(1, MigrationsInfrastructureFixtureBase.MigratorPlugin.MigratedAsyncCallCount);
     }
 
     [ConditionalFact]
@@ -92,8 +139,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
 
         GiveMeSomeTime(db);
 
-        var migrator = db.GetService<IMigrator>();
-        migrator.Migrate("Migration6");
+        db.Database.Migrate(null, "Migration6");
 
         var history = db.GetService<IHistoryRepository>();
         Assert.Collection(
@@ -121,6 +167,9 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         Assert.Collection(
             history.GetAppliedMigrations(),
             x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
+
+        Assert.Equal(LogLevel.Error,
+            Fixture.TestSqlLoggerFactory.Log.Single(l => l.Id == RelationalEventId.PendingModelChangesWarning).Level);
     }
 
     [ConditionalFact]
@@ -158,28 +207,6 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
             x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
             x => Assert.Equal("00000000000004_Migration4", x.MigrationId));
-    }
-
-    [ConditionalFact]
-    public virtual async Task Can_apply_all_migrations_async()
-    {
-        using var db = Fixture.CreateContext();
-        await db.Database.EnsureDeletedAsync();
-
-        await GiveMeSomeTimeAsync(db);
-
-        await db.Database.MigrateAsync();
-
-        var history = db.GetService<IHistoryRepository>();
-        Assert.Collection(
-            await history.GetAppliedMigrationsAsync(),
-            x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
-            x => Assert.Equal("00000000000002_Migration2", x.MigrationId),
-            x => Assert.Equal("00000000000003_Migration3", x.MigrationId),
-            x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
-            x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
-            x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
-            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
     }
 
     [ConditionalFact]
@@ -444,11 +471,15 @@ public abstract class MigrationsInfrastructureFixtureBase
     protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
     {
         TestStore.UseConnectionString = true;
-        return base.AddServices(serviceCollection);
+        return base.AddServices(serviceCollection)
+            .AddSingleton<IMigratorPlugin, MigratorPlugin>();
     }
 
     protected override string StoreName
         => "MigrationsTest";
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
 
     public EmptyMigrationsContext CreateEmptyContext()
         => new(
@@ -460,9 +491,6 @@ public abstract class MigrationsInfrastructureFixtureBase
                         .BuildServiceProvider(validateScopes: true))
                 .Options);
 
-    public new virtual MigrationsContext CreateContext()
-        => base.CreateContext();
-
     public class EmptyMigrationsContext(DbContextOptions options) : DbContext(options);
 
     public class MigrationsContext(DbContextOptions options) : PoolableDbContext(options)
@@ -470,10 +498,61 @@ public abstract class MigrationsInfrastructureFixtureBase
         public DbSet<Foo> Foos { get; set; }
     }
 
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        modelBuilder.Entity<Foo>(b => b.ToTable("Table1"));
+    }
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder).ConfigureWarnings(e => e
+            .Log(RelationalEventId.PendingModelChangesWarning)
+            .Log(RelationalEventId.NonTransactionalMigrationOperationWarning)
+        );
+
+    protected override bool ShouldLogCategory(string logCategory)
+        => logCategory == DbLoggerCategory.Migrations.Name;
+
     public class Foo
     {
         public int Id { get; set; }
+        public int Bar { get; set; }
         public string Description { get; set; }
+    }
+
+    public class MigratorPlugin : IMigratorPlugin
+    {
+        public static int MigratedCallCount { get; private set; }
+        public static int MigratedAsyncCallCount { get; private set; }
+        public static int MigratingCallCount { get; private set; }
+        public static int MigratingAsyncCallCount { get; private set; }
+
+        public static void ResetCounts()
+        {
+            MigratedCallCount = 0;
+            MigratedAsyncCallCount = 0;
+            MigratingCallCount = 0;
+            MigratingAsyncCallCount = 0;
+        }
+
+        public void Migrated(DbContext context, IMigratorData data)
+        {
+            MigratedCallCount++;
+        }
+
+        public Task MigratedAsync(DbContext context, IMigratorData data, CancellationToken cancellationToken)
+        {
+            MigratedAsyncCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public void Migrating(DbContext context, IMigratorData data)
+            => MigratingCallCount++;
+
+        public Task MigratingAsync(DbContext context, IMigratorData data, CancellationToken cancellationToken = default)
+        {
+            MigratingAsyncCallCount++;
+            return Task.CompletedTask;
+        }
     }
 
     [DbContext(typeof(MigrationsContext))]

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Index = Microsoft.EntityFrameworkCore.Metadata.Internal.Index;
@@ -58,6 +59,7 @@ public class RelationalEventIdTest : EventIdTestBase
             { typeof(IMigrator), () => new FakeMigrator() },
             { typeof(Migration), () => new FakeMigration() },
             { typeof(IMigrationsAssembly), () => new FakeMigrationsAssembly() },
+            { typeof(MigrationCommand), () => new FakeMigrationCommand() },
             { typeof(MethodCallExpression), () => Expression.Call(constantExpression, typeof(object).GetMethod("ToString")) },
             { typeof(Expression), () => constantExpression },
             { typeof(IEntityType), () => entityType },
@@ -146,6 +148,18 @@ public class RelationalEventIdTest : EventIdTestBase
             string toMigration = null,
             MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
             => throw new NotImplementedException();
+
+        public void Migrate(string targetMigration, Action<DbContext, IMigratorData> seed, TimeSpan? lockTimeout)
+            => throw new NotImplementedException();
+
+        public Task MigrateAsync(string targetMigration,
+            Func<DbContext, IMigratorData, CancellationToken, Task> seed,
+            TimeSpan? lockTimeout,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public bool HasPendingModelChanges()
+            => throw new NotImplementedException();
     }
 
     private class FakeMigrationsAssembly : IMigrationsAssembly
@@ -163,6 +177,45 @@ public class RelationalEventIdTest : EventIdTestBase
             => throw new NotImplementedException();
 
         public string FindMigrationId(string nameOrId)
+            => throw new NotImplementedException();
+    }
+
+    private class FakeMigrationCommand : MigrationCommand
+    {
+        public FakeMigrationCommand()
+            : base(new FakeRelationalCommand(), null, new FakeRelationalCommandDiagnosticsLogger())
+        {
+        }
+    }
+
+    private class FakeRelationalCommand : IRelationalCommand
+    {
+        public string CommandText { get; } = "";
+
+        public IReadOnlyList<IRelationalParameter> Parameters { get; } = [];
+
+        public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
+            => throw new NotImplementedException();
+
+        public int ExecuteNonQuery(RelationalCommandParameterObject parameterObject)
+            => throw new NotImplementedException();
+
+        public Task<int> ExecuteNonQueryAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
+            => throw new NotImplementedException();
+
+        public Task<RelationalDataReader> ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public object ExecuteScalar(RelationalCommandParameterObject parameterObject)
+            => throw new NotImplementedException();
+
+        public Task<object> ExecuteScalarAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public void PopulateFrom(IRelationalCommandTemplate commandTemplate)
             => throw new NotImplementedException();
     }
 

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -22,7 +22,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger), new(CreateRelationalCommand(), null, logger)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
@@ -63,7 +63,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger), new(CreateRelationalCommand(), null, logger)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         IDbContextTransaction tx;
         using (tx = fakeConnection.BeginTransaction())
@@ -113,7 +113,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger), new(CreateRelationalCommand(), null, logger, transactionSuppressed: true)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         IDbContextTransaction tx;
         using (tx = fakeConnection.BeginTransaction())
@@ -122,17 +122,15 @@ public class MigrationCommandExecutorTest
             {
                 Assert.Equal(
                     RelationalStrings.TransactionSuppressedMigrationInUserTransaction,
-                    (await Assert.ThrowsAsync<NotSupportedException>(
-                        async ()
-                            => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection))).Message);
+                    (await Assert.ThrowsAsync<NotSupportedException>(async ()
+                        => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.TransactionSuppressedMigrationInUserTransaction,
-                    Assert.Throws<NotSupportedException>(
-                        ()
-                            => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection)).Message);
+                    Assert.Throws<NotSupportedException>(()
+                        => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection)).Message);
             }
 
             tx.Rollback();
@@ -166,7 +164,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger, transactionSuppressed: true)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
@@ -201,7 +199,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger), new(CreateRelationalCommand(), null, logger, transactionSuppressed: true)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
@@ -241,7 +239,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(), null, logger, transactionSuppressed: true), new(CreateRelationalCommand(), null, logger)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
@@ -283,7 +281,7 @@ public class MigrationCommandExecutorTest
             new(CreateRelationalCommand(commandText: "Third"), null, logger)
         };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
@@ -353,19 +351,17 @@ public class MigrationCommandExecutorTest
 
         var commandList = new List<MigrationCommand> { new(CreateRelationalCommand(), null, logger) };
 
-        var migrationCommandExecutor = new MigrationCommandExecutor();
+        var migrationCommandExecutor = CreateMigrationCommandExecutor();
 
         if (async)
         {
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async ()
-                    => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection));
+            await Assert.ThrowsAsync<InvalidOperationException>(async ()
+                => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection));
         }
         else
         {
-            Assert.Throws<InvalidOperationException>(
-                ()
-                    => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection));
+            Assert.Throws<InvalidOperationException>(()
+                => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection));
         }
 
         Assert.Equal(1, fakeDbConnection.OpenCount);
@@ -376,6 +372,9 @@ public class MigrationCommandExecutorTest
         Assert.Equal(0, fakeDbConnection.DbTransactions[0].CommitCount);
         Assert.Equal(0, fakeDbConnection.DbTransactions[0].RollbackCount);
     }
+
+    private static IMigrationCommandExecutor CreateMigrationCommandExecutor()
+        => FakeRelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<IMigrationCommandExecutor>();
 
     private const string ConnectionString = "Fake Connection String";
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
@@ -27,7 +27,7 @@ public class FakeRelationalOptionsExtension : RelationalOptionsExtension
 
     public static IServiceCollection AddEntityFrameworkRelationalDatabase(IServiceCollection serviceCollection)
     {
-        var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection)
+        new EntityFrameworkRelationalServicesBuilder(serviceCollection)
             .TryAdd<LoggingDefinitions, TestRelationalLoggingDefinitions>()
             .TryAdd<IDatabaseProvider, DatabaseProvider<FakeRelationalOptionsExtension>>()
             .TryAdd<ISqlGenerationHelper, RelationalSqlGenerationHelper>()
@@ -38,9 +38,8 @@ public class FakeRelationalOptionsExtension : RelationalOptionsExtension
             .TryAdd<IHistoryRepository>(_ => null)
             .TryAdd<IUpdateSqlGenerator, FakeSqlGenerator>()
             .TryAdd<IModificationCommandBatchFactory, TestModificationCommandBatchFactory>()
-            .TryAdd<IRelationalDatabaseCreator, FakeRelationalDatabaseCreator>();
-
-        builder.TryAddCoreServices();
+            .TryAdd<IRelationalDatabaseCreator, FakeRelationalDatabaseCreator>()
+            .TryAddCoreServices();
 
         return serviceCollection;
     }

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -2192,7 +2192,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
                         + $" {nameof(MultipleAnswersInverse)}.{nameof(MultipleAnswersInverse.Answers)}",
                         nameof(PartialAnswerInverse.Answer)),
                 "CoreEventId.MultipleInversePropertiesSameTargetWarning"),
-            Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+            Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
@@ -48,12 +48,7 @@ public class ListLoggerFactory(Func<string, bool> shouldLogCategory) : ILoggerFa
     }
 
     private void CheckDisposed()
-    {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException(nameof(ListLoggerFactory));
-        }
-    }
+        => ObjectDisposedException.ThrowIf(_disposed, typeof(ListLoggerFactory));
 
     public void AddProvider(ILoggerProvider provider)
         => CheckDisposed();

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -14,7 +14,8 @@ public class TestSqlServerRetryingExecutionStrategy : SqlServerRetryingExecution
         -1, // Physical connection is not usable
         -2, // Timeout
         42008, // Mirroring (Only when a database is deleted and another one is created in fast succession)
-        42019 // CREATE DATABASE operation failed
+        42019, // CREATE DATABASE operation failed
+        65536, // Used for testing
     ];
 
     public TestSqlServerRetryingExecutionStrategy()

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -68,32 +68,16 @@ CREATE TABLE "Table1" (
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000001_Migration1', '7.0.0-test');
 
-COMMIT;
-
-BEGIN TRANSACTION;
-
 ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000002_Migration2', '7.0.0-test');
 
-COMMIT;
-
-BEGIN TRANSACTION;
-
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000003_Migration3', '7.0.0-test');
 
-COMMIT;
-
-BEGIN TRANSACTION;
-
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
-
-COMMIT;
-
-BEGIN TRANSACTION;
 
 INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
 
@@ -102,10 +86,6 @@ Empty Lines')
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000005_Migration5', '7.0.0-test');
 
-COMMIT;
-
-BEGIN TRANSACTION;
-
 INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
@@ -113,10 +93,6 @@ Empty Lines')
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000006_Migration6', '7.0.0-test');
-
-COMMIT;
-
-BEGIN TRANSACTION;
 
 INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
 Value With
@@ -260,10 +236,6 @@ ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
 
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000002_Migration2';
-
-COMMIT;
-
-BEGIN TRANSACTION;
 
 DROP TABLE "Table1";
 


### PR DESCRIPTION
Use a single transaction for all migrations in the script

Fixes #17578
Fixes #22616