### PR TITLE
Fix to #34056 - AOT/Query: for queries with JSON, interceptors generate code with labels that are not uniquified

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
@@ -4,6 +4,9 @@
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using static Microsoft.EntityFrameworkCore.TestUtilities.PrecompiledQueryTestHelpers;
 using Blog = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.Blog;
+using Post = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.Post;
+using JsonRoot = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.JsonRoot;
+using JsonBranch = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.JsonBranch;
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class PrecompiledQueryRelationalFixture
@@ -27,9 +30,26 @@ public abstract class PrecompiledQueryRelationalFixture
 
     protected override async Task SeedAsync(PrecompiledQueryRelationalTestBase.PrecompiledQueryContext context)
     {
-        context.Blogs.AddRange(
-            new Blog { Id = 8, Name = "Blog1" },
-            new Blog { Id = 9, Name = "Blog2" });
+        var blog1 = new Blog { Id = 8, Name = "Blog1", Json = [] };
+        var blog2 = new Blog
+        {
+            Id = 9,
+            Name = "Blog2",
+            Json =
+            [
+            new JsonRoot { Number = 1, Text = "One", Inner = new JsonBranch { Date = new DateTime(2001, 1, 1) } },
+            new JsonRoot { Number = 2, Text = "Two", Inner = new JsonBranch { Date = new DateTime(2002, 2, 2) } },
+            ]};
+
+        context.Blogs.AddRange(blog1, blog2);
+
+        var post11 = new Post { Id = 11, Title = "Post11", Blog = blog1 };
+        var post12 = new Post { Id = 12, Title = "Post12", Blog = blog1 };
+        var post21 = new Post { Id = 21, Title = "Post21", Blog = blog2 };
+        var post22 = new Post { Id = 22, Title = "Post22", Blog = blog2 };
+        var post23 = new Post { Id = 23, Title = "Post23", Blog = blog2 };
+
+        context.Posts.AddRange(post11, post12, post21, post22, post23);
         await context.SaveChangesAsync();
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -24,7 +24,7 @@ public class PrecompiledQuerySqlServerTest(
             """
 @__id_0='3'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > @__id_0
 """);
@@ -106,7 +106,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] IN (7, 8)
 """);
@@ -118,7 +118,7 @@ WHERE [b].[Id] IN (7, 8)
 
          AssertSql(
              """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] IS NOT NULL AND LEFT([b].[Name], LEN([b].[Name])) = [b].[Name]
 """);
@@ -132,7 +132,7 @@ WHERE [b].[Name] IS NOT NULL AND LEFT([b].[Name], LEN([b].[Name])) = [b].[Name]
             """
 @__pattern_0_startswith='foo%' (Size = 4000)
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] LIKE @__pattern_0_startswith ESCAPE N'\'
 """);
@@ -144,7 +144,7 @@ WHERE [b].[Name] LIKE @__pattern_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] LIKE N'foo%'
 """);
@@ -156,7 +156,7 @@ WHERE [b].[Name] LIKE N'foo%'
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -167,7 +167,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 0
 """);
@@ -256,7 +256,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE CAST([b].[Id] AS smallint) = CAST(8 AS smallint)
 """);
@@ -279,7 +279,7 @@ WHERE CAST([b].[Id] AS smallint) = CAST(8 AS smallint)
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -290,7 +290,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -301,7 +301,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > 8
 """);
@@ -313,7 +313,7 @@ WHERE [b].[Id] > 8
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > 8
 """);
@@ -325,7 +325,7 @@ WHERE [b].[Id] > 8
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -336,7 +336,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -347,7 +347,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -358,7 +358,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -391,7 +391,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -402,7 +402,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -413,7 +413,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -424,7 +424,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -435,7 +435,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -736,7 +736,7 @@ WHERE [b].[Id] > 8
             """
 @__p_0='1'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -745,7 +745,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='3'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -760,7 +760,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='1'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -769,7 +769,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='3'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -784,7 +784,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='1'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -793,7 +793,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='3'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -808,7 +808,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='1'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -817,7 +817,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
             """
 @__p_0='3'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
@@ -830,25 +830,25 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -860,25 +860,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -890,25 +890,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -920,25 +920,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -950,7 +950,7 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """);
@@ -962,27 +962,27 @@ WHERE [b].[Id] = 8
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
@@ -995,27 +995,27 @@ ORDER BY [b].[Id] DESC
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
@@ -1028,27 +1028,27 @@ ORDER BY [b].[Id] DESC
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
@@ -1061,27 +1061,27 @@ ORDER BY [b].[Id] DESC
 
         AssertSql(
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 ORDER BY [b].[Id] DESC
 """,
             //
             """
-SELECT TOP(1) [b].[Id], [b].[Name]
+SELECT TOP(1) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 ORDER BY [b].[Id] DESC
@@ -1192,25 +1192,25 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -1222,25 +1222,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -1252,25 +1252,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -1282,25 +1282,25 @@ WHERE [b].[Id] = 7
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 8
 """,
             //
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 7
 """);
@@ -1424,13 +1424,33 @@ WHERE [b].[Id] = 9 AND [b].[Name] = N'Blog2Suffix'
 
         AssertSql(
             """
