### PR TITLE
Revert "impements #11261 sequence cache support" for 9.0

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -809,19 +809,6 @@ public static class ScaffoldingModelExtensions
             root = root?.Chain(isCyclic) ?? isCyclic;
         }
 
-        if (sequence.IsCached != Sequence.DefaultIsCached)
-        {
-            var useNoCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseNoCache));
-
-            root = root?.Chain(useNoCache) ?? useNoCache;
-        }
-        else
-        {
-            var useCache = new FluentApiCodeFragment(nameof(SequenceBuilder.UseCache)) { Arguments = { sequence.CacheSize } };
-
-            root = root?.Chain(useCache) ?? useCache;
-        }
-
         return root;
     }
 

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -778,24 +778,6 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("cyclic: true");
             }
 
-            if (operation.IsCached && operation.CacheSize.HasValue)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached))
-                    .AppendLine(",")
-                    .Append("cacheSize: ")
-                    .Append(Code.Literal(operation.CacheSize));
-            }
-            else if (!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached));
-            }
-
             if (operation.OldSequence.IncrementBy != 1)
             {
                 builder
@@ -825,24 +807,6 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                 builder
                     .AppendLine(",")
                     .Append("oldCyclic: true");
-            }
-
-            if (operation.OldSequence.IsCached && operation.OldSequence.CacheSize.HasValue)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("oldCached: ")
-                    .Append(Code.Literal(operation.OldSequence.IsCached))
-                    .AppendLine(",")
-                    .Append("oldCacheSize: ")
-                    .Append(Code.Literal(operation.OldSequence.CacheSize));
-            }
-            else if (!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("oldCached: ")
-                    .Append(Code.Literal(operation.OldSequence.IsCached));
             }
 
             builder.Append(")");
@@ -1059,24 +1023,6 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                 builder
                     .AppendLine(",")
                     .Append("cyclic: true");
-            }
-
-            if (operation.IsCached && operation.CacheSize.HasValue)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached))
-                    .AppendLine(",")
-                    .Append("cacheSize: ")
-                    .Append(Code.Literal(operation.CacheSize));
-            }
-            else if(!operation.IsCached)
-            {
-                builder
-                    .AppendLine(",")
-                    .Append("cached: ")
-                    .Append(Code.Literal(operation.IsCached));
             }
 
             builder.Append(")");

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -393,21 +393,6 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                 .Append(".IsCyclic()");
         }
 
-        if (sequence.IsCached != Sequence.DefaultIsCached)
-        {
-            stringBuilder
-                .AppendLine()
-                .Append(".UseNoCache()");
-        }
-        else if (sequence.CacheSize != Sequence.DefaultCacheSize)
-        {
-            stringBuilder
-                .AppendLine()
-                .Append(".UseCache(")
-                .Append(Code.Literal(sequence.CacheSize))
-                .Append(")");
-        }
-
         GenerateSequenceAnnotations(sequenceBuilderName, sequence, stringBuilder);
     }
 

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -269,21 +269,6 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             builder.IsCyclic(sequence.IsCyclic.Value);
         }
 
-        if (sequence.IsCached.HasValue && !sequence.IsCached.Value)
-        {
-            builder.UseNoCache();
-        }
-        else if (sequence.IsCached.HasValue && sequence.CacheSize.HasValue)
-        {
-            builder.UseCache(sequence.CacheSize);
-        }
-        else
-        {
-            builder.UseCache();
-        }
-
-        builder.Metadata.AddAnnotations(sequence.GetAnnotations());
-
         return builder;
     }
 

--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -1734,24 +1734,6 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
                 .Append("maxValue: ").Append(code.Literal(sequence.MaxValue));
         }
 
