### PR TITLE
Implement nullability simplification for `COLLATE` and `AT TIME ZONE`

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsProceduralQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsProceduralQueryTestBase.cs
@@ -118,6 +118,7 @@ public abstract class OperatorsProceduralQueryTestBase : NonSharedModelTestBase
             { typeof(bool), typeof(OperatorEntityBool) },
             { typeof(bool?), typeof(OperatorEntityNullableBool) },
             { typeof(DateTimeOffset), typeof(OperatorEntityDateTimeOffset) },
+            { typeof(DateTimeOffset?), typeof(OperatorEntityNullableDateTimeOffset) },
         };
 
         ExpectedData = OperatorsData.Instance;
@@ -136,6 +137,7 @@ public abstract class OperatorsProceduralQueryTestBase : NonSharedModelTestBase
         ctx.Set<OperatorEntityBool>().AddRange(ExpectedData.OperatorEntitiesBool);
         ctx.Set<OperatorEntityNullableBool>().AddRange(ExpectedData.OperatorEntitiesNullableBool);
         ctx.Set<OperatorEntityDateTimeOffset>().AddRange(ExpectedData.OperatorEntitiesDateTimeOffset);
+        ctx.Set<OperatorEntityNullableDateTimeOffset>().AddRange(ExpectedData.OperatorEntitiesNullableDateTimeOffset);
 
         await ctx.SaveChangesAsync();
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
@@ -26,6 +26,7 @@ public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
         ctx.Set<OperatorEntityBool>().AddRange(ExpectedData.OperatorEntitiesBool);
         ctx.Set<OperatorEntityNullableBool>().AddRange(ExpectedData.OperatorEntitiesNullableBool);
         ctx.Set<OperatorEntityDateTimeOffset>().AddRange(ExpectedData.OperatorEntitiesDateTimeOffset);
+        ctx.Set<OperatorEntityNullableDateTimeOffset>().AddRange(ExpectedData.OperatorEntitiesNullableDateTimeOffset);
 
         return ctx.SaveChangesAsync();
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -51,6 +51,16 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Collate_is_null(bool async)
+        => AssertCount(
+            async,
+            ss => ss.Set<Customer>(),
+            ss => ss.Set<Customer>(),
+            c => EF.Functions.Collate(c.Region, CaseSensitiveCollation) == null,
+            c => c.Region == null);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Least(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorEntityNullableDateTimeOffset.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorEntityNullableDateTimeOffset.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.Operators;
+
+#nullable disable
+
+public class OperatorEntityNullableDateTimeOffset : OperatorEntityBase
+{
+    public DateTimeOffset? Value { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorsContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorsContext.cs
@@ -16,5 +16,6 @@ public class OperatorsContext(DbContextOptions options) : DbContext(options)
         modelBuilder.Entity<OperatorEntityBool>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<OperatorEntityNullableBool>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<OperatorEntityDateTimeOffset>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<OperatorEntityNullableDateTimeOffset>().Property(x => x.Id).ValueGeneratedNever();
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorsData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Operators/OperatorsData.cs
@@ -56,6 +56,13 @@ public class OperatorsData : ISetSource
         () => new DateTimeOffset(new DateTime(2000, 1, 1, 9, 0, 0), new TimeSpan(13, 0, 0))
     ];
 
+   private readonly List<Expression<Func<DateTimeOffset?>>> _nullableDateTimeOffsetValues =
+    [
+        () => null,
+        () => new DateTimeOffset(new DateTime(2000, 1, 1, 10, 0, 0), new TimeSpan(-8, 0, 0)),
+        () => new DateTimeOffset(new DateTime(2000, 1, 1, 9, 0, 0), new TimeSpan(13, 0, 0))
+    ];
+
     public IReadOnlyList<OperatorEntityString> OperatorEntitiesString { get; }
     public IReadOnlyList<OperatorEntityInt> OperatorEntitiesInt { get; }
     public IReadOnlyList<OperatorEntityNullableInt> OperatorEntitiesNullableInt { get; }
@@ -63,6 +70,7 @@ public class OperatorsData : ISetSource
     public IReadOnlyList<OperatorEntityBool> OperatorEntitiesBool { get; }
     public IReadOnlyList<OperatorEntityNullableBool> OperatorEntitiesNullableBool { get; }
     public IReadOnlyList<OperatorEntityDateTimeOffset> OperatorEntitiesDateTimeOffset { get; }
+    public IReadOnlyList<OperatorEntityNullableDateTimeOffset> OperatorEntitiesNullableDateTimeOffset { get; }
     public IDictionary<Type, List<Expression>> ConstantExpressionsPerType { get; }
 
     private OperatorsData()
@@ -74,6 +82,7 @@ public class OperatorsData : ISetSource
         OperatorEntitiesBool = CreateBools();
         OperatorEntitiesNullableBool = CreateNullableBools();
         OperatorEntitiesDateTimeOffset = CreateDateTimeOffsets();
+        OperatorEntitiesNullableDateTimeOffset = CreateNullableDateTimeOffsets();
 
         ConstantExpressionsPerType = new Dictionary<Type, List<Expression>>
         {
@@ -84,6 +93,7 @@ public class OperatorsData : ISetSource
             { typeof(bool), _boolValues.Select(x => x.Body).ToList() },
             { typeof(bool?), _nullableBoolValues.Select(x => x.Body).ToList() },
             { typeof(DateTimeOffset), _dateTimeOffsetValues.Select(x => x.Body).ToList() },
+            { typeof(DateTimeOffset?), _nullableDateTimeOffsetValues.Select(x => x.Body).ToList() },
         };
     }
 
@@ -125,6 +135,11 @@ public class OperatorsData : ISetSource
             return (IQueryable<TEntity>)OperatorEntitiesDateTimeOffset.AsQueryable();
         }
 