-SELECT [u].[Id], [u].[Name]
+SELECT [u].[Id], [u].[BlogId], [u].[Title]
 FROM (
-    SELECT [b].[Id], [b].[Name]
+    SELECT [p].[Id], [p].[BlogId], [p].[Title]
+    FROM [Posts] AS [p]
+    WHERE [p].[Id] > 11
+    UNION
+    SELECT [p0].[Id], [p0].[BlogId], [p0].[Title]
+    FROM [Posts] AS [p0]
+    WHERE [p0].[Id] < 21
+) AS [u]
+ORDER BY [u].[Id]
+""");
+    }
+
+    public override async Task UnionOnEntitiesWithJson()
+    {
+        await base.UnionOnEntitiesWithJson();
+
+        AssertSql(
+            """
+SELECT [u].[Id], [u].[Name], [u].[Json]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[Json]
     FROM [Blogs] AS [b]
     WHERE [b].[Id] > 7
     UNION
-    SELECT [b0].[Id], [b0].[Name]
+    SELECT [b0].[Id], [b0].[Name], [b0].[Json]
     FROM [Blogs] AS [b0]
     WHERE [b0].[Id] < 10
 ) AS [u]
@@ -1444,13 +1464,33 @@ ORDER BY [u].[Id]
 
         AssertSql(
             """
-SELECT [u].[Id], [u].[Name]
+SELECT [u].[Id], [u].[BlogId], [u].[Title]
 FROM (
-    SELECT [b].[Id], [b].[Name]
+    SELECT [p].[Id], [p].[BlogId], [p].[Title]
+    FROM [Posts] AS [p]
+    WHERE [p].[Id] > 11
+    UNION ALL
+    SELECT [p0].[Id], [p0].[BlogId], [p0].[Title]
+    FROM [Posts] AS [p0]
+    WHERE [p0].[Id] < 21
+) AS [u]
+ORDER BY [u].[Id]
+""");
+    }
+
+    public override async Task ConcatOnEntitiesWithJson()
+    {
+        await base.ConcatOnEntitiesWithJson();
+
+        AssertSql(
+            """
+SELECT [u].[Id], [u].[Name], [u].[Json]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[Json]
     FROM [Blogs] AS [b]
     WHERE [b].[Id] > 7
     UNION ALL
-    SELECT [b0].[Id], [b0].[Name]
+    SELECT [b0].[Id], [b0].[Name], [b0].[Json]
     FROM [Blogs] AS [b0]
     WHERE [b0].[Id] < 10
 ) AS [u]
@@ -1464,13 +1504,33 @@ ORDER BY [u].[Id]
 
         AssertSql(
             """
-SELECT [i].[Id], [i].[Name]
+SELECT [i].[Id], [i].[BlogId], [i].[Title]
 FROM (
-    SELECT [b].[Id], [b].[Name]
+    SELECT [p].[Id], [p].[BlogId], [p].[Title]
+    FROM [Posts] AS [p]
+    WHERE [p].[Id] > 11
+    INTERSECT
+    SELECT [p0].[Id], [p0].[BlogId], [p0].[Title]
+    FROM [Posts] AS [p0]
+    WHERE [p0].[Id] < 22
+) AS [i]
+ORDER BY [i].[Id]
+""");
+    }
+
+    public override async Task IntersectOnEntitiesWithJson()
+    {
+        await base.IntersectOnEntitiesWithJson();
+
+        AssertSql(
+            """
+SELECT [i].[Id], [i].[Name], [i].[Json]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[Json]
     FROM [Blogs] AS [b]
     WHERE [b].[Id] > 7
     INTERSECT
-    SELECT [b0].[Id], [b0].[Name]
+    SELECT [b0].[Id], [b0].[Name], [b0].[Json]
     FROM [Blogs] AS [b0]
     WHERE [b0].[Id] > 8
 ) AS [i]
@@ -1484,13 +1544,33 @@ ORDER BY [i].[Id]
 
         AssertSql(
             """
-SELECT [e].[Id], [e].[Name]
+SELECT [e].[Id], [e].[BlogId], [e].[Title]
 FROM (
-    SELECT [b].[Id], [b].[Name]
+    SELECT [p].[Id], [p].[BlogId], [p].[Title]
+    FROM [Posts] AS [p]
+    WHERE [p].[Id] > 11
+    EXCEPT
+    SELECT [p0].[Id], [p0].[BlogId], [p0].[Title]
+    FROM [Posts] AS [p0]
+    WHERE [p0].[Id] > 21
+) AS [e]
+ORDER BY [e].[Id]
+""");
+    }
+
+    public override async Task ExceptOnEntitiesWithJson()
+    {
+        await base.ExceptOnEntitiesWithJson();
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[Name], [e].[Json]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[Json]
     FROM [Blogs] AS [b]
     WHERE [b].[Id] > 7
     EXCEPT
-    SELECT [b0].[Id], [b0].[Name]
+    SELECT [b0].[Id], [b0].[Name], [b0].[Json]
     FROM [Blogs] AS [b0]
     WHERE [b0].[Id] > 8
 ) AS [e]