-        if (sequence.IsCached && sequence.CacheSize.HasValue)
-        {
-            mainBuilder
-                .AppendLine(",")
-                .Append("cached: ")
-                .Append(code.Literal(sequence.IsCached))
-                .AppendLine(",")
-                .Append("cacheSize: ")
-                .Append(code.Literal(sequence.CacheSize));
-        }
-        else if (!sequence.IsCached)
-        {
-            mainBuilder
-                .AppendLine(",")
-                .Append("cached: ")
-                .Append(code.Literal(sequence.IsCached));
-        }
-
         if (sequence.ModelSchema is null && sequence.Schema is not null)
         {
             mainBuilder.AppendLine(",")

--- a/src/EFCore.Relational/Metadata/Builders/IConventionSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionSequenceBuilder.cs
@@ -169,40 +169,4 @@ public interface IConventionSequenceBuilder : IConventionAnnotatableBuilder
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the given cyclicity can be set for the sequence.</returns>
     bool CanSetIsCyclic(bool? cyclic, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Sets that sequence does not use preallocated values.
-    /// </summary>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>
-    ///     The same builder instance if the configuration was applied,
-    ///     <see langword="null" /> otherwise.
-    /// </returns>
-    IConventionSequenceBuilder? UseNoCache(bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Returns a value indicating nocache can be set for the sequence.
-    /// </summary>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns><see langword="true" /> if nocache can be set for the sequence.</returns>
-    bool CanSetNoCache(bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Sets amount of preallocated values.
-    /// </summary>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>
-    ///     The same builder instance if the configuration was applied,
-    ///     <see langword="null" /> otherwise.
-    /// </returns>
-    IConventionSequenceBuilder? UseCache(int? cacheSize, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Returns a value indicating whether the given cache size can be set for the sequence.
-    /// </summary>
-    /// <param name="cacheSize">The cache size for the sequence.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns><see langword="true" /> if the given cache size can be set for the sequence.</returns>
-    bool CanSetCache(int? cacheSize, bool fromDataAnnotation = false);
 }

--- a/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
@@ -115,35 +115,6 @@ public class SequenceBuilder : IInfrastructure<IConventionSequenceBuilder>
     }
 
     /// <summary>
-    ///     Sets that sequence does not use preallocated values.
-    /// </summary>
-    /// <remarks>
-    ///     See <see href="https://aka.ms/efcore-docs-sequences">Database sequences</see> for more information and examples.
-    /// </remarks>
-    /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual SequenceBuilder UseNoCache()
-    {
-        Builder.UseNoCache(ConfigurationSource.Explicit);
-
-        return this;
-    }
-
-    /// <summary>
-    ///     Sets the amount of preallocated values for the <see cref="ISequence" />.
-    /// </summary>
-    /// <remarks>
-    ///     See <see href="https://aka.ms/efcore-docs-sequences">Database sequences</see> for more information and examples.
-    /// </remarks>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
-    /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual SequenceBuilder UseCache(int? cacheSize = default)
-    {
-        Builder.UseCache(cacheSize, ConfigurationSource.Explicit);
-
-        return this;
-    }
-
-    /// <summary>
     ///     Adds or updates an annotation on the sequence. If an annotation with the key specified in <paramref name="annotation" />
     ///     already exists, its value will be updated.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -351,8 +351,6 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
             sequence.IsCyclic,
             sequence.MinValue,
             sequence.MaxValue,
-            sequence.IsCached,
-            sequence.CacheSize,
             sequence.ModelSchema is null);
 
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IConventionSequence.cs
+++ b/src/EFCore.Relational/Metadata/IConventionSequence.cs
@@ -115,34 +115,4 @@ public interface IConventionSequence : IReadOnlySequence, IConventionAnnotatable
     /// </summary>
     /// <returns>The configuration source for <see cref="IReadOnlySequence.IsCyclic" />.</returns>
     ConfigurationSource? GetIsCyclicConfigurationSource();
-
-    /// <summary>
-    ///     Sets whether the sequence use preallocated values.
-    /// </summary>
-    /// <param name="cached">
-    ///     If <see langword="true" />, then the sequence use preallocated values.
-    /// </param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The configured value.</returns>
-    bool? SetIsCached(bool? cached, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Gets the configuration source for <see cref="IReadOnlySequence.IsCached" />.
-    /// </summary>
-    /// <returns>The configuration source for <see cref="IReadOnlySequence.IsCached" />.</returns>
-    ConfigurationSource? GetIsCachedConfigurationSource();
-
-    /// <summary>
-    ///     Sets the amount of preallocated values.
-    /// </summary>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The configured value.</returns>
-    int? SetCacheSize(int? cacheSize, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Gets the configuration source for <see cref="IReadOnlySequence.CacheSize" />.
-    /// </summary>
-    /// <returns>The configuration source for <see cref="IReadOnlySequence.CacheSize" />.</returns>
-    ConfigurationSource? GetCacheSizeConfigurationSource();
 }

--- a/src/EFCore.Relational/Metadata/IMutableSequence.cs
+++ b/src/EFCore.Relational/Metadata/IMutableSequence.cs
@@ -46,14 +46,4 @@ public interface IMutableSequence : IReadOnlySequence, IMutableAnnotatable
     ///     is reached.
     /// </summary>
     new bool IsCyclic { get; set; }
-
-    /// <summary>
-    ///     Gets or sets the value indicating whether the sequence use preallocated values.
-    /// </summary>
-    new bool IsCached { get; set; }
-
-    /// <summary>
-    ///     Gets or sets the amount of preallocated values, or <see langword="null" /> if none has been set.
-    /// </summary>
-    new int? CacheSize { get; set; }
 }

--- a/src/EFCore.Relational/Metadata/IReadOnlySequence.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlySequence.cs
@@ -67,16 +67,6 @@ public interface IReadOnlySequence : IReadOnlyAnnotatable
     bool IsCyclic { get; }
 
     /// <summary>
-    ///     Gets the value indicating whether the sequence use preallocated values.
-    /// </summary>
-    bool IsCached { get; }
-
-    /// <summary>
-    ///     Gets the amount of preallocated values, or <see langword="null" /> if none has been set.
-    /// </summary>
-    int? CacheSize { get; }
-
-    /// <summary>
     ///     <para>
     ///         Creates a human-readable representation of the given metadata.
     ///     </para>
@@ -133,20 +123,6 @@ public interface IReadOnlySequence : IReadOnlyAnnotatable
         {
             builder.Append(" Max: ")
                 .Append(MaxValue);
-        }
-
-        if (!IsCached)
-        {
-            builder.Append(" No Cache");
-        }
-        else if (CacheSize != null)
-        {
-            builder.Append(" Cache: ")
-                .Append(CacheSize);
-        }
-        else
-        {
-            builder.Append(" Cache");
         }
 
         if ((options & MetadataDebugStringOptions.SingleLine) == 0)

--- a/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
@@ -188,60 +188,6 @@ public class InternalSequenceBuilder : AnnotatableBuilder<Sequence, IConventionM
         => configurationSource.Overrides(Metadata.GetIsCyclicConfigurationSource())
             || Metadata.IsCyclic == cyclic;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual IConventionSequenceBuilder? UseNoCache(ConfigurationSource configurationSource)
-    {
-        if (CanSetNoCache(configurationSource))
-        {
-            Metadata.SetIsCached(false, configurationSource);
-            Metadata.SetCacheSize(null, configurationSource);
-            return this;
-        }
-        return null;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual bool CanSetNoCache(ConfigurationSource configurationSource)
-                => configurationSource.Overrides(Metadata.GetIsCachedConfigurationSource())
-            || Metadata.IsCached == false;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual IConventionSequenceBuilder? UseCache(int? cacheSize, ConfigurationSource configurationSource)
-    {
-        if (CanSetCacheSize(cacheSize, configurationSource))
-        {
-            Metadata.SetIsCached(true, configurationSource);
-            Metadata.SetCacheSize(cacheSize, configurationSource);
-            return this;
-        }
-        return null;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual bool CanSetCacheSize(long? cacheSize, ConfigurationSource configurationSource)
-        => configurationSource.Overrides(Metadata.GetCacheSizeConfigurationSource())
-            || Metadata.CacheSize == cacheSize;
-
     /// <inheritdoc />
     IConventionSequence IConventionSequenceBuilder.Metadata
     {
@@ -326,24 +272,4 @@ public class InternalSequenceBuilder : AnnotatableBuilder<Sequence, IConventionM
     [DebuggerStepThrough]
     bool IConventionSequenceBuilder.CanSetIsCyclic(bool? cyclic, bool fromDataAnnotation)
         => CanSetIsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    IConventionSequenceBuilder? IConventionSequenceBuilder.UseNoCache(bool fromDataAnnotation)
-        => UseNoCache(fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    bool IConventionSequenceBuilder.CanSetNoCache(bool fromDataAnnotation)
-        => CanSetNoCache(fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    IConventionSequenceBuilder? IConventionSequenceBuilder.UseCache(int? cacheSize, bool fromDataAnnotation)
-        => UseCache(cacheSize, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    bool IConventionSequenceBuilder.CanSetCache(int? cacheSize, bool fromDataAnnotation)
-        => CanSetCacheSize(cacheSize, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -21,8 +21,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     private long? _maxValue;
     private Type? _type;
     private bool? _isCyclic;
-    private bool? _isCached;
-    private int? _cacheSize;
     private InternalSequenceBuilder? _builder;
 
     private ConfigurationSource _configurationSource;
@@ -32,8 +30,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     private ConfigurationSource? _maxValueConfigurationSource;
     private ConfigurationSource? _typeConfigurationSource;
     private ConfigurationSource? _isCyclicConfigurationSource;
-    private ConfigurationSource? _isCachedConfigurationSource;
-    private ConfigurationSource? _cacheSizeConfigurationSource;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -89,22 +85,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static readonly bool DefaultIsCached = true;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static readonly int? DefaultCacheSize = default;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public Sequence(
         string name,
         string? schema,
@@ -140,8 +120,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
         _maxValue = data.MaxValue;
         _type = data.ClrType;
         _isCyclic = data.IsCyclic;
-        _isCached = data.IsCached;
-        _cacheSize = data.CacheSize;
         _builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder);
     }
 
@@ -599,86 +577,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsCached
-    {
-        get => _isCached ?? DefaultIsCached;
-        set => SetIsCached(value, ConfigurationSource.Explicit);
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual bool? SetIsCached(bool? cached, ConfigurationSource configurationSource)
-    {
-        EnsureMutable();
-
-        _isCached = cached;
-
-        _isCachedConfigurationSource = cached == null
-            ? null
-            : configurationSource.Max(_isCachedConfigurationSource);
-
-        return cached;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual ConfigurationSource? GetIsCachedConfigurationSource()
-        => _isCachedConfigurationSource;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual int? CacheSize
-    {
-        get => _cacheSize;
-        set => SetCacheSize(value, ConfigurationSource.Explicit);
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual int? SetCacheSize(int? cacheSize, ConfigurationSource configurationSource)
-    {
-        EnsureMutable();
-
-        _cacheSize = cacheSize;
-
-        _cacheSizeConfigurationSource = cacheSize == null
-            ? null
-            : configurationSource.Max(_cacheSizeConfigurationSource);
-
-        return cacheSize;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual ConfigurationSource? GetCacheSizeConfigurationSource()
-        => _cacheSizeConfigurationSource;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public override string ToString()
         => ((ISequence)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
@@ -790,26 +688,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     bool? IConventionSequence.SetIsCyclic(bool? cyclic, bool fromDataAnnotation)
         => SetIsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [DebuggerStepThrough]
-    int? IConventionSequence.SetCacheSize(int? cacheSize, bool fromDataAnnotation)
-        => SetCacheSize(cacheSize, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [DebuggerStepThrough]
-    bool? IConventionSequence.SetIsCached(bool? cached, bool fromDataAnnotation)
-        => SetIsCached(cached, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
     [Obsolete("Don't use this in any new code")] // DO NOT REMOVE
     // Used in model snapshot processor code path. See issue#18557
     private sealed class SequenceData
@@ -830,10 +708,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
 
         public bool IsCyclic { get; set; }
 
-        public bool IsCached { get; set; }
-
-        public int? CacheSize { get; set; }
-
         public static SequenceData Deserialize(string value)
         {
             try
@@ -850,8 +724,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
                 data.MaxValue = AsLong(ExtractValue(value, ref position));
                 data.ClrType = AsType(ExtractValue(value, ref position)!);
                 data.IsCyclic = AsBool(ExtractValue(value, ref position));
-                data.IsCached = AsBool(ExtractValue(value, ref position));
-                data.CacheSize = AsInt(ExtractValue(value, ref position));
                 // ReSharper restore PossibleInvalidOperationException
 
                 return data;
@@ -882,9 +754,6 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
 
         private static long? AsLong(string? value)
             => value == null ? null : long.Parse(value, CultureInfo.InvariantCulture);
-
-        private static int? AsInt(string? value)
-            => value == null ? null : int.Parse(value, CultureInfo.InvariantCulture);
 
         private static Type AsType(string value)
             => value == nameof(Int64)

--- a/src/EFCore.Relational/Metadata/RuntimeSequence.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeSequence.cs
@@ -20,8 +20,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     private readonly long? _minValue;
     private readonly long? _maxValue;
     private readonly bool _isCyclic;
-    private readonly int? _cacheSize;
-    private readonly bool _isCached;
     private readonly bool _modelSchemaIsNull;
 
     /// <summary>
@@ -36,8 +34,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     /// <param name="cyclic">Whether the sequence is cyclic.</param>
     /// <param name="minValue">The minimum value.</param>
     /// <param name="maxValue">The maximum value.</param>
-    /// <param name="cacheSize">The cache size.</param>
-    /// <param name="cached">Whether the sequence use preallocated values.</param>
     /// <param name="modelSchemaIsNull">A value indicating whether <see cref="ModelSchema" /> is null.</param>
     public RuntimeSequence(
         string name,
@@ -49,8 +45,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
         bool cyclic = false,
         long? minValue = null,
         long? maxValue = null,
-        bool cached = true,
-        int? cacheSize = null,
         bool modelSchemaIsNull = false)
     {
         Model = model;
@@ -62,8 +56,6 @@ public class RuntimeSequence : AnnotatableBase, ISequence
         _isCyclic = cyclic;
         _minValue = minValue;
         _maxValue = maxValue;
-        _isCached = cached;
-        _cacheSize = cacheSize;
         _modelSchemaIsNull = modelSchemaIsNull;
     }
 
@@ -162,19 +154,5 @@ public class RuntimeSequence : AnnotatableBase, ISequence
     {
         [DebuggerStepThrough]
         get => _isCyclic;
-    }
-
-    /// <inheritdoc />
-    bool IReadOnlySequence.IsCached
-    {
-        [DebuggerStepThrough]
-        get => _isCached;
-    }
-
-    /// <inheritdoc />
-    int? IReadOnlySequence.CacheSize
-    {
-        [DebuggerStepThrough]
-        get => _cacheSize;
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1727,8 +1727,6 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
             || source.MaxValue != target.MaxValue
             || source.MinValue != target.MinValue
             || source.IsCyclic != target.IsCyclic
-            || source.IsCached != target.IsCached
-            || source.CacheSize != target.CacheSize
             || HasDifferences(sourceMigrationsAnnotations, targetMigrationsAnnotations))
         {
             var alterSequenceOperation = new AlterSequenceOperation { Schema = target.Schema, Name = target.Name };
@@ -1782,8 +1780,6 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
         sequenceOperation.MinValue = sequence.MinValue;
         sequenceOperation.MaxValue = sequence.MaxValue;
         sequenceOperation.IsCyclic = sequence.IsCyclic;
-        sequenceOperation.IsCached = sequence.IsCached;
-        sequenceOperation.CacheSize = sequence.CacheSize;
         sequenceOperation.AddAnnotations(migrationsAnnotations);
 
         return sequenceOperation;

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -522,10 +522,6 @@ public class MigrationBuilder
     /// <param name="oldMinValue">The previous minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="oldMaxValue">The previous maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="oldCyclic">Indicates whether or not the sequence would previously re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
-    /// <param name="oldCached">Indicates whether the sequence previously used preallocated values</param>
-    /// <param name="oldCacheSize">The previous amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual AlterOperationBuilder<AlterSequenceOperation> AlterSequence(
         string name,
@@ -537,11 +533,7 @@ public class MigrationBuilder
         int oldIncrementBy = 1,
         long? oldMinValue = null,
         long? oldMaxValue = null,
-        bool oldCyclic = false,
-        bool cached = true,
-        int? cacheSize = null,
-        bool oldCached = true,
-        int? oldCacheSize = null)
+        bool oldCyclic = false)
     {
         Check.NotEmpty(name, nameof(name));
 
@@ -553,16 +545,12 @@ public class MigrationBuilder
             MinValue = minValue,
             MaxValue = maxValue,
             IsCyclic = cyclic,
-            IsCached = cached,
-            CacheSize = cacheSize,
             OldSequence = new CreateSequenceOperation
             {
                 IncrementBy = oldIncrementBy,
                 MinValue = oldMinValue,
                 MaxValue = oldMaxValue,
-                IsCyclic = oldCyclic,
-                IsCached = oldCached,
-                CacheSize = oldCacheSize,
+                IsCyclic = oldCyclic
             }
         };
         Operations.Add(operation);
@@ -714,8 +702,6 @@ public class MigrationBuilder
     /// <param name="minValue">The minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="maxValue">The maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="cyclic">Indicates whether or not the sequence will re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateSequenceOperation> CreateSequence(
         string name,
@@ -724,10 +710,8 @@ public class MigrationBuilder
         int incrementBy = 1,
         long? minValue = null,
         long? maxValue = null,
-        bool cyclic = false,
-        bool cached = true,
-        int? cacheSize = null)
-        => CreateSequence<long>(name, schema, startValue, incrementBy, minValue, maxValue, cyclic, cached, cacheSize);
+        bool cyclic = false)
+        => CreateSequence<long>(name, schema, startValue, incrementBy, minValue, maxValue, cyclic);
 
     /// <summary>
     ///     Builds a <see cref="CreateSequenceOperation" /> to create a new sequence.
@@ -743,8 +727,6 @@ public class MigrationBuilder
     /// <param name="minValue">The minimum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="maxValue">The maximum value of the sequence, or <see langword="null" /> if not specified.</param>
     /// <param name="cyclic">Indicates whether or not the sequence will re-start when the maximum value is reached.</param>
-    /// <param name="cached">Indicates whether the sequence use preallocated values.</param>
-    /// <param name="cacheSize">The amount of preallocated values.</param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateSequenceOperation> CreateSequence<T>(
         string name,
@@ -753,9 +735,7 @@ public class MigrationBuilder
         int incrementBy = 1,
         long? minValue = null,
         long? maxValue = null,
-        bool cyclic = false,
-        bool cached = true,
-        int? cacheSize = null)
+        bool cyclic = false)
     {
         Check.NotEmpty(name, nameof(name));
 
@@ -768,9 +748,7 @@ public class MigrationBuilder
             IncrementBy = incrementBy,
             MinValue = minValue,
             MaxValue = maxValue,
-            IsCyclic = cyclic,
-            IsCached = cached,
-            CacheSize = cacheSize
+            IsCyclic = cyclic
         };
         Operations.Add(operation);
 

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1290,23 +1290,6 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
         }
 
         builder.Append(operation.IsCyclic ? " CYCLE" : " NO CYCLE");
-
-        if (!operation.IsCached)
-        {
-            builder
-                .Append(" NO CACHE");
-        }
-        else if (operation.CacheSize != null)
-        {
-            builder
-                .Append(" CACHE ")
-                .Append(intTypeMapping.GenerateSqlLiteral(operation.CacheSize.Value));
-        }
-        else if (forAlter)
-        {
-            builder
-                .Append(" CACHE");
-        }
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Migrations/Operations/SequenceOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/SequenceOperation.cs
@@ -31,14 +31,4 @@ public abstract class SequenceOperation : MigrationOperation
     ///     Indicates whether or not the sequence will re-start when the maximum value is reached.
     /// </summary>
     public virtual bool IsCyclic { get; set; }
-
-    /// <summary>
-    ///     Indicates whether the sequence use preallocated values.
-    /// </summary>
-    public virtual bool IsCached { get; set; } = true;
-
-    /// <summary>
-    ///     The amount of preallocated values of the sequence, or <see langword="null" /> if not specified.
-    /// </summary>
-    public virtual int? CacheSize { get; set; }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
@@ -57,16 +57,6 @@ public class DatabaseSequence : Annotatable
     /// </summary>
     public virtual bool? IsCyclic { get; set; }
 
-    /// <summary>
-    ///     Indicates whether the sequence use preallocated values, or <see langword="null" /> if not set.
-    /// </summary>
-    public virtual bool? IsCached { get; set; }
-
-    /// <summary>
-    ///     The amount of preallocated values, or <see langword="null" /> if not set.
-    /// </summary>
-    public virtual int? CacheSize { get; set; }
-
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
@@ -486,9 +486,7 @@ public static class SqlServerLoggerExtensions
         int increment,
         long start,
         long min,
-        long max,
-        bool cached,
-        int? cacheSize)
+        long max)
     {
         // No DiagnosticsSource events because these are purely design-time messages
         var definition = SqlServerResources.LogFoundSequence(diagnostics);
@@ -507,9 +505,7 @@ public static class SqlServerLoggerExtensions
                     increment,
                     start,
                     min,
-                    max,
-                    cached,
-                    cacheSize));
+                    max));
         }
     }
 

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1548,22 +1548,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         }
 
         builder.Append(operation.IsCyclic ? " CYCLE" : " NO CYCLE");
-
-        if (!operation.IsCached)
-        {
-            builder.Append(" NO CACHE");
-        }
-        else if (operation.CacheSize.HasValue)
-        {
-            builder
-            .Append(" CACHE ")
-                .Append(IntegerConstant(operation.CacheSize.Value));
-        }
-        else if (forAlter)
-        {
-            builder
-                .Append(" CACHE");
-        }
     }
 
     /// <summary>
@@ -2295,9 +2279,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             && operation.Columns.Any(c => table?.FindColumn(c)?.IsNullable != false);
 
     private static string IntegerConstant(long value)
-        => string.Format(CultureInfo.InvariantCulture, "{0}", value);
-
-    private static string IntegerConstant(int value)
         => string.Format(CultureInfo.InvariantCulture, "{0}", value);
 
     private static bool IsMemoryOptimized(Annotatable annotatable, IModel? model, string? schema, string tableName)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -706,8 +706,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max},
