### PR TITLE
Add missing ConditionalTheory Attribute to Delete_FromSql_converted_to_subquery

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
@@ -32,6 +32,8 @@ public abstract class NorthwindBulkUpdatesRelationalTestBase<TFixture> : Northwi
             RelationalStrings.ExecuteDeleteOnNonEntityType,
             () => base.Delete_non_entity_projection_3(async));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_FromSql_converted_to_subquery(bool async)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             () => Fixture.CreateContext(),


### PR DESCRIPTION
Fixes #34301 

As part of #34257 the `Delete_FromSql_converted_to_subquery` got copied to a new file without the test attributes
