### PR TITLE
Fix to #34211 - Issue occurs when trying to generate query string when mapping entity with json to a view with a custom schema

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -356,9 +356,11 @@ public static class RelationalEntityTypeExtensions
     public static string? GetDefaultViewSchema(this IReadOnlyEntityType entityType)
     {
         var ownership = entityType.FindOwnership();
-        if (ownership is { IsUnique: true })
+        if (ownership != null)
         {
-            return ownership.PrincipalEntityType.GetViewSchema();
+            return ownership.PrincipalEntityType.GetViewName() != null
+                ? ownership.PrincipalEntityType.GetViewSchema()
+                : entityType.Model.GetDefaultSchema();
         }
 
         return GetViewName(entityType) != null ? entityType.Model.GetDefaultSchema() : null;


### PR DESCRIPTION
Problem was in database model processing. When then entity is mapped to json, and its owner is mapped to a view, we should map that entity to the same view as the owner. We have a logic that looks at the annotation on the entity first, and if that's not found, try to compute the view name and view schema based on the owner (or use defaults). We were computing the view name correctly, but there was a problem is schema computation. Logic was that if the entity is owned AND if that ownership is unique (i.e. 1-1 owned mapping) we could look for the parent's schema. However, we should also do this for 1-many ownership that is mapped to JSON.

Fix is to add the missing condition, to make it consistent with other places in the code.

Fixes #34211