-        ///     cached: {cached}, cache size: {cacheSize}.
+        ///     Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}.
         /// </summary>
         public static FallbackEventDefinition LogFoundSequence(IDiagnosticsLogger logger)
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -243,8 +243,8 @@
     <comment>Debug SqlServerEventId.PrimaryKeyFound string string</comment>
   </data>
   <data name="LogFoundSequence" xml:space="preserve">
-    <value>Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}, cached: {cached}, cacheSize: {cacheSize}.</value>
-    <comment>Debug SqlServerEventId.SequenceFound string string bool int long long long bool int</comment>
+    <value>Found sequence with '{name}', data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}.</value>
+    <comment>Debug SqlServerEventId.SequenceFound string string bool int long long long</comment>
   </data>
   <data name="LogFoundTable" xml:space="preserve">
     <value>Found table with name '{name}'.</value>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -427,9 +427,7 @@ SELECT
         WHEN [s].[maximum_value] >  9223372036854775807 THEN  9223372036854775807
         WHEN [s].[maximum_value] < -9223372036854775808 THEN -9223372036854775808
         ELSE [s].[maximum_value]
-        END AS bigint) AS maximum_value,
-    [s].[is_cached],
-    [s].[cache_size]
+        END AS bigint) AS maximum_value
 FROM [sys].[sequences] AS [s]
 JOIN [sys].[types] AS [t] ON [s].[user_type_id] = [t].[user_type_id]
 """;
@@ -457,8 +455,6 @@ WHERE "
             var startValue = reader.GetValueOrDefault<long>("start_value");
             var minValue = reader.GetValueOrDefault<long>("minimum_value");
             var maxValue = reader.GetValueOrDefault<long>("maximum_value");
-            var cached = reader.GetValueOrDefault<bool>("is_cached");
-            var cacheSize = reader.GetValueOrDefault<int?>("cache_size");
 
             // Swap store type if type alias is used
             if (typeAliases.TryGetValue($"[{storeTypeSchema}].[{storeType}]", out var value))
@@ -468,7 +464,7 @@ WHERE "
 
             storeType = GetStoreType(storeType, maxLength: 0, precision: precision, scale: scale);
 
-            _logger.SequenceFound(DisplayName(schema, name), storeType, cyclic, incrementBy, startValue, minValue, maxValue, cached, cacheSize);
+            _logger.SequenceFound(DisplayName(schema, name), storeType, cyclic, incrementBy, startValue, minValue, maxValue);
 
             var sequence = new DatabaseSequence
             {
@@ -480,9 +476,7 @@ WHERE "
                 IncrementBy = incrementBy,
                 StartValue = startValue,
                 MinValue = minValue,
-                MaxValue = maxValue,
-                IsCached = cached,
-                CacheSize = cacheSize
+                MaxValue = maxValue
             };
 
             if (DefaultSequenceMinMax.TryGetValue(storeType, out var defaultMinMax))

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -791,14 +791,10 @@ mb.AlterSequence(
                 Assert.Null(o.MinValue);
                 Assert.Null(o.MaxValue);
                 Assert.False(o.IsCyclic);
-                Assert.True(o.IsCached);
-                Assert.Null(o.CacheSize);
                 Assert.Equal(1, o.OldSequence.IncrementBy);
                 Assert.Null(o.OldSequence.MinValue);
                 Assert.Null(o.OldSequence.MaxValue);
                 Assert.False(o.OldSequence.IsCyclic);
-                Assert.True(o.OldSequence.IsCached);
-                Assert.Null(o.OldSequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -812,16 +808,12 @@ mb.AlterSequence(
                 MinValue = 2,
                 MaxValue = 4,
                 IsCyclic = true,
-                IsCached = true,
-                CacheSize = 20,
                 OldSequence =
                 {
                     IncrementBy = 4,
                     MinValue = 3,
                     MaxValue = 5,
-                    IsCyclic = true,
-                    IsCached = true,
-                    CacheSize = 2
+                    IsCyclic = true
                 }
             },
             """
