### PR TITLE
Get partition keys, container name, and JsonIdDefinition from the root entity in the hierarchy by default

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -196,7 +196,9 @@ public static class CosmosEntityTypeExtensions
     /// <param name="entityType">The entity type.</param>
     /// <returns>The names of the partition key properties, or <see langword="null"/> if not set.</returns>
     public static IReadOnlyList<string> GetPartitionKeyPropertyNames(this IReadOnlyEntityType entityType)
-        => entityType[CosmosAnnotationNames.PartitionKeyNames] as IReadOnlyList<string> ?? Array.Empty<string>();
+        => entityType[CosmosAnnotationNames.PartitionKeyNames] as IReadOnlyList<string>
+            ?? entityType.BaseType?.GetPartitionKeyPropertyNames()
+            ?? Array.Empty<string>();
 
     /// <summary>
     ///     Sets the names of the properties that are used to store the hierarchical partition key.

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -63,6 +63,13 @@ public class CosmosModelValidator : ModelValidator
                 continue;
             }
 
+            if (entityType.BaseType != null
+                && entityType.FindAnnotation(CosmosAnnotationNames.ContainerName)?.Value != null)
+            {
+                throw new InvalidOperationException(
+                    CosmosStrings.ContainerNotOnRoot(entityType.DisplayName(), entityType.BaseType.DisplayName()));
+            }
+
             var ownership = entityType.FindOwnership();
             if (ownership != null)
             {
@@ -345,6 +352,13 @@ public class CosmosModelValidator : ModelValidator
             }
             else
             {
+                if (entityType.BaseType != null
+                    && entityType.FindAnnotation(CosmosAnnotationNames.PartitionKeyNames)?.Value != null)
+                {
+                    throw new InvalidOperationException(
+                        CosmosStrings.PartitionKeyNotOnRoot(entityType.DisplayName(), entityType.BaseType.DisplayName()));
+                }
+
                 foreach (var partitionKeyPropertyName in partitionKeyPropertyNames)
                 {
                     var partitionKey = entityType.FindProperty(partitionKeyPropertyName);

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
@@ -29,9 +29,11 @@ public static class CosmosEntityTypeExtensions
     /// </summary>
     /// <param name="entityType">The entity type.</param>
     public static IJsonIdDefinition? GetJsonIdDefinition(this IEntityType entityType)
-        => entityType.GetOrAddRuntimeAnnotationValue(CosmosAnnotationNames.JsonIdDefinition,
-            static e =>
-                ((CosmosModelRuntimeInitializerDependencies)e!.Model.FindRuntimeAnnotationValue(
-                    CosmosAnnotationNames.ModelDependencies)!).JsonIdDefinitionFactory.Create(e),
-            entityType);
+        => entityType.BaseType?.GetJsonIdDefinition()
+            ?? entityType.GetOrAddRuntimeAnnotationValue(
+                CosmosAnnotationNames.JsonIdDefinition,
+                static e =>
+                    ((CosmosModelRuntimeInitializerDependencies)e!.Model.FindRuntimeAnnotationValue(
+                        CosmosAnnotationNames.ModelDependencies)!).JsonIdDefinitionFactory.Create(e),
+                entityType);
 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -58,6 +58,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 entityType, container, property);
 
         /// <summary>
+        ///     An Azure Cosmos DB container name is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Container names must be defined on the root entity type of a hierarchy.
+        /// </summary>
+        public static string ContainerNotOnRoot(object? entityType, object? baseEntityType)
+            => string.Format(
+                GetString("ContainerNotOnRoot", nameof(entityType), nameof(baseEntityType)),
+                entityType, baseEntityType);
+
+        /// <summary>
         ///     Cosmos-specific methods can only be used when the context is using the Cosmos provider.
         /// </summary>
         public static string CosmosNotInUse
@@ -342,6 +350,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("PartitionKeyBadValueType", nameof(propertyType), nameof(entityType), nameof(property), nameof(valueType)),
                 propertyType, entityType, property, valueType);
+
+        /// <summary>
+        ///     A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.
+        /// </summary>
+        public static string PartitionKeyNotOnRoot(object? entityType, object? baseEntityType)
+            => string.Format(
+                GetString("PartitionKeyNotOnRoot", nameof(entityType), nameof(baseEntityType)),
+                entityType, baseEntityType);
 
         /// <summary>
         ///     Unable to execute a 'ReadItem' query since the partition key value is missing. Consider using the 'WithPartitionKey' method on the query to specify partition key to use.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -132,6 +132,9 @@
   <data name="ContainerContainingPropertyConflict" xml:space="preserve">
     <value>The entity type '{entityType}' is mapped to the container '{container}' but it is also configured as being contained in property '{property}'.</value>
   </data>
+  <data name="ContainerNotOnRoot" xml:space="preserve">
+    <value>An Azure Cosmos DB container name is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Container names must be defined on the root entity type of a hierarchy.</value>
+  </data>
   <data name="CosmosNotInUse" xml:space="preserve">
     <value>Cosmos-specific methods can only be used when the context is using the Cosmos provider.</value>
   </data>
@@ -288,6 +291,9 @@
   </data>
   <data name="PartitionKeyBadValueType" xml:space="preserve">
     <value>The partition key value supplied for '{propertyType}' property '{entityType}.{property}' is of type '{valueType}'. Partition key values must be of a type assignable to the property.</value>
+  </data>
+  <data name="PartitionKeyNotOnRoot" xml:space="preserve">
+    <value>A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.</value>
   </data>
   <data name="PartitionKeyMissing" xml:space="preserve">
     <value>Unable to execute a 'ReadItem' query since the partition key value is missing. Consider using the 'WithPartitionKey' method on the query to specify partition key to use.</value>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
@@ -375,8 +375,7 @@ WHERE (c["Discriminator"] IN ("SharedContainerEntity2", "SharedContainerEntity2C
             modelBuilder.Entity<SharedContainerEntity2>()
                 .ToContainer("SharedContainer")
                 .HasPartitionKey(e => e.PartitionKey);
-            modelBuilder.Entity<SharedContainerEntity2Child>()
-                .HasPartitionKey(e => e.PartitionKey);
+            modelBuilder.Entity<SharedContainerEntity2Child>();
         }
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -616,7 +616,7 @@ public class CosmosTestStore : TestStore
             => throw new NotImplementedException();
 
         IReadOnlyEntityType IReadOnlyEntityType.BaseType
-            => throw new NotImplementedException();
+            => null!;
 
         IReadOnlyModel IReadOnlyTypeBase.Model
             => throw new NotImplementedException();


### PR DESCRIPTION
Fixes #34176

Also, model validation.