@@ -1504,7 +1584,7 @@ ORDER BY [e].[Id]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE (
     SELECT COUNT(*)
@@ -1521,7 +1601,7 @@ WHERE (
             """
 @__ids_0='[1,2,3]' (Size = 4000)
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] IN (
     SELECT [i].[value]
@@ -1536,7 +1616,7 @@ WHERE [b].[Id] IN (
 
         AssertSql(
             """
-SELECT [m].[Id], [m].[Name]
+SELECT [m].[Id], [m].[Name], [m].[Json]
 FROM (
     SELECT * FROM "Blogs" WHERE "Id" > 8
 ) AS [m]
@@ -1553,7 +1633,7 @@ ORDER BY [m].[Id]
 p0='8'
 p1='9'
 
-SELECT [m].[Id], [m].[Name]
+SELECT [m].[Id], [m].[Name], [m].[Json]
 FROM (
     SELECT * FROM "Blogs" WHERE "Id" > @p0 AND "Id" < @p1
 ) AS [m]
@@ -1677,7 +1757,7 @@ GROUP BY [b].[Id]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -1688,7 +1768,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -1699,7 +1779,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -1710,7 +1790,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -1721,7 +1801,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }
@@ -1764,7 +1844,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] = N'Blog2'
 """);
@@ -1803,7 +1883,7 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
 """);
@@ -1817,7 +1897,7 @@ ORDER BY [b].[Name]
             """
 @__p_0='1'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
 OFFSET @__p_0 ROWS
@@ -1832,7 +1912,7 @@ OFFSET @__p_0 ROWS
             """
 @__p_0='1'
 
-SELECT TOP(@__p_0) [b].[Id], [b].[Name]
+SELECT TOP(@__p_0) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
 """);
@@ -1875,7 +1955,7 @@ FROM [Blogs] AS [b]
 @__starts_0_startswith='blog%' (Size = 4000)
 @__ends_1_endswith='%2' (Size = 4000)
 
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] LIKE @__starts_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__ends_1_endswith ESCAPE N'\'
 """);
@@ -1890,7 +1970,7 @@ WHERE [b].[Name] LIKE @__starts_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__
 @__foo_0_startswith='X%' (Size = 4000)
 @__foo_0_endswith='%X' (Size = 4000)
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo_0_endswith ESCAPE N'\'
 """);
@@ -1905,7 +1985,7 @@ WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo
 @__foo_0_startswith='X%' (Size = 4000)
 @__foo_0_endswith='%X' (Size = 4000)
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo_0_endswith ESCAPE N'\'
 """);
@@ -1917,7 +1997,7 @@ WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name], [p].[Id], [p].[BlogId], [p].[Title]
+SELECT [b].[Id], [b].[Name], [b].[Json], [p].[Id], [p].[BlogId], [p].[Title]
 FROM [Blogs] AS [b]
 LEFT JOIN [Posts] AS [p] ON [b].[Id] = [p].[BlogId]
 WHERE [b].[Id] > 8
@@ -1931,7 +2011,7 @@ ORDER BY [b].[Id]
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
 """,
@@ -1950,7 +2030,7 @@ ORDER BY [b].[Id]
 
         AssertSql(
             """
-SELECT [b].[Name], [b].[Id]
+SELECT [b].[Name], [b].[Id], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
 """);
@@ -1965,7 +2045,7 @@ ORDER BY [b].[Name]
 @__id1_0='8'
 @__id2_1='9'
 
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
 """,
@@ -1973,7 +2053,7 @@ WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
             """
 @__id1_0='8'
 
-SELECT TOP(2) [b].[Id], [b].[Name]
+SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = @__id1_0
 """);
@@ -1985,12 +2065,12 @@ WHERE [b].[Id] = @__id1_0
 
         AssertSql(
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """,
             //
             """
-SELECT [b].[Id], [b].[Name]
+SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 """);
     }


### PR DESCRIPTION
Problem was that when we generate shaper for extracting json values from the reader (streaming) we use hard-coded name for a label that's used in the loop going through json properties. This is fine for normal scenarios, since compiler can figure out the right label to jump to based on scope/reference, but when we generate c# code from that expression, we run into issues for case of nested JSON. Existing code already works if the label is not named explicitly - LinqToCSharpSyntaxTranslator generates names for unnamed labels and uniquifies the names when needed. Fix is to add the uniquification to all labels, not only the unnamed one.

Also fixed another small bug in LinqToCSharpSyntaxTranslator encountered in the testing - when we process LambdaExpression and are dealing with lifted statements (that need to be incorporated into the lambda body), we assumed it would always be a single expression, but it could also be a block. Fix is to add handling for the block case, which is simply pre-pending lifted statements to the ones already in the block.

Added JSON entities to Blog so that we can test the scenario, also added some posts (there were none) for cases which don't work with JSON entities, e.g. set ops.

Fixes #34056