@@ -849,14 +841,10 @@ mb.AlterSequence(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
-                Assert.Equal(20, o.CacheSize);
                 Assert.Equal(4, o.OldSequence.IncrementBy);
                 Assert.Equal(3, o.OldSequence.MinValue);
                 Assert.Equal(5, o.OldSequence.MaxValue);
                 Assert.True(o.OldSequence.IsCyclic);
-                Assert.True(o.OldSequence.IsCached);
-                Assert.Equal(2, o.OldSequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -1028,9 +1016,7 @@ mb.CreateSequence<int>(
                 IncrementBy = 5,
                 MinValue = 2,
                 MaxValue = 4,
-                IsCyclic = true,
-                IsCached = true,
-                CacheSize = 20
+                IsCyclic = true
             },
             """
 mb.CreateSequence(
@@ -1040,9 +1026,7 @@ mb.CreateSequence(
     incrementBy: 5,
     minValue: 2L,
     maxValue: 4L,
-    cyclic: true,
-    cached: true,
-    cacheSize: 20);
+    cyclic: true);
 """,
             o =>
             {
@@ -1054,77 +1038,7 @@ mb.CreateSequence(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
-                Assert.Equal(20, o.CacheSize);
             });
-
-    [ConditionalFact]
-    public void CreateSequenceOperationCache()
-    => Test(
-        new CreateSequenceOperation
-        {
-            Name = "EntityFrameworkHiLoSequence",
-            Schema = "dbo",
-            ClrType = typeof(long),
-            IsCached = true,
-            CacheSize = 20
-        },
-        """
-mb.CreateSequence(
-    name: "EntityFrameworkHiLoSequence",
-    schema: "dbo",
-    cached: true,
-    cacheSize: 20);
-""",
-        o =>
-        {
-            Assert.True(o.IsCached);
-            Assert.Equal(20, o.CacheSize);
-        });
-
-    [ConditionalFact]
-    public void CreateSequenceOperationNoCache()
-    => Test(
-        new CreateSequenceOperation
-        {
-            Name = "EntityFrameworkHiLoSequence",
-            Schema = "dbo",
-            ClrType = typeof(long),
-            IsCached = false,
-        },
-        """
-mb.CreateSequence(
-    name: "EntityFrameworkHiLoSequence",
-    schema: "dbo",
-    cached: false);
-""",
-        o =>
-        {
-            Assert.False(o.IsCached);
-            Assert.Null(o.CacheSize);
-        });
-
-    [ConditionalFact]
-    public void CreateSequenceOperationDefaultCache()
-    => Test(
-        new CreateSequenceOperation
-        {
-            Name = "EntityFrameworkHiLoSequence",
-            Schema = "dbo",
-            ClrType = typeof(long),
-            IsCached = true
-        },
-        """
-mb.CreateSequence(
-    name: "EntityFrameworkHiLoSequence",
-    schema: "dbo");
-""",
-        o =>
-        {
-            Assert.True(o.IsCached);
-            Assert.Null(o.CacheSize);
-        });
-
 
     [ConditionalFact]
     public void CreateSequenceOperation_all_args_not_long()
@@ -1138,9 +1052,7 @@ mb.CreateSequence(
                 IncrementBy = 5,
                 MinValue = 2,
                 MaxValue = 4,
-                IsCyclic = true,
-                IsCached = true,
-                CacheSize = 20
+                IsCyclic = true
             },
             """
 mb.CreateSequence<int>(
@@ -1150,9 +1062,7 @@ mb.CreateSequence<int>(
     incrementBy: 5,
     minValue: 2L,
     maxValue: 4L,
-    cyclic: true,
-    cached: true,
-    cacheSize: 20);
+    cyclic: true);
 """,
             o =>
             {
@@ -1164,8 +1074,6 @@ mb.CreateSequence<int>(
                 Assert.Equal(2, o.MinValue);
                 Assert.Equal(4, o.MaxValue);
                 Assert.True(o.IsCyclic);
-                Assert.True(o.IsCached);
-                Assert.Equal(20, o.CacheSize);
             });
 
     [ConditionalFact]

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -824,14 +824,10 @@ mb.AlterSequence(
     minValue: 2L,
     maxValue: 4L,
     cyclic: true,
-    cached: true,
-    cacheSize: 20,
     oldIncrementBy: 4,
     oldMinValue: 3L,
     oldMaxValue: 5L,
-    oldCyclic: true,
-    oldCached: true,
-    oldCacheSize: 2);
+    oldCyclic: true);
 """,
             o =>
             {

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -1878,7 +1878,6 @@ namespace RootNamespace
                     .HasMax(3)
                     .IncrementsBy(2)
                     .IsCyclic()
-                    .UseCache(20)
                     .HasAnnotation("foo", "bar");
             },
             AddBoilerPlate(
@@ -1890,7 +1889,6 @@ namespace RootNamespace
                 .HasMin(1L)
                 .HasMax(3L)
                 .IsCyclic()
-                .UseCache(20)
                 .HasAnnotation("foo", "bar");
 """),
             model =>
@@ -1903,8 +1901,6 @@ namespace RootNamespace
                 Assert.Equal(3, sequence.MaxValue);
                 Assert.Equal(2, sequence.IncrementBy);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
                 Assert.Equal("bar", sequence["foo"]);
             });
 

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1415,7 +1415,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 => modelBuilder
                     .HasAnnotation("ChangeDetector.SkipDetectChanges", "true")
                     .HasAnnotation("ProductVersion", "1.1.6")
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
         }
 
@@ -1428,7 +1428,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     .HasAnnotation("ChangeDetector.SkipDetectChanges", "true")
                     .HasAnnotation("ProductVersion", "2.2.2-servicing-10034")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 #pragma warning restore 612, 618
             }
