### PR TITLE
Generate suppressible error when entity saved to Cosmos without PK value set

### DIFF
--- a/src/EFCore.Cosmos/Diagnostics/CosmosEventId.cs
+++ b/src/EFCore.Cosmos/Diagnostics/CosmosEventId.cs
@@ -36,6 +36,9 @@ public static class CosmosEventId
         ExecutedReplaceItem,
         ExecutedDeleteItem,
 
+        // Update events
+        PrimaryKeyValueNotSet = CoreEventId.ProviderBaseId + 200,
+
         // Model validation events
         NoPartitionKeyDefined = CoreEventId.ProviderBaseId + 600,
 
@@ -170,4 +173,22 @@ public static class CosmosEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId NoPartitionKeyDefined = MakeValidationId(Id.NoPartitionKeyDefined);
+
+    private static EventId MakeUpdateId(Id id)
+        => new((int)id, DbLoggerCategory.Update.Name + "." + id);
+
+    /// <summary>
+    ///     A property is not configured to generate values and has the CLR default or sentinel value while saving a new entity
+    ///     to the database. The Azure Cosmos DB database provider for EF Core does not generate key values by default. This means key
+    ///     values must be explicitly set before saving new entities. See https://aka.ms/ef-cosmos-keys for more information.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Update" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId PrimaryKeyValueNotSet = MakeUpdateId(Id.PrimaryKeyValueNotSet);
 }

--- a/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
+++ b/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
@@ -487,6 +487,33 @@ public static class CosmosLoggerExtensions
         }
     }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static void PrimaryKeyValueNotSet(
+        this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+        IProperty property)
+    {
+        var definition = CosmosResources.LogPrimaryKeyValueNotSet(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, property.DeclaringType.DisplayName(), property.Name);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new PropertyEventData(
+                definition,
+                (d, p) => ((EventDefinition<string, string>)d).GenerateMessage(((PropertyEventData)p).Property.DeclaringType.DisplayName(), ((PropertyEventData)p).Property.Name),
+                property);
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
     private static string FormatParameters(IReadOnlyList<(string Name, object? Value)> parameters, bool shouldLogParameterValues)
         => FormatParameters(parameters.Select(p => new SqlParameter(p.Name, p.Value)).ToList(), shouldLogParameterValues);
 

--- a/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggingDefinitions.cs
+++ b/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggingDefinitions.cs
@@ -82,4 +82,12 @@ public class CosmosLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public EventDefinitionBase? LogNoPartitionKeyDefined;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public EventDefinitionBase? LogPrimaryKeyValueNotSet;
 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -685,6 +685,31 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         }
 
         /// <summary>