+        if (typeof(TEntity) == typeof(OperatorEntityNullableDateTimeOffset))
+        {
+            return (IQueryable<TEntity>)OperatorEntitiesNullableDateTimeOffset.AsQueryable();
+        }
+
         throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
     }
 
@@ -151,4 +166,8 @@ public class OperatorsData : ISetSource
     public IReadOnlyList<OperatorEntityDateTimeOffset> CreateDateTimeOffsets()
         => _dateTimeOffsetValues
             .Select((x, i) => new OperatorEntityDateTimeOffset { Id = i + 1, Value = _dateTimeOffsetValues[i].Compile()() }).ToList();
+
+    public IReadOnlyList<OperatorEntityNullableDateTimeOffset> CreateNullableDateTimeOffsets()
+        => _nullableDateTimeOffsetValues.Select((x, i) => new OperatorEntityNullableDateTimeOffset { Id = i + 1, Value = _nullableDateTimeOffsetValues[i].Compile()() })
+            .ToList();
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -121,6 +121,18 @@ WHERE [c].[ContactName] = N'maria anders' COLLATE Latin1_General_CS_AS
 """);
     }
 
+    public override async Task Collate_is_null(bool async)
+    {
+        await base.Collate_is_null(async);
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[Region] COLLATE Latin1_General_CS_AS IS NULL
+""");
+    }
+
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Least(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -129,7 +129,7 @@ WHERE [c].[ContactName] = N'maria anders' COLLATE Latin1_General_CS_AS
             """
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[Region] COLLATE Latin1_General_CS_AS IS NULL
+WHERE [c].[Region] IS NULL
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -266,7 +266,9 @@ WHERE [o].[Value] AT TIME ZONE 'UTC' = [o0].[Value]
                         select e.Id).ToList();
 
         var actual = (from e in context.Set<OperatorEntityNullableDateTimeOffset>()
-                      where !((DateTimeOffset?)EF.Functions.AtTimeZone(e.Value.Value, "UTC")).HasValue
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                      where EF.Functions.AtTimeZone(e.Value.Value, "UTC") == null
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
                       select e.Id).ToList();
 
         Assert.Equal(expected.Count, actual.Count);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -279,7 +279,7 @@ WHERE [o].[Value] AT TIME ZONE 'UTC' = [o0].[Value]
             """
 SELECT [o].[Id]
 FROM [OperatorEntityNullableDateTimeOffset] AS [o]
-WHERE [o].[Value] AT TIME ZONE 'UTC' IS NULL
+WHERE [o].[Value] IS NULL
 """);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -252,4 +252,34 @@ CROSS JOIN [OperatorEntityDateTimeOffset] AS [o0]
 WHERE [o].[Value] AT TIME ZONE 'UTC' = [o0].[Value]
 """);
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
+    public virtual async Task Where_AtTimeZone_is_null(bool async)
+    {
+        var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);
+        using var context = contextFactory.CreateContext();
+
+        var expected = (from e in ExpectedData.OperatorEntitiesNullableDateTimeOffset
+                        where e.Value == null
+                        select e.Id).ToList();
+
+        var actual = (from e in context.Set<OperatorEntityNullableDateTimeOffset>()
+                      where !((DateTimeOffset?)EF.Functions.AtTimeZone(e.Value.Value, "UTC")).HasValue
+                      select e.Id).ToList();
+
+        Assert.Equal(expected.Count, actual.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i], actual[i]);
+        }
+
+        AssertSql(
+            """
+SELECT [o].[Id]
+FROM [OperatorEntityNullableDateTimeOffset] AS [o]
+WHERE [o].[Value] AT TIME ZONE 'UTC' IS NULL
+""");
+    }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindDbFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindDbFunctionsQuerySqliteTest.cs
@@ -56,6 +56,18 @@ WHERE "c"."CustomerID" NOT GLOB 'T*'
 """);
     }
 
+    public override async Task Collate_is_null(bool async)
+    {
+        await base.Collate_is_null(async);
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM "Customers" AS "c"
+WHERE "c"."Region" COLLATE BINARY IS NULL
+""");
+    }
+
     protected override string CaseInsensitiveCollation
         => "NOCASE";
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindDbFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindDbFunctionsQuerySqliteTest.cs
@@ -64,7 +64,7 @@ WHERE "c"."CustomerID" NOT GLOB 'T*'
             """
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE "c"."Region" COLLATE BINARY IS NULL
+WHERE "c"."Region" IS NULL
 """);
     }
 


### PR DESCRIPTION
This changeset extends the simplification for `IS [NOT] NULL` to handle `COLLATE` and `AT TIME ZONE`.

Closes #34295