@@ -1442,7 +1442,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 modelBuilder
                     .HasAnnotation("ProductVersion", "3.1.1")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True', 'True', '20'")
+                    .HasAnnotation("Relational:Sequence:Bar.Foo", "'Foo', 'Bar', '2', '2', '1', '3', 'Int32', 'True'")
                     .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 #pragma warning restore 612, 618
             }
@@ -1459,8 +1459,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     .HasMin(1)
                     .HasMax(3)
                     .IncrementsBy(2)
-                    .IsCyclic()
-                    .UseCache(20);
+                    .IsCyclic();
         }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1174,8 +1174,7 @@ public partial class TestDbContext : DbContext
                     .IncrementsBy(2)
                     .HasMin(2)
                     .HasMax(100)
-                    .IsCyclic()
-                    .UseCache(20),
+                    .IsCyclic(),
                 new ModelCodeGenerationOptions(),
                 code => AssertContains(
                     """
@@ -1199,8 +1198,6 @@ public partial class TestDbContext : DbContext
                     Assert.Equal(2, sequence.MinValue);
                     Assert.Equal(100, sequence.MaxValue);
                     Assert.True(sequence.IsCyclic);
-                    Assert.True(sequence.IsCached);
-                    Assert.Equal(20, sequence.CacheSize);
                 });
 
         [ConditionalFact]

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1183,8 +1183,7 @@ public partial class TestDbContext : DbContext
             .IncrementsBy(2)
             .HasMin(2L)
             .HasMax(100L)
-            .IsCyclic()
-            .UseCache(20);
+            .IsCyclic();
 """,
                     code.ContextFile.Code),
                 model =>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1621,9 +1621,6 @@ public class RelationalScaffoldingModelFactoryTest
                 Assert.Null(first.MaxValue);
                 Assert.Null(first.MinValue);
                 Assert.False(first.IsCyclic);
-                Assert.True(first.IsCached);
-                Assert.Null(first.CacheSize);
-                Assert.Equal("Hello there", first["CustomAnnotation"]);
             });
     }
 

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -2407,46 +2407,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal("TestSequence", sequence.Name);
             });
 
-
-    [ConditionalFact]
-    public virtual Task Create_sequence_nocache()
-        => Test(
-            builder => { },
-            builder => builder.HasSequence("Alpha").UseNoCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.Equal("Alpha", sequence.Name);
-                Assert.False(sequence.IsCached);
-            });
-
-
-    [ConditionalFact]
-    public virtual Task Create_sequence_cache()
-        => Test(
-            builder => { },
-            builder => builder.HasSequence("Beta").UseCache(20),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.Equal("Beta", sequence.Name);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
-            });
-
-    [ConditionalFact]
-    public virtual Task Create_sequence_default_cache()
-        => Test(
-            builder => { },
-            builder => builder.HasSequence("Gamma").UseCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.Equal("Gamma", sequence.Name);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
-            });
-
     [ConditionalFact]
     public virtual Task Create_sequence_all_settings()
         => Test(
@@ -2456,8 +2416,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 .IncrementsBy(2)
                 .HasMin(2)
                 .HasMax(916)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
@@ -2468,8 +2427,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal(2, sequence.MinValue);
                 Assert.Equal(916, sequence.MaxValue);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -2482,8 +2439,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 .IncrementsBy(2)
                 .HasMin(-5)
                 .HasMax(10)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             model =>
             {
                 var sequence = Assert.Single(model.Sequences);
@@ -2492,8 +2448,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal(-5, sequence.MinValue);
                 Assert.Equal(10, sequence.MaxValue);
                 Assert.True(sequence.IsCyclic);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
             });
 
     [ConditionalFact]
@@ -2506,85 +2460,6 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var sequence = Assert.Single(model.Sequences);
                 Assert.Equal(2, sequence.IncrementBy);
-            });
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_default_cache_to_cache()
-        => Test(
-            builder => builder.HasSequence<int>("Delta").UseCache(),
-            builder => { },
-            builder => builder.HasSequence<int>("Delta").UseCache(20),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
-            });
-
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_default_cache_to_nocache()
-        => Test(
-            builder => builder.HasSequence<int>("Epsilon").UseCache(),
-            builder => { },
-            builder => builder.HasSequence<int>("Epsilon").UseNoCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.False(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
-            });
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_cache_to_nocache()
-        => Test(
-            builder => builder.HasSequence<int>("Zeta").UseCache(20),
-            builder => { },
-            builder => builder.HasSequence<int>("Zeta").UseNoCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.False(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
-            });
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_cache_to_default_cache()
-        => Test(
-            builder => builder.HasSequence<int>("Eta").UseCache(20),
-            builder => { },
-            builder => builder.HasSequence<int>("Eta").UseCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
-            });
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_nocache_to_cache()
-        => Test(
-            builder => builder.HasSequence<int>("Theta").UseNoCache(),
-            builder => { },
-            builder => builder.HasSequence<int>("Theta").UseCache(20),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
-                Assert.Equal(20, sequence.CacheSize);
-            });
-
-    [ConditionalFact]
-    public virtual Task Alter_sequence_nocache_to_default_cache()
-        => Test(
-            builder => builder.HasSequence<int>("Iota").UseNoCache(),
-            builder => { },
-            builder => builder.HasSequence<int>("Iota").UseCache(),
-            model =>
-            {
-                var sequence = Assert.Single(model.Sequences);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
             });
 
     [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Extensions/RelationalBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalBuilderExtensionsTest.cs
@@ -1019,9 +1019,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -1035,9 +1032,7 @@ public class RelationalBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         var sequence = modelBuilder.Model.FindSequence("Snook");
 
@@ -1054,9 +1049,7 @@ public class RelationalBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         var sequence = modelBuilder.Model.FindSequence("Snook");
 
@@ -1075,9 +1068,7 @@ public class RelationalBuilderExtensionsTest
                     b.IncrementsBy(11)
                         .StartsAt(1729)
                         .HasMin(111)
-                        .HasMax(2222)
-                        .IsCyclic(false)
-                        .UseCache(20);
+                        .HasMax(2222);
                 });
 
         var sequence = modelBuilder.Model.FindSequence("Snook");
@@ -1097,9 +1088,7 @@ public class RelationalBuilderExtensionsTest
                     b.IncrementsBy(11)
                         .StartsAt(1729)
                         .HasMin(111)
-                        .HasMax(2222)
-                        .IsCyclic(false)
-                        .UseCache(20);
+                        .HasMax(2222);
                 });
 
         var sequence = modelBuilder.Model.FindSequence("Snook");
@@ -1116,9 +1105,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Equal(111, sequence.MinValue);
         Assert.Equal(2222, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
     }
 
     [ConditionalFact]
@@ -1131,9 +1117,7 @@ public class RelationalBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         var sequence = modelBuilder.Model.FindSequence("Snook", "Tasty");
 
@@ -1150,9 +1134,7 @@ public class RelationalBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         var sequence = modelBuilder.Model.FindSequence("Snook", "Tasty");
 
@@ -1166,7 +1148,7 @@ public class RelationalBuilderExtensionsTest
 
         modelBuilder
             .HasSequence<int>(
-                "Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222).IsCyclic(false).UseCache(20));
+                "Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222));
 
         var sequence = modelBuilder.Model.FindSequence("Snook", "Tasty");
 
@@ -1181,7 +1163,7 @@ public class RelationalBuilderExtensionsTest
         modelBuilder
             .HasSequence(
                 typeof(int), "Snook", "Tasty",
-                b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222).IsCyclic(false).UseCache(20));
+                b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222));
 
         var sequence = modelBuilder.Model.FindSequence("Snook", "Tasty");
 
@@ -1482,9 +1464,6 @@ public class RelationalBuilderExtensionsTest
         Assert.Equal(1729, sequence.StartValue);
         Assert.Equal(111, sequence.MinValue);
         Assert.Equal(2222, sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
         Assert.Same(typeof(int), sequence.Type);
     }
 

--- a/test/EFCore.Relational.Tests/Extensions/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalMetadataExtensionsTest.cs
@@ -448,8 +448,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.True(((IConventionSequence)sequence).IsInModel);
 
         Assert.Same(sequence, model.FindSequence("Foo"));
@@ -459,9 +457,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MinValue = 2001;
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
-        sequence.IsCyclic = false;
-        sequence.IsCached = true;
-        sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
         Assert.Null(sequence.Schema);
@@ -470,9 +465,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2001, sequence.MinValue);
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
 
         Assert.Same(sequence, model.RemoveSequence("Foo"));
 
@@ -499,9 +491,7 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
+
         Assert.Same(sequence, model.FindSequence("Foo", "Smoo"));
 
         sequence.StartValue = 1729;
@@ -509,9 +499,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MinValue = 2001;
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
-        sequence.IsCyclic = false;
-        sequence.IsCached = true;
-        sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
         Assert.Equal("Smoo", sequence.Schema);
@@ -520,9 +507,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2001, sequence.MinValue);
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
     }
 
     [ConditionalFact]