+        ///     The key property '{entityType}.{property}' is not configured to generate values and has the CLR default or sentinel value while saving a new entity to the database. The Azure Cosmos DB database provider for EF Core does not generate key values by default. This means key values must be explicitly set before saving new entities. See https://aka.ms/ef-cosmos-keys for more information.
+        /// </summary>
+        public static EventDefinition<string, string> LogPrimaryKeyValueNotSet(IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogPrimaryKeyValueNotSet;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogPrimaryKeyValueNotSet,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        CosmosEventId.PrimaryKeyValueNotSet,
+                        LogLevel.Warning,
+                        "CosmosEventId.PrimaryKeyValueNotSet",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CosmosEventId.PrimaryKeyValueNotSet,
+                            _resourceManager.GetString("LogPrimaryKeyValueNotSet")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     Azure Cosmos DB does not support synchronous I/O. Make sure to use and correctly await only async methods when using Entity Framework Core to access Azure Cosmos DB. See https://aka.ms/ef-cosmos-nosync for more information.
         /// </summary>
         public static EventDefinition LogSyncNotSupported(IDiagnosticsLogger logger)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -209,6 +209,10 @@
     <value>No partition key has been configured for entity type '{entityType}'. It is highly recommended that an appropriate partition key be defined. See https://aka.ms/efdocs-cosmos-partition-keys for more information.</value>
     <comment>Warning CosmosEventId.NoPartitionKeyDefined string</comment>
   </data>
+  <data name="LogPrimaryKeyValueNotSet" xml:space="preserve">
+    <value>The key property '{entityType}.{property}' is not configured to generate values and has the CLR default or sentinel value while saving a new entity to the database. The Azure Cosmos DB database provider for EF Core does not generate key values by default. This means key values must be explicitly set before saving new entities. See https://aka.ms/ef-cosmos-keys for more information.</value>
+    <comment>Warning CosmosEventId.PrimaryKeyValueNotSet string string</comment>
+  </data>
   <data name="LogSyncNotSupported" xml:space="preserve">
     <value>Azure Cosmos DB does not support synchronous I/O. Make sure to use and correctly await only async methods when using Entity Framework Core to access Azure Cosmos DB. See https://aka.ms/ef-cosmos-nosync for more information.</value>
     <comment>Error CosmosEventId.SyncNotSupported</comment>

--- a/src/EFCore/Update/IUpdateEntry.cs
+++ b/src/EFCore/Update/IUpdateEntry.cs
@@ -67,6 +67,13 @@ public interface IUpdateEntry
     bool HasTemporaryValue(IProperty property);
 
     /// <summary>
+    ///     Gets a value indicating if the specified property has an explicit value set.
+    /// </summary>
+    /// <param name="property">The property to be checked.</param>
+    /// <returns><see langword="true" /> if the property has an explicitly set value, otherwise <see langword="false" />.</returns>
+    bool HasExplicitValue(IProperty property);
+
+    /// <summary>
     ///     Gets a value indicating if the specified property has a store-generated value that has not yet been saved to the entity.
     /// </summary>
     /// <param name="property">The property to be checked.</param>

--- a/test/EFCore.Cosmos.FunctionalTests/DefaultKeyValuesTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/DefaultKeyValuesTest.cs
@@ -1,0 +1,661 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class DefaultKeyValuesTest : IClassFixture<DefaultKeyValuesTest.CosmosDefaultKeyValuesTestFixture>
+{
+    public static IEnumerable<object[]> IsAsyncData = [[false], [true]];
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    protected void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
+
+    protected CosmosDefaultKeyValuesTestFixture Fixture { get; }
+
+    public DefaultKeyValuesTest(CosmosDefaultKeyValuesTestFixture fixture)
+    {
+        Fixture = fixture;
+        ClearLog();
+    }
+
+    [ConditionalFact]
+    public async Task Single_key_value_with_single_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleKeySinglePartitionKey());
+        await AssertKeyValueNotSet(context, nameof(SingleKeySinglePartitionKey), nameof(SingleKeySinglePartitionKey.Id));
+
+        context.Add(new SingleKeySinglePartitionKey { PartitionKey = 1 });
+        await AssertKeyValueNotSet(context, nameof(SingleKeySinglePartitionKey), nameof(SingleKeySinglePartitionKey.Id));
+
+        context.Add(new SingleKeySinglePartitionKey { Id = 1 });
+        await AssertSaves(context);
+
+        context.Add(new SingleKeySinglePartitionKey { Id = 1, PartitionKey = 1 });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_key_value_with_single_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeKeySinglePartitionKey());
+        await AssertKeyValueNotSet(context, nameof(CompositeKeySinglePartitionKey), nameof(CompositeKeySinglePartitionKey.Id3));
+
+        context.Add(new CompositeKeySinglePartitionKey { PartitionKey = 1 });
+        await AssertKeyValueNotSet(context, nameof(CompositeKeySinglePartitionKey), nameof(CompositeKeySinglePartitionKey.Id3));
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id2 = Guid.NewGuid(), Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id2 = Guid.NewGuid(), PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id2 = Guid.NewGuid(), Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Single_key_value_with_composite_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleKeyCompositePartitionKey());
+        await AssertKeyValueNotSet(context, nameof(SingleKeyCompositePartitionKey), nameof(SingleKeyCompositePartitionKey.Id));
+
+        context.Add(new SingleKeyCompositePartitionKey { PartitionKey1 = 1 });
+        await AssertKeyValueNotSet(context, nameof(SingleKeyCompositePartitionKey), nameof(SingleKeyCompositePartitionKey.Id));
+
+        context.Add(new SingleKeyCompositePartitionKey { PartitionKey2 = Guid.NewGuid() });
+        await AssertKeyValueNotSet(context, nameof(SingleKeyCompositePartitionKey), nameof(SingleKeyCompositePartitionKey.Id));
+
+        context.Add(new SingleKeyCompositePartitionKey { PartitionKey3 = true });
+        await AssertKeyValueNotSet(context, nameof(SingleKeyCompositePartitionKey), nameof(SingleKeyCompositePartitionKey.Id));
+
+        context.Add(new SingleKeyCompositePartitionKey { PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertKeyValueNotSet(context, nameof(SingleKeyCompositePartitionKey), nameof(SingleKeyCompositePartitionKey.Id));
+
+        context.Add(new SingleKeyCompositePartitionKey { Id = 1 });
+        await AssertSaves(context);
+
+        context.Add(new SingleKeyCompositePartitionKey { Id = 1, PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleKeyCompositePartitionKey { Id = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleKeyCompositePartitionKey { Id = 1, PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_key_value_with_composite_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeKeyCompositePartitionKey());
+        await AssertKeyValueNotSet(context, nameof(CompositeKeyCompositePartitionKey), nameof(CompositeKeyCompositePartitionKey.Id3));
+
+        context.Add(new CompositeKeyCompositePartitionKey { PartitionKey1 = 1 });
+        await AssertKeyValueNotSet(context, nameof(CompositeKeyCompositePartitionKey), nameof(CompositeKeyCompositePartitionKey.Id3));
+
+        context.Add(new CompositeKeyCompositePartitionKey { PartitionKey2 = Guid.NewGuid() });
+        await AssertKeyValueNotSet(context, nameof(CompositeKeyCompositePartitionKey), nameof(CompositeKeyCompositePartitionKey.Id3));
+
+        context.Add(new CompositeKeyCompositePartitionKey { PartitionKey3 = true });
+        await AssertKeyValueNotSet(context, nameof(CompositeKeyCompositePartitionKey), nameof(CompositeKeyCompositePartitionKey.Id3));
+
+        context.Add(new CompositeKeyCompositePartitionKey { PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertKeyValueNotSet(context, nameof(CompositeKeyCompositePartitionKey), nameof(CompositeKeyCompositePartitionKey.Id3));
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey
+        {
+            Id1 = 1, PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id1 = 1, PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey
+        {
+            Id2 = Guid.NewGuid(), PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id2 = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id2 = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey
+        {
+            Id3 = true, PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id3 = true, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeKeyCompositePartitionKey { Id3 = true, PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Single_same_key_and_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleSameKeyAndPartitionKey());
+        await AssertKeyValueNotSet(context, nameof(SingleSameKeyAndPartitionKey), nameof(SingleSameKeyAndPartitionKey.Id));
+
+        context.Add(new SingleSameKeyAndPartitionKey { Id = 1 });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_same_key_and_partition_key_must_have_key_set()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeSameKeyAndPartitionKey());
+        await AssertKeyValueNotSet(context, nameof(CompositeSameKeyAndPartitionKey), nameof(CompositeSameKeyAndPartitionKey.Key3));
+
+        context.Add(new CompositeSameKeyAndPartitionKey { Key1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameKeyAndPartitionKey { Key2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameKeyAndPartitionKey { Key3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameKeyAndPartitionKey { Key1 = 1, Key2 = Guid.NewGuid(), Key3 = true });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Single_key_value_with_single_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleGeneratedKeySinglePartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeySinglePartitionKey { PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeySinglePartitionKey { Id = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeySinglePartitionKey { Id = Guid.NewGuid(), PartitionKey = 1 });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_key_value_with_single_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id2 = Guid.NewGuid(), Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id2 = Guid.NewGuid(), PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id2 = Guid.NewGuid(), Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeySinglePartitionKey { Id1 = 1, Id2 = Guid.NewGuid(), Id3 = true, PartitionKey = 1 });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Single_key_value_with_composite_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { PartitionKey1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { Id = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { Id = Guid.NewGuid(), PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { Id = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new SingleGeneratedKeyCompositePartitionKey { Id = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_key_value_with_composite_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { PartitionKey1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey
+        {
+            Id1 = 1, PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id1 = 1, PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey
+        {
+            Id2 = Guid.NewGuid(), PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id2 = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id2 = Guid.NewGuid(), PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey
+        {
+            Id3 = true, PartitionKey1 = 1, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true
+        });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id3 = true, PartitionKey2 = Guid.NewGuid(), PartitionKey3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeGeneratedKeyCompositePartitionKey { Id3 = true, PartitionKey2 = Guid.NewGuid() });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Single_same_key_and_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new SingleSameGeneratedKeyAndPartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new SingleSameGeneratedKeyAndPartitionKey { Id = Guid.NewGuid() });
+        await AssertSaves(context);
+    }
+
+    [ConditionalFact]
+    public async Task Composite_same_key_and_partition_key_can_use_generated_value()
+    {
+        using var context = CreateContext();
+
+        context.Add(new CompositeSameGeneratedKeyAndPartitionKey());
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameGeneratedKeyAndPartitionKey { Key1 = 1 });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameGeneratedKeyAndPartitionKey { Key2 = Guid.NewGuid() });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameGeneratedKeyAndPartitionKey { Key3 = true });
+        await AssertSaves(context);
+
+        context.Add(new CompositeSameGeneratedKeyAndPartitionKey { Key1 = 1, Key2 = Guid.NewGuid(), Key3 = true });
+        await AssertSaves(context);
+    }
+
+    private static async Task AssertSaves(DefaultKeyValuesTestContext context)
+    {
+        var entry = context.ChangeTracker.Entries().Single();
+
+        Assert.Equal(EntityState.Added, entry.State);
+        await context.SaveChangesAsync();
+        Assert.Equal(EntityState.Unchanged, entry.State);
+
+        context.ChangeTracker.Clear();
+    }
+
+    private static async Task AssertKeyValueNotSet(
+        DefaultKeyValuesTestContext context, string entityTypeName, string propertyName)
+    {
+        Assert.Equal(
+            CoreStrings.WarningAsErrorTemplate(
+                CosmosEventId.PrimaryKeyValueNotSet.ToString(),
+                CosmosResources.LogPrimaryKeyValueNotSet(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
+                    entityTypeName, propertyName),
+                "CosmosEventId.PrimaryKeyValueNotSet"),
+            (await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync())).InnerException!.Message);
+
+        context.ChangeTracker.Clear();
+    }
+
+    protected DefaultKeyValuesTestContext CreateContext()
+        => Fixture.CreateContext();
+
+    public class CosmosDefaultKeyValuesTestFixture : SharedStoreFixtureBase<DefaultKeyValuesTestContext>
+    {
+        protected override string StoreName
+            => nameof(DefaultKeyValuesTest);
+
+        protected override bool UsePooling
+            => false;
+
+        protected override ITestStoreFactory TestStoreFactory
+            => CosmosTestStoreFactory.Instance;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+    }
+
+    public class DefaultKeyValuesTestContext(DbContextOptions dbContextOptions) : DbContext(dbContextOptions)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SingleKeySinglePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.PartitionKey);
+                b.HasKey(e => new { e.Id, e.PartitionKey });
+            });
+
+            modelBuilder.Entity<CompositeKeySinglePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.PartitionKey);
+                b.HasKey(e => new { e.Id1, e.Id2, e.Id3, e.PartitionKey });
+            });
+
+            modelBuilder.Entity<SingleKeyCompositePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.HasKey(e => new { e.Id, e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+            });
+
+            modelBuilder.Entity<CompositeKeyCompositePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.HasKey(e => new { e.Id1, e.Id2, e.Id3, e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+            });
+
+            modelBuilder.Entity<SingleSameKeyAndPartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.Id);
+                b.HasKey(e => e.Id);
+            });
+
+            modelBuilder.Entity<CompositeSameKeyAndPartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.Key1, e.Key2, e.Key3 });
+                b.HasKey(e => new { e.Key1, e.Key2, e.Key3 });
+            });
+
+            modelBuilder.Entity<SingleGeneratedKeySinglePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.PartitionKey);
+                b.HasKey(e => new { e.Id, e.PartitionKey });
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<CompositeGeneratedKeySinglePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.PartitionKey);
+                b.HasKey(e => new { e.Id1, e.Id2, e.Id3, e.PartitionKey });
+                b.Property(e => e.Id2).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<SingleGeneratedKeyCompositePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.HasKey(e => new { e.Id, e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<CompositeGeneratedKeyCompositePartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.HasKey(e => new { e.Id1, e.Id2, e.Id3, e.PartitionKey1, e.PartitionKey2, e.PartitionKey3 });
+                b.Property(e => e.Id2).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<SingleSameGeneratedKeyAndPartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => e.Id);
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<CompositeSameGeneratedKeyAndPartitionKey>(b =>
+            {
+                b.ToContainer(b.Metadata.ClrType.Name);
+                b.HasPartitionKey(e => new { e.Key1, e.Key2, e.Key3 });
+                b.HasKey(e => new { e.Key1, e.Key2, e.Key3 });
+                b.Property(e => e.Key2).ValueGeneratedOnAdd();
+            });
+        }
+    }
+
+    protected class SingleKeySinglePartitionKey
+    {
+        public int Id { get; set; }
+        public int PartitionKey { get; set; }
+    }
+
+    protected class CompositeKeySinglePartitionKey
+    {
+        public int Id1 { get; set; }
+        public Guid Id2 { get; set; }
+        public bool Id3 { get; set; }
+        public int PartitionKey { get; set; }
+    }
+
+    protected class SingleKeyCompositePartitionKey
+    {
+        public int Id { get; set; }
+        public int PartitionKey1 { get; set; }
+        public Guid PartitionKey2 { get; set; }
+        public bool PartitionKey3 { get; set; }
+    }
+
+    protected class CompositeKeyCompositePartitionKey
+    {
+        public int Id1 { get; set; }
+        public Guid Id2 { get; set; }
+        public bool Id3 { get; set; }
+        public int PartitionKey1 { get; set; }
+        public Guid PartitionKey2 { get; set; }
+        public bool PartitionKey3 { get; set; }
+    }
+
+    protected class SingleSameKeyAndPartitionKey
+    {
+        public int Id { get; set; }
+    }
+
+    protected class CompositeSameKeyAndPartitionKey
+    {
+        public int Key1 { get; set; }
+        public Guid Key2 { get; set; }
+        public bool Key3 { get; set; }
+    }
+
+    protected class SingleGeneratedKeySinglePartitionKey
+    {
+        public Guid Id { get; set; }
+        public int PartitionKey { get; set; }
+    }
+
+    protected class CompositeGeneratedKeySinglePartitionKey
+    {
+        public int Id1 { get; set; }
+        public Guid Id2 { get; set; }
+        public bool Id3 { get; set; }
+        public int PartitionKey { get; set; }
+    }
+
+    protected class SingleGeneratedKeyCompositePartitionKey
+    {
+        public Guid Id { get; set; }
+        public int PartitionKey1 { get; set; }
+        public Guid PartitionKey2 { get; set; }
+        public bool PartitionKey3 { get; set; }
+    }
+
+    protected class CompositeGeneratedKeyCompositePartitionKey
+    {
+        public int Id1 { get; set; }
+        public Guid Id2 { get; set; }
+        public bool Id3 { get; set; }
+        public int PartitionKey1 { get; set; }
+        public Guid PartitionKey2 { get; set; }
+        public bool PartitionKey3 { get; set; }
+    }
+
+    protected class SingleSameGeneratedKeyAndPartitionKey
+    {
+        public Guid Id { get; set; }
+    }
+
+    protected class CompositeSameGeneratedKeyAndPartitionKey
+    {
+        public int Key1 { get; set; }
+        public Guid Key2 { get; set; }
+        public bool Key3 { get; set; }
+    }
+}

