### PR TITLE
[release/8.0] Use placeholder value to fix CredScan

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -299,7 +299,7 @@ stages:
                   env:
                     HelixAccessToken: $(_HelixAccessToken)
                     SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-                    MSSQL_SA_PASSWORD: "Password12!"
+                    MSSQL_SA_PASSWORD: "PLACEHOLDER"
                     COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
                     DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,7 +244,7 @@ extends:
                   HelixAccessToken: $(_HelixAccessToken)
                   # We need to set this env var to publish helix results to Azure Dev Ops
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-                  MSSQL_SA_PASSWORD: "Password12!"
+                  MSSQL_SA_PASSWORD: "PLACEHOLDER"
                   # Work-around for https://github.com/dotnet/runtime/issues/70758
                   COMPlus_EnableWriteXorExecute: 0
                   DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -21,7 +21,7 @@
     <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <HelixSource>efcore/localbuild/</HelixSource>
     <HelixBuild>t001</HelixBuild>
-    <MSSQL_SA_PASSWORD>Password12!</MSSQL_SA_PASSWORD>
+    <MSSQL_SA_PASSWORD>PLACEHOLDER</MSSQL_SA_PASSWORD>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We can use the special value `PLACEHOLDER` to tell CredScan these credentials are fake ones.