@@ -544,10 +528,7 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
         Assert.Same(typeof(long), sequence.Type);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
     }
 
     [ConditionalFact]
@@ -569,9 +550,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
 
         model.SetDefaultSchema("Smoo");
 
@@ -582,9 +560,6 @@ public class RelationalMetadataExtensionsTest
         sequence.MinValue = 2001;
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
-        sequence.IsCyclic = true;
-        sequence.IsCached = true;
-        sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
         Assert.Equal("Smoo", sequence.Schema);
@@ -593,9 +568,6 @@ public class RelationalMetadataExtensionsTest
         Assert.Equal(2001, sequence.MinValue);
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
-        Assert.True(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Metadata/SequenceTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/SequenceTest.cs
@@ -22,8 +22,6 @@ public class SequenceTest
         Assert.Null(sequence.MaxValue);
         Assert.Same(typeof(long), sequence.Type);
         Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(model, sequence.Model);
 
         model.SetDefaultSchema("db0");
@@ -38,8 +36,6 @@ public class SequenceTest
         Assert.Null(conventionSequence.GetMaxValueConfigurationSource());
         Assert.Null(conventionSequence.GetTypeConfigurationSource());
         Assert.Null(conventionSequence.GetIsCyclicConfigurationSource());
-        Assert.Null(conventionSequence.GetIsCachedConfigurationSource());
-        Assert.Null(conventionSequence.GetCacheSizeConfigurationSource());
     }
 
     [ConditionalFact]
@@ -56,8 +52,6 @@ public class SequenceTest
         sequence.MaxValue = 2010;
         sequence.Type = typeof(int);
         sequence.IsCyclic = true;
-        sequence.IsCached = true;
-        sequence.CacheSize = 20;
 
         Assert.Equal("Foo", sequence.Name);
         Assert.Equal("Smoo", sequence.Schema);
@@ -67,8 +61,6 @@ public class SequenceTest
         Assert.Equal(2010, sequence.MaxValue);
         Assert.Same(typeof(int), sequence.Type);
         Assert.True(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
 
         var conventionSequence = (IConventionSequence)sequence;
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetConfigurationSource());
@@ -78,8 +70,6 @@ public class SequenceTest
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetMaxValueConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetTypeConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetIsCyclicConfigurationSource());
-        Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetIsCachedConfigurationSource());
-        Assert.Equal(ConfigurationSource.Explicit, conventionSequence.GetCacheSizeConfigurationSource());
     }
 
     [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -4286,8 +4286,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(2, operations.Count);
@@ -4303,8 +4302,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(20, operation.CacheSize);
             });
 
     [ConditionalFact]
@@ -4363,15 +4360,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Alpha", "dbo")
                 .StartsAt(2)
                 .IncrementsBy(5)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(1, operations.Count);
@@ -4383,8 +4378,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
 
@@ -4396,15 +4389,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Echo", "dbo")
                 .StartsAt(2)
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(5)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(1, operations.Count);
@@ -4416,8 +4407,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(5, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
 
@@ -4429,15 +4418,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Delta", "dbo")
                 .StartsAt(2)
                 .IncrementsBy(3)
                 .HasMin(5)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(1, operations.Count);
@@ -4449,8 +4436,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(5, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(20, operation.CacheSize);
             });
 
     [ConditionalFact]
@@ -4461,15 +4446,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Foxtrot", "dbo")
                 .StartsAt(2)
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic(false)
-                .UseCache(20),
+                .IsCyclic(false),
             operations =>
             {
                 Assert.Equal(1, operations.Count);
@@ -4481,240 +4464,8 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, operation.MinValue);
                 Assert.Equal(4, operation.MaxValue);
                 Assert.False(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(20, operation.CacheSize);
             },
             skipSourceConventions: true);