--- a/test/EFCore.Cosmos.FunctionalTests/DefaultKeyValuesTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/DefaultKeyValuesTest.cs
@@ -6,23 +6,10 @@ using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class DefaultKeyValuesTest : IClassFixture<DefaultKeyValuesTest.CosmosDefaultKeyValuesTestFixture>
+public class DefaultKeyValuesTest(DefaultKeyValuesTest.CosmosDefaultKeyValuesTestFixture fixture)
+    : IClassFixture<DefaultKeyValuesTest.CosmosDefaultKeyValuesTestFixture>
 {
-    public static IEnumerable<object[]> IsAsyncData = [[false], [true]];
-
-    private void AssertSql(params string[] expected)
-        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
-
-    protected void ClearLog()
-        => Fixture.TestSqlLoggerFactory.Clear();
-
-    protected CosmosDefaultKeyValuesTestFixture Fixture { get; }
-
-    public DefaultKeyValuesTest(CosmosDefaultKeyValuesTestFixture fixture)
-    {
-        Fixture = fixture;
-        ClearLog();
-    }
+    protected CosmosDefaultKeyValuesTestFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public async Task Single_key_value_with_single_partition_key_must_have_key_set()
@@ -213,7 +200,7 @@ public class DefaultKeyValuesTest : IClassFixture<DefaultKeyValuesTest.CosmosDef
         using var context = CreateContext();
 
         context.Add(new CompositeSameKeyAndPartitionKey());
-        await AssertKeyValueNotSet(context, nameof(CompositeSameKeyAndPartitionKey), nameof(CompositeSameKeyAndPartitionKey.Key3));
+        await AssertKeyValueNotSet(context, nameof(CompositeSameKeyAndPartitionKey), nameof(CompositeSameKeyAndPartitionKey.Key1));
 
         context.Add(new CompositeSameKeyAndPartitionKey { Key1 = 1 });
         await AssertSaves(context);

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -546,6 +546,9 @@ public class CosmosTestStore : TestStore
         public bool HasTemporaryValue(IProperty property)
             => throw new NotImplementedException();
 
+        public bool HasExplicitValue(IProperty property)
+            => throw new NotImplementedException();
+
         public bool HasStoreGeneratedValue(IProperty property)
             => throw new NotImplementedException();
 

--- a/test/EFCore.Cosmos.Tests/Diagnostics/CosmosEventIdTest.cs
+++ b/test/EFCore.Cosmos.Tests/Diagnostics/CosmosEventIdTest.cs
@@ -14,11 +14,13 @@ public class CosmosEventIdTest : EventIdTestBase
     public void Every_eventId_has_a_logger_method_and_logs_when_level_enabled()
     {
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention);
+        var entityType = model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention)!;
+        var property = entityType.AddProperty("A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
 
         var fakeFactories = new Dictionary<Type, Func<object>>
         {
             { typeof(IEntityType), () => entityType },
+            { typeof(IProperty), () => property },
             {
                 typeof(CosmosSqlQuery), () => new CosmosSqlQuery(
                     "Some SQL...",

--- a/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
@@ -163,7 +163,7 @@ public abstract class MaterializationInterceptionTestBase<TContext> : SingletonI
         }
     }
 
-    private static int _id;
+    private static int _id = 1;
 
     [ConditionalTheory] // Issue #30244
     [ClassData(typeof(DataGenerator<bool, bool>))]

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -118,6 +118,9 @@ public class ExceptionTest
         public bool HasTemporaryValue(IProperty property)
             => throw new NotImplementedException();
 
+        public bool HasExplicitValue(IProperty property)
+            => throw new NotImplementedException();
+
         public bool HasStoreGeneratedValue(IProperty property)
             => throw new NotImplementedException();
 


### PR DESCRIPTION
Fixes #34180

We throw if there is no property in the primary key that is not generated and does not have a value set, excluding partition key properties.