-
-
-    [ConditionalFact]
-    public void Alter_sequence_cache_size()
-        => Execute(
-            source => source.HasSequence<int>("Gamma", "dbo")
-                .StartsAt(2)
-                .IncrementsBy(3)
-                .HasMin(1)
-                .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
-            source => source.HasSequence<int>("Gamma", "dbo")
-                .StartsAt(2)
-                .IncrementsBy(3)
-                .HasMin(1)
-                .HasMax(4)
-                .IsCyclic()
-                .UseCache(5),
-            operations =>
-            {
-                Assert.Equal(1, operations.Count);
-
-                var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-                Assert.Equal("Gamma", operation.Name);
-                Assert.Equal("dbo", operation.Schema);
-                Assert.Equal(3, operation.IncrementBy);
-                Assert.Equal(1, operation.MinValue);
-                Assert.Equal(4, operation.MaxValue);
-                Assert.True(operation.IsCyclic);
-                Assert.True(operation.IsCached);
-                Assert.Equal(5, operation.CacheSize);
-            });
-
-
-
-    [ConditionalFact]
-    public void Alter_sequence_default_cache_to_nocache()
-        => Execute(
-            source => source.HasSequence<int>("Eta", "dbo")
-                .StartsAt(2)
-                .IncrementsBy(3)
-                .HasMin(1)
-                .HasMax(4)
-                .IsCyclic()
-                .UseCache(),
-            source => source.HasSequence<int>("Eta", "dbo")
-                .StartsAt(2)
-                .IncrementsBy(3)
-                .HasMin(1)
-                .HasMax(4)
-                .IsCyclic()
-                .UseNoCache(),
-            operations =>
-            {
-                Assert.Equal(1, operations.Count);
-
-                var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-                Assert.Equal("Eta", operation.Name);
-                Assert.Equal("dbo", operation.Schema);
-                Assert.Equal(3, operation.IncrementBy);
-                Assert.Equal(1, operation.MinValue);
-                Assert.Equal(4, operation.MaxValue);
-                Assert.True(operation.IsCyclic);
-                Assert.False(operation.IsCached);
-                Assert.Null(operation.CacheSize);
-            });
-
-    [ConditionalFact]
-    public void Alter_sequence_default_cache_to_cache()
-    => Execute(
-        source => source.HasSequence<int>("Theta", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(),
-        source => source.HasSequence<int>("Theta", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(20),
-        operations =>
-        {
-            Assert.Equal(1, operations.Count);
-
-            var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-            Assert.Equal("Theta", operation.Name);
-            Assert.Equal("dbo", operation.Schema);
-            Assert.Equal(3, operation.IncrementBy);
-            Assert.Equal(1, operation.MinValue);
-            Assert.Equal(4, operation.MaxValue);
-            Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
-            Assert.Equal(20, operation.CacheSize);
-        });
-
-
-
-    [ConditionalFact]
-    public void Alter_sequence_nocache_to_cache()
-    => Execute(
-        source => source.HasSequence<int>("Epsilon", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseNoCache(),
-        source => source.HasSequence<int>("Epsilon", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(20),
-        operations =>
-        {
-            Assert.Equal(1, operations.Count);
-
-            var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-            Assert.Equal("Epsilon", operation.Name);
-            Assert.Equal("dbo", operation.Schema);
-            Assert.Equal(3, operation.IncrementBy);
-            Assert.Equal(1, operation.MinValue);
-            Assert.Equal(4, operation.MaxValue);
-            Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
-            Assert.Equal(20, operation.CacheSize);
-        });
-
-
-    [ConditionalFact]
-    public void Alter_sequence_nocache_to_default_cache()
-    => Execute(
-        source => source.HasSequence<int>("Kappa", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseNoCache(),
-        source => source.HasSequence<int>("Kappa", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(),
-        operations =>
-        {
-            Assert.Equal(1, operations.Count);
-
-            var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-            Assert.Equal("Kappa", operation.Name);
-            Assert.Equal("dbo", operation.Schema);
-            Assert.Equal(3, operation.IncrementBy);
-            Assert.Equal(1, operation.MinValue);
-            Assert.Equal(4, operation.MaxValue);
-            Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
-            Assert.Null(operation.CacheSize);
-        });
-
-    [ConditionalFact]
-    public void Alter_sequence_cache_to_default_cache()
-    => Execute(
-        source => source.HasSequence<int>("Omicron", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(20),
-        source => source.HasSequence<int>("Omicron", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(),
-        operations =>
-        {
-            Assert.Equal(1, operations.Count);
-
-            var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-            Assert.Equal("Omicron", operation.Name);
-            Assert.Equal("dbo", operation.Schema);
-            Assert.Equal(3, operation.IncrementBy);
-            Assert.Equal(1, operation.MinValue);
-            Assert.Equal(4, operation.MaxValue);
-            Assert.True(operation.IsCyclic);
-            Assert.True(operation.IsCached);
-            Assert.Null(operation.CacheSize);
-        });
-
-    [ConditionalFact]
-    public void Alter_sequence_cache_to_nocache()
-    => Execute(
-        source => source.HasSequence<int>("Phi", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseCache(20),
-        source => source.HasSequence<int>("Phi", "dbo")
-            .StartsAt(2)
-            .IncrementsBy(3)
-            .HasMin(1)
-            .HasMax(4)
-            .IsCyclic()
-            .UseNoCache(),
-        operations =>
-        {
-            Assert.Equal(1, operations.Count);
-
-            var operation = Assert.IsType<AlterSequenceOperation>(operations[0]);
-            Assert.Equal("Phi", operation.Name);
-            Assert.Equal("dbo", operation.Schema);
-            Assert.Equal(3, operation.IncrementBy);
-            Assert.Equal(1, operation.MinValue);
-            Assert.Equal(4, operation.MaxValue);
-            Assert.True(operation.IsCyclic);
-            Assert.False(operation.IsCached);
-            Assert.Null(operation.CacheSize);
-        });
 
     [ConditionalFact]
     public void Alter_sequence_type()
@@ -4724,15 +4475,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<long>("Hotel", "dbo")
                 .StartsAt(2)
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(2, operations.Count);
@@ -4750,8 +4499,6 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 Assert.Equal(1, createOperation.MinValue);
                 Assert.Equal(4, createOperation.MaxValue);
                 Assert.True(createOperation.IsCyclic);
-                Assert.True(createOperation.IsCached);
-                Assert.Equal(20, createOperation.CacheSize);
             },
             skipSourceConventions: true);
 
@@ -4763,15 +4510,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Golf", "dbo")
                 .StartsAt(5)
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations =>
             {
                 Assert.Equal(1, operations.Count);
@@ -4792,15 +4537,13 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                 .IncrementsBy(3)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             source => source.HasSequence<int>("Golf", "dbo")
                 .StartsAt(5)
                 .IncrementsBy(6)
                 .HasMin(1)
                 .HasMax(4)
-                .IsCyclic()
-                .UseCache(20),
+                .IsCyclic(),
             operations => Assert.Collection(
                 operations,
                 o => Assert.IsType<AlterSequenceOperation>(o),

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -3120,39 +3120,9 @@ CREATE SEQUENCE [TestSequence] AS smallint START WITH 1 INCREMENT BY 1 NO CYCLE;
             """
 IF SCHEMA_ID(N'dbo2') IS NULL EXEC(N'CREATE SCHEMA [dbo2];');
 """,
-//
+            //
             """
-CREATE SEQUENCE [dbo2].[TestSequence] START WITH 3 INCREMENT BY 2 MINVALUE 2 MAXVALUE 916 CYCLE CACHE 20;
-""");
-    }
-
-    public override async Task Create_sequence_nocache()
-    {
-        await base.Create_sequence_nocache();
-
-        AssertSql(
-            """
-CREATE SEQUENCE [Alpha] START WITH 1 INCREMENT BY 1 NO CYCLE NO CACHE;
-""");
-    }
-
-    public override async Task Create_sequence_cache()
-    {
-        await base.Create_sequence_cache();
-
-        AssertSql(
-            """
-CREATE SEQUENCE [Beta] START WITH 1 INCREMENT BY 1 NO CYCLE CACHE 20;
-""");
-    }
-
-    public override async Task Create_sequence_default_cache()
-    {
-        await base.Create_sequence_default_cache();
-
-        AssertSql(
-            """
-CREATE SEQUENCE [Gamma] START WITH 1 INCREMENT BY 1 NO CYCLE;
+CREATE SEQUENCE [dbo2].[TestSequence] START WITH 3 INCREMENT BY 2 MINVALUE 2 MAXVALUE 916 CYCLE;
 """);
     }
 
@@ -3162,7 +3132,7 @@ CREATE SEQUENCE [Gamma] START WITH 1 INCREMENT BY 1 NO CYCLE;
 
         AssertSql(
             """
-ALTER SEQUENCE [foo] INCREMENT BY 2 MINVALUE -5 MAXVALUE 10 CYCLE CACHE 20;
+ALTER SEQUENCE [foo] INCREMENT BY 2 MINVALUE -5 MAXVALUE 10 CYCLE;
 """,
             //
             """
@@ -3176,67 +3146,7 @@ ALTER SEQUENCE [foo] RESTART WITH -3;
 
         AssertSql(
             """
-ALTER SEQUENCE [foo] INCREMENT BY 2 NO MINVALUE NO MAXVALUE NO CYCLE CACHE;
-""");
-    }
-
-    public override async Task Alter_sequence_default_cache_to_cache()
-    {
-        await base.Alter_sequence_default_cache_to_cache();
-
-        AssertSql(
-            """
-ALTER SEQUENCE [Delta] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE CACHE 20;
-""");
-    }
-
-    public override async Task Alter_sequence_default_cache_to_nocache()
-    {
-        await base.Alter_sequence_default_cache_to_nocache();
-
-        AssertSql(
-            """
-ALTER SEQUENCE [Epsilon] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE NO CACHE;
-""");
-    }
-
-    public override async Task Alter_sequence_cache_to_nocache()
-    {
-        await base.Alter_sequence_cache_to_nocache();
-
-        AssertSql(
-            """
-ALTER SEQUENCE [Zeta] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE NO CACHE;
-""");
-    }
-
-    public override async Task Alter_sequence_cache_to_default_cache()
-    {
-        await base.Alter_sequence_cache_to_default_cache();
-
-        AssertSql(
-            """
-ALTER SEQUENCE [Eta] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE CACHE;
-""");
-    }
-
-    public override async Task Alter_sequence_nocache_to_cache()
-    {
-        await base.Alter_sequence_nocache_to_cache();
-
-        AssertSql(
-            """
-ALTER SEQUENCE [Theta] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE CACHE 20;
-""");
-    }
-
-    public override async Task Alter_sequence_nocache_to_default_cache()
-    {
-        await base.Alter_sequence_nocache_to_default_cache();
-
-        AssertSql(
-"""
-ALTER SEQUENCE [Iota] INCREMENT BY 1 NO MINVALUE NO MAXVALUE NO CYCLE CACHE;
+ALTER SEQUENCE [foo] INCREMENT BY 2 NO MINVALUE NO MAXVALUE NO CYCLE;
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -35,8 +35,7 @@ CREATE SEQUENCE db2.CustomFacetsSequence
     INCREMENT BY 2
     MAXVALUE 8
     MINVALUE -3
-    CYCLE
-    CACHE 20;",
+    CYCLE;",
             Enumerable.Empty<string>(),
             Enumerable.Empty<string>(),
             (dbModel, scaffoldingFactory) =>
@@ -50,8 +49,6 @@ CREATE SEQUENCE db2.CustomFacetsSequence
                 Assert.Null(defaultSequence.StartValue);
                 Assert.Null(defaultSequence.MinValue);
                 Assert.Null(defaultSequence.MaxValue);
-                Assert.True(defaultSequence.IsCached);
-                Assert.Null(defaultSequence.CacheSize);
 
                 var customSequence = dbModel.Sequences.First(ds => ds.Name == "CustomFacetsSequence");
                 Assert.Equal("db2", customSequence.Schema);
@@ -89,73 +86,11 @@ CREATE SEQUENCE db2.CustomFacetsSequence
                         Assert.Null(s.MinValue);
                         Assert.Null(s.MaxValue);
                     });
-                Assert.True(customSequence.IsCached);
-                Assert.Equal(20, customSequence.CacheSize);
             },
             @"
 DROP SEQUENCE DefaultFacetsSequence;
 
 DROP SEQUENCE db2.CustomFacetsSequence");
-
-    [ConditionalFact]
-    public void Create_sequences_caches()
-    => Test(
-        @"
-CREATE SEQUENCE db2.DefaultCacheSequence
-    CACHE;
-
-CREATE SEQUENCE db2.NoCacheSequence
-    NO CACHE;
-
-CREATE SEQUENCE db2.CacheSequence
-    CACHE 20;",
-        Enumerable.Empty<string>(),
-        Enumerable.Empty<string>(),
-        (dbModel, scaffoldingFactory) =>
-        {
-            var defaultCacheSequence = dbModel.Sequences.First(ds => ds.Name == "DefaultCacheSequence");
-            Assert.Equal("db2", defaultCacheSequence.Schema);
-            Assert.Equal("DefaultCacheSequence", defaultCacheSequence.Name);
-            Assert.Equal("bigint", defaultCacheSequence.StoreType);
-            Assert.False(defaultCacheSequence.IsCyclic);
-            Assert.Equal(1, defaultCacheSequence.IncrementBy);
-            Assert.Null(defaultCacheSequence.StartValue);
-            Assert.Null(defaultCacheSequence.MinValue);
-            Assert.Null(defaultCacheSequence.MaxValue);
-            Assert.True(defaultCacheSequence.IsCached);
-            Assert.Null(defaultCacheSequence.CacheSize);
-
-            var noCacheSequence = dbModel.Sequences.First(ds => ds.Name == "NoCacheSequence");
-            Assert.Equal("db2", noCacheSequence.Schema);
-            Assert.Equal("NoCacheSequence", noCacheSequence.Name);
-            Assert.Equal("bigint", noCacheSequence.StoreType);
-            Assert.False(noCacheSequence.IsCyclic);
-            Assert.Equal(1, noCacheSequence.IncrementBy);
-            Assert.Null(noCacheSequence.StartValue);
-            Assert.Null(noCacheSequence.MinValue);
-            Assert.Null(noCacheSequence.MaxValue);
-            Assert.False(noCacheSequence.IsCached);
-            Assert.Null(noCacheSequence.CacheSize);
-
-            var cacheSequence = dbModel.Sequences.First(ds => ds.Name == "CacheSequence");
-            Assert.Equal("db2", cacheSequence.Schema);
-            Assert.Equal("CacheSequence", cacheSequence.Name);
-            Assert.Equal("bigint", cacheSequence.StoreType);
-            Assert.False(cacheSequence.IsCyclic);
-            Assert.Equal(1, cacheSequence.IncrementBy);
-            Assert.Null(cacheSequence.StartValue);
-            Assert.Null(cacheSequence.MinValue);
-            Assert.Null(cacheSequence.MaxValue);
-            Assert.True(cacheSequence.IsCached);
-            Assert.Equal(20, cacheSequence.CacheSize);
-        },
-        @"
-DROP SEQUENCE db2.DefaultCacheSequence;
-
-DROP SEQUENCE db2.NoCacheSequence;
-
-DROP SEQUENCE db2.CacheSequence;");
-
 
     [ConditionalFact]
     public void Sequence_min_max_start_values_are_null_if_default()
@@ -179,9 +114,6 @@ CREATE SEQUENCE [BigIntSequence] AS bigint;",
                         Assert.Null(s.StartValue);
                         Assert.Null(s.MinValue);
                         Assert.Null(s.MaxValue);
-                        Assert.False(s.IsCyclic);
-                        Assert.True(s.IsCached);
-                        Assert.Null(s.CacheSize);
                     });
 
                 var model = scaffoldingFactory.Create(dbModel, new());
@@ -260,9 +192,6 @@ CREATE SEQUENCE [NumericSequence] AS numeric;",
                         Assert.NotNull(s.StartValue);
                         Assert.NotNull(s.MinValue);
                         Assert.NotNull(s.MaxValue);
-                        Assert.False(s.IsCyclic);
-                        Assert.True(s.IsCached);
-                        Assert.Null(s.CacheSize);
                     });
 
                 var model = scaffoldingFactory.Create(dbModel, new());
@@ -322,8 +251,6 @@ CREATE SEQUENCE [dbo].[HighDecimalSequence]
                         Assert.Equal(long.MinValue, s.MinValue);
                         Assert.NotNull(s.MaxValue);
                         Assert.Equal(long.MaxValue, s.MaxValue);
-                        Assert.True(s.IsCached);
-                        Assert.Null(s.CacheSize);
                     });
 
                 var model = scaffoldingFactory.Create(dbModel, new());
@@ -369,8 +296,6 @@ CREATE SEQUENCE [TypeAliasSequence] AS [dbo].[TestTypeAlias];",
                 Assert.Null(sequence.StartValue);
                 Assert.Null(sequence.MinValue);
                 Assert.Null(sequence.MaxValue);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());
 
@@ -409,8 +334,6 @@ CREATE SEQUENCE [TypeFacetSequence] AS decimal(10, 0);",
                 Assert.Equal("decimal(10, 0)", sequence.StoreType);
                 Assert.False(sequence.IsCyclic);
                 Assert.Equal(1, sequence.IncrementBy);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());
 
@@ -449,8 +372,6 @@ CREATE SEQUENCE [db2].[Sequence]",
                 Assert.Equal("bigint", sequence.StoreType);
                 Assert.False(sequence.IsCyclic);
                 Assert.Equal(1, sequence.IncrementBy);
-                Assert.True(sequence.IsCached);
-                Assert.Null(sequence.CacheSize);
 
                 var model = scaffoldingFactory.Create(dbModel, new());
 

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -309,9 +309,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -338,9 +335,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -354,9 +348,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder.UseHiLo("Snook", "Tasty");
 
@@ -381,9 +373,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder.UseHiLo("Snook", "Tasty");
 
@@ -457,9 +447,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -473,9 +460,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder.UseKeySequences("Snook", "Tasty");
 
@@ -500,9 +485,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder.UseKeySequences("Snook", "Tasty");
 
@@ -525,9 +508,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1729, sequence.StartValue);
         Assert.Equal(111, sequence.MinValue);
         Assert.Equal(2222, sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Equal(20, sequence.CacheSize);
         Assert.Same(typeof(int), sequence.Type);
     }
 
@@ -632,9 +612,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -665,9 +642,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -681,9 +655,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder
             .Entity<Customer>()
@@ -708,7 +680,7 @@ public class SqlServerBuilderExtensionsTest
         var modelBuilder = CreateConventionModelBuilder();
 
         modelBuilder
-            .HasSequence<int>("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222).IsCyclic(false).UseCache(20))
+            .HasSequence<int>("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222))
             .Entity<Customer>()
             .Property(e => e.Id)
             .UseHiLo("Snook", "Tasty");
@@ -735,9 +707,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder
             .Entity<Customer>()
@@ -767,9 +737,7 @@ public class SqlServerBuilderExtensionsTest
                     b.IncrementsBy(11)
                         .StartsAt(1729)
                         .HasMin(111)
-                        .HasMax(2222)
-                        .IsCyclic(false)
-                        .UseCache(20);
+                        .HasMax(2222);
                 });
 
         modelBuilder
@@ -839,9 +807,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -874,9 +839,6 @@ public class SqlServerBuilderExtensionsTest
         Assert.Equal(1, sequence.StartValue);
         Assert.Null(sequence.MinValue);
         Assert.Null(sequence.MaxValue);
-        Assert.False(sequence.IsCyclic);
-        Assert.True(sequence.IsCached);
-        Assert.Null(sequence.CacheSize);
         Assert.Same(typeof(long), sequence.Type);
     }
 
@@ -890,9 +852,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder
             .Entity<Customer>()
@@ -917,9 +877,7 @@ public class SqlServerBuilderExtensionsTest
         var modelBuilder = CreateConventionModelBuilder();
 
         modelBuilder
-            .HasSequence<int>("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20))
+            .HasSequence<int>("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222))
             .Entity<Customer>()
             .Property(e => e.Id)
             .UseSequence("Snook", "Tasty");
@@ -946,9 +904,7 @@ public class SqlServerBuilderExtensionsTest
             .IncrementsBy(11)
             .StartsAt(1729)
             .HasMin(111)
-            .HasMax(2222)
-            .IsCyclic(false)
-            .UseCache(20);
+            .HasMax(2222);
 
         modelBuilder
             .Entity<Customer>()
@@ -978,9 +934,7 @@ public class SqlServerBuilderExtensionsTest
                     b.IncrementsBy(11)
                         .StartsAt(1729)
                         .HasMin(111)
-                        .HasMax(2222)
-                        .IsCyclic(false)
-                        .UseCache(20);
+                        .HasMax(2222);
                 });
 
         modelBuilder

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsSqliteTest.cs
@@ -2058,33 +2058,6 @@ CREATE TABLE "Contacts" (
     public override Task Alter_sequence_increment_by()
         => AssertNotSupportedAsync(base.Alter_sequence_increment_by, SqliteStrings.SequencesNotSupported);
 
-    public override Task Alter_sequence_cache_to_default_cache()
-        => AssertNotSupportedAsync(base.Alter_sequence_cache_to_default_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Alter_sequence_cache_to_nocache()
-        => AssertNotSupportedAsync(base.Alter_sequence_cache_to_nocache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Alter_sequence_default_cache_to_cache()
-        => AssertNotSupportedAsync(base.Alter_sequence_default_cache_to_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Alter_sequence_default_cache_to_nocache()
-        => AssertNotSupportedAsync(base.Alter_sequence_default_cache_to_nocache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Alter_sequence_nocache_to_cache()
-        => AssertNotSupportedAsync(base.Alter_sequence_nocache_to_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Alter_sequence_nocache_to_default_cache()
-        => AssertNotSupportedAsync(base.Alter_sequence_nocache_to_default_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Create_sequence_cache()
-        => AssertNotSupportedAsync(base.Create_sequence_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Create_sequence_default_cache()
-        => AssertNotSupportedAsync(base.Create_sequence_default_cache, SqliteStrings.SequencesNotSupported);
-
-    public override Task Create_sequence_nocache()
-        => AssertNotSupportedAsync(base.Create_sequence_nocache, SqliteStrings.SequencesNotSupported);
-
     public override Task Alter_sequence_restart_with()
         => AssertNotSupportedAsync(base.Alter_sequence_restart_with, SqliteStrings.SequencesNotSupported);
 

--- a/test/EFCore.Sqlite.Tests/Diagnostics/SqliteEventIdTest.cs
+++ b/test/EFCore.Sqlite.Tests/Diagnostics/SqliteEventIdTest.cs
@@ -67,11 +67,5 @@ public class SqliteEventIdTest : EventIdTestBase
 
         public bool IsCyclic
             => throw new NotImplementedException();
-
-        public bool IsCached
-            => throw new NotImplementedException();
-
-        public int? CacheSize
-            => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
We can revisit this after 9, when we can make a final decision on the design and implementation.

Replaces #33412.