### PR TITLE
Apply primary constructor cleanup everywhere

### DIFF
--- a/benchmark/EFCore.Benchmarks/Models/Orders/OrdersContextBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/OrdersContextBase.cs
@@ -5,22 +5,15 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
-public abstract class OrdersContextBase : DbContext
+public abstract class OrdersContextBase(IServiceProvider serviceProvider) : DbContext
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    protected OrdersContextBase(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
     public DbSet<Customer> Customers { get; set; }
     public DbSet<Order> Orders { get; set; }
     public DbSet<OrderLine> OrderLines { get; set; }
     public DbSet<Product> Products { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        => ConfigureProvider(optionsBuilder.UseInternalServiceProvider(_serviceProvider));
+        => ConfigureProvider(optionsBuilder.UseInternalServiceProvider(serviceProvider));
 
     protected abstract void ConfigureProvider(DbContextOptionsBuilder optionsBuilder);
 }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -593,15 +593,10 @@ public class CosmosOptionsExtension : IDbContextOptionsExtension
     {
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
         private string? _logFragment;
         private int? _serviceProviderHash;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new CosmosOptionsExtension Extension
             => (CosmosOptionsExtension)base.Extension;

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -150,14 +150,9 @@ public class InMemoryOptionsExtension : IDbContextOptionsExtension
     {
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
         private string? _logFragment;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new InMemoryOptionsExtension Extension
             => (InMemoryOptionsExtension)base.Extension;

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.Helper.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.Helper.cs
@@ -8,17 +8,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
 
 public partial class InMemoryQueryExpression
 {
-    private sealed class ResultEnumerable : IEnumerable<ValueBuffer>
+    private sealed class ResultEnumerable(Func<ValueBuffer> getElement) : IEnumerable<ValueBuffer>
     {
-        private readonly Func<ValueBuffer> _getElement;
-
-        public ResultEnumerable(Func<ValueBuffer> getElement)
-        {
-            _getElement = getElement;
-        }
-
         public IEnumerator<ValueBuffer> GetEnumerator()
-            => new ResultEnumerator(_getElement());
+            => new ResultEnumerator(getElement());
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
@@ -84,19 +77,11 @@ public partial class InMemoryQueryExpression
         }
     }
 
-    private sealed class ProjectionMemberToIndexConvertingExpressionVisitor : ExpressionVisitor
+    private sealed class ProjectionMemberToIndexConvertingExpressionVisitor(
+        Expression queryExpression,
+        Dictionary<ProjectionMember, int> projectionMemberMappings)
+        : ExpressionVisitor
     {
-        private readonly Expression _queryExpression;
-        private readonly Dictionary<ProjectionMember, int> _projectionMemberMappings;
-
-        public ProjectionMemberToIndexConvertingExpressionVisitor(
-            Expression queryExpression,
-            Dictionary<ProjectionMember, int> projectionMemberMappings)
-        {
-            _queryExpression = queryExpression;
-            _projectionMemberMappings = projectionMemberMappings;
-        }
-
         [return: NotNullIfNotNull(nameof(expression))]
         public override Expression? Visit(Expression? expression)
         {
@@ -107,8 +92,8 @@ public partial class InMemoryQueryExpression
                     "ProjectionBindingExpression must have projection member.");
 
                 return new ProjectionBindingExpression(
-                    _queryExpression,
-                    _projectionMemberMappings[projectionBindingExpression.ProjectionMember],
+                    queryExpression,
+                    projectionMemberMappings[projectionBindingExpression.ProjectionMember],
                     projectionBindingExpression.Type);
             }
 
@@ -116,35 +101,25 @@ public partial class InMemoryQueryExpression
         }
     }
 
-    private sealed class ProjectionIndexRemappingExpressionVisitor : ExpressionVisitor
+    private sealed class ProjectionIndexRemappingExpressionVisitor(
+        Expression oldExpression,
+        Expression newExpression,
+        int[] indexMap)
+        : ExpressionVisitor
     {
-        private readonly Expression _oldExpression;
-        private readonly Expression _newExpression;
-        private readonly int[] _indexMap;
-
-        public ProjectionIndexRemappingExpressionVisitor(
-            Expression oldExpression,
-            Expression newExpression,
-            int[] indexMap)
-        {
-            _oldExpression = oldExpression;
-            _newExpression = newExpression;
-            _indexMap = indexMap;
-        }
-
         [return: NotNullIfNotNull(nameof(expression))]
         public override Expression? Visit(Expression? expression)
         {
             if (expression is ProjectionBindingExpression projectionBindingExpression
-                && ReferenceEquals(projectionBindingExpression.QueryExpression, _oldExpression))
+                && ReferenceEquals(projectionBindingExpression.QueryExpression, oldExpression))
             {
                 Check.DebugAssert(
                     projectionBindingExpression.Index != null,
                     "ProjectionBindingExpression must have index.");
 
                 return new ProjectionBindingExpression(
-                    _newExpression,
-                    _indexMap[projectionBindingExpression.Index.Value],
+                    newExpression,
+                    indexMap[projectionBindingExpression.Index.Value],
                     projectionBindingExpression.Type);
             }
 
@@ -160,26 +135,17 @@ public partial class InMemoryQueryExpression
                 : base.VisitExtension(extensionExpression);
     }
 
-    private sealed class QueryExpressionReplacingExpressionVisitor : ExpressionVisitor
+    private sealed class QueryExpressionReplacingExpressionVisitor(Expression oldQuery, Expression newQuery) : ExpressionVisitor
     {
-        private readonly Expression _oldQuery;
-        private readonly Expression _newQuery;
-
-        public QueryExpressionReplacingExpressionVisitor(Expression oldQuery, Expression newQuery)
-        {
-            _oldQuery = oldQuery;
-            _newQuery = newQuery;
-        }
-
         [return: NotNullIfNotNull(nameof(expression))]
         public override Expression? Visit(Expression? expression)
             => expression is ProjectionBindingExpression projectionBindingExpression
-                && ReferenceEquals(projectionBindingExpression.QueryExpression, _oldQuery)
+                && ReferenceEquals(projectionBindingExpression.QueryExpression, oldQuery)
                     ? projectionBindingExpression.ProjectionMember != null
                         ? new ProjectionBindingExpression(
-                            _newQuery, projectionBindingExpression.ProjectionMember!, projectionBindingExpression.Type)
+                            newQuery, projectionBindingExpression.ProjectionMember!, projectionBindingExpression.Type)
                         : new ProjectionBindingExpression(
-                            _newQuery, projectionBindingExpression.Index!.Value, projectionBindingExpression.Type)
+                            newQuery, projectionBindingExpression.Index!.Value, projectionBindingExpression.Type)
                     : base.Visit(expression);
     }
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -14,32 +14,22 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
 /// </summary>
 public partial class InMemoryShapedQueryCompilingExpressionVisitor
 {
-    private sealed class QueryingEnumerable<T> : IAsyncEnumerable<T>, IEnumerable<T>, IQueryingEnumerable
+    private sealed class QueryingEnumerable<T>(
+        QueryContext queryContext,
+        IEnumerable<ValueBuffer> innerEnumerable,
+        Func<QueryContext, ValueBuffer, T> shaper,
+        Type contextType,
+        bool standAloneStateManager,
+        bool threadSafetyChecksEnabled)
+        : IAsyncEnumerable<T>, IEnumerable<T>, IQueryingEnumerable
     {
-        private readonly QueryContext _queryContext;
-        private readonly IEnumerable<ValueBuffer> _innerEnumerable;
-        private readonly Func<QueryContext, ValueBuffer, T> _shaper;
-        private readonly Type _contextType;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
-        private readonly bool _standAloneStateManager;
-        private readonly bool _threadSafetyChecksEnabled;
-
-        public QueryingEnumerable(
-            QueryContext queryContext,
-            IEnumerable<ValueBuffer> innerEnumerable,
-            Func<QueryContext, ValueBuffer, T> shaper,
-            Type contextType,
-            bool standAloneStateManager,
-            bool threadSafetyChecksEnabled)
-        {
-            _queryContext = queryContext;
-            _innerEnumerable = innerEnumerable;
-            _shaper = shaper;
-            _contextType = contextType;
-            _queryLogger = queryContext.QueryLogger;
-            _standAloneStateManager = standAloneStateManager;
-            _threadSafetyChecksEnabled = threadSafetyChecksEnabled;
-        }
+        private readonly QueryContext _queryContext = queryContext;
+        private readonly IEnumerable<ValueBuffer> _innerEnumerable = innerEnumerable;
+        private readonly Func<QueryContext, ValueBuffer, T> _shaper = shaper;
+        private readonly Type _contextType = contextType;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger = queryContext.QueryLogger;
+        private readonly bool _standAloneStateManager = standAloneStateManager;
+        private readonly bool _threadSafetyChecksEnabled = threadSafetyChecksEnabled;
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             => new Enumerator(this, cancellationToken);

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
@@ -185,14 +185,9 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     public virtual void ApplyServices(IServiceCollection services)
         => services.AddEntityFrameworkProxies();
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
         private string? _logFragment;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new ProxiesOptionsExtension Extension
             => (ProxiesOptionsExtension)base.Extension;

--- a/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
@@ -20,14 +20,9 @@ public class DbCommandInterceptorAggregator : InterceptorAggregator<IDbCommandIn
     protected override IDbCommandInterceptor CreateChain(IEnumerable<IDbCommandInterceptor> interceptors)
         => new CompositeDbCommandInterceptor(interceptors);
 
-    private sealed class CompositeDbCommandInterceptor : IDbCommandInterceptor
+    private sealed class CompositeDbCommandInterceptor(IEnumerable<IDbCommandInterceptor> interceptors) : IDbCommandInterceptor
     {
-        private readonly IDbCommandInterceptor[] _interceptors;
-
-        public CompositeDbCommandInterceptor(IEnumerable<IDbCommandInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IDbCommandInterceptor[] _interceptors = interceptors.ToArray();
 
         public InterceptionResult<DbCommand> CommandCreating(
             CommandCorrelatedEventData eventData,

--- a/src/EFCore.Relational/Diagnostics/Internal/DbConnectionInterceptorAggregator.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/DbConnectionInterceptorAggregator.cs
@@ -20,14 +20,9 @@ public class DbConnectionInterceptorAggregator : InterceptorAggregator<IDbConnec
     protected override IDbConnectionInterceptor CreateChain(IEnumerable<IDbConnectionInterceptor> interceptors)
         => new CompositeDbConnectionInterceptor(interceptors);
 
-    private sealed class CompositeDbConnectionInterceptor : IDbConnectionInterceptor
+    private sealed class CompositeDbConnectionInterceptor(IEnumerable<IDbConnectionInterceptor> interceptors) : IDbConnectionInterceptor
     {
-        private readonly IDbConnectionInterceptor[] _interceptors;
-
-        public CompositeDbConnectionInterceptor(IEnumerable<IDbConnectionInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IDbConnectionInterceptor[] _interceptors = interceptors.ToArray();
 
         public InterceptionResult<DbConnection> ConnectionCreating(
             ConnectionCreatingEventData eventData,

--- a/src/EFCore.Relational/Diagnostics/Internal/DbTransactionInterceptorAggregator.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/DbTransactionInterceptorAggregator.cs
@@ -20,14 +20,9 @@ public class DbTransactionInterceptorAggregator : InterceptorAggregator<IDbTrans
     protected override IDbTransactionInterceptor CreateChain(IEnumerable<IDbTransactionInterceptor> interceptors)
         => new CompositeDbTransactionInterceptor(interceptors);
 
-    private sealed class CompositeDbTransactionInterceptor : IDbTransactionInterceptor
+    private sealed class CompositeDbTransactionInterceptor(IEnumerable<IDbTransactionInterceptor> interceptors) : IDbTransactionInterceptor
     {
-        private readonly IDbTransactionInterceptor[] _interceptors;
-
-        public CompositeDbTransactionInterceptor(IEnumerable<IDbTransactionInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IDbTransactionInterceptor[] _interceptors = interceptors.ToArray();
 
         public InterceptionResult<DbTransaction> TransactionStarting(
             DbConnection connection,

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -104,16 +104,11 @@ public class RelationalCommandCache : IPrintableExpression
         }
     }
 
-    private readonly struct CommandCacheKey : IEquatable<CommandCacheKey>
+    private readonly struct CommandCacheKey(Expression queryExpression, IReadOnlyDictionary<string, object?> parameterValues)
+        : IEquatable<CommandCacheKey>
     {
-        private readonly Expression _queryExpression;
-        private readonly IReadOnlyDictionary<string, object?> _parameterValues;
-
-        public CommandCacheKey(Expression queryExpression, IReadOnlyDictionary<string, object?> parameterValues)
-        {
-            _queryExpression = queryExpression;
-            _parameterValues = parameterValues;
-        }
+        private readonly Expression _queryExpression = queryExpression;
+        private readonly IReadOnlyDictionary<string, object?> _parameterValues = parameterValues;
 
         public override bool Equals(object? obj)
             => obj is CommandCacheKey commandCacheKey

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -579,17 +579,12 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         return baseValue == null ? (T?)(object?)null : (T?)property.GetGetter().GetClrValue(baseValue);
     }
 
-    private sealed class ParameterBasedComplexPropertyChainExpression : Expression
+    private sealed class ParameterBasedComplexPropertyChainExpression(
+        SqlParameterExpression parameterExpression,
+        IComplexProperty firstComplexProperty)
+        : Expression
     {
-        public ParameterBasedComplexPropertyChainExpression(
-            SqlParameterExpression parameterExpression,
-            IComplexProperty firstComplexProperty)
-        {
-            ParameterExpression = parameterExpression;
-            ComplexPropertyChain = new List<IComplexProperty> { firstComplexProperty };
-        }
-
-        public SqlParameterExpression ParameterExpression { get; }
-        public List<IComplexProperty> ComplexPropertyChain { get; }
+        public SqlParameterExpression ParameterExpression { get; } = parameterExpression;
+        public List<IComplexProperty> ComplexPropertyChain { get; } = new() { firstComplexProperty };
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1786,22 +1786,15 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             return source.CreateEFPropertyExpression(property);
         }
 
-        private sealed class AnnotationApplyingExpressionVisitor : ExpressionVisitor
+        private sealed class AnnotationApplyingExpressionVisitor(IReadOnlyList<IAnnotation> annotations) : ExpressionVisitor
         {
-            private readonly IReadOnlyList<IAnnotation> _annotations;
-
-            public AnnotationApplyingExpressionVisitor(IReadOnlyList<IAnnotation> annotations)
-            {
-                _annotations = annotations;
-            }
-
             [return: NotNullIfNotNull(nameof(expression))]
             public override Expression? Visit(Expression? expression)
             {
                 if (expression is TableExpression te)
                 {
                     TableExpressionBase ownedTable = te;
-                    foreach (var annotation in _annotations)
+                    foreach (var annotation in annotations)
                     {
                         ownedTable = ownedTable.AddAnnotation(annotation.Name, annotation.Value);
                     }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -2116,18 +2116,13 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         return baseListParameter.Select(e => e != null ? (TProperty?)getter.GetClrValue(e) : (TProperty?)(object?)null).ToList();
     }
 
-    private sealed class ParameterBasedComplexPropertyChainExpression : Expression
+    private sealed class ParameterBasedComplexPropertyChainExpression(
+        SqlParameterExpression parameterExpression,
+        IComplexProperty firstComplexProperty)
+        : Expression
     {
-        public ParameterBasedComplexPropertyChainExpression(
-            SqlParameterExpression parameterExpression,
-            IComplexProperty firstComplexProperty)
-        {
-            ParameterExpression = parameterExpression;
-            ComplexPropertyChain = [firstComplexProperty];
-        }
-
-        public SqlParameterExpression ParameterExpression { get; }
-        public List<IComplexProperty> ComplexPropertyChain { get; }
+        public SqlParameterExpression ParameterExpression { get; } = parameterExpression;
+        public List<IComplexProperty> ComplexPropertyChain { get; } = [firstComplexProperty];
     }
 
     private static bool CanEvaluate(Expression expression)

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -1240,7 +1240,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                     {
                         AddMatchingPredecessorEdge(
                             indexPredecessorsMap, value, command,
-                            new CommandDependency(index, breakable: index.Filter != null || hasNullValue));
+                            new CommandDependency(index, Breakable: index.Filter != null || hasNullValue));
                     }
                 }
             }
@@ -1322,13 +1322,13 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         for (var i = 0; i < deletedCommands.List.Count - 1; i++)
                         {
                             var deleted = deletedCommands.List[i];
-                            _modificationCommandGraph.AddEdge(deleted, lastDelete, new CommandDependency(deleted.Table!, breakable: true));
+                            _modificationCommandGraph.AddEdge(deleted, lastDelete, new CommandDependency(deleted.Table!, Breakable: true));
                         }
 
                         deletedDictionary[table] = (deletedCommands.List, true);
                     }
 
-                    _modificationCommandGraph.AddEdge(lastDelete, command, new CommandDependency(command.Table!, breakable: true));
+                    _modificationCommandGraph.AddEdge(lastDelete, command, new CommandDependency(command.Table!, Breakable: true));
                 }
             }
         }
@@ -1345,15 +1345,5 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         return Task.CompletedTask;
     }
 
-    private sealed record class CommandDependency
-    {
-        public CommandDependency(IAnnotatable metadata, bool breakable = false)
-        {
-            Metadata = metadata;
-            Breakable = breakable;
-        }
-
-        public IAnnotatable Metadata { get; }
-        public bool Breakable { get; }
-    }
+    private sealed record class CommandDependency(IAnnotatable Metadata, bool Breakable = false);
 }

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -118,15 +118,8 @@ public class SharedTableEntryMap<TValue>
         }
     }
 
-    private sealed class EntryComparer : IComparer<IUpdateEntry>
+    private sealed class EntryComparer(ITable table) : IComparer<IUpdateEntry>
     {
-        private readonly ITable _table;
-
-        public EntryComparer(ITable table)
-        {
-            _table = table;
-        }
-
         public int Compare(IUpdateEntry? x, IUpdateEntry? y)
         {
             if (ReferenceEquals(x, y))
@@ -144,9 +137,9 @@ public class SharedTableEntryMap<TValue>
                 return 1;
             }
 
-            return !_table.GetRowInternalForeignKeys(x.EntityType).Any()
+            return !table.GetRowInternalForeignKeys(x.EntityType).Any()
                 ? -1
-                : !_table.GetRowInternalForeignKeys(y.EntityType).Any()
+                : !table.GetRowInternalForeignKeys(y.EntityType).Any()
                     ? 1
                     : StringComparer.Ordinal.Compare(x.EntityType.Name, y.EntityType.Name);
         }

--- a/src/EFCore.SqlServer.HierarchyId/Infrastructure/Internal/SqlServerHierarchyIdOptionsExtension.cs
+++ b/src/EFCore.SqlServer.HierarchyId/Infrastructure/Internal/SqlServerHierarchyIdOptionsExtension.cs
@@ -65,13 +65,8 @@ public class SqlServerHierarchyIdOptionsExtension : IDbContextOptionsExtension
         }
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
-
         private new SqlServerHierarchyIdOptionsExtension Extension
             => (SqlServerHierarchyIdOptionsExtension)base.Extension;
 

--- a/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
@@ -54,13 +54,8 @@ public class SqlServerNetTopologySuiteOptionsExtension : IDbContextOptionsExtens
         }
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
-
         private new SqlServerNetTopologySuiteOptionsExtension Extension
             => (SqlServerNetTopologySuiteOptionsExtension)base.Extension;
 

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -279,14 +279,9 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
         }
     }
 
-    private sealed class ExtensionInfo : RelationalExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : RelationalExtensionInfo(extension)
     {
         private string? _logFragment;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new SqlServerOptionsExtension Extension
             => (SqlServerOptionsExtension)base.Extension;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -41,18 +41,13 @@ public class SqlServerCompiledQueryCacheKeyGenerator : RelationalCompiledQueryCa
             GenerateCacheKeyCore(query, async),
             _sqlServerConnection.IsMultipleActiveResultSetsEnabled);
 
-    private readonly struct SqlServerCompiledQueryCacheKey : IEquatable<SqlServerCompiledQueryCacheKey>
+    private readonly struct SqlServerCompiledQueryCacheKey(
+        RelationalCompiledQueryCacheKey relationalCompiledQueryCacheKey,
+        bool multipleActiveResultSetsEnabled)
+        : IEquatable<SqlServerCompiledQueryCacheKey>
     {
-        private readonly RelationalCompiledQueryCacheKey _relationalCompiledQueryCacheKey;
-        private readonly bool _multipleActiveResultSetsEnabled;
-
-        public SqlServerCompiledQueryCacheKey(
-            RelationalCompiledQueryCacheKey relationalCompiledQueryCacheKey,
-            bool multipleActiveResultSetsEnabled)
-        {
-            _relationalCompiledQueryCacheKey = relationalCompiledQueryCacheKey;
-            _multipleActiveResultSetsEnabled = multipleActiveResultSetsEnabled;
-        }
+        private readonly RelationalCompiledQueryCacheKey _relationalCompiledQueryCacheKey = relationalCompiledQueryCacheKey;
+        private readonly bool _multipleActiveResultSetsEnabled = multipleActiveResultSetsEnabled;
 
         public override bool Equals(object? obj)
             => obj is SqlServerCompiledQueryCacheKey sqlServerCompiledQueryCacheKey

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -526,19 +526,13 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         return false;
     }
 
-    private sealed class TemporalAnnotationApplyingExpressionVisitor : ExpressionVisitor
+    private sealed class TemporalAnnotationApplyingExpressionVisitor(Func<TableExpression, TableExpressionBase> annotationApplyingFunc)
+        : ExpressionVisitor
     {
-        private readonly Func<TableExpression, TableExpressionBase> _annotationApplyingFunc;
-
-        public TemporalAnnotationApplyingExpressionVisitor(Func<TableExpression, TableExpressionBase> annotationApplyingFunc)
-        {
-            _annotationApplyingFunc = annotationApplyingFunc;
-        }
-
         [return: NotNullIfNotNull(nameof(expression))]
         public override Expression? Visit(Expression? expression)
             => expression is TableExpression tableExpression
-                ? _annotationApplyingFunc(tableExpression)
+                ? annotationApplyingFunc(tableExpression)
                 : base.Visit(expression);
     }
 }

--- a/src/EFCore.SqlServer/Utilities/EnumerableExtensions.cs
+++ b/src/EFCore.SqlServer/Utilities/EnumerableExtensions.cs
@@ -17,18 +17,11 @@ internal static class EnumerableExtensions
         where T : class
         => source.Distinct(new DynamicEqualityComparer<T>(comparer));
 
-    private sealed class DynamicEqualityComparer<T> : IEqualityComparer<T>
+    private sealed class DynamicEqualityComparer<T>(Func<T?, T?, bool> func) : IEqualityComparer<T>
         where T : class
     {
-        private readonly Func<T?, T?, bool> _func;
-
-        public DynamicEqualityComparer(Func<T?, T?, bool> func)
-        {
-            _func = func;
-        }
-
         public bool Equals(T? x, T? y)
-            => _func(x, y);
+            => func(x, y);
 
         public int GetHashCode(T obj)
             => 0; // force Equals

--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
@@ -91,14 +91,9 @@ public class SqliteOptionsExtension : RelationalOptionsExtension
     public override void ApplyServices(IServiceCollection services)
         => services.AddEntityFrameworkSqlite();
 
-    private sealed class ExtensionInfo : RelationalExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : RelationalExtensionInfo(extension)
     {
         private string? _logFragment;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new SqliteOptionsExtension Extension
             => (SqliteOptionsExtension)base.Extension;

--- a/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
@@ -54,13 +54,8 @@ public class SqliteNetTopologySuiteOptionsExtension : IDbContextOptionsExtension
         }
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
-
         private new SqliteNetTopologySuiteOptionsExtension Extension
             => (SqliteNetTopologySuiteOptionsExtension)base.Extension;
 

--- a/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
@@ -157,15 +157,8 @@ public class CompositeValueFactory : IDependentKeyValueFactory<IReadOnlyList<obj
     protected static IEqualityComparer<IReadOnlyList<object?>> CreateEqualityComparer(IReadOnlyList<IProperty> properties)
         => new CompositeCustomComparer(properties.Select(p => p.GetKeyValueComparer()).ToArray());
 
-    private sealed class CompositeCustomComparer : IEqualityComparer<IReadOnlyList<object?>>
+    private sealed class CompositeCustomComparer(ValueComparer[] comparers) : IEqualityComparer<IReadOnlyList<object?>>
     {
-        private readonly ValueComparer[] _comparers;
-
-        public CompositeCustomComparer(ValueComparer[] comparers)
-        {
-            _comparers = comparers;
-        }
-
         public bool Equals(IReadOnlyList<object?>? x, IReadOnlyList<object?>? y)
         {
             if (ReferenceEquals(x, y))
@@ -183,15 +176,15 @@ public class CompositeValueFactory : IDependentKeyValueFactory<IReadOnlyList<obj
                 return false;
             }
 
-            if (x.Count != _comparers.Length
-                || y.Count != _comparers.Length)
+            if (x.Count != comparers.Length
+                || y.Count != comparers.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < _comparers.Length; i++)
+            for (var i = 0; i < comparers.Length; i++)
             {
-                if (!_comparers[i].Equals(x[i], y[i]))
+                if (!comparers[i].Equals(x[i], y[i]))
                 {
                     return false;
                 }
@@ -208,7 +201,7 @@ public class CompositeValueFactory : IDependentKeyValueFactory<IReadOnlyList<obj
             // ReSharper disable once LoopCanBeConvertedToQuery
             for (var i = 0; i < obj.Count; i++)
             {
-                hashCode.Add(_comparers[i].GetHashCode(obj[i]));
+                hashCode.Add(comparers[i].GetHashCode(obj[i]));
             }
 
             return hashCode.ToHashCode();

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.OriginalValues.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public sealed partial class InternalEntityEntry
 {
-    private readonly struct OriginalValues
+    private readonly struct OriginalValues(InternalEntityEntry entry)
     {
-        private readonly ISnapshot _values;
-
-        public OriginalValues(InternalEntityEntry entry)
-        {
-            _values = entry.EntityType.OriginalValuesFactory(entry);
-        }
+        private readonly ISnapshot _values = entry.EntityType.OriginalValuesFactory(entry);
 
         public object? GetValue(InternalEntityEntry entry, IProperty property)
             => property.GetOriginalValueIndex() is var index && index == -1

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.RelationshipsSnapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.RelationshipsSnapshot.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public sealed partial class InternalEntityEntry
 {
-    private readonly struct RelationshipsSnapshot
+    private readonly struct RelationshipsSnapshot(InternalEntityEntry entry)
     {
-        private readonly ISnapshot _values;
-
-        public RelationshipsSnapshot(InternalEntityEntry entry)
-        {
-            _values = entry.EntityType.RelationshipSnapshotFactory(entry);
-        }
+        private readonly ISnapshot _values = entry.EntityType.RelationshipSnapshotFactory(entry);
 
         public object? GetValue(InternalEntityEntry entry, IPropertyBase propertyBase)
             => IsEmpty ? entry[propertyBase] : _values[propertyBase.GetRelationshipIndex()];

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.SidecarValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.SidecarValues.cs
@@ -5,15 +5,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public sealed partial class InternalEntityEntry
 {
-    private readonly struct SidecarValues
+    private readonly struct SidecarValues(ISnapshot values)
     {
-        private readonly ISnapshot _values;
-
-        public SidecarValues(ISnapshot values)
-        {
-            _values = values;
-        }
-
         public bool TryGetValue(int index, out object? value)
         {
             if (IsEmpty)
@@ -22,15 +15,15 @@ public sealed partial class InternalEntityEntry
                 return false;
             }
 
-            value = _values[index];
+            value = values[index];
             return true;
         }
 
         public object? GetValue(int index)
-            => _values[index];
+            => values[index];
 
         public T GetValue<T>(int index)
-            => _values.GetValue<T>(index);
+            => values.GetValue<T>(index);
 
         public void SetValue(IProperty property, object? value, int index)
         {
@@ -44,13 +37,13 @@ public sealed partial class InternalEntityEntry
                         property.Name, property.DeclaringType.DisplayName(), property.ClrType.DisplayName()));
             }
 
-            _values[index] = SnapshotValue(property, value);
+            values[index] = SnapshotValue(property, value);
         }
 
         private static object? SnapshotValue(IProperty property, object? value)
             => property.GetValueComparer().Snapshot(value);
 
         public bool IsEmpty
-            => _values == null;
+            => values == null;
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
@@ -119,19 +119,12 @@ public class SimplePrincipalKeyValueFactory<TKey> : IPrincipalKeyValueFactory<TK
                 : CreateFromCurrentValues(entry),
             EqualityComparer);
 
-    private sealed class NoNullsCustomEqualityComparer : IEqualityComparer<TKey>
+    private sealed class NoNullsCustomEqualityComparer(ValueComparer<TKey> comparer) : IEqualityComparer<TKey>
     {
-        private readonly ValueComparer<TKey> _comparer;
-
-        public NoNullsCustomEqualityComparer(ValueComparer<TKey> comparer)
-        {
-            _comparer = comparer;
-        }
-
         public bool Equals(TKey? x, TKey? y)
-            => _comparer.Equals(x, y);
+            => comparer.Equals(x, y);
 
         public int GetHashCode([DisallowNull] TKey obj)
-            => _comparer.GetHashCode(obj);
+            => comparer.GetHashCode(obj);
     }
 }

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -346,39 +346,28 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
             => instance;
     }
 
-    internal sealed class DefaultDoubleValueComparer : DefaultValueComparer<double>
+    internal sealed class DefaultDoubleValueComparer(bool favorStructuralComparisons)
+        : DefaultValueComparer<double>((v1, v2) => v1.Equals(v2), favorStructuralComparisons)
     {
-        public DefaultDoubleValueComparer(bool favorStructuralComparisons)
-            : base((v1, v2) => v1.Equals(v2), favorStructuralComparisons)
-        {
-        }
-
         public override Expression ExtractEqualsBody(Expression leftExpression, Expression rightExpression)
             => Expression.Call(leftExpression, DoubleEqualsMethodInfo, rightExpression);
     }
 
-    internal sealed class DefaultFloatValueComparer : DefaultValueComparer<float>
+    internal sealed class DefaultFloatValueComparer(bool favorStructuralComparisons)
+        : DefaultValueComparer<float>((v1, v2) => v1.Equals(v2), favorStructuralComparisons)
     {
-        public DefaultFloatValueComparer(bool favorStructuralComparisons)
-            : base((v1, v2) => v1.Equals(v2), favorStructuralComparisons)
-        {
-        }
-
         public override Expression ExtractEqualsBody(Expression leftExpression, Expression rightExpression)
             => Expression.Call(leftExpression, FloatEqualsMethodInfo, rightExpression);
     }
 
-    internal sealed class DefaultDateTimeOffsetValueComparer : DefaultValueComparer<DateTimeOffset>
+    internal sealed class DefaultDateTimeOffsetValueComparer(bool favorStructuralComparisons)
+        : DefaultValueComparer<DateTimeOffset>((v1, v2) => v1.EqualsExact(v2), favorStructuralComparisons)
     {
         private static readonly MethodInfo EqualsExactMethodInfo
             = typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.EqualsExact), [typeof(DateTimeOffset)])!;
 
         // In .NET, two DateTimeOffset instances are considered equal if they represent the same point in time but with different
         // time zone offsets. This comparer uses EqualsExact, which considers such DateTimeOffset as non-equal.
-        public DefaultDateTimeOffsetValueComparer(bool favorStructuralComparisons)
-            : base((v1, v2) => v1.EqualsExact(v2), favorStructuralComparisons)
-        {
-        }
 
         public override Expression ExtractEqualsBody(Expression leftExpression, Expression rightExpression)
             => Expression.Call(leftExpression, EqualsExactMethodInfo, rightExpression);

--- a/src/EFCore/Diagnostics/Internal/IdentityResolutionInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/IdentityResolutionInterceptorAggregator.cs
@@ -15,14 +15,10 @@ public class IdentityResolutionInterceptorAggregator : InterceptorAggregator<IId
     protected override IIdentityResolutionInterceptor CreateChain(IEnumerable<IIdentityResolutionInterceptor> interceptors)
         => new CompositeIdentityResolutionInterceptor(interceptors);
 
-    private sealed class CompositeIdentityResolutionInterceptor : IIdentityResolutionInterceptor
+    private sealed class CompositeIdentityResolutionInterceptor(IEnumerable<IIdentityResolutionInterceptor> interceptors)
+        : IIdentityResolutionInterceptor
     {
-        private readonly IIdentityResolutionInterceptor[] _interceptors;
-
-        public CompositeIdentityResolutionInterceptor(IEnumerable<IIdentityResolutionInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IIdentityResolutionInterceptor[] _interceptors = interceptors.ToArray();
 
         public void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity)
         {

--- a/src/EFCore/Diagnostics/Internal/MaterializationInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/MaterializationInterceptorAggregator.cs
@@ -19,14 +19,10 @@ public class MaterializationInterceptorAggregator : InterceptorAggregator<IMater
     protected override IMaterializationInterceptor CreateChain(IEnumerable<IMaterializationInterceptor> interceptors)
         => new CompositeMaterializationInterceptor(interceptors);
 
-    private sealed class CompositeMaterializationInterceptor : IMaterializationInterceptor
+    private sealed class CompositeMaterializationInterceptor(IEnumerable<IMaterializationInterceptor> interceptors)
+        : IMaterializationInterceptor
     {
-        private readonly IMaterializationInterceptor[] _interceptors;
-
-        public CompositeMaterializationInterceptor(IEnumerable<IMaterializationInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IMaterializationInterceptor[] _interceptors = interceptors.ToArray();
 
         public InterceptionResult<object> CreatingInstance(
             MaterializationInterceptionData materializationData,

--- a/src/EFCore/Diagnostics/Internal/QueryExpressionInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/QueryExpressionInterceptorAggregator.cs
@@ -15,14 +15,10 @@ public class QueryExpressionInterceptorAggregator : InterceptorAggregator<IQuery
     protected override IQueryExpressionInterceptor CreateChain(IEnumerable<IQueryExpressionInterceptor> interceptors)
         => new CompositeQueryExpressionInterceptor(interceptors);
 
-    private sealed class CompositeQueryExpressionInterceptor : IQueryExpressionInterceptor
+    private sealed class CompositeQueryExpressionInterceptor(IEnumerable<IQueryExpressionInterceptor> interceptors)
+        : IQueryExpressionInterceptor
     {
-        private readonly IQueryExpressionInterceptor[] _interceptors;
-
-        public CompositeQueryExpressionInterceptor(IEnumerable<IQueryExpressionInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly IQueryExpressionInterceptor[] _interceptors = interceptors.ToArray();
 
         public Expression QueryCompilationStarting(
             Expression queryExpression,

--- a/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
@@ -19,14 +19,9 @@ public class SaveChangesInterceptorAggregator : InterceptorAggregator<ISaveChang
     protected override ISaveChangesInterceptor CreateChain(IEnumerable<ISaveChangesInterceptor> interceptors)
         => new CompositeSaveChangesInterceptor(interceptors);
 
-    private sealed class CompositeSaveChangesInterceptor : ISaveChangesInterceptor
+    private sealed class CompositeSaveChangesInterceptor(IEnumerable<ISaveChangesInterceptor> interceptors) : ISaveChangesInterceptor
     {
-        private readonly ISaveChangesInterceptor[] _interceptors;
-
-        public CompositeSaveChangesInterceptor(IEnumerable<ISaveChangesInterceptor> interceptors)
-        {
-            _interceptors = interceptors.ToArray();
-        }
+        private readonly ISaveChangesInterceptor[] _interceptors = interceptors.ToArray();
 
         public InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
         {

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2565,29 +2565,23 @@ public static class EntityFrameworkQueryableExtensions
                         arguments: [source.Expression, Expression.Quote(navigationPropertyPath)]))
                 : source);
 
-    private sealed class IncludableQueryable<TEntity, TProperty> : IIncludableQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
+    private sealed class IncludableQueryable<TEntity, TProperty>(IQueryable<TEntity> queryable)
+        : IIncludableQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
     {
-        private readonly IQueryable<TEntity> _queryable;
-
-        public IncludableQueryable(IQueryable<TEntity> queryable)
-        {
-            _queryable = queryable;
-        }
-
         public Expression Expression
-            => _queryable.Expression;
+            => queryable.Expression;
 
         public Type ElementType
-            => _queryable.ElementType;
+            => queryable.ElementType;
 
         public IQueryProvider Provider
-            => _queryable.Provider;
+            => queryable.Provider;
 
         public IAsyncEnumerator<TEntity> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-            => ((IAsyncEnumerable<TEntity>)_queryable).GetAsyncEnumerator(cancellationToken);
+            => ((IAsyncEnumerable<TEntity>)queryable).GetAsyncEnumerator(cancellationToken);
 
         public IEnumerator<TEntity> GetEnumerator()
-            => _queryable.GetEnumerator();
+            => queryable.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -607,15 +607,10 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         }
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(CoreOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
         private int? _serviceProviderHash;
         private string? _logFragment;
-
-        public ExtensionInfo(CoreOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new CoreOptionsExtension Extension
             => (CoreOptionsExtension)base.Extension;

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
@@ -7,70 +7,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
 public partial class ConventionDispatcher
 {
-    private sealed class ImmediateConventionScope : ConventionScope
+    private sealed class ImmediateConventionScope(ConventionSet conventionSet, ConventionDispatcher dispatcher) : ConventionScope
     {
-        private readonly ConventionSet _conventionSet;
-        private readonly ConventionDispatcher _dispatcher;
-        private readonly ConventionContext<IConventionEntityTypeBuilder> _entityTypeBuilderConventionContext;
-        private readonly ConventionContext<IConventionEntityType> _entityTypeConventionContext;
-        private readonly ConventionContext<IConventionComplexPropertyBuilder> _complexPropertyBuilderConventionContext;
-        private readonly ConventionContext<IConventionComplexProperty> _complexPropertyConventionContext;
-        private readonly ConventionContext<IConventionForeignKeyBuilder> _relationshipBuilderConventionContext;
-        private readonly ConventionContext<IConventionForeignKey> _foreignKeyConventionContext;
-        private readonly ConventionContext<IConventionSkipNavigationBuilder> _skipNavigationBuilderConventionContext;
-        private readonly ConventionContext<IConventionSkipNavigation> _skipNavigationConventionContext;
-        private readonly ConventionContext<IConventionNavigationBuilder> _navigationConventionBuilderContext;
-        private readonly ConventionContext<IConventionNavigation> _navigationConventionContext;
-        private readonly ConventionContext<IConventionIndexBuilder> _indexBuilderConventionContext;
-        private readonly ConventionContext<IConventionIndex> _indexConventionContext;
-        private readonly ConventionContext<IConventionKeyBuilder> _keyBuilderConventionContext;
-        private readonly ConventionContext<IConventionKey> _keyConventionContext;
-        private readonly ConventionContext<IConventionPropertyBuilder> _propertyBuilderConventionContext;
-        private readonly ConventionContext<IConventionProperty> _propertyConventionContext;
-        private readonly ConventionContext<IConventionModelBuilder> _modelBuilderConventionContext;
-        private readonly ConventionContext<IConventionTriggerBuilder> _triggerBuilderConventionContext;
-        private readonly ConventionContext<IConventionTrigger> _triggerConventionContext;
-        private readonly ConventionContext<IConventionAnnotation> _annotationConventionContext;
-        private readonly ConventionContext<IReadOnlyList<IConventionProperty>> _propertyListConventionContext;
-        private readonly ConventionContext<string> _stringConventionContext;
-        private readonly ConventionContext<string?> _nullableStringConventionContext;
-        private readonly ConventionContext<FieldInfo> _fieldInfoConventionContext;
-        private readonly ConventionContext<IElementType> _elementTypeConventionContext;
-        private readonly ConventionContext<bool?> _boolConventionContext;
-        private readonly ConventionContext<IReadOnlyList<bool>?> _boolListConventionContext;
-
-        public ImmediateConventionScope(ConventionSet conventionSet, ConventionDispatcher dispatcher)
-        {
-            _conventionSet = conventionSet;
-            _dispatcher = dispatcher;
-            _entityTypeBuilderConventionContext = new ConventionContext<IConventionEntityTypeBuilder>(dispatcher);
-            _entityTypeConventionContext = new ConventionContext<IConventionEntityType>(dispatcher);
-            _complexPropertyBuilderConventionContext = new ConventionContext<IConventionComplexPropertyBuilder>(dispatcher);
-            _complexPropertyConventionContext = new ConventionContext<IConventionComplexProperty>(dispatcher);
-            _relationshipBuilderConventionContext = new ConventionContext<IConventionForeignKeyBuilder>(dispatcher);
-            _foreignKeyConventionContext = new ConventionContext<IConventionForeignKey>(dispatcher);
-            _skipNavigationBuilderConventionContext = new ConventionContext<IConventionSkipNavigationBuilder>(dispatcher);
-            _skipNavigationConventionContext = new ConventionContext<IConventionSkipNavigation>(dispatcher);
-            _navigationConventionBuilderContext = new ConventionContext<IConventionNavigationBuilder>(dispatcher);
-            _navigationConventionContext = new ConventionContext<IConventionNavigation>(dispatcher);
-            _indexBuilderConventionContext = new ConventionContext<IConventionIndexBuilder>(dispatcher);
-            _indexConventionContext = new ConventionContext<IConventionIndex>(dispatcher);
-            _keyBuilderConventionContext = new ConventionContext<IConventionKeyBuilder>(dispatcher);
-            _keyConventionContext = new ConventionContext<IConventionKey>(dispatcher);
-            _propertyBuilderConventionContext = new ConventionContext<IConventionPropertyBuilder>(dispatcher);
-            _propertyConventionContext = new ConventionContext<IConventionProperty>(dispatcher);
-            _modelBuilderConventionContext = new ConventionContext<IConventionModelBuilder>(dispatcher);
-            _triggerBuilderConventionContext = new ConventionContext<IConventionTriggerBuilder>(dispatcher);
-            _triggerConventionContext = new ConventionContext<IConventionTrigger>(dispatcher);
-            _annotationConventionContext = new ConventionContext<IConventionAnnotation>(dispatcher);
-            _propertyListConventionContext = new ConventionContext<IReadOnlyList<IConventionProperty>>(dispatcher);
-            _stringConventionContext = new ConventionContext<string>(dispatcher);
-            _nullableStringConventionContext = new ConventionContext<string?>(dispatcher);
-            _fieldInfoConventionContext = new ConventionContext<FieldInfo>(dispatcher);
-            _elementTypeConventionContext = new ConventionContext<IElementType>(dispatcher);
-            _boolConventionContext = new ConventionContext<bool?>(dispatcher);
-            _boolListConventionContext = new ConventionContext<IReadOnlyList<bool>?>(dispatcher);
-        }
+        private readonly ConventionContext<IConventionEntityTypeBuilder> _entityTypeBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionEntityType> _entityTypeConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionComplexPropertyBuilder> _complexPropertyBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionComplexProperty> _complexPropertyConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionForeignKeyBuilder> _relationshipBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionForeignKey> _foreignKeyConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionSkipNavigationBuilder> _skipNavigationBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionSkipNavigation> _skipNavigationConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionNavigationBuilder> _navigationConventionBuilderContext = new(dispatcher);
+        private readonly ConventionContext<IConventionNavigation> _navigationConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionIndexBuilder> _indexBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionIndex> _indexConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionKeyBuilder> _keyBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionKey> _keyConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionPropertyBuilder> _propertyBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionProperty> _propertyConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionModelBuilder> _modelBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionTriggerBuilder> _triggerBuilderConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionTrigger> _triggerConventionContext = new(dispatcher);
+        private readonly ConventionContext<IConventionAnnotation> _annotationConventionContext = new(dispatcher);
+        private readonly ConventionContext<IReadOnlyList<IConventionProperty>> _propertyListConventionContext = new(dispatcher);
+        private readonly ConventionContext<string> _stringConventionContext = new(dispatcher);
+        private readonly ConventionContext<string?> _nullableStringConventionContext = new(dispatcher);
+        private readonly ConventionContext<FieldInfo> _fieldInfoConventionContext = new(dispatcher);
+        private readonly ConventionContext<IElementType> _elementTypeConventionContext = new(dispatcher);
+        private readonly ConventionContext<bool?> _boolConventionContext = new(dispatcher);
+        private readonly ConventionContext<IReadOnlyList<bool>?> _boolListConventionContext = new(dispatcher);
 
         public override void Run(ConventionDispatcher dispatcher)
             => Check.DebugFail("Immediate convention scope cannot be run again.");
@@ -78,10 +43,10 @@ public partial class ConventionDispatcher
         public IConventionModelBuilder OnModelFinalizing(IConventionModelBuilder modelBuilder)
         {
             _modelBuilderConventionContext.ResetState(modelBuilder);
-            foreach (var modelConvention in _conventionSet.ModelFinalizingConventions)
+            foreach (var modelConvention in conventionSet.ModelFinalizingConventions)
             {
                 // Execute each convention in a separate batch so each will get an up-to-date model as they are meant to be only run once
-                using (_dispatcher.DelayConventions())
+                using (dispatcher.DelayConventions())
                 {
                     modelConvention.ProcessModelFinalizing(modelBuilder, _modelBuilderConventionContext);
                     if (_modelBuilderConventionContext.ShouldStopProcessing())
@@ -96,10 +61,10 @@ public partial class ConventionDispatcher
 
         public IConventionModelBuilder OnModelInitialized(IConventionModelBuilder modelBuilder)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _modelBuilderConventionContext.ResetState(modelBuilder);
-                foreach (var modelConvention in _conventionSet.ModelInitializedConventions)
+                foreach (var modelConvention in conventionSet.ModelInitializedConventions)
                 {
                     modelConvention.ProcessModelInitialized(modelBuilder, _modelBuilderConventionContext);
                     if (_modelBuilderConventionContext.ShouldStopProcessing())
@@ -118,13 +83,13 @@ public partial class ConventionDispatcher
             IConventionAnnotation? annotation,
             IConventionAnnotation? oldAnnotation)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
 #if DEBUG
                 var initialValue = modelBuilder.Metadata[name];
 #endif
-                foreach (var modelConvention in _conventionSet.ModelAnnotationChangedConventions)
+                foreach (var modelConvention in conventionSet.ModelAnnotationChangedConventions)
                 {
                     modelConvention.ProcessModelAnnotationChanged(
                         modelBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -148,13 +113,13 @@ public partial class ConventionDispatcher
         public override string? OnModelEmbeddedDiscriminatorNameChanged(
             IConventionModelBuilder modelBuilder, string? oldName, string? newName)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _stringConventionContext.ResetState(newName);
 #if DEBUG
                 var initialValue = modelBuilder.Metadata.GetEmbeddedDiscriminatorName();
 #endif
-                foreach (var modelConvention in _conventionSet.ModelEmbeddedDiscriminatorNameConventions)
+                foreach (var modelConvention in conventionSet.ModelEmbeddedDiscriminatorNameConventions)
                 {
                     modelConvention.ProcessEmbeddedDiscriminatorName(modelBuilder, newName, oldName, _stringConventionContext);
 
@@ -176,13 +141,13 @@ public partial class ConventionDispatcher
 
         public override string? OnTypeIgnored(IConventionModelBuilder modelBuilder, string name, Type? type)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _stringConventionContext.ResetState(name);
 #if DEBUG
                 var initialValue = modelBuilder.Metadata.IsIgnored(name);
 #endif
-                foreach (var entityTypeConvention in _conventionSet.TypeIgnoredConventions)
+                foreach (var entityTypeConvention in conventionSet.TypeIgnoredConventions)
                 {
                     entityTypeConvention.ProcessTypeIgnored(modelBuilder, name, type, _stringConventionContext);
                     if (_stringConventionContext.ShouldStopProcessing())
@@ -202,13 +167,13 @@ public partial class ConventionDispatcher
 
         public override IConventionEntityTypeBuilder? OnEntityTypeAdded(IConventionEntityTypeBuilder entityTypeBuilder)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _entityTypeBuilderConventionContext.ResetState(entityTypeBuilder);
 #if DEBUG
                 var initialValue = entityTypeBuilder.Metadata.IsInModel;
 #endif
-                foreach (var entityTypeConvention in _conventionSet.EntityTypeAddedConventions)
+                foreach (var entityTypeConvention in conventionSet.EntityTypeAddedConventions)
                 {
                     if (!entityTypeBuilder.Metadata.IsInModel)
                     {
@@ -235,10 +200,10 @@ public partial class ConventionDispatcher
             IConventionModelBuilder modelBuilder,
             IConventionEntityType entityType)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _entityTypeConventionContext.ResetState(entityType);
-                foreach (var entityTypeConvention in _conventionSet.EntityTypeRemovedConventions)
+                foreach (var entityTypeConvention in conventionSet.EntityTypeRemovedConventions)
                 {
                     entityTypeConvention.ProcessEntityTypeRemoved(modelBuilder, entityType, _entityTypeConventionContext);
                     if (_entityTypeConventionContext.ShouldStopProcessing())
@@ -261,12 +226,12 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = entityTypeBuilder.Metadata.IsIgnored(name);
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _stringConventionContext.ResetState(name);
                 foreach (var entityType in entityTypeBuilder.Metadata.GetDerivedTypesInclusive())
                 {
-                    foreach (var entityTypeConvention in _conventionSet.EntityTypeMemberIgnoredConventions)
+                    foreach (var entityTypeConvention in conventionSet.EntityTypeMemberIgnoredConventions)
                     {
                         if (!entityTypeBuilder.Metadata.IsIgnored(name))
                         {
@@ -301,11 +266,11 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = entityTypeBuilder.Metadata.GetDiscriminatorPropertyName();
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _nullableStringConventionContext.ResetState(name);
 
-                foreach (var entityTypeConvention in _conventionSet.DiscriminatorPropertySetConventions)
+                foreach (var entityTypeConvention in conventionSet.DiscriminatorPropertySetConventions)
                 {
                     entityTypeConvention.ProcessDiscriminatorPropertySet(
                         entityTypeBuilder, name, _nullableStringConventionContext);
@@ -332,10 +297,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = entityTypeBuilder.Metadata.BaseType;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _entityTypeConventionContext.ResetState(newBaseType);
-                foreach (var entityTypeConvention in _conventionSet.EntityTypeBaseTypeChangedConventions)
+                foreach (var entityTypeConvention in conventionSet.EntityTypeBaseTypeChangedConventions)
                 {
                     if (!entityTypeBuilder.Metadata.IsInModel)
                     {
@@ -372,10 +337,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = entityTypeBuilder.Metadata.FindPrimaryKey();
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _keyConventionContext.ResetState(newPrimaryKey);
-                foreach (var keyConvention in _conventionSet.EntityTypePrimaryKeyChangedConventions)
+                foreach (var keyConvention in conventionSet.EntityTypePrimaryKeyChangedConventions)
                 {
                     // Some conventions rely on this running even if the new key has been removed
                     keyConvention.ProcessEntityTypePrimaryKeyChanged(
@@ -408,10 +373,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = entityTypeBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var entityTypeConvention in _conventionSet.EntityTypeAnnotationChangedConventions)
+                foreach (var entityTypeConvention in conventionSet.EntityTypeAnnotationChangedConventions)
                 {
                     entityTypeConvention.ProcessEntityTypeAnnotationChanged(
                         entityTypeBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -443,10 +408,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = propertyBuilder.Metadata.IsIgnored(name);
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _stringConventionContext.ResetState(name);
-                foreach (var entityTypeConvention in _conventionSet.ComplexTypeMemberIgnoredConventions)
+                foreach (var entityTypeConvention in conventionSet.ComplexTypeMemberIgnoredConventions)
                 {
                     if (!propertyBuilder.Metadata.IsIgnored(name))
                     {
@@ -482,10 +447,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = complexTypeBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var complexTypeConvention in _conventionSet.ComplexTypeAnnotationChangedConventions)
+                foreach (var complexTypeConvention in conventionSet.ComplexTypeAnnotationChangedConventions)
                 {
                     complexTypeConvention.ProcessComplexTypeAnnotationChanged(
                         complexTypeBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -508,13 +473,13 @@ public partial class ConventionDispatcher
         public override IConventionComplexPropertyBuilder? OnComplexPropertyAdded(
             IConventionComplexPropertyBuilder propertyBuilder)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _complexPropertyBuilderConventionContext.ResetState(propertyBuilder);
 #if DEBUG
                 var initialValue = propertyBuilder.Metadata.IsInModel;
 #endif
-                foreach (var complexPropertyConvention in _conventionSet.ComplexPropertyAddedConventions)
+                foreach (var complexPropertyConvention in conventionSet.ComplexPropertyAddedConventions)
                 {
                     if (!propertyBuilder.Metadata.IsInModel)
                     {
@@ -541,10 +506,10 @@ public partial class ConventionDispatcher
             IConventionTypeBaseBuilder typeBaseBuilder,
             IConventionComplexProperty property)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _complexPropertyConventionContext.ResetState(property);
-                foreach (var complexPropertyConvention in _conventionSet.ComplexPropertyRemovedConventions)
+                foreach (var complexPropertyConvention in conventionSet.ComplexPropertyRemovedConventions)
                 {
                     complexPropertyConvention.ProcessComplexPropertyRemoved(typeBaseBuilder, property, _complexPropertyConventionContext);
                     if (_complexPropertyConventionContext.ShouldStopProcessing())
@@ -567,10 +532,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = propertyBuilder.Metadata.IsNullable;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(propertyBuilder.Metadata.IsNullable);
-                foreach (var propertyConvention in _conventionSet.ComplexPropertyNullabilityChangedConventions)
+                foreach (var propertyConvention in conventionSet.ComplexPropertyNullabilityChangedConventions)
                 {
                     if (!propertyBuilder.Metadata.IsInModel)
                     {
@@ -607,7 +572,7 @@ public partial class ConventionDispatcher
             var initialValue = propertyBuilder.Metadata.FieldInfo;
 #endif
             _fieldInfoConventionContext.ResetState(newFieldInfo);
-            foreach (var propertyConvention in _conventionSet.ComplexPropertyFieldChangedConventions)
+            foreach (var propertyConvention in conventionSet.ComplexPropertyFieldChangedConventions)
             {
                 propertyConvention.ProcessComplexPropertyFieldChanged(
                     propertyBuilder, newFieldInfo, oldFieldInfo, _fieldInfoConventionContext);
@@ -638,10 +603,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = propertyBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var propertyConvention in _conventionSet.ComplexPropertyAnnotationChangedConventions)
+                foreach (var propertyConvention in conventionSet.ComplexPropertyAnnotationChangedConventions)
                 {
                     propertyConvention.ProcessComplexPropertyAnnotationChanged(
                         propertyBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -670,10 +635,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _relationshipBuilderConventionContext.ResetState(relationshipBuilder);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyAddedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyAddedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -702,10 +667,10 @@ public partial class ConventionDispatcher
             IConventionEntityTypeBuilder entityTypeBuilder,
             IConventionForeignKey foreignKey)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _foreignKeyConventionContext.ResetState(foreignKey);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyRemovedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyRemovedConventions)
                 {
                     foreignKeyConvention.ProcessForeignKeyRemoved(entityTypeBuilder, foreignKey, _foreignKeyConventionContext);
                     if (_foreignKeyConventionContext.ShouldStopProcessing())
@@ -727,10 +692,10 @@ public partial class ConventionDispatcher
             var initialProperties = relationshipBuilder.Metadata.Properties;
             var initialPrincipalKey = relationshipBuilder.Metadata.PrincipalKey;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _propertyListConventionContext.ResetState(relationshipBuilder.Metadata.Properties);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyPropertiesChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyPropertiesChangedConventions)
                 {
                     // Some conventions rely on this running even if the relationship has been removed
                     foreignKeyConvention.ProcessForeignKeyPropertiesChanged(
@@ -741,7 +706,7 @@ public partial class ConventionDispatcher
                         if (_propertyListConventionContext.Result != null)
                         {
                             // Preserve the old configuration to let the conventions finish processing them
-                            _dispatcher.OnForeignKeyPropertiesChanged(relationshipBuilder, oldDependentProperties, oldPrincipalKey);
+                            dispatcher.OnForeignKeyPropertiesChanged(relationshipBuilder, oldDependentProperties, oldPrincipalKey);
                         }
 
                         return _propertyListConventionContext.Result;
@@ -765,10 +730,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = relationshipBuilder.Metadata.IsUnique;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(relationshipBuilder.Metadata.IsUnique);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyUniquenessChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyUniquenessChangedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -798,10 +763,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = relationshipBuilder.Metadata.IsRequired;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(relationshipBuilder.Metadata.IsRequired);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyRequirednessChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyRequirednessChangedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -831,10 +796,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = relationshipBuilder.Metadata.IsRequiredDependent;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(relationshipBuilder.Metadata.IsRequiredDependent);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyDependentRequirednessChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyDependentRequirednessChangedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -864,10 +829,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = relationshipBuilder.Metadata.IsOwnership;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(relationshipBuilder.Metadata.IsOwnership);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyOwnershipChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyOwnershipChangedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -893,10 +858,10 @@ public partial class ConventionDispatcher
         public override IConventionForeignKeyBuilder? OnForeignKeyPrincipalEndChanged(
             IConventionForeignKeyBuilder relationshipBuilder)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _relationshipBuilderConventionContext.ResetState(relationshipBuilder);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyPrincipalEndChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyPrincipalEndChangedConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -928,10 +893,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = relationshipBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyAnnotationChangedConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyAnnotationChangedConventions)
                 {
                     foreignKeyConvention.ProcessForeignKeyAnnotationChanged(
                         relationshipBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -960,10 +925,10 @@ public partial class ConventionDispatcher
                 ? relationshipBuilder.Metadata.DependentToPrincipal
                 : relationshipBuilder.Metadata.PrincipalToDependent;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _navigationConventionContext.ResetState(null);
-                foreach (var foreignKeyConvention in _conventionSet.ForeignKeyNullNavigationSetConventions)
+                foreach (var foreignKeyConvention in conventionSet.ForeignKeyNullNavigationSetConventions)
                 {
                     if (!relationshipBuilder.Metadata.IsInModel)
                     {
@@ -997,10 +962,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _navigationConventionBuilderContext.ResetState(navigationBuilder);
-                foreach (var navigationConvention in _conventionSet.NavigationAddedConventions)
+                foreach (var navigationConvention in conventionSet.NavigationAddedConventions)
                 {
                     navigationConvention.ProcessNavigationAdded(navigationBuilder, _navigationConventionBuilderContext);
                     if (_navigationConventionBuilderContext.ShouldStopProcessing())
@@ -1033,10 +998,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = navigation[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var navigationConvention in _conventionSet.NavigationAnnotationChangedConventions)
+                foreach (var navigationConvention in conventionSet.NavigationAnnotationChangedConventions)
                 {
                     navigationConvention.ProcessNavigationAnnotationChanged(
                         relationshipBuilder, navigation, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -1063,10 +1028,10 @@ public partial class ConventionDispatcher
             string navigationName,
             MemberInfo? memberInfo)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _stringConventionContext.ResetState(navigationName);
-                foreach (var navigationConvention in _conventionSet.NavigationRemovedConventions)
+                foreach (var navigationConvention in conventionSet.NavigationRemovedConventions)
                 {
                     navigationConvention.ProcessNavigationRemoved(
                         sourceEntityTypeBuilder, targetEntityTypeBuilder, navigationName, memberInfo, _stringConventionContext);
@@ -1089,10 +1054,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _skipNavigationBuilderConventionContext.ResetState(navigationBuilder);
-                foreach (var skipNavigationConvention in _conventionSet.SkipNavigationAddedConventions)
+                foreach (var skipNavigationConvention in conventionSet.SkipNavigationAddedConventions)
                 {
                     if (!navigationBuilder.Metadata.IsInModel)
                     {
@@ -1128,10 +1093,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = navigationBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var skipNavigationConvention in _conventionSet.SkipNavigationAnnotationChangedConventions)
+                foreach (var skipNavigationConvention in conventionSet.SkipNavigationAnnotationChangedConventions)
                 {
                     if (navigationBuilder.Metadata.IsInModel
                         && navigationBuilder.Metadata.FindAnnotation(name) != annotation)
@@ -1170,10 +1135,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = navigationBuilder.Metadata.ForeignKey;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _foreignKeyConventionContext.ResetState(foreignKey);
-                foreach (var skipNavigationConvention in _conventionSet.SkipNavigationForeignKeyChangedConventions)
+                foreach (var skipNavigationConvention in conventionSet.SkipNavigationForeignKeyChangedConventions)
                 {
                     skipNavigationConvention.ProcessSkipNavigationForeignKeyChanged(
                         navigationBuilder, foreignKey, oldForeignKey, _foreignKeyConventionContext);
@@ -1182,7 +1147,7 @@ public partial class ConventionDispatcher
                         if (_foreignKeyConventionContext.Result != null)
                         {
                             // Preserve the old configuration to let the conventions finish processing them
-                            _dispatcher.OnSkipNavigationForeignKeyChanged(navigationBuilder, foreignKey, oldForeignKey);
+                            dispatcher.OnSkipNavigationForeignKeyChanged(navigationBuilder, foreignKey, oldForeignKey);
                         }
 
                         return _foreignKeyConventionContext.Result;
@@ -1211,10 +1176,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = navigationBuilder.Metadata.Inverse;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _skipNavigationConventionContext.ResetState(inverse);
-                foreach (var skipNavigationConvention in _conventionSet.SkipNavigationInverseChangedConventions)
+                foreach (var skipNavigationConvention in conventionSet.SkipNavigationInverseChangedConventions)
                 {
                     skipNavigationConvention.ProcessSkipNavigationInverseChanged(
                         navigationBuilder, inverse, oldInverse, _skipNavigationConventionContext);
@@ -1237,10 +1202,10 @@ public partial class ConventionDispatcher
             IConventionEntityTypeBuilder entityTypeBuilder,
             IConventionSkipNavigation navigation)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _skipNavigationConventionContext.ResetState(navigation);
-                foreach (var skipNavigationConvention in _conventionSet.SkipNavigationRemovedConventions)
+                foreach (var skipNavigationConvention in conventionSet.SkipNavigationRemovedConventions)
                 {
                     skipNavigationConvention.ProcessSkipNavigationRemoved(
                         entityTypeBuilder, navigation, _skipNavigationConventionContext);
@@ -1261,10 +1226,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _triggerBuilderConventionContext.ResetState(triggerBuilder);
-                foreach (var triggerConvention in _conventionSet.TriggerAddedConventions)
+                foreach (var triggerConvention in conventionSet.TriggerAddedConventions)
                 {
                     if (!triggerBuilder.Metadata.IsInModel)
                     {
@@ -1289,10 +1254,10 @@ public partial class ConventionDispatcher
 
         public override IConventionTrigger? OnTriggerRemoved(IConventionEntityTypeBuilder entityTypeBuilder, IConventionTrigger trigger)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _triggerConventionContext.ResetState(trigger);
-                foreach (var triggerConvention in _conventionSet.TriggerRemovedConventions)
+                foreach (var triggerConvention in conventionSet.TriggerRemovedConventions)
                 {
                     triggerConvention.ProcessTriggerRemoved(entityTypeBuilder, trigger, _triggerConventionContext);
                     if (_triggerConventionContext.ShouldStopProcessing())
@@ -1312,10 +1277,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _keyBuilderConventionContext.ResetState(keyBuilder);
-                foreach (var keyConvention in _conventionSet.KeyAddedConventions)
+                foreach (var keyConvention in conventionSet.KeyAddedConventions)
                 {
                     if (!keyBuilder.Metadata.IsInModel)
                     {
@@ -1340,10 +1305,10 @@ public partial class ConventionDispatcher
 
         public override IConventionKey? OnKeyRemoved(IConventionEntityTypeBuilder entityTypeBuilder, IConventionKey key)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _keyConventionContext.ResetState(key);
-                foreach (var keyConvention in _conventionSet.KeyRemovedConventions)
+                foreach (var keyConvention in conventionSet.KeyRemovedConventions)
                 {
                     keyConvention.ProcessKeyRemoved(entityTypeBuilder, key, _keyConventionContext);
                     if (_keyConventionContext.ShouldStopProcessing())
@@ -1370,10 +1335,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = keyBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var keyConvention in _conventionSet.KeyAnnotationChangedConventions)
+                foreach (var keyConvention in conventionSet.KeyAnnotationChangedConventions)
                 {
                     keyConvention.ProcessKeyAnnotationChanged(
                         keyBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -1400,10 +1365,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _indexBuilderConventionContext.ResetState(indexBuilder);
-                foreach (var indexConvention in _conventionSet.IndexAddedConventions)
+                foreach (var indexConvention in conventionSet.IndexAddedConventions)
                 {
                     if (!indexBuilder.Metadata.IsInModel)
                     {
@@ -1428,10 +1393,10 @@ public partial class ConventionDispatcher
 
         public override IConventionIndex? OnIndexRemoved(IConventionEntityTypeBuilder entityTypeBuilder, IConventionIndex index)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _indexConventionContext.ResetState(index);
-                foreach (var indexConvention in _conventionSet.IndexRemovedConventions)
+                foreach (var indexConvention in conventionSet.IndexRemovedConventions)
                 {
                     indexConvention.ProcessIndexRemoved(entityTypeBuilder, index, _indexConventionContext);
                     if (_indexConventionContext.ShouldStopProcessing())
@@ -1449,10 +1414,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = indexBuilder.Metadata.IsUnique;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(indexBuilder.Metadata.IsUnique);
-                foreach (var indexConvention in _conventionSet.IndexUniquenessChangedConventions)
+                foreach (var indexConvention in conventionSet.IndexUniquenessChangedConventions)
                 {
                     if (!indexBuilder.Metadata.IsInModel)
                     {
@@ -1480,10 +1445,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = indexBuilder.Metadata.IsDescending;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolListConventionContext.ResetState(indexBuilder.Metadata.IsDescending);
-                foreach (var indexConvention in _conventionSet.IndexSortOrderChangedConventions)
+                foreach (var indexConvention in conventionSet.IndexSortOrderChangedConventions)
                 {
                     if (!indexBuilder.Metadata.IsInModel)
                     {
@@ -1519,10 +1484,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = indexBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var indexConvention in _conventionSet.IndexAnnotationChangedConventions)
+                foreach (var indexConvention in conventionSet.IndexAnnotationChangedConventions)
                 {
                     indexConvention.ProcessIndexAnnotationChanged(
                         indexBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -1549,10 +1514,10 @@ public partial class ConventionDispatcher
                 return null;
             }
 
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _propertyBuilderConventionContext.ResetState(propertyBuilder);
-                foreach (var propertyConvention in _conventionSet.PropertyAddedConventions)
+                foreach (var propertyConvention in conventionSet.PropertyAddedConventions)
                 {
                     if (!propertyBuilder.Metadata.IsInModel)
                     {
@@ -1584,10 +1549,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = propertyBuilder.Metadata.IsNullable;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(propertyBuilder.Metadata.IsNullable);
-                foreach (var propertyConvention in _conventionSet.PropertyNullabilityChangedConventions)
+                foreach (var propertyConvention in conventionSet.PropertyNullabilityChangedConventions)
                 {
                     if (!propertyBuilder.Metadata.IsInModel)
                     {
@@ -1619,10 +1584,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = builder.Metadata.IsNullable;
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _boolConventionContext.ResetState(builder.Metadata.IsNullable);
-                foreach (var elementConvention in _conventionSet.ElementTypeNullabilityChangedConventions)
+                foreach (var elementConvention in conventionSet.ElementTypeNullabilityChangedConventions)
                 {
                     if (!builder.Metadata.IsInModel)
                     {
@@ -1659,7 +1624,7 @@ public partial class ConventionDispatcher
             var initialValue = propertyBuilder.Metadata.FieldInfo;
 #endif
             _fieldInfoConventionContext.ResetState(newFieldInfo);
-            foreach (var propertyConvention in _conventionSet.PropertyFieldChangedConventions)
+            foreach (var propertyConvention in conventionSet.PropertyFieldChangedConventions)
             {
                 propertyConvention.ProcessPropertyFieldChanged(
                     propertyBuilder, newFieldInfo, oldFieldInfo, _fieldInfoConventionContext);
@@ -1691,7 +1656,7 @@ public partial class ConventionDispatcher
             var initialValue = propertyBuilder.Metadata.GetElementType();
 #endif
             _elementTypeConventionContext.ResetState(newElementType);
-            foreach (var propertyConvention in _conventionSet.PropertyElementTypeChangedConventions)
+            foreach (var propertyConvention in conventionSet.PropertyElementTypeChangedConventions)
             {
                 propertyConvention.ProcessPropertyElementTypeChanged(
                     propertyBuilder, newElementType, oldElementType, _elementTypeConventionContext);
@@ -1723,10 +1688,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = propertyBuilder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var propertyConvention in _conventionSet.PropertyAnnotationChangedConventions)
+                foreach (var propertyConvention in conventionSet.PropertyAnnotationChangedConventions)
                 {
                     propertyConvention.ProcessPropertyAnnotationChanged(
                         propertyBuilder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -1761,10 +1726,10 @@ public partial class ConventionDispatcher
 #if DEBUG
             var initialValue = builder.Metadata[name];
 #endif
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _annotationConventionContext.ResetState(annotation);
-                foreach (var elementConvention in _conventionSet.ElementTypeAnnotationChangedConventions)
+                foreach (var elementConvention in conventionSet.ElementTypeAnnotationChangedConventions)
                 {
                     elementConvention.ProcessElementTypeAnnotationChanged(
                         builder, name, annotation, oldAnnotation, _annotationConventionContext);
@@ -1789,10 +1754,10 @@ public partial class ConventionDispatcher
             IConventionTypeBaseBuilder typeBaseBuilder,
             IConventionProperty property)
         {
-            using (_dispatcher.DelayConventions())
+            using (dispatcher.DelayConventions())
             {
                 _propertyConventionContext.ResetState(property);
-                foreach (var propertyConvention in _conventionSet.PropertyRemovedConventions)
+                foreach (var propertyConvention in conventionSet.PropertyRemovedConventions)
                 {
                     propertyConvention.ProcessPropertyRemoved(typeBaseBuilder, property, _propertyConventionContext);
                     if (_propertyConventionContext.ShouldStopProcessing())

--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -95,17 +95,10 @@ public class ModelCleanupConvention :
         }
     }
 
-    private sealed class GraphAdapter : Graph<IConventionEntityType>
+    private sealed class GraphAdapter(IConventionModel model) : Graph<IConventionEntityType>
     {
-        private readonly IConventionModel _model;
-
-        public GraphAdapter(IConventionModel model)
-        {
-            _model = model;
-        }
-
         public override IEnumerable<IConventionEntityType> Vertices
-            => _model.GetEntityTypes();
+            => model.GetEntityTypes();
 
         public override IEnumerable<IConventionEntityType> GetOutgoingNeighbors(IConventionEntityType from)
             => from.GetForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -1420,24 +1420,16 @@ public class RelationshipDiscoveryConvention :
         => entityTypeBuilder.HasAnnotation(CoreAnnotationNames.AmbiguousNavigations, ambiguousNavigations);
 
     [DebuggerDisplay("{DebuggerDisplay(),nq}")]
-    private sealed class RelationshipCandidate
+    private sealed class RelationshipCandidate(
+        IConventionEntityTypeBuilder targetTypeBuilder,
+        List<PropertyInfo> navigations,
+        List<PropertyInfo> inverseNavigations,
+        bool ownership)
     {
-        public RelationshipCandidate(
-            IConventionEntityTypeBuilder targetTypeBuilder,
-            List<PropertyInfo> navigations,
-            List<PropertyInfo> inverseNavigations,
-            bool ownership)
-        {
-            TargetTypeBuilder = targetTypeBuilder;
-            NavigationProperties = navigations;
-            InverseProperties = inverseNavigations;
-            IsOwnership = ownership;
-        }
-
-        public IConventionEntityTypeBuilder TargetTypeBuilder { [DebuggerStepThrough] get; }
-        public List<PropertyInfo> NavigationProperties { [DebuggerStepThrough] get; }
-        public List<PropertyInfo> InverseProperties { [DebuggerStepThrough] get; }
-        public bool IsOwnership { [DebuggerStepThrough] get; }
+        public IConventionEntityTypeBuilder TargetTypeBuilder { [DebuggerStepThrough] get; } = targetTypeBuilder;
+        public List<PropertyInfo> NavigationProperties { [DebuggerStepThrough] get; } = navigations;
+        public List<PropertyInfo> InverseProperties { [DebuggerStepThrough] get; } = inverseNavigations;
+        public bool IsOwnership { [DebuggerStepThrough] get; } = ownership;
 
         private string DebuggerDisplay()
             => TargetTypeBuilder.Metadata.ToDebugString(MetadataDebugStringOptions.SingleLineDefault)

--- a/src/EFCore/Query/Internal/CompiledQueryBase.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryBase.cs
@@ -18,16 +18,10 @@ public abstract class CompiledQueryBase<TContext, TResult>
 
     private ExecutorAndModel? _executor;
 
-    private sealed class ExecutorAndModel
+    private sealed class ExecutorAndModel(Func<QueryContext, TResult> executor, IModel model)
     {
-        public ExecutorAndModel(Func<QueryContext, TResult> executor, IModel model)
-        {
-            Executor = executor;
-            Model = model;
-        }
-
-        public Func<QueryContext, TResult> Executor { get; }
-        public IModel Model { get; }
+        public Func<QueryContext, TResult> Executor { get; } = executor;
+        public IModel Model { get; } = model;
     }
 
     /// <summary>
@@ -109,27 +103,19 @@ public abstract class CompiledQueryBase<TContext, TResult>
                 return new ExecutorAndModel(t.CreateCompiledQuery(queryCompiler, expression), c.Model);
             });
 
-    private sealed class QueryExpressionRewriter : ExpressionVisitor
+    private sealed class QueryExpressionRewriter(
+        TContext context,
+        IReadOnlyCollection<ParameterExpression> parameters)
+        : ExpressionVisitor
     {
-        private readonly TContext _context;
-        private readonly IReadOnlyCollection<ParameterExpression> _parameters;
-
-        public QueryExpressionRewriter(
-            TContext context,
-            IReadOnlyCollection<ParameterExpression> parameters)
-        {
-            _context = context;
-            _parameters = parameters;
-        }
-
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
             if (typeof(TContext).IsAssignableFrom(parameterExpression.Type))
             {
-                return Expression.Constant(_context);
+                return Expression.Constant(context);
             }
 
-            return _parameters.Contains(parameterExpression)
+            return parameters.Contains(parameterExpression)
                 ? Expression.Parameter(
                     parameterExpression.Type,
                     QueryCompilationContext.QueryParameterPrefix + parameterExpression.Name)

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -13,36 +13,25 @@ public partial class NavigationExpandingExpressionVisitor
     ///     Expands navigations in the given tree for given source.
     ///     Optionally also expands navigations for includes.
     /// </summary>
-    private class ExpandingExpressionVisitor : ExpressionVisitor
+    private class ExpandingExpressionVisitor(
+        NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
+        NavigationExpansionExpression source,
+        INavigationExpansionExtensibilityHelper extensibilityHelper)
+        : ExpressionVisitor
     {
-        private readonly NavigationExpandingExpressionVisitor _navigationExpandingExpressionVisitor;
-        private readonly NavigationExpansionExpression _source;
-        private readonly INavigationExpansionExtensibilityHelper _extensibilityHelper;
-
-        public ExpandingExpressionVisitor(
-            NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
-            NavigationExpansionExpression source,
-            INavigationExpansionExtensibilityHelper extensibilityHelper)
-        {
-            _navigationExpandingExpressionVisitor = navigationExpandingExpressionVisitor;
-            _source = source;
-            _extensibilityHelper = extensibilityHelper;
-            Model = navigationExpandingExpressionVisitor._queryCompilationContext.Model;
-        }
-
         public Expression Expand(Expression expression, bool applyIncludes = false)
         {
             expression = Visit(expression);
             if (applyIncludes)
             {
-                expression = new IncludeExpandingExpressionVisitor(_navigationExpandingExpressionVisitor, _source, _extensibilityHelper)
+                expression = new IncludeExpandingExpressionVisitor(navigationExpandingExpressionVisitor, source, extensibilityHelper)
                     .Visit(expression);
             }
 
             return expression;
         }
 
-        protected IModel Model { get; }
+        protected IModel Model { get; } = navigationExpandingExpressionVisitor._queryCompilationContext.Model;
 
         protected override Expression VisitExtension(Expression expression)
         {
@@ -154,10 +143,10 @@ public partial class NavigationExpandingExpressionVisitor
                 }
 
                 // make sure that we can actually expand this navigation (later)
-                _extensibilityHelper.ValidateQueryRootCreation(targetType, entityReference.EntityQueryRootExpression);
+                extensibilityHelper.ValidateQueryRootCreation(targetType, entityReference.EntityQueryRootExpression);
 
                 var ownedEntityReference = new EntityReference(targetType, entityReference.EntityQueryRootExpression);
-                _navigationExpandingExpressionVisitor.PopulateEagerLoadedNavigations(ownedEntityReference.IncludePaths);
+                navigationExpandingExpressionVisitor.PopulateEagerLoadedNavigations(ownedEntityReference.IncludePaths);
                 ownedEntityReference.MarkAsOptional();
                 if (entityReference.IncludePaths.TryGetValue(navigation, out var includePath))
                 {
@@ -227,9 +216,9 @@ public partial class NavigationExpandingExpressionVisitor
                     var secondTargetType = navigation.TargetEntityType;
                     // we can use the entity reference here. If the join entity wasn't temporal,
                     // the query root creation validator would have thrown the exception when it was being created
-                    _extensibilityHelper.ValidateQueryRootCreation(secondTargetType, entityReference.EntityQueryRootExpression);
-                    var innerQueryable = _extensibilityHelper.CreateQueryRoot(secondTargetType, entityReference.EntityQueryRootExpression);
-                    var innerSource = (NavigationExpansionExpression)_navigationExpandingExpressionVisitor.Visit(innerQueryable);
+                    extensibilityHelper.ValidateQueryRootCreation(secondTargetType, entityReference.EntityQueryRootExpression);
+                    var innerQueryable = extensibilityHelper.CreateQueryRoot(secondTargetType, entityReference.EntityQueryRootExpression);
+                    var innerSource = (NavigationExpansionExpression)navigationExpandingExpressionVisitor.Visit(innerQueryable);
 
                     if (includeTree != null)
                     {
@@ -277,9 +266,9 @@ public partial class NavigationExpandingExpressionVisitor
                     // Second pseudo-navigation is a collection
                     var secondTargetType = navigation.TargetEntityType;
 
-                    _extensibilityHelper.ValidateQueryRootCreation(secondTargetType, entityReference.EntityQueryRootExpression);
-                    var innerQueryable = _extensibilityHelper.CreateQueryRoot(secondTargetType, entityReference.EntityQueryRootExpression);
-                    var innerSource = (NavigationExpansionExpression)_navigationExpandingExpressionVisitor.Visit(innerQueryable);
+                    extensibilityHelper.ValidateQueryRootCreation(secondTargetType, entityReference.EntityQueryRootExpression);
+                    var innerQueryable = extensibilityHelper.CreateQueryRoot(secondTargetType, entityReference.EntityQueryRootExpression);
+                    var innerSource = (NavigationExpansionExpression)navigationExpandingExpressionVisitor.Visit(innerQueryable);
 
                     if (includeTree != null)
                     {
@@ -357,9 +346,9 @@ public partial class NavigationExpandingExpressionVisitor
 
             Check.DebugAssert(!targetType.IsOwned(), "Owned entity expanding foreign key.");
 
-            _extensibilityHelper.ValidateQueryRootCreation(targetType, entityReference.EntityQueryRootExpression);
-            var innerQueryable = _extensibilityHelper.CreateQueryRoot(targetType, entityReference.EntityQueryRootExpression);
-            var innerSource = (NavigationExpansionExpression)_navigationExpandingExpressionVisitor.Visit(innerQueryable);
+            extensibilityHelper.ValidateQueryRootCreation(targetType, entityReference.EntityQueryRootExpression);
+            var innerQueryable = extensibilityHelper.CreateQueryRoot(targetType, entityReference.EntityQueryRootExpression);
+            var innerSource = (NavigationExpansionExpression)navigationExpandingExpressionVisitor.Visit(innerQueryable);
 
             // Value known to be non-null
             var innerEntityReference = UnwrapEntityReference(innerSource.PendingSelector)!;
@@ -440,14 +429,14 @@ public partial class NavigationExpandingExpressionVisitor
                             predicateBody, innerParameter)));
             }
 
-            var outerKeySelector = _navigationExpandingExpressionVisitor.GenerateLambda(
-                outerKey, _source.CurrentParameter);
-            var innerKeySelector = _navigationExpandingExpressionVisitor.ProcessLambdaExpression(
+            var outerKeySelector = navigationExpandingExpressionVisitor.GenerateLambda(
+                outerKey, source.CurrentParameter);
+            var innerKeySelector = navigationExpandingExpressionVisitor.ProcessLambdaExpression(
                 innerSource, Expression.Lambda(innerKey, innerParameter));
 
-            var resultSelectorOuterParameter = Expression.Parameter(_source.SourceElementType, "o");
+            var resultSelectorOuterParameter = Expression.Parameter(source.SourceElementType, "o");
             var resultSelectorInnerParameter = Expression.Parameter(innerSource.SourceElementType, "i");
-            var resultType = TransparentIdentifierFactory.Create(_source.SourceElementType, innerSource.SourceElementType);
+            var resultType = TransparentIdentifierFactory.Create(source.SourceElementType, innerSource.SourceElementType);
 
             var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer")!;
             var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner")!;
@@ -471,16 +460,16 @@ public partial class NavigationExpandingExpressionVisitor
                 innerEntityReference.MarkAsOptional();
             }
 
-            _source.UpdateSource(
+            source.UpdateSource(
                 Expression.Call(
                     (innerJoin
                         ? QueryableMethods.Join
                         : QueryableExtensions.LeftJoinMethodInfo).MakeGenericMethod(
-                        _source.SourceElementType,
+                        source.SourceElementType,
                         innerSource.SourceElementType,
                         outerKeySelector.ReturnType,
                         resultSelector.ReturnType),
-                    _source.Source,
+                    source.Source,
                     innerSource.Source,
                     Expression.Quote(outerKeySelector),
                     Expression.Quote(innerKeySelector),
@@ -488,7 +477,7 @@ public partial class NavigationExpandingExpressionVisitor
 
             entityReference.ForeignKeyExpansionMap[(foreignKey, onDependent)] = innerSource.PendingSelector;
 
-            _source.UpdateCurrentTree(new NavigationTreeNode(_source.CurrentTree, innerSource.CurrentTree));
+            source.UpdateCurrentTree(new NavigationTreeNode(source.CurrentTree, innerSource.CurrentTree));
 
             return innerSource.PendingSelector;
         }
@@ -498,26 +487,19 @@ public partial class NavigationExpandingExpressionVisitor
     ///     Expands an include tree. This is separate and needed because we may need to reconstruct parts of
     ///     <see cref="NewExpression" /> to apply includes.
     /// </summary>
-    private sealed class IncludeExpandingExpressionVisitor : ExpandingExpressionVisitor
+    private sealed class IncludeExpandingExpressionVisitor(
+        NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
+        NavigationExpansionExpression source,
+        INavigationExpansionExtensibilityHelper extensibilityHelper)
+        : ExpandingExpressionVisitor(navigationExpandingExpressionVisitor, source, extensibilityHelper)
     {
         private static readonly MethodInfo FetchJoinEntityMethodInfo =
             typeof(NavigationExpandingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(FetchJoinEntity))!;
 
-        private readonly bool _queryStateManager;
-        private readonly bool _ignoreAutoIncludes;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
-
-        public IncludeExpandingExpressionVisitor(
-            NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
-            NavigationExpansionExpression source,
-            INavigationExpansionExtensibilityHelper extensibilityHelper)
-            : base(navigationExpandingExpressionVisitor, source, extensibilityHelper)
-        {
-            _logger = navigationExpandingExpressionVisitor._queryCompilationContext.Logger;
-            _queryStateManager = navigationExpandingExpressionVisitor._queryCompilationContext.QueryTrackingBehavior is
-                QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
-            _ignoreAutoIncludes = navigationExpandingExpressionVisitor._queryCompilationContext.IgnoreAutoIncludes;
-        }
+        private readonly bool _queryStateManager = navigationExpandingExpressionVisitor._queryCompilationContext.QueryTrackingBehavior is
+            QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+        private readonly bool _ignoreAutoIncludes = navigationExpandingExpressionVisitor._queryCompilationContext.IgnoreAutoIncludes;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger = navigationExpandingExpressionVisitor._queryCompilationContext.Logger;
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
@@ -931,33 +913,23 @@ public partial class NavigationExpandingExpressionVisitor
     ///     <see cref="NavigationExpansionExpression" /> remembers the pending selector so we don't expand
     ///     navigations unless we need to. This visitor applies them when we need to.
     /// </summary>
-    private sealed class PendingSelectorExpandingExpressionVisitor : ExpressionVisitor
+    private sealed class PendingSelectorExpandingExpressionVisitor(
+        NavigationExpandingExpressionVisitor visitor,
+        INavigationExpansionExtensibilityHelper extensibilityHelper,
+        bool applyIncludes = false)
+        : ExpressionVisitor
     {
-        private readonly NavigationExpandingExpressionVisitor _visitor;
-        private readonly bool _applyIncludes;
-        private readonly INavigationExpansionExtensibilityHelper _extensibilityHelper;
-
-        public PendingSelectorExpandingExpressionVisitor(
-            NavigationExpandingExpressionVisitor visitor,
-            INavigationExpansionExtensibilityHelper extensibilityHelper,
-            bool applyIncludes = false)
-        {
-            _visitor = visitor;
-            _extensibilityHelper = extensibilityHelper;
-            _applyIncludes = applyIncludes;
-        }
-
         [return: NotNullIfNotNull(nameof(expression))]
         public override Expression? Visit(Expression? expression)
         {
             if (expression is NavigationExpansionExpression navigationExpansionExpression)
             {
-                _visitor.ApplyPendingOrderings(navigationExpansionExpression);
+                visitor.ApplyPendingOrderings(navigationExpansionExpression);
 
-                var pendingSelector = new ExpandingExpressionVisitor(_visitor, navigationExpansionExpression, _extensibilityHelper)
-                    .Expand(navigationExpansionExpression.PendingSelector, _applyIncludes);
-                pendingSelector = _visitor._subqueryMemberPushdownExpressionVisitor.Visit(pendingSelector);
-                pendingSelector = _visitor.Visit(pendingSelector);
+                var pendingSelector = new ExpandingExpressionVisitor(visitor, navigationExpansionExpression, extensibilityHelper)
+                    .Expand(navigationExpansionExpression.PendingSelector, applyIncludes);
+                pendingSelector = visitor._subqueryMemberPushdownExpressionVisitor.Visit(pendingSelector);
+                pendingSelector = visitor.Visit(pendingSelector);
                 pendingSelector = Visit(pendingSelector);
                 navigationExpansionExpression.ApplySelector(pendingSelector);
 
@@ -1064,23 +1036,15 @@ public partial class NavigationExpandingExpressionVisitor
     /// <summary>
     ///     Allows self reference of query root inside query filters/defining queries.
     /// </summary>
-    private sealed class SelfReferenceEntityQueryableRewritingExpressionVisitor : ExpressionVisitor
+    private sealed class SelfReferenceEntityQueryableRewritingExpressionVisitor(
+        NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
+        IEntityType entityType)
+        : ExpressionVisitor
     {
-        private readonly NavigationExpandingExpressionVisitor _navigationExpandingExpressionVisitor;
-        private readonly IEntityType _entityType;
-
-        public SelfReferenceEntityQueryableRewritingExpressionVisitor(
-            NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
-            IEntityType entityType)
-        {
-            _navigationExpandingExpressionVisitor = navigationExpandingExpressionVisitor;
-            _entityType = entityType;
-        }
-
         protected override Expression VisitExtension(Expression extensionExpression)
             => extensionExpression is EntityQueryRootExpression entityQueryRootExpression
-                && entityQueryRootExpression.EntityType == _entityType
-                    ? _navigationExpandingExpressionVisitor.CreateNavigationExpansionExpression(entityQueryRootExpression, _entityType)
+                && entityQueryRootExpression.EntityType == entityType
+                    ? navigationExpandingExpressionVisitor.CreateNavigationExpansionExpression(entityQueryRootExpression, entityType)
                     : base.VisitExtension(extensionExpression);
     }
 
@@ -1208,15 +1172,9 @@ public partial class NavigationExpandingExpressionVisitor
                     : base.VisitMember(memberExpression);
     }
 
-    private sealed class RemoveRedundantNavigationComparisonExpressionVisitor : ExpressionVisitor
+    private sealed class RemoveRedundantNavigationComparisonExpressionVisitor(IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        : ExpressionVisitor
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
-
-        public RemoveRedundantNavigationComparisonExpressionVisitor(IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-        {
-            _logger = logger;
-        }
-
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
             => binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
                 && TryRemoveNavigationComparison(
@@ -1272,7 +1230,7 @@ public partial class NavigationExpandingExpressionVisitor
 
                 if (nonNullNavigationData.Navigation?.IsCollection == true)
                 {
-                    _logger.PossibleUnintendedCollectionNavigationNullComparisonWarning(nonNullNavigationData.Navigation);
+                    logger.PossibleUnintendedCollectionNavigationNullComparisonWarning(nonNullNavigationData.Navigation);
 
                     // Inner would be non-null when navigation is non-null
                     result = Expression.MakeBinary(
@@ -1288,7 +1246,7 @@ public partial class NavigationExpandingExpressionVisitor
                 {
                     if (leftNavigationData.Navigation == rightNavigationData.Navigation)
                     {
-                        _logger.PossibleUnintendedReferenceComparisonWarning(leftNavigationData.Current, rightNavigationData.Current);
+                        logger.PossibleUnintendedReferenceComparisonWarning(leftNavigationData.Current, rightNavigationData.Current);
                         // Inner would be non-null when navigation is non-null
                         result = Expression.MakeBinary(nodeType, leftNavigationData.Inner!.Current, rightNavigationData.Inner!.Current);
                     }

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -85,25 +85,17 @@ public partial class NavigationExpandingExpressionVisitor
     /// <summary>
     ///     A tree structure of includes for a given entity type in <see cref="EntityReference" />.
     /// </summary>
-    private sealed class IncludeTreeNode : Dictionary<INavigationBase, IncludeTreeNode>
+    private sealed class IncludeTreeNode(IEntityType entityType, EntityReference? reference, bool setLoaded)
+        : Dictionary<INavigationBase, IncludeTreeNode>
     {
-        private EntityReference? _entityReference;
-
         public IncludeTreeNode(IEntityType entityType)
             : this(entityType, null, setLoaded: true)
         {
         }
 
-        public IncludeTreeNode(IEntityType entityType, EntityReference? entityReference, bool setLoaded)
-        {
-            EntityType = entityType;
-            _entityReference = entityReference;
-            SetLoaded = setLoaded;
-        }
-
-        public IEntityType EntityType { get; }
+        public IEntityType EntityType { get; } = entityType;
         public LambdaExpression? FilterExpression { get; private set; }
-        public bool SetLoaded { get; private set; }
+        public bool SetLoaded { get; private set; } = setLoaded;
 
         public IncludeTreeNode AddNavigation(INavigationBase navigation, bool setLoaded)
         {
@@ -118,17 +110,17 @@ public partial class NavigationExpandingExpressionVisitor
             }
 
             IncludeTreeNode? nodeToAdd = null;
-            if (_entityReference != null)
+            if (reference != null)
             {
                 if (navigation is INavigation concreteNavigation
-                    && _entityReference.ForeignKeyExpansionMap.TryGetValue(
+                    && reference.ForeignKeyExpansionMap.TryGetValue(
                         (concreteNavigation.ForeignKey, concreteNavigation.IsOnDependent), out var expansion))
                 {
                     // Value known to be non-null
                     nodeToAdd = UnwrapEntityReference(expansion)!.IncludePaths;
                 }
                 else if (navigation is ISkipNavigation skipNavigation
-                         && _entityReference.ForeignKeyExpansionMap.TryGetValue(
+                         && reference.ForeignKeyExpansionMap.TryGetValue(
                              (skipNavigation.ForeignKey, skipNavigation.IsOnDependent), out var firstExpansion)
                          // Value known to be non-null
                          && UnwrapEntityReference(firstExpansion)!.ForeignKeyExpansionMap.TryGetValue(
@@ -169,7 +161,7 @@ public partial class NavigationExpandingExpressionVisitor
         }
 
         public void AssignEntityReference(EntityReference entityReference)
-            => _entityReference = entityReference;
+            => reference = entityReference;
 
         public void ApplyFilter(LambdaExpression filterExpression)
             => FilterExpression = filterExpression;
@@ -370,18 +362,12 @@ public partial class NavigationExpandingExpressionVisitor
     ///     <see cref="NavigationExpansionExpression" />. Contains <see cref="Value" />,
     ///     which can be <see cref="NewExpression" /> or <see cref="EntityReference" />.
     /// </summary>
-    private sealed class NavigationTreeExpression : NavigationTreeNode, IPrintableExpression
+    private sealed class NavigationTreeExpression(Expression value) : NavigationTreeNode(null, null), IPrintableExpression
     {
-        public NavigationTreeExpression(Expression value)
-            : base(null, null)
-        {
-            Value = value;
-        }
-
         /// <summary>
         ///     Either <see cref="NewExpression" /> or <see cref="EntityReference" />.
         /// </summary>
-        public Expression Value { get; private set; }
+        public Expression Value { get; private set; } = value;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
@@ -463,15 +449,9 @@ public partial class NavigationExpandingExpressionVisitor
     ///     Owned navigations are not expanded, since they map differently in different providers.
     ///     This remembers such references so that they can still be treated like navigations.
     /// </summary>
-    private sealed class OwnedNavigationReference : Expression, IPrintableExpression
+    private sealed class OwnedNavigationReference(Expression parent, INavigation navigation, EntityReference entityReference)
+        : Expression, IPrintableExpression
     {
-        public OwnedNavigationReference(Expression parent, INavigation navigation, EntityReference entityReference)
-        {
-            Parent = parent;
-            Navigation = navigation;
-            EntityReference = entityReference;
-        }
-
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
             Parent = visitor.Visit(Parent);
@@ -479,9 +459,9 @@ public partial class NavigationExpandingExpressionVisitor
             return this;
         }
 
-        public Expression Parent { get; private set; }
-        public INavigation Navigation { get; }
-        public EntityReference EntityReference { get; }
+        public Expression Parent { get; private set; } = parent;
+        public INavigation Navigation { get; } = navigation;
+        public EntityReference EntityReference { get; } = entityReference;
 
         public override Type Type
             => Navigation.ClrType;
@@ -505,14 +485,8 @@ public partial class NavigationExpandingExpressionVisitor
     /// <summary>
     ///     Queryable properties are not expanded (similar to <see cref="OwnedNavigationReference" />.
     /// </summary>
-    private sealed class PrimitiveCollectionReference : Expression, IPrintableExpression
+    private sealed class PrimitiveCollectionReference(Expression parent, IProperty property) : Expression, IPrintableExpression
     {
-        public PrimitiveCollectionReference(Expression parent, IProperty property)
-        {
-            Parent = parent;
-            Property = property;
-        }
-
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
             Parent = visitor.Visit(Parent);
@@ -520,8 +494,8 @@ public partial class NavigationExpandingExpressionVisitor
             return this;
         }
 
-        public Expression Parent { get; private set; }
-        public new IProperty Property { get; }
+        public Expression Parent { get; private set; } = parent;
+        public new IProperty Property { get; } = property;
 
         public override Type Type
             => Property.ClrType;

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -850,43 +850,27 @@ public static class ExecutionStrategyExtensions
                 s.CommitFailed && await s.VerifySucceeded(s.State, ct).ConfigureAwait(false),
                 s.Result), cancellationToken);
 
-    private sealed class ExecutionState<TState, TResult>
+    private sealed class ExecutionState<TState, TResult>(
+        Func<TState, TResult> operation,
+        Func<TState, bool> verifySucceeded,
+        TState state)
     {
-        public ExecutionState(
-            Func<TState, TResult> operation,
-            Func<TState, bool> verifySucceeded,
-            TState state)
-        {
-            Operation = operation;
-            VerifySucceeded = verifySucceeded;
-            State = state;
-            Result = default!;
-        }
-
-        public Func<TState, TResult> Operation { get; }
-        public Func<TState, bool> VerifySucceeded { get; }
-        public TState State { get; }
-        public TResult Result { get; set; }
+        public Func<TState, TResult> Operation { get; } = operation;
+        public Func<TState, bool> VerifySucceeded { get; } = verifySucceeded;
+        public TState State { get; } = state;
+        public TResult Result { get; set; } = default!;
         public bool CommitFailed { get; set; }
     }
 
-    private sealed class ExecutionStateAsync<TState, TResult>
+    private sealed class ExecutionStateAsync<TState, TResult>(
+        Func<TState, CancellationToken, Task<TResult>> operation,
+        Func<TState, CancellationToken, Task<bool>> verifySucceeded,
+        TState state)
     {
-        public ExecutionStateAsync(
-            Func<TState, CancellationToken, Task<TResult>> operation,
-            Func<TState, CancellationToken, Task<bool>> verifySucceeded,
-            TState state)
-        {
-            Operation = operation;
-            VerifySucceeded = verifySucceeded;
-            State = state;
-            Result = default!;
-        }
-
-        public Func<TState, CancellationToken, Task<TResult>> Operation { get; }
-        public Func<TState, CancellationToken, Task<bool>> VerifySucceeded { get; }
-        public TState State { get; }
-        public TResult Result { get; set; }
+        public Func<TState, CancellationToken, Task<TResult>> Operation { get; } = operation;
+        public Func<TState, CancellationToken, Task<bool>> VerifySucceeded { get; } = verifySucceeded;
+        public TState State { get; } = state;
+        public TResult Result { get; set; } = default!;
         public bool CommitFailed { get; set; }
     }
 }

--- a/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
+++ b/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
@@ -140,17 +140,11 @@ public class HiLoValueGeneratorState : IDisposable
         return newValue;
     }
 
-    private sealed class HiLoValue
+    private sealed class HiLoValue(long low, long high)
     {
-        public HiLoValue(long low, long high)
-        {
-            Low = low;
-            High = high;
-        }
+        public long Low { get; } = low;
 
-        public long Low { get; }
-
-        public long High { get; }
+        public long High { get; } = high;
 
         public HiLoValue NextValue()
             => new(Low + 1, High);

--- a/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
@@ -43,18 +43,11 @@ public class ValueGeneratorCache : IValueGeneratorCache
 
     private readonly ConcurrentDictionary<CacheKey, ValueGenerator?> _cache = new();
 
-    private readonly struct CacheKey : IEquatable<CacheKey>
+    private readonly struct CacheKey(IProperty property, ITypeBase typeBase) : IEquatable<CacheKey>
     {
-        private readonly Guid _modelId;
-        private readonly string? _property;
-        private readonly string? _typeBase;
-
-        public CacheKey(IProperty property, ITypeBase typeBase)
-        {
-            _modelId = typeBase.Model.ModelId;
-            _property = property.Name;
-            _typeBase = typeBase.Name;
-        }
+        private readonly Guid _modelId = typeBase.Model.ModelId;
+        private readonly string? _property = property.Name;
+        private readonly string? _typeBase = typeBase.Name;
 
         public bool Equals(CacheKey other)
             => (_property!.Equals(other._property, StringComparison.Ordinal)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -931,28 +931,21 @@ namespace Microsoft.Data.Sqlite
             return values;
         }
 
-        private sealed class AggregateDefinition<TAccumulate, TResult>
+        private sealed class AggregateDefinition<TAccumulate, TResult>(
+            string name,
+            TAccumulate seed,
+            Func<TAccumulate, SqliteValueReader, TAccumulate>? func,
+            Func<TAccumulate, TResult>? resultSelector)
         {
-            public AggregateDefinition(string name, TAccumulate seed, Func<TAccumulate, SqliteValueReader, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector)
-            {
-                Name = name;
-                Seed = seed;
-                Func = func;
-                ResultSelector = resultSelector;
-            }
-
-            public string Name { get; }
-            public TAccumulate Seed { get; }
-            public Func<TAccumulate, SqliteValueReader, TAccumulate>? Func { get; }
-            public Func<TAccumulate, TResult>? ResultSelector { get; }
+            public string Name { get; } = name;
+            public TAccumulate Seed { get; } = seed;
+            public Func<TAccumulate, SqliteValueReader, TAccumulate>? Func { get; } = func;
+            public Func<TAccumulate, TResult>? ResultSelector { get; } = resultSelector;
         }
 
-        private sealed class AggregateContext<T>
+        private sealed class AggregateContext<T>(T seed)
         {
-            public AggregateContext(T seed)
-                => Accumulate = seed;
-
-            public T Accumulate { get; set; }
+            public T Accumulate { get; set; } = seed;
             public Exception? Exception { get; set; }
         }
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionPoolGroup.cs
@@ -3,21 +3,14 @@
 
 namespace Microsoft.Data.Sqlite
 {
-    internal class SqliteConnectionPoolGroup
+    internal class SqliteConnectionPoolGroup(SqliteConnectionStringBuilder connectionOptions, string connectionString, bool isNonPooled)
     {
         private SqliteConnectionPool? _pool;
         private State _state = State.Active;
 
-        public SqliteConnectionPoolGroup(SqliteConnectionStringBuilder connectionOptions, string connectionString, bool isNonPooled)
-        {
-            ConnectionOptions = connectionOptions;
-            ConnectionString = connectionString;
-            IsNonPooled = isNonPooled;
-        }
-
-        public SqliteConnectionStringBuilder ConnectionOptions { get; }
-        public string ConnectionString { get; }
-        public bool IsNonPooled { get; }
+        public SqliteConnectionStringBuilder ConnectionOptions { get; } = connectionOptions;
+        public string ConnectionString { get; } = connectionString;
+        public bool IsNonPooled { get; } = isNonPooled;
 
         public bool IsDisabled
             => _state == State.Disabled;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
@@ -7,71 +7,58 @@ using static SQLitePCL.raw;
 
 namespace Microsoft.Data.Sqlite
 {
-    internal class SqliteParameterBinder : SqliteValueBinder
+    internal class SqliteParameterBinder(sqlite3_stmt stmt, sqlite3 handle, int index, object value, int? size, SqliteType? sqliteType)
+        : SqliteValueBinder(value, sqliteType)
     {
-        private readonly sqlite3_stmt _stmt;
-        private readonly sqlite3 _handle;
-        private readonly int _index;
-        private readonly int? _size;
-
-        public SqliteParameterBinder(sqlite3_stmt stmt, sqlite3 handle, int index, object value, int? size, SqliteType? sqliteType)
-            : base(value, sqliteType)
-        {
-            _stmt = stmt;
-            _handle = handle;
-            _index = index;
-            _size = size;
-        }
-
         protected override void BindBlob(byte[] value)
         {
             var blob = value;
             if (ShouldTruncate(value.Length))
             {
-                blob = new byte[_size!.Value];
-                Array.Copy(value, blob, _size.Value);
+                blob = new byte[size!.Value];
+                Array.Copy(value, blob, size.Value);
             }
 
-            var rc = sqlite3_bind_blob(_stmt, _index, blob);
-            SqliteException.ThrowExceptionForRC(rc, _handle);
+            var rc = sqlite3_bind_blob(stmt, index, blob);
+            SqliteException.ThrowExceptionForRC(rc, handle);
         }
 
         protected override void BindDoubleCore(double value)
         {
-            var rc = sqlite3_bind_double(_stmt, _index, value);
+            var rc = sqlite3_bind_double(stmt, index, value);
 
-            SqliteException.ThrowExceptionForRC(rc, _handle);
+            SqliteException.ThrowExceptionForRC(rc, handle);
         }
 
         protected override void BindInt64(long value)
         {
-            var rc = sqlite3_bind_int64(_stmt, _index, value);
+            var rc = sqlite3_bind_int64(stmt, index, value);
 
-            SqliteException.ThrowExceptionForRC(rc, _handle);
+            SqliteException.ThrowExceptionForRC(rc, handle);
         }
 
         protected override void BindNull()
         {
-            var rc = sqlite3_bind_null(_stmt, _index);
+            var rc = sqlite3_bind_null(stmt, index);
 
-            SqliteException.ThrowExceptionForRC(rc, _handle);
+            SqliteException.ThrowExceptionForRC(rc, handle);
         }
 
         protected override void BindText(string value)
         {
             var rc = sqlite3_bind_text(
-                _stmt,
-                _index,
+                stmt,
+                index,
                 ShouldTruncate(value.Length)
-                    ? value.Substring(0, _size!.Value)
+                    ? value.Substring(0, size!.Value)
                     : value);
 
-            SqliteException.ThrowExceptionForRC(rc, _handle);
+            SqliteException.ThrowExceptionForRC(rc, handle);
         }
 
         private bool ShouldTruncate(int length)
-            => _size.HasValue
-                && length > _size.Value
-                && _size.Value != -1;
+            => size.HasValue
+                && length > size.Value
+                && size.Value != -1;
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterReader.cs
@@ -7,36 +7,27 @@ using static SQLitePCL.raw;
 
 namespace Microsoft.Data.Sqlite
 {
-    internal class SqliteParameterReader : SqliteValueReader
+    internal class SqliteParameterReader(string function, sqlite3_value[] values) : SqliteValueReader
     {
-        private readonly string _function;
-        private readonly sqlite3_value[] _values;
-
-        public SqliteParameterReader(string function, sqlite3_value[] values)
-        {
-            _function = function;
-            _values = values;
-        }
-
         public override int FieldCount
-            => _values.Length;
+            => values.Length;
 
         protected override string GetOnNullErrorMsg(int ordinal)
-            => Resources.UDFCalledWithNull(_function, ordinal);
+            => Resources.UDFCalledWithNull(function, ordinal);
 
         protected override double GetDoubleCore(int ordinal)
-            => sqlite3_value_double(_values[ordinal]);
+            => sqlite3_value_double(values[ordinal]);
 
         protected override long GetInt64Core(int ordinal)
-            => sqlite3_value_int64(_values[ordinal]);
+            => sqlite3_value_int64(values[ordinal]);
 
         protected override string GetStringCore(int ordinal)
-            => sqlite3_value_text(_values[ordinal]).utf8_to_string();
+            => sqlite3_value_text(values[ordinal]).utf8_to_string();
 
         protected override byte[] GetBlobCore(int ordinal)
-            => sqlite3_value_blob(_values[ordinal]).ToArray();
+            => sqlite3_value_blob(values[ordinal]).ToArray();
 
         protected override int GetSqliteType(int ordinal)
-            => sqlite3_value_type(_values[ordinal]);
+            => sqlite3_value_type(values[ordinal]);
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
@@ -6,29 +6,21 @@ using static SQLitePCL.raw;
 
 namespace Microsoft.Data.Sqlite
 {
-    internal class SqliteResultBinder : SqliteValueBinder
+    internal class SqliteResultBinder(sqlite3_context ctx, object? value) : SqliteValueBinder(value)
     {
-        private readonly sqlite3_context _ctx;
-
-        public SqliteResultBinder(sqlite3_context ctx, object? value)
-            : base(value)
-        {
-            _ctx = ctx;
-        }
-
         protected override void BindBlob(byte[] value)
-            => sqlite3_result_blob(_ctx, value);
+            => sqlite3_result_blob(ctx, value);
 
         protected override void BindDoubleCore(double value)
-            => sqlite3_result_double(_ctx, value);
+            => sqlite3_result_double(ctx, value);
 
         protected override void BindInt64(long value)
-            => sqlite3_result_int64(_ctx, value);
+            => sqlite3_result_int64(ctx, value);
 
         protected override void BindNull()
-            => sqlite3_result_null(_ctx);
+            => sqlite3_result_null(ctx);
 
         protected override void BindText(string value)
-            => sqlite3_result_text(_ctx, value);
+            => sqlite3_result_text(ctx, value);
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
@@ -9,20 +9,11 @@ using Microsoft.Data.Sqlite.Properties;
 namespace Microsoft.Data.Sqlite
 {
     // TODO: Make generic
-    internal abstract class SqliteValueBinder
+    internal abstract class SqliteValueBinder(object? value, SqliteType? sqliteType)
     {
-        private readonly object? _value;
-        private readonly SqliteType? _sqliteType;
-
         protected SqliteValueBinder(object? value)
             : this(value, null)
         {
-        }
-
-        protected SqliteValueBinder(object? value, SqliteType? sqliteType)
-        {
-            _value = value;
-            _sqliteType = sqliteType;
         }
 
         protected abstract void BindInt64(long value);
@@ -47,33 +38,33 @@ namespace Microsoft.Data.Sqlite
 
         public virtual void Bind()
         {
-            if (_value == null)
+            if (value == null)
             {
                 BindNull();
 
                 return;
             }
 
-            var type = _value.GetType().UnwrapNullableType().UnwrapEnumType();
+            var type = value.GetType().UnwrapNullableType().UnwrapEnumType();
             if (type == typeof(bool))
             {
-                var value = (bool)_value ? 1L : 0;
-                BindInt64(value);
+                var value1 = (bool)value ? 1L : 0;
+                BindInt64(value1);
             }
             else if (type == typeof(byte))
             {
-                var value = (long)(byte)_value;
-                BindInt64(value);
+                var value1 = (long)(byte)value;
+                BindInt64(value1);
             }
             else if (type == typeof(byte[]))
             {
-                var value = (byte[])_value;
-                BindBlob(value);
+                var value1 = (byte[])value;
+                BindBlob(value1);
             }
             else if (type == typeof(char))
             {
-                var chr = (char)_value;
-                if (_sqliteType != SqliteType.Integer)
+                var chr = (char)value;
+                if (sqliteType != SqliteType.Integer)
                 {
                     var value = new string(chr, 1);
                     BindText(value);
@@ -86,8 +77,8 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(DateTime))
             {
-                var dateTime = (DateTime)_value;
-                if (_sqliteType == SqliteType.Real)
+                var dateTime = (DateTime)value;
+                if (sqliteType == SqliteType.Real)
                 {
                     var value = ToJulianDate(dateTime);
                     BindDouble(value);
@@ -100,8 +91,8 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(DateTimeOffset))
             {
-                var dateTimeOffset = (DateTimeOffset)_value;
-                if (_sqliteType == SqliteType.Real)
+                var dateTimeOffset = (DateTimeOffset)value;
+                if (sqliteType == SqliteType.Real)
                 {
                     var value = ToJulianDate(dateTimeOffset.DateTime);
                     BindDouble(value);
@@ -115,8 +106,8 @@ namespace Microsoft.Data.Sqlite
 #if NET6_0_OR_GREATER
             else if (type == typeof(DateOnly))
             {
-                var dateOnly = (DateOnly)_value;
-                if (_sqliteType == SqliteType.Real)
+                var dateOnly = (DateOnly)value;
+                if (sqliteType == SqliteType.Real)
                 {
                     var value = ToJulianDate(dateOnly.Year, dateOnly.Month, dateOnly.Day, 0, 0, 0, 0);
                     BindDouble(value);
@@ -129,8 +120,8 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(TimeOnly))
             {
-                var timeOnly = (TimeOnly)_value;
-                if (_sqliteType == SqliteType.Real)
+                var timeOnly = (TimeOnly)value;
+                if (sqliteType == SqliteType.Real)
                 {
                     var value = GetTotalDays(timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond);
                     BindDouble(value);
@@ -150,23 +141,23 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(decimal))
             {
-                var value = ((decimal)_value).ToString("0.0###########################", CultureInfo.InvariantCulture);
-                BindText(value);
+                var value1 = ((decimal)value).ToString("0.0###########################", CultureInfo.InvariantCulture);
+                BindText(value1);
             }
             else if (type == typeof(double))
             {
-                var value = (double)_value;
-                BindDouble(value);
+                var value1 = (double)value;
+                BindDouble(value1);
             }
             else if (type == typeof(float))
             {
-                var value = (double)(float)_value;
-                BindDouble(value);
+                var value1 = (double)(float)value;
+                BindDouble(value1);
             }
             else if (type == typeof(Guid))
             {
-                var guid = (Guid)_value;
-                if (_sqliteType != SqliteType.Blob)
+                var guid = (Guid)value;
+                if (sqliteType != SqliteType.Blob)
                 {
                     var value = guid.ToString().ToUpperInvariant();
                     BindText(value);
@@ -179,33 +170,33 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(int))
             {
-                var value = (long)(int)_value;
-                BindInt64(value);
+                var value1 = (long)(int)value;
+                BindInt64(value1);
             }
             else if (type == typeof(long))
             {
-                var value = (long)_value;
-                BindInt64(value);
+                var value1 = (long)value;
+                BindInt64(value1);
             }
             else if (type == typeof(sbyte))
             {
-                var value = (long)(sbyte)_value;
-                BindInt64(value);
+                var value1 = (long)(sbyte)value;
+                BindInt64(value1);
             }
             else if (type == typeof(short))
             {
-                var value = (long)(short)_value;
-                BindInt64(value);
+                var value1 = (long)(short)value;
+                BindInt64(value1);
             }
             else if (type == typeof(string))
             {
-                var value = (string)_value;
-                BindText(value);
+                var value1 = (string)value;
+                BindText(value1);
             }
             else if (type == typeof(TimeSpan))
             {
-                var timeSpan = (TimeSpan)_value;
-                if (_sqliteType == SqliteType.Real)
+                var timeSpan = (TimeSpan)value;
+                if (sqliteType == SqliteType.Real)
                 {
                     var value = timeSpan.TotalDays;
                     BindDouble(value);
@@ -218,18 +209,18 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(uint))
             {
-                var value = (long)(uint)_value;
-                BindInt64(value);
+                var value1 = (long)(uint)value;
+                BindInt64(value1);
             }
             else if (type == typeof(ulong))
             {
-                var value = (long)(ulong)_value;
-                BindInt64(value);
+                var value1 = (long)(ulong)value;
+                BindInt64(value1);
             }
             else if (type == typeof(ushort))
             {
-                var value = (long)(ushort)_value;
-                BindInt64(value);
+                var value1 = (long)(ushort)value;
+                BindInt64(value1);
             }
             else
             {

--- a/src/Shared/CodeAnnotations.cs
+++ b/src/Shared/CodeAnnotations.cs
@@ -14,26 +14,23 @@ internal sealed class InvokerParameterNameAttribute : Attribute;
 internal sealed class NoEnumerationAttribute : Attribute;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-internal sealed class ContractAnnotationAttribute : Attribute
+internal sealed class ContractAnnotationAttribute(string contract, bool forceFullStates) : Attribute
 {
-    public string Contract { get; }
+    public string Contract { get; } = contract;
 
-    public bool ForceFullStates { get; }
+    public bool ForceFullStates { get; } = forceFullStates;
 
     public ContractAnnotationAttribute(string contract)
         : this(contract, false)
     {
     }
-
-    public ContractAnnotationAttribute(string contract, bool forceFullStates)
-    {
-        Contract = contract;
-        ForceFullStates = forceFullStates;
-    }
 }
 
 [AttributeUsage(AttributeTargets.All)]
-internal sealed class UsedImplicitlyAttribute : Attribute
+internal sealed class UsedImplicitlyAttribute(
+    ImplicitUseKindFlags useKindFlags,
+    ImplicitUseTargetFlags targetFlags)
+    : Attribute
 {
     public UsedImplicitlyAttribute()
         : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default)
@@ -50,27 +47,14 @@ internal sealed class UsedImplicitlyAttribute : Attribute
     {
     }
 
-    public UsedImplicitlyAttribute(
-        ImplicitUseKindFlags useKindFlags,
-        ImplicitUseTargetFlags targetFlags)
-    {
-        UseKindFlags = useKindFlags;
-        TargetFlags = targetFlags;
-    }
-
-    public ImplicitUseKindFlags UseKindFlags { get; }
-    public ImplicitUseTargetFlags TargetFlags { get; }
+    public ImplicitUseKindFlags UseKindFlags { get; } = useKindFlags;
+    public ImplicitUseTargetFlags TargetFlags { get; } = targetFlags;
 }
 
 [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Delegate)]
-internal sealed class StringFormatMethodAttribute : Attribute
+internal sealed class StringFormatMethodAttribute(string formatParameterName) : Attribute
 {
-    public StringFormatMethodAttribute(string formatParameterName)
-    {
-        FormatParameterName = formatParameterName;
-    }
-
-    public string FormatParameterName { get; }
+    public string FormatParameterName { get; } = formatParameterName;
 }
 
 [Flags]

--- a/src/Shared/EnumerableExtensions.cs
+++ b/src/Shared/EnumerableExtensions.cs
@@ -34,18 +34,11 @@ internal static class EnumerableExtensions
         }
     }
 
-    private sealed class DynamicEqualityComparer<T> : IEqualityComparer<T>
+    private sealed class DynamicEqualityComparer<T>(Func<T?, T?, bool> func) : IEqualityComparer<T>
         where T : class
     {
-        private readonly Func<T?, T?, bool> _func;
-
-        public DynamicEqualityComparer(Func<T?, T?, bool> func)
-        {
-            _func = func;
-        }
-
         public bool Equals(T? x, T? y)
-            => _func(x, y);
+            => func(x, y);
 
         public int GetHashCode(T obj)
             => 0;

--- a/src/Shared/IDictionaryDebugView.cs
+++ b/src/Shared/IDictionaryDebugView.cs
@@ -5,14 +5,9 @@
 
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
-    internal sealed class IDictionaryDebugView<TKey, TValue>
+    internal sealed class IDictionaryDebugView<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
     {
-        private readonly IDictionary<TKey, TValue> _dict;
-
-        public IDictionaryDebugView(IDictionary<TKey, TValue> dictionary)
-        {
-            _dict = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
-        }
+        private readonly IDictionary<TKey, TValue> _dict = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public KeyValuePair<TKey, TValue>[] Items
@@ -26,14 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         }
     }
 
-    internal sealed class DictionaryKeyCollectionDebugView<TKey, TValue>
+    internal sealed class DictionaryKeyCollectionDebugView<TKey, TValue>(ICollection<TKey> collection)
     {
-        private readonly ICollection<TKey> _collection;
-
-        public DictionaryKeyCollectionDebugView(ICollection<TKey> collection)
-        {
-            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
-        }
+        private readonly ICollection<TKey> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public TKey[] Items
@@ -47,14 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         }
     }
 
-    internal sealed class DictionaryValueCollectionDebugView<TKey, TValue>
+    internal sealed class DictionaryValueCollectionDebugView<TKey, TValue>(ICollection<TValue> collection)
     {
-        private readonly ICollection<TValue> _collection;
-
-        public DictionaryValueCollectionDebugView(ICollection<TValue> collection)
-        {
-            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
-        }
+        private readonly ICollection<TValue> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public TValue[] Items

--- a/src/ef/AnsiTextWriter.cs
+++ b/src/ef/AnsiTextWriter.cs
@@ -6,15 +6,8 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Tools;
 
-internal class AnsiTextWriter
+internal class AnsiTextWriter(TextWriter writer)
 {
-    private readonly TextWriter _writer;
-
-    public AnsiTextWriter(TextWriter writer)
-    {
-        _writer = writer;
-    }
-
     public void WriteLine(string? text)
     {
         if (text != null)
@@ -22,7 +15,7 @@ internal class AnsiTextWriter
             Interpret(text);
         }
 
-        _writer.Write(Environment.NewLine);
+        writer.Write(Environment.NewLine);
     }
 
     private void Interpret(string value)
@@ -35,7 +28,7 @@ internal class AnsiTextWriter
             var length = match.Index - start;
             if (length != 0)
             {
-                _writer.Write(value.Substring(start, length));
+                writer.Write(value.Substring(start, length));
             }
 
             Apply(match.Groups[1].Value);
@@ -45,7 +38,7 @@ internal class AnsiTextWriter
 
         if (start != value.Length)
         {
-            _writer.Write(value.Substring(start));
+            writer.Write(value.Substring(start));
         }
     }
 

--- a/src/ef/CommandLineUtils/CommandLineApplication.cs
+++ b/src/ef/CommandLineUtils/CommandLineApplication.cs
@@ -573,31 +573,24 @@ internal class CommandLineApplication(bool throwOnUnexpectedArg = true)
         return File.ReadLines(fileName);
     }
 
-    private sealed class CommandArgumentEnumerator : IEnumerator<CommandArgument>
+    private sealed class CommandArgumentEnumerator(IEnumerator<CommandArgument> enumerator) : IEnumerator<CommandArgument>
     {
-        private readonly IEnumerator<CommandArgument> _enumerator;
-
-        public CommandArgumentEnumerator(IEnumerator<CommandArgument> enumerator)
-        {
-            _enumerator = enumerator;
-        }
-
         public CommandArgument Current
-            => _enumerator.Current;
+            => enumerator.Current;
 
         object IEnumerator.Current
             => Current;
 
         public void Dispose()
-            => _enumerator.Dispose();
+            => enumerator.Dispose();
 
         public bool MoveNext()
             // If current argument allows multiple values, we don't move forward and
             // all later values will be added to current CommandArgument.Values
             => Current?.MultipleValues == true
-                || _enumerator.MoveNext();
+                || enumerator.MoveNext();
 
         public void Reset()
-            => _enumerator.Reset();
+            => enumerator.Reset();
     }
 }

--- a/src/ef/CommandLineUtils/CommandParsingException.cs
+++ b/src/ef/CommandLineUtils/CommandParsingException.cs
@@ -5,13 +5,7 @@ using System;
 
 namespace Microsoft.DotNet.Cli.CommandLine;
 
-internal class CommandParsingException : Exception
+internal class CommandParsingException(CommandLineApplication command, string message) : Exception(message)
 {
-    public CommandParsingException(CommandLineApplication command, string message)
-        : base(message)
-    {
-        Command = command;
-    }
-
-    public CommandLineApplication Command { get; }
+    public CommandLineApplication Command { get; } = command;
 }

--- a/src/ef/WrappedException.cs
+++ b/src/ef/WrappedException.cs
@@ -3,19 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.Tools;
 
-internal class WrappedException : Exception
+internal class WrappedException(string type, string message, string stackTrace) : Exception(message)
 {
-    private readonly string _stackTrace;
-
-    public WrappedException(string type, string message, string stackTrace)
-        : base(message)
-    {
-        Type = type;
-        _stackTrace = stackTrace;
-    }
-
-    public string Type { get; }
+    public string Type { get; } = type;
 
     public override string ToString()
-        => _stackTrace;
+        => stackTrace;
 }

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
@@ -6,18 +6,13 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>
+public abstract class AspNetIdentityCustomTypesDefaultTestBase<TFixture>(TFixture fixture)
     : AspNetIdentityTestBase<TFixture, CustomTypesIdentityContext, CustomUserString, CustomRoleString, string, CustomUserClaimString,
-        CustomUserRoleString, CustomUserLoginString, CustomRoleClaimString, CustomUserTokenString>
+        CustomUserRoleString, CustomUserLoginString, CustomRoleClaimString, CustomUserTokenString>(fixture)
     where TFixture : AspNetIdentityTestBase<TFixture, CustomTypesIdentityContext, CustomUserString, CustomRoleString, string,
         CustomUserClaimString, CustomUserRoleString, CustomUserLoginString, CustomRoleClaimString, CustomUserTokenString>.
     AspNetIdentityFixtureBase
 {
-    protected AspNetIdentityCustomTypesDefaultTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public async Task Can_lazy_load_User_navigations()
     {

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
@@ -6,17 +6,12 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>
+public abstract class AspNetIdentityCustomTypesIntKeyTestBase<TFixture>(TFixture fixture)
     : AspNetIdentityTestBase<TFixture, CustomTypesIdentityContextInt, CustomUserInt, CustomRoleInt, int, CustomUserClaimInt,
-        CustomUserRoleInt, CustomUserLoginInt, CustomRoleClaimInt, CustomUserTokenInt>
+        CustomUserRoleInt, CustomUserLoginInt, CustomRoleClaimInt, CustomUserTokenInt>(fixture)
     where TFixture : AspNetIdentityTestBase<TFixture, CustomTypesIdentityContextInt, CustomUserInt, CustomRoleInt, int, CustomUserClaimInt,
         CustomUserRoleInt, CustomUserLoginInt, CustomRoleClaimInt, CustomUserTokenInt>.AspNetIdentityFixtureBase
 {
-    protected AspNetIdentityCustomTypesIntKeyTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public async Task Can_use_navigation_properties_on_User()
     {

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityDefaultTestBase.cs
@@ -6,17 +6,12 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class AspNetIdentityDefaultTestBase<TFixture>
+public abstract class AspNetIdentityDefaultTestBase<TFixture>(TFixture fixture)
     : AspNetIdentityTestBase<TFixture, IdentityDbContext, IdentityUser, IdentityRole, string, IdentityUserClaim<string>,
-        IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>>
+        IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>>(fixture)
     where TFixture : AspNetIdentityTestBase<TFixture, IdentityDbContext, IdentityUser, IdentityRole, string, IdentityUserClaim<string>,
         IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>>.AspNetIdentityFixtureBase
 {
-    protected AspNetIdentityDefaultTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override List<EntityTypeMapping> ExpectedMappings
         =>
         [

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityIntKeyTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityIntKeyTestBase.cs
@@ -6,19 +6,14 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class AspNetIdentityIntKeyTestBase<TFixture>
+public abstract class AspNetIdentityIntKeyTestBase<TFixture>(TFixture fixture)
     : AspNetIdentityTestBase<TFixture, IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>,
         IdentityUser<int>, IdentityRole<int>, int, IdentityUserClaim<int>, IdentityUserRole<int>, IdentityUserLogin<int>,
-        IdentityRoleClaim<int>, IdentityUserToken<int>>
+        IdentityRoleClaim<int>, IdentityUserToken<int>>(fixture)
     where TFixture : AspNetIdentityTestBase<TFixture, IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, IdentityUser<int>,
         IdentityRole<int>, int, IdentityUserClaim<int>, IdentityUserRole<int>, IdentityUserLogin<int>, IdentityRoleClaim<int>,
         IdentityUserToken<int>>.AspNetIdentityFixtureBase
 {
-    protected AspNetIdentityIntKeyTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override List<EntityTypeMapping> ExpectedMappings
         =>
         [

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 public abstract class
     AspNetIdentityTestBase<TFixture, TContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim,
-        TUserToken> : IClassFixture<TFixture>
+        TUserToken>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : AspNetIdentityTestBase<TFixture, TContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim,
         TUserToken>.AspNetIdentityFixtureBase
     where TUser : IdentityUser<TKey>, new()
@@ -22,11 +22,6 @@ public abstract class
     where TRoleClaim : IdentityRoleClaim<TKey>, new()
     where TContext : IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>
 {
-    protected AspNetIdentityTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     protected virtual bool HasForeignKeyIndexes
         => true;
 
@@ -450,7 +445,7 @@ public abstract class
         await context.SaveChangesAsync();
     }
 
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     public abstract class AspNetIdentityFixtureBase
         : SharedStoreFixtureBase<TContext>

--- a/test/EFCore.AspNet.Specification.Tests/ConfigurationDbContextTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/ConfigurationDbContextTestBase.cs
@@ -8,15 +8,12 @@ using IdentityServer4.EntityFramework.Stores;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ConfigurationDbContextTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class ConfigurationDbContextTestBase<TFixture>(
+    ConfigurationDbContextTestBase<TFixture>.ConfigurationDbContextFixtureBase fixture)
+    : IClassFixture<TFixture>
     where TFixture : ConfigurationDbContextTestBase<TFixture>.ConfigurationDbContextFixtureBase
 {
-    protected ConfigurationDbContextTestBase(ConfigurationDbContextFixtureBase fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected ConfigurationDbContextFixtureBase Fixture { get; }
+    protected ConfigurationDbContextFixtureBase Fixture { get; } = fixture;
 
     protected virtual bool HasForeignKeyIndexes
         => true;

--- a/test/EFCore.AspNet.Specification.Tests/PersistedGrantDbContextTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/PersistedGrantDbContextTestBase.cs
@@ -11,15 +11,12 @@ using IdentityServer4.Stores.Serialization;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class PersistedGrantDbContextTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class PersistedGrantDbContextTestBase<TFixture>(
+    PersistedGrantDbContextTestBase<TFixture>.PersistedGrantDbContextFixtureBase fixture)
+    : IClassFixture<TFixture>
     where TFixture : PersistedGrantDbContextTestBase<TFixture>.PersistedGrantDbContextFixtureBase
 {
-    protected PersistedGrantDbContextTestBase(PersistedGrantDbContextFixtureBase fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected PersistedGrantDbContextFixtureBase Fixture { get; }
+    protected PersistedGrantDbContextFixtureBase Fixture { get; } = fixture;
 
     [ConditionalFact]
     public async Task Can_call_PersistedGrantStore_GetAllAsync()

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -679,15 +679,10 @@ OFFSET 0 LIMIT 1
 
     public class CosmosFixture : ServiceProviderFixtureBase, IAsyncLifetime
     {
-        public CosmosFixture()
-        {
-            TestStore = CosmosTestStore.Create(DatabaseName);
-        }
-
         protected override ITestStoreFactory TestStoreFactory
             => CosmosTestStoreFactory.Instance;
 
-        public virtual CosmosTestStore TestStore { get; }
+        public virtual CosmosTestStore TestStore { get; } = CosmosTestStore.Create(DatabaseName);
 
         public async Task<EmbeddedTransportationContextOptions> CreateOptions(
             Action<ModelBuilder> onModelCreating = null,

--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -8,13 +8,8 @@ using Microsoft.EntityFrameworkCore.TestModels;
 namespace Microsoft.EntityFrameworkCore;
 
 [SqlServerConfiguredCondition]
-public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>, IAsyncLifetime
+public class ConfigurationPatternsTest(CrossStoreFixture fixture) : IClassFixture<CrossStoreFixture>, IAsyncLifetime
 {
-    public ConfigurationPatternsTest(CrossStoreFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     [ConditionalFact]
     public void Can_register_multiple_context_types()
     {
@@ -182,7 +177,7 @@ public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>, IAsyn
         public MultipleProvidersContext Context { get; } = context;
     }
 
-    private CrossStoreFixture Fixture { get; }
+    private CrossStoreFixture Fixture { get; } = fixture;
     private TestStore ExistingTestStore { get; set; }
     private static readonly string StoreName = "CrossStoreConfigurationPatternsTest";
 
@@ -194,13 +189,8 @@ public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>, IAsyn
     }
 
     [SqlServerConfiguredCondition]
-    public class NestedContextDifferentStores : IClassFixture<CrossStoreFixture>, IAsyncLifetime
+    public class NestedContextDifferentStores(CrossStoreFixture fixture) : IClassFixture<CrossStoreFixture>, IAsyncLifetime
     {
-        public NestedContextDifferentStores(CrossStoreFixture fixture)
-        {
-            Fixture = fixture;
-        }
-
         [ConditionalFact]
         public async Task Can_use_one_context_nested_inside_another_of_a_different_type()
         {
@@ -241,7 +231,7 @@ public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>, IAsyn
             Assert.NotSame(blog0, blog0Prime);
         }
 
-        private CrossStoreFixture Fixture { get; }
+        private CrossStoreFixture Fixture { get; } = fixture;
         private TestStore ExistingTestStore { get; set; }
         private static readonly string StoreName = "CrossStoreNestedContextTest";
 

--- a/test/EFCore.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -6,14 +6,9 @@ using Microsoft.EntityFrameworkCore.TestModels;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class EndToEndTest : IAsyncLifetime
+public abstract class EndToEndTest(CrossStoreFixture fixture) : IAsyncLifetime
 {
-    protected EndToEndTest(CrossStoreFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected CrossStoreFixture Fixture { get; }
+    protected CrossStoreFixture Fixture { get; } = fixture;
     protected abstract ITestStoreFactory TestStoreFactory { get; }
     protected TestStore TestStore { get; private set; }
 

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -846,13 +846,8 @@ public class CSharpHelperTest
             => throw new NotSupportedException();
     }
 
-    private class SimpleTestNonImplementedTypeMapping : RelationalTypeMapping
+    private class SimpleTestNonImplementedTypeMapping() : RelationalTypeMapping("storeType", typeof(SimpleTestType))
     {
-        public SimpleTestNonImplementedTypeMapping()
-            : base("storeType", typeof(SimpleTestType))
-        {
-        }
-
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => throw new NotSupportedException();
     }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -8,17 +8,8 @@ using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 
 [Collection(nameof(ModelCodeGeneratorTestCollection))]
-public abstract class ModelCodeGeneratorTestBase
+public abstract class ModelCodeGeneratorTestBase(ModelCodeGeneratorTestFixture fixture, ITestOutputHelper output)
 {
-    private readonly ModelCodeGeneratorTestFixture _fixture;
-    private readonly ITestOutputHelper _output;
-
-    protected ModelCodeGeneratorTestBase(ModelCodeGeneratorTestFixture fixture, ITestOutputHelper output)
-    {
-        _fixture = fixture;
-        _output = output;
-    }
-
     protected Task TestAsync(
         Action<ModelBuilder> buildModel,
         ModelCodeGenerationOptions options,
@@ -74,7 +65,7 @@ public abstract class ModelCodeGeneratorTestBase
         options.ModelNamespace ??= "TestNamespace";
         options.ContextName = "TestDbContext";
         options.ConnectionString = "Initial Catalog=TestDatabase";
-        options.ProjectDir = _fixture.ProjectDir;
+        options.ProjectDir = fixture.ProjectDir;
 
         var scaffoldedModel = generator.GenerateModel(
             model,
@@ -147,7 +138,7 @@ public abstract class ModelCodeGeneratorTestBase
     protected IServiceCollection CreateServices()
     {
         var testAssembly = MockAssembly.Create();
-        var reporter = new TestOperationReporter(_output);
+        var reporter = new TestOperationReporter(output);
         var services = new DesignTimeServicesBuilder(testAssembly, testAssembly, reporter, [])
             .CreateServiceCollection("Microsoft.EntityFrameworkCore.SqlServer");
         return services;

--- a/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
@@ -5,27 +5,19 @@ using Microsoft.EntityFrameworkCore.Design.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-public class TestAppServiceProviderFactory : AppServiceProviderFactory
+public class TestAppServiceProviderFactory(Assembly startupAssembly, TestOperationReporter reporter, bool throwOnCreate = false)
+    : AppServiceProviderFactory(startupAssembly, reporter)
 {
-    private readonly bool _throwOnCreate;
-
     public TestAppServiceProviderFactory(Assembly startupAssembly, bool throwOnCreate = false)
         : this(startupAssembly, new TestOperationReporter(), throwOnCreate)
     {
     }
 
-    public TestAppServiceProviderFactory(Assembly startupAssembly, TestOperationReporter reporter, bool throwOnCreate = false)
-        : base(startupAssembly, reporter)
-    {
-        TestOperationReporter = reporter;
-        _throwOnCreate = throwOnCreate;
-    }
-
-    public TestOperationReporter TestOperationReporter { get; }
+    public TestOperationReporter TestOperationReporter { get; } = reporter;
 
     public override IServiceProvider Create(string[] args)
     {
-        Assert.False(_throwOnCreate, "Service provider shouldn't be used in this case.");
+        Assert.False(throwOnCreate, "Service provider shouldn't be used in this case.");
 
         return base.Create(args);
     }

--- a/test/EFCore.InMemory.FunctionalTests/FindInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/FindInMemoryTest.cs
@@ -3,13 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class FindInMemoryTest : FindTestBase<FindInMemoryTest.FindInMemoryFixture>
+public abstract class FindInMemoryTest(FindInMemoryTest.FindInMemoryFixture fixture)
+    : FindTestBase<FindInMemoryTest.FindInMemoryFixture>(fixture)
 {
-    protected FindInMemoryTest(FindInMemoryFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public class FindInMemoryTestSet(FindInMemoryFixture fixture) : FindInMemoryTest(fixture)
     {
         protected override TestFinder Finder { get; } = new FindViaSetFinder();

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTestBase.cs
@@ -3,14 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class GraphUpdatesInMemoryTestBase<TFixture> : GraphUpdatesTestBase<TFixture>
+public abstract class GraphUpdatesInMemoryTestBase<TFixture>(TFixture fixture) : GraphUpdatesTestBase<TFixture>(fixture)
     where TFixture : GraphUpdatesInMemoryTestBase<TFixture>.GraphUpdatesInMemoryFixtureBase, new()
 {
-    protected GraphUpdatesInMemoryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     // In-memory database does not have database default values
     public override Task Can_insert_when_bool_PK_in_composite_key_has_sentinel_value(bool async, bool initialValue)
         => Task.CompletedTask;

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/ProxyGraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/ProxyGraphUpdatesInMemoryTest.cs
@@ -6,14 +6,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public class ProxyGraphUpdatesInMemoryTest
 {
-    public abstract class ProxyGraphUpdatesInMemoryTestBase<TFixture> : ProxyGraphUpdatesTestBase<TFixture>
+    public abstract class ProxyGraphUpdatesInMemoryTestBase<TFixture>(TFixture fixture) : ProxyGraphUpdatesTestBase<TFixture>(fixture)
         where TFixture : ProxyGraphUpdatesInMemoryTestBase<TFixture>.ProxyGraphUpdatesInMemoryFixtureBase, new()
     {
-        protected ProxyGraphUpdatesInMemoryTestBase(TFixture fixture)
-            : base(fixture)
-        {
-        }
-
         [ConditionalFact(Skip = "FK constraint checking. Issue #2166")]
         public override Task Optional_one_to_one_relationships_are_one_to_one()
             => base.Optional_one_to_one_relationships_are_one_to_one();

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
@@ -17,12 +17,7 @@ public class InMemoryFixture
     public static IServiceProvider DefaultNullabilitySensitiveCheckProvider { get; }
         = BuildServiceProvider();
 
-    public readonly IServiceProvider ServiceProvider;
-
-    public InMemoryFixture()
-    {
-        ServiceProvider = BuildServiceProvider();
-    }
+    public readonly IServiceProvider ServiceProvider = BuildServiceProvider();
 
     public static ServiceProvider BuildServiceProvider(ILoggerFactory loggerFactory)
         => BuildServiceProvider(new ServiceCollection().AddSingleton(loggerFactory));

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryServiceCollectionExtensionsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryServiceCollectionExtensionsTest.cs
@@ -3,10 +3,4 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class InMemoryServiceCollectionExtensionsTest : EntityFrameworkServiceCollectionExtensionsTestBase
-{
-    public InMemoryServiceCollectionExtensionsTest()
-        : base(InMemoryTestHelpers.Instance)
-    {
-    }
-}
+public class InMemoryServiceCollectionExtensionsTest() : EntityFrameworkServiceCollectionExtensionsTestBase(InMemoryTestHelpers.Instance);

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderAssemblyScanTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderAssemblyScanTest.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
 {
-    private readonly Assembly _mockEntityTypeAssembly;
-
-    public InMemoryModelBuilderAssemblyScanTest()
-    {
-        _mockEntityTypeAssembly = MockAssembly.Create(
-            typeof(ScannerCustomerEntityConfiguration), typeof(ScannerCustomerEntityConfiguration2),
-            typeof(AbstractCustomerEntityConfiguration), typeof(AbstractCustomerEntityConfigurationImpl));
-    }
+    private readonly Assembly _mockEntityTypeAssembly = MockAssembly.Create(
+        typeof(ScannerCustomerEntityConfiguration), typeof(ScannerCustomerEntityConfiguration2),
+        typeof(AbstractCustomerEntityConfiguration), typeof(AbstractCustomerEntityConfigurationImpl));
 
     [ConditionalFact]
     public void Should_scan_assemblies_for_entity_type_configurations()

--- a/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
@@ -7,15 +7,10 @@ public class OptimisticConcurrencyULongInMemoryTest(F1ULongInMemoryFixture fixtu
 
 public class OptimisticConcurrencyInMemoryTest(F1InMemoryFixture fixture) : OptimisticConcurrencyInMemoryTestBase<F1InMemoryFixture, byte[]>(fixture);
 
-public abstract class OptimisticConcurrencyInMemoryTestBase<TFixture, TRowVersion>
-    : OptimisticConcurrencyTestBase<TFixture, TRowVersion>
+public abstract class OptimisticConcurrencyInMemoryTestBase<TFixture, TRowVersion>(TFixture fixture)
+    : OptimisticConcurrencyTestBase<TFixture, TRowVersion>(fixture)
     where TFixture : F1FixtureBase<TRowVersion>, new()
 {
-    protected OptimisticConcurrencyInMemoryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact(Skip = "Optimistic Offline Lock #2195")]
     public override Task Simple_concurrency_exception_can_be_resolved_with_store_values()
         => Task.CompletedTask;

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -437,18 +437,13 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
     private class Entity3101
     {
-        public Entity3101()
-        {
-            Children = new Collection<Child3101>();
-        }
-
         public int Id { get; set; }
 
         public int? RootEntityId { get; set; }
 
         public Entity3101 RootEntity { get; set; }
 
-        public ICollection<Child3101> Children { get; set; }
+        public ICollection<Child3101> Children { get; set; } = new Collection<Child3101>();
     }
 
     private class Child3101

--- a/test/EFCore.InMemory.FunctionalTests/QueryExpressionInterceptionInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/QueryExpressionInterceptionInMemoryTestBase.cs
@@ -3,13 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class QueryExpressionInterceptionInMemoryTestBase : QueryExpressionInterceptionTestBase
+public abstract class QueryExpressionInterceptionInMemoryTestBase(
+    QueryExpressionInterceptionInMemoryTestBase.InterceptionInMemoryFixtureBase fixture)
+    : QueryExpressionInterceptionTestBase(fixture)
 {
-    protected QueryExpressionInterceptionInMemoryTestBase(InterceptionInMemoryFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task<UniverseContext> SeedAsync(UniverseContext context)
     {
         await base.SeedAsync(context);

--- a/test/EFCore.InMemory.FunctionalTests/SaveChangesInterceptionInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/SaveChangesInterceptionInMemoryTestBase.cs
@@ -3,13 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class SaveChangesInterceptionInMemoryTestBase : SaveChangesInterceptionTestBase
+public abstract class SaveChangesInterceptionInMemoryTestBase(
+    SaveChangesInterceptionInMemoryTestBase.InterceptionInMemoryFixtureBase fixture)
+    : SaveChangesInterceptionTestBase(fixture)
 {
-    protected SaveChangesInterceptionInMemoryTestBase(InterceptionInMemoryFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     protected override bool SupportsOptimisticConcurrency
         => false;
 

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
@@ -363,13 +363,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                         && ((int)constant.Value!) == 1);
                 });
 
-        private class FakeValueComparer : ValueComparer<int>
+        private class FakeValueComparer() : ValueComparer<int>((l, r) => false, v => 0, v => 1)
         {
-            public FakeValueComparer()
-                : base((l, r) => false, v => 0, v => 1)
-            {
-            }
-
             public override Type Type { get; } = typeof(int);
 
             public override bool Equals(object? left, object? right)

--- a/test/EFCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -69,26 +69,14 @@ public class StoreGeneratedInMemoryTest
         public int Value { get; set; }
     }
 
-    protected class WrappedIntClassConverter : ValueConverter<WrappedIntClass, int>
-    {
-        public WrappedIntClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntClassConverter() : ValueConverter<WrappedIntClass, int>(
+        v => v.Value,
+        v => new WrappedIntClass { Value = v });
 
-    protected class WrappedIntClassComparer : ValueComparer<WrappedIntClass?>
-    {
-        public WrappedIntClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntClassComparer() : ValueComparer<WrappedIntClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntClass { Value = v.Value });
 
     protected class WrappedIntClassValueGenerator : ValueGenerator<WrappedIntClass>
     {
@@ -104,15 +92,9 @@ public class StoreGeneratedInMemoryTest
         public int Value { get; set; }
     }
 
-    protected class WrappedIntStructConverter : ValueConverter<WrappedIntStruct, int>
-    {
-        public WrappedIntStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntStructConverter() : ValueConverter<WrappedIntStruct, int>(
+        v => v.Value,
+        v => new WrappedIntStruct { Value = v });
 
     protected class WrappedIntStructValueGenerator : ValueGenerator<WrappedIntStruct>
     {
@@ -128,15 +110,9 @@ public class StoreGeneratedInMemoryTest
         public int Value { get; set; }
     }
 
-    protected class WrappedIntRecordConverter : ValueConverter<WrappedIntRecord, int>
-    {
-        public WrappedIntRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntRecordConverter() : ValueConverter<WrappedIntRecord, int>(
+        v => v.Value,
+        v => new WrappedIntRecord { Value = v });
 
     protected class WrappedIntRecordValueGenerator : ValueGenerator<WrappedIntRecord>
     {
@@ -152,26 +128,14 @@ public class StoreGeneratedInMemoryTest
         public int Value { get; set; }
     }
 
-    protected class WrappedIntKeyClassConverter : ValueConverter<WrappedIntKeyClass, int>
-    {
-        public WrappedIntKeyClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyClassConverter() : ValueConverter<WrappedIntKeyClass, int>(
+        v => v.Value,
+        v => new WrappedIntKeyClass { Value = v });
 
-    protected class WrappedIntKeyClassComparer : ValueComparer<WrappedIntKeyClass?>
-    {
-        public WrappedIntKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntKeyClassComparer() : ValueComparer<WrappedIntKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntKeyClass { Value = v.Value });
 
     protected struct WrappedIntKeyStruct
     {
@@ -190,30 +154,18 @@ public class StoreGeneratedInMemoryTest
             => !left.Equals(right);
     }
 
-    protected class WrappedIntKeyStructConverter : ValueConverter<WrappedIntKeyStruct, int>
-    {
-        public WrappedIntKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyStructConverter() : ValueConverter<WrappedIntKeyStruct, int>(
+        v => v.Value,
+        v => new WrappedIntKeyStruct { Value = v });
 
     protected record WrappedIntKeyRecord
     {
         public int Value { get; set; }
     }
 
-    protected class WrappedIntKeyRecordConverter : ValueConverter<WrappedIntKeyRecord, int>
-    {
-        public WrappedIntKeyRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyRecordConverter() : ValueConverter<WrappedIntKeyRecord, int>(
+        v => v.Value,
+        v => new WrappedIntKeyRecord { Value = v });
 
     protected class WrappedIntClassPrincipal
     {
@@ -754,26 +706,14 @@ public class StoreGeneratedInMemoryTest
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringClassConverter : ValueConverter<WrappedStringClass, string>
-    {
-        public WrappedStringClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringClassConverter() : ValueConverter<WrappedStringClass, string>(
+        v => v.Value!,
+        v => new WrappedStringClass { Value = v });
 
-    protected class WrappedStringClassComparer : ValueComparer<WrappedStringClass?>
-    {
-        public WrappedStringClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedStringClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedStringClassComparer() : ValueComparer<WrappedStringClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedStringClass { Value = v.Value });
 
     protected class WrappedStringClassValueGenerator : ValueGenerator<WrappedStringClass>
     {
@@ -789,15 +729,9 @@ public class StoreGeneratedInMemoryTest
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringStructConverter : ValueConverter<WrappedStringStruct, string>
-    {
-        public WrappedStringStructConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringStructConverter() : ValueConverter<WrappedStringStruct, string>(
+        v => v.Value!,
+        v => new WrappedStringStruct { Value = v });
 
     protected class WrappedStringStructValueGenerator : ValueGenerator<WrappedStringStruct>
     {
@@ -813,15 +747,9 @@ public class StoreGeneratedInMemoryTest
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringRecordConverter : ValueConverter<WrappedStringRecord, string>
-    {
-        public WrappedStringRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringRecordConverter() : ValueConverter<WrappedStringRecord, string>(
+        v => v.Value!,
+        v => new WrappedStringRecord { Value = v });
 
     protected class WrappedStringRecordValueGenerator : ValueGenerator<WrappedStringRecord>
     {
@@ -837,26 +765,14 @@ public class StoreGeneratedInMemoryTest
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringKeyClassConverter : ValueConverter<WrappedStringKeyClass, string>
-    {
-        public WrappedStringKeyClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyClassConverter() : ValueConverter<WrappedStringKeyClass, string>(
+        v => v.Value!,
+        v => new WrappedStringKeyClass { Value = v });
 
-    protected class WrappedStringKeyClassComparer : ValueComparer<WrappedStringKeyClass?>
-    {
-        public WrappedStringKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedStringKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedStringKeyClassComparer() : ValueComparer<WrappedStringKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedStringKeyClass { Value = v.Value });
 
     protected struct WrappedStringKeyStruct
     {
@@ -875,30 +791,18 @@ public class StoreGeneratedInMemoryTest
             => !left.Equals(right);
     }
 
-    protected class WrappedStringKeyStructConverter : ValueConverter<WrappedStringKeyStruct, string>
-    {
-        public WrappedStringKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedStringKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyStructConverter() : ValueConverter<WrappedStringKeyStruct, string>(
+        v => v.Value,
+        v => new WrappedStringKeyStruct { Value = v });
 
     protected record WrappedStringKeyRecord
     {
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringKeyRecordConverter : ValueConverter<WrappedStringKeyRecord, string>
-    {
-        public WrappedStringKeyRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyRecordConverter() : ValueConverter<WrappedStringKeyRecord, string>(
+        v => v.Value!,
+        v => new WrappedStringKeyRecord { Value = v });
 
     protected class WrappedStringClassPrincipal
     {
@@ -1310,26 +1214,14 @@ public class StoreGeneratedInMemoryTest
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidClassConverter : ValueConverter<WrappedGuidClass, Guid>
-    {
-        public WrappedGuidClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidClassConverter() : ValueConverter<WrappedGuidClass, Guid>(
+        v => v.Value,
+        v => new WrappedGuidClass { Value = v });
 
-    protected class WrappedGuidClassComparer : ValueComparer<WrappedGuidClass?>
-    {
-        public WrappedGuidClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value.GetHashCode() : 0,
-                v => v == null ? null : new WrappedGuidClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedGuidClassComparer() : ValueComparer<WrappedGuidClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value.GetHashCode() : 0,
+        v => v == null ? null : new WrappedGuidClass { Value = v.Value });
 
     protected class WrappedGuidClassValueGenerator : ValueGenerator<WrappedGuidClass>
     {
@@ -1345,15 +1237,9 @@ public class StoreGeneratedInMemoryTest
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidStructConverter : ValueConverter<WrappedGuidStruct, Guid>
-    {
-        public WrappedGuidStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidStructConverter() : ValueConverter<WrappedGuidStruct, Guid>(
+        v => v.Value,
+        v => new WrappedGuidStruct { Value = v });
 
     protected class WrappedGuidStructValueGenerator : ValueGenerator<WrappedGuidStruct>
     {
@@ -1369,15 +1255,9 @@ public class StoreGeneratedInMemoryTest
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidRecordConverter : ValueConverter<WrappedGuidRecord, Guid>
-    {
-        public WrappedGuidRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidRecordConverter() : ValueConverter<WrappedGuidRecord, Guid>(
+        v => v.Value,
+        v => new WrappedGuidRecord { Value = v });
 
     protected class WrappedGuidRecordValueGenerator : ValueGenerator<WrappedGuidRecord>
     {
@@ -1393,26 +1273,14 @@ public class StoreGeneratedInMemoryTest
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidKeyClassConverter : ValueConverter<WrappedGuidKeyClass, Guid>
-    {
-        public WrappedGuidKeyClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyClassConverter() : ValueConverter<WrappedGuidKeyClass, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyClass { Value = v });
 
-    protected class WrappedGuidKeyClassComparer : ValueComparer<WrappedGuidKeyClass?>
-    {
-        public WrappedGuidKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value.GetHashCode() : 0,
-                v => v == null ? null : new WrappedGuidKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedGuidKeyClassComparer() : ValueComparer<WrappedGuidKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value.GetHashCode() : 0,
+        v => v == null ? null : new WrappedGuidKeyClass { Value = v.Value });
 
     protected struct WrappedGuidKeyStruct
     {
@@ -1431,30 +1299,18 @@ public class StoreGeneratedInMemoryTest
             => !left.Equals(right);
     }
 
-    protected class WrappedGuidKeyStructConverter : ValueConverter<WrappedGuidKeyStruct, Guid>
-    {
-        public WrappedGuidKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyStructConverter() : ValueConverter<WrappedGuidKeyStruct, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyStruct { Value = v });
 
     protected record WrappedGuidKeyRecord
     {
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidKeyRecordConverter : ValueConverter<WrappedGuidKeyRecord, Guid>
-    {
-        public WrappedGuidKeyRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyRecordConverter() : ValueConverter<WrappedGuidKeyRecord, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyRecord { Value = v });
 
     protected class WrappedGuidClassPrincipal
     {
@@ -1851,26 +1707,14 @@ public class StoreGeneratedInMemoryTest
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriClassConverter : ValueConverter<WrappedUriClass, Uri>
-    {
-        public WrappedUriClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriClassConverter() : ValueConverter<WrappedUriClass, Uri>(
+        v => v.Value!,
+        v => new WrappedUriClass { Value = v });
 
-    protected class WrappedUriClassComparer : ValueComparer<WrappedUriClass?>
-    {
-        public WrappedUriClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedUriClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedUriClassComparer() : ValueComparer<WrappedUriClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedUriClass { Value = v.Value });
 
     protected class WrappedUriClassValueGenerator : ValueGenerator<WrappedUriClass>
     {
@@ -1886,15 +1730,9 @@ public class StoreGeneratedInMemoryTest
         public Uri Value { get; set; }
     }
 
-    protected class WrappedUriStructConverter : ValueConverter<WrappedUriStruct, Uri>
-    {
-        public WrappedUriStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedUriStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriStructConverter() : ValueConverter<WrappedUriStruct, Uri>(
+        v => v.Value,
+        v => new WrappedUriStruct { Value = v });
 
     protected class WrappedUriStructValueGenerator : ValueGenerator<WrappedUriStruct>
     {
@@ -1910,15 +1748,9 @@ public class StoreGeneratedInMemoryTest
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriRecordConverter : ValueConverter<WrappedUriRecord, Uri>
-    {
-        public WrappedUriRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriRecordConverter() : ValueConverter<WrappedUriRecord, Uri>(
+        v => v.Value!,
+        v => new WrappedUriRecord { Value = v });
 
     protected class WrappedUriRecordValueGenerator : ValueGenerator<WrappedUriRecord>
     {
@@ -1934,26 +1766,14 @@ public class StoreGeneratedInMemoryTest
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriKeyClassConverter : ValueConverter<WrappedUriKeyClass, Uri>
-    {
-        public WrappedUriKeyClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyClassConverter() : ValueConverter<WrappedUriKeyClass, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyClass { Value = v });
 
-    protected class WrappedUriKeyClassComparer : ValueComparer<WrappedUriKeyClass?>
-    {
-        public WrappedUriKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedUriKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedUriKeyClassComparer() : ValueComparer<WrappedUriKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedUriKeyClass { Value = v.Value });
 
     protected struct WrappedUriKeyStruct
     {
@@ -1975,30 +1795,18 @@ public class StoreGeneratedInMemoryTest
             => !left.Equals(right);
     }
 
-    protected class WrappedUriKeyStructConverter : ValueConverter<WrappedUriKeyStruct, Uri>
-    {
-        public WrappedUriKeyStructConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyStructConverter() : ValueConverter<WrappedUriKeyStruct, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyStruct { Value = v });
 
     protected record WrappedUriKeyRecord
     {
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriKeyRecordConverter : ValueConverter<WrappedUriKeyRecord, Uri>
-    {
-        public WrappedUriKeyRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyRecordConverter() : ValueConverter<WrappedUriKeyRecord, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyRecord { Value = v });
 
     protected class WrappedUriClassPrincipal
     {

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
@@ -6,14 +6,9 @@ using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class UpdatesInMemoryTestBase<TFixture> : UpdatesTestBase<TFixture>
+public abstract class UpdatesInMemoryTestBase<TFixture>(TFixture fixture) : UpdatesTestBase<TFixture>(fixture)
     where TFixture : UpdatesInMemoryTestBase<TFixture>.UpdatesInMemoryFixtureBase
 {
-    protected UpdatesInMemoryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override string UpdateConcurrencyMessage
         => InMemoryStrings.UpdateConcurrencyException;
 

--- a/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
@@ -405,47 +405,19 @@ public class ChangeDetectionProxyTests
         }
     }
 
-    private class DefaultContext : TestContext<ChangeValueEntity>
-    {
-        public DefaultContext()
-            : base(nameof(DefaultContext), false, true)
-        {
-        }
-    }
+    private class DefaultContext() : TestContext<ChangeValueEntity>(nameof(DefaultContext), false, true);
 
-    private class SnapshotContext : TestContext<ChangeValueEntity>
-    {
-        public SnapshotContext()
-            : base(nameof(SnapshotContext), false, true, true, ChangeTrackingStrategy.Snapshot)
-        {
-        }
-    }
+    private class SnapshotContext() : TestContext<ChangeValueEntity>(
+        nameof(SnapshotContext), false, true, true, ChangeTrackingStrategy.Snapshot);
 
-    private class ChangedNotificationsContext : TestContext<ChangeValueEntity>
-    {
-        public ChangedNotificationsContext()
-            : base(nameof(ChangedNotificationsContext), false, true, true, ChangeTrackingStrategy.ChangedNotifications)
-        {
-        }
-    }
+    private class ChangedNotificationsContext() : TestContext<ChangeValueEntity>(
+        nameof(ChangedNotificationsContext), false, true, true, ChangeTrackingStrategy.ChangedNotifications);
 
-    private class ChangingAndChangedNotificationsContext : TestContext<ChangeValueEntity>
-    {
-        public ChangingAndChangedNotificationsContext()
-            : base(
-                nameof(ChangingAndChangedNotificationsContext), false, true, true,
-                ChangeTrackingStrategy.ChangingAndChangedNotifications)
-        {
-        }
-    }
+    private class ChangingAndChangedNotificationsContext() : TestContext<ChangeValueEntity>(
+        nameof(ChangingAndChangedNotificationsContext), false, true, true,
+        ChangeTrackingStrategy.ChangingAndChangedNotifications);
 
-    private class ChangingAndChangedNotificationsWithOriginalValuesContext : TestContext<ChangeValueEntity>
-    {
-        public ChangingAndChangedNotificationsWithOriginalValuesContext()
-            : base(
-                nameof(ChangingAndChangedNotificationsWithOriginalValuesContext), false, true, true,
-                ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)
-        {
-        }
-    }
+    private class ChangingAndChangedNotificationsWithOriginalValuesContext() : TestContext<ChangeValueEntity>(
+        nameof(ChangingAndChangedNotificationsWithOriginalValuesContext), false, true, true,
+        ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
 }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -125,31 +125,17 @@ public class LazyLoadingProxyTests
                 () => phone.Texts).Message);
     }
 
-    private class LazyContextIgnoreVirtuals<TEntity> : TestContext<TEntity>
-        where TEntity : class
-    {
-        public LazyContextIgnoreVirtuals()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
-        {
-        }
-    }
+    private class LazyContextIgnoreVirtuals<TEntity>() : TestContext<TEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
+        where TEntity : class;
 
-    private class LazyContext<TEntity> : TestContext<TEntity>
-        where TEntity : class
-    {
-        public LazyContext()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
-        {
-        }
-    }
+    private class LazyContext<TEntity>() : TestContext<TEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
+        where TEntity : class;
 
-    private class LazyContextDisabledNavigation : TestContext<LazyNonVirtualNavEntity>
+    private class LazyContextDisabledNavigation() : TestContext<LazyNonVirtualNavEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
     {
-        public LazyContextDisabledNavigation()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
-        {
-        }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -158,13 +144,9 @@ public class LazyLoadingProxyTests
         }
     }
 
-    private class LazyContextAllowingFieldNavigation : TestContext<LazyFieldNavEntity>
+    private class LazyContextAllowingFieldNavigation() : TestContext<LazyFieldNavEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
     {
-        public LazyContextAllowingFieldNavigation()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
-        {
-        }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -173,13 +155,9 @@ public class LazyLoadingProxyTests
         }
     }
 
-    private class LazyContextDisabledFieldNavigation : TestContext<LazyFieldNavEntity>
+    private class LazyContextDisabledFieldNavigation() : TestContext<LazyFieldNavEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
     {
-        public LazyContextDisabledFieldNavigation()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
-        {
-        }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -189,13 +167,9 @@ public class LazyLoadingProxyTests
         }
     }
 
-    private class LazyContextOwnedFieldNavigation : TestContext<LazyFieldOwnedNavEntity>
+    private class LazyContextOwnedFieldNavigation() : TestContext<LazyFieldOwnedNavEntity>(
+        dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
     {
-        public LazyContextOwnedFieldNavigation()
-            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
-        {
-        }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -9,13 +9,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class CommandInterceptionTestBase : InterceptionTestBase
+public abstract class CommandInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture) : InterceptionTestBase(fixture)
 {
-    protected CommandInterceptionTestBase(InterceptionFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false, false)]
     [InlineData(true, false)]
@@ -48,13 +43,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class PassiveReaderCommandInterceptor : CommandInterceptorBase
-    {
-        public PassiveReaderCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-    }
+    protected class PassiveReaderCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader);
 
     [ConditionalTheory]
     [InlineData(false, false)]
@@ -89,13 +78,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class PassiveScalarCommandInterceptor : CommandInterceptorBase
-    {
-        public PassiveScalarCommandInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
-    }
+    protected class PassiveScalarCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar);
 
     [ConditionalTheory]
     [InlineData(false, false)]
@@ -128,13 +111,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class PassiveNonQueryCommandInterceptor : CommandInterceptorBase
-    {
-        public PassiveNonQueryCommandInterceptor()
-            : base(DbCommandMethod.ExecuteNonQuery)
-        {
-        }
-    }
+    protected class PassiveNonQueryCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteNonQuery);
 
     [ConditionalTheory]
     [InlineData(false, false)]
@@ -170,13 +147,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class SuppressingReaderCommandInterceptor : CommandInterceptorBase
+    protected class SuppressingReaderCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public SuppressingReaderCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult<DbDataReader> ReaderExecuting(
             DbCommand command,
             CommandEventData eventData,
@@ -229,13 +201,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class SuppressingCreateCommandInterceptor : CommandInterceptorBase
+    protected class SuppressingCreateCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public SuppressingCreateCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult<DbCommand> CommandCreating(
             CommandCorrelatedEventData eventData,
             InterceptionResult<DbCommand> result)
@@ -302,13 +269,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class SuppressingScalarCommandInterceptor : CommandInterceptorBase
+    protected class SuppressingScalarCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar)
     {
-        public SuppressingScalarCommandInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
-
         public const string InterceptedResult = "Bet you weren't expecting a string!";
 
         public override InterceptionResult<object> ScalarExecuting(
@@ -364,13 +326,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class SuppressingNonQueryCommandInterceptor : CommandInterceptorBase
+    protected class SuppressingNonQueryCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteNonQuery)
     {
-        public SuppressingNonQueryCommandInterceptor()
-            : base(DbCommandMethod.ExecuteNonQuery)
-        {
-        }
-
         public override InterceptionResult<int> NonQueryExecuting(
             DbCommand command,
             CommandEventData eventData,
@@ -437,13 +394,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class MutatingReaderCommandInterceptor : CommandInterceptorBase
+    protected class MutatingReaderCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public MutatingReaderCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult<DbDataReader> ReaderExecuting(
             DbCommand command,
             CommandEventData eventData,
@@ -469,13 +421,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             => command.CommandText = command.CommandText.Replace("Singularity", "Brane");
     }
 
-    protected class MutatingReaderCommandInitializedInterceptor : CommandInterceptorBase
+    protected class MutatingReaderCommandInitializedInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public MutatingReaderCommandInitializedInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override DbCommand CommandInitialized(CommandEndEventData eventData, DbCommand result)
         {
             result.CommandText = result.CommandText.Replace("Singularity", "Brane");
@@ -529,13 +476,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class MutatingScalarCommandInterceptor : CommandInterceptorBase
+    protected class MutatingScalarCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar)
     {
-        public MutatingScalarCommandInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
-
         public const string MutatedSql = "SELECT 2";
 
         public override InterceptionResult<object> ScalarExecuting(
@@ -560,13 +502,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class MutatingScalarCommandInitializedInterceptor : CommandInterceptorBase
+    protected class MutatingScalarCommandInitializedInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar)
     {
-        public MutatingScalarCommandInitializedInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
-
         public override DbCommand CommandInitialized(CommandEndEventData eventData, DbCommand result)
         {
             result.CommandText = MutatingScalarCommandInterceptor.MutatedSql;
@@ -667,13 +604,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class QueryReplacingReaderCommandInterceptor : CommandInterceptorBase
+    protected class QueryReplacingReaderCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public QueryReplacingReaderCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult<DbDataReader> ReaderExecuting(
             DbCommand command,
             CommandEventData eventData,
@@ -740,13 +672,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class QueryReplacingScalarCommandInterceptor : CommandInterceptorBase
+    protected class QueryReplacingScalarCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar)
     {
-        public QueryReplacingScalarCommandInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
-
         public override InterceptionResult<object> ScalarExecuting(
             DbCommand command,
             CommandEventData eventData,
@@ -887,13 +814,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class ResultReplacingReaderCommandInterceptor : CommandInterceptorBase
+    protected class ResultReplacingReaderCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public ResultReplacingReaderCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override DbDataReader ReaderExecuted(
             DbCommand command,
             CommandExecutedEventData eventData,
@@ -1026,14 +948,9 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class ResultReplacingScalarCommandInterceptor : CommandInterceptorBase
+    protected class ResultReplacingScalarCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteScalar)
     {
         public const string InterceptedResult = "Bet you weren't expecting a string!";
-
-        public ResultReplacingScalarCommandInterceptor()
-            : base(DbCommandMethod.ExecuteScalar)
-        {
-        }
 
         public override object ScalarExecuted(
             DbCommand command,
@@ -1088,13 +1005,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    protected class ResultReplacingNonQueryCommandInterceptor : CommandInterceptorBase
+    protected class ResultReplacingNonQueryCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteNonQuery)
     {
-        public ResultReplacingNonQueryCommandInterceptor()
-            : base(DbCommandMethod.ExecuteNonQuery)
-        {
-        }
-
         public override int NonQueryExecuted(
             DbCommand command,
             CommandExecutedEventData eventData,
@@ -1510,13 +1422,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class NextResultCommandInterceptor : CommandInterceptorBase
+    protected class NextResultCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public NextResultCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult DataReaderClosing(
             DbCommand command,
             DataReaderClosingEventData eventData,
@@ -1564,13 +1471,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
         return interceptor.CommandText;
     }
 
-    protected class SuppressReaderCloseCommandInterceptor : CommandInterceptorBase
+    protected class SuppressReaderCloseCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public SuppressReaderCloseCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult DataReaderDisposing(
             DbCommand command,
             DataReaderDisposingEventData eventData,
@@ -1802,15 +1704,8 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             expected,
             actual.Replace("\r", string.Empty).Replace("\n", " "));
 
-    protected abstract class CommandInterceptorBase : IDbCommandInterceptor
+    protected abstract class CommandInterceptorBase(DbCommandMethod commandMethod) : IDbCommandInterceptor
     {
-        private readonly DbCommandMethod _commandMethod;
-
-        protected CommandInterceptorBase(DbCommandMethod commandMethod)
-        {
-            _commandMethod = commandMethod;
-        }
-
         public DbContext Context { get; set; }
         public Exception Exception { get; set; }
         public string CommandText { get; set; }
@@ -2107,7 +2002,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.NotEqual(default, eventData.ConnectionId);
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
             Assert.Equal(CommandSource, eventData.CommandSource);
             Assert.Equal(CommandSource, eventData.CommandSource);
             Assert.Same(Context, eventData.Context);
@@ -2123,7 +2018,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.Equal(CommandText, command.CommandText);
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
             Assert.Equal(CommandSource, eventData.CommandSource);
 
             ExecutedCalled = true;
@@ -2134,7 +2029,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.NotNull(eventData.Context);
             Assert.NotEqual(default, eventData.CommandId);
             Assert.NotEqual(default, eventData.ConnectionId);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
 
             Context = eventData.Context;
             CommandId = eventData.CommandId;
@@ -2149,7 +2044,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.Same(Context, eventData.Context);
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
             Assert.Equal(CommandSource, eventData.CommandSource);
 
             CreatedCalled = true;
@@ -2163,7 +2058,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.NotEqual(default, eventData.ConnectionId);
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
             Assert.Equal(CommandSource, eventData.CommandSource);
             Assert.NotEmpty(command.CommandText);
 
@@ -2179,7 +2074,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
             Assert.Equal(CommandSource, eventData.CommandSource);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
             Assert.NotNull(eventData.Exception);
 
             Exception = eventData.Exception;
@@ -2193,7 +2088,7 @@ public abstract class CommandInterceptionTestBase : InterceptionTestBase
             Assert.Equal(CommandId, eventData.CommandId);
             Assert.Equal(ConnectionId, eventData.ConnectionId);
             Assert.Equal(CommandSource, eventData.CommandSource);
-            Assert.Equal(_commandMethod, eventData.ExecuteMethod);
+            Assert.Equal(commandMethod, eventData.ExecuteMethod);
 
             CanceledCalled = true;
         }

--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ConcurrencyDetectorDisabledRelationalTestBase<TFixture> : ConcurrencyDetectorDisabledTestBase<TFixture>
+public abstract class ConcurrencyDetectorDisabledRelationalTestBase<TFixture>(TFixture fixture)
+    : ConcurrencyDetectorDisabledTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
-    protected ConcurrencyDetectorDisabledRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected string NormalizeDelimitersInRawString(string sql)
         => (Fixture.TestStore as RelationalTestStore)?.NormalizeDelimitersInRawString(sql) ?? sql;
 

--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ConcurrencyDetectorEnabledRelationalTestBase<TFixture> : ConcurrencyDetectorEnabledTestBase<TFixture>
+public abstract class ConcurrencyDetectorEnabledRelationalTestBase<TFixture>(TFixture fixture)
+    : ConcurrencyDetectorEnabledTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
-    protected ConcurrencyDetectorEnabledRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected string NormalizeDelimitersInRawString(string sql)
         => (Fixture.TestStore as RelationalTestStore)?.NormalizeDelimitersInRawString(sql) ?? sql;
 

--- a/test/EFCore.Relational.Specification.Tests/ConnectionInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConnectionInterceptionTestBase.cs
@@ -5,13 +5,8 @@ using System.Data;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ConnectionInterceptionTestBase : InterceptionTestBase
+public abstract class ConnectionInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture) : InterceptionTestBase(fixture)
 {
-    protected ConnectionInterceptionTestBase(InterceptionFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false)]
     [InlineData(true)]

--- a/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class DataAnnotationRelationalTestBase<TFixture> : DataAnnotationTestBase<TFixture>
+public abstract class DataAnnotationRelationalTestBase<TFixture>(TFixture fixture) : DataAnnotationTestBase<TFixture>(fixture)
     where TFixture : DataAnnotationRelationalTestBase<TFixture>.DataAnnotationRelationalFixtureBase, new()
 {
-    protected DataAnnotationRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual void ForeignKey_to_ForeignKey_on_many_to_many()
     {

--- a/test/EFCore.Relational.Specification.Tests/DesignTimeTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/DesignTimeTestBase.cs
@@ -5,15 +5,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class DesignTimeTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class DesignTimeTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : DesignTimeTestBase<TFixture>.DesignTimeFixtureBase
 {
-    protected TFixture Fixture { get; }
-
-    protected DesignTimeTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
+    protected TFixture Fixture { get; } = fixture;
 
     protected abstract Assembly ProviderAssembly { get; }
 

--- a/test/EFCore.Relational.Specification.Tests/ManyToManyTrackingRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ManyToManyTrackingRelationalTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ManyToManyTrackingRelationalTestBase<TFixture> : ManyToManyTrackingTestBase<TFixture>
+public abstract class ManyToManyTrackingRelationalTestBase<TFixture>(TFixture fixture) : ManyToManyTrackingTestBase<TFixture>(fixture)
     where TFixture : ManyToManyTrackingRelationalTestBase<TFixture>.ManyToManyTrackingRelationalFixture
 {
-    protected ManyToManyTrackingRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public void Many_to_many_delete_behaviors_are_set()
     {

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
@@ -8,7 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-public abstract class MigrationsSqlGeneratorTestBase
+public abstract class MigrationsSqlGeneratorTestBase(
+    TestHelpers testHelpers,
+    IServiceCollection customServices = null,
+    DbContextOptions options = null)
 {
     protected static string EOL
         => Environment.NewLine;
@@ -750,19 +753,9 @@ public abstract class MigrationsSqlGeneratorTestBase
                 pb.HasKey("FirstName", "LastName");
             });
 
-    protected TestHelpers TestHelpers { get; }
-    protected DbContextOptions ContextOptions { get; }
-    protected IServiceCollection CustomServices { get; }
-
-    protected MigrationsSqlGeneratorTestBase(
-        TestHelpers testHelpers,
-        IServiceCollection customServices = null,
-        DbContextOptions options = null)
-    {
-        TestHelpers = testHelpers;
-        CustomServices = customServices;
-        ContextOptions = options;
-    }
+    protected TestHelpers TestHelpers { get; } = testHelpers;
+    protected DbContextOptions ContextOptions { get; } = options;
+    protected IServiceCollection CustomServices { get; } = customServices;
 
     protected virtual void Generate(MigrationOperation operation, MigrationsSqlGenerationOptions options)
         => Generate(null, [operation], options);

--- a/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
+++ b/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
@@ -693,37 +693,14 @@ public class RelationalModelBuilderTest : ModelBuilderTest
         }
     }
 
-    public abstract class RelationalOneToManyTestBase : OneToManyTestBase
-    {
-        protected RelationalOneToManyTestBase(RelationalModelBuilderFixture fixture)
-            : base(fixture)
-        {
-        }
-    }
+    public abstract class RelationalOneToManyTestBase(RelationalModelBuilderFixture fixture) : OneToManyTestBase(fixture);
 
-    public abstract class RelationalManyToOneTestBase : ManyToOneTestBase
-    {
-        protected RelationalManyToOneTestBase(RelationalModelBuilderFixture fixture)
-            : base(fixture)
-        {
-        }
-    }
+    public abstract class RelationalManyToOneTestBase(RelationalModelBuilderFixture fixture) : ManyToOneTestBase(fixture);
 
-    public abstract class RelationalOneToOneTestBase : OneToOneTestBase
-    {
-        protected RelationalOneToOneTestBase(RelationalModelBuilderFixture fixture)
-            : base(fixture)
-        {
-        }
-    }
+    public abstract class RelationalOneToOneTestBase(RelationalModelBuilderFixture fixture) : OneToOneTestBase(fixture);
 
-    public abstract class RelationalManyToManyTestBase : ManyToManyTestBase
+    public abstract class RelationalManyToManyTestBase(RelationalModelBuilderFixture fixture) : ManyToManyTestBase(fixture)
     {
-        protected RelationalManyToManyTestBase(RelationalModelBuilderFixture fixture)
-            : base(fixture)
-        {
-        }
-
         [ConditionalFact] // Issue #27990
         public virtual void Can_use_ForeignKeyAttribute_with_InversePropertyAttribute()
         {
@@ -859,13 +836,8 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
     }
 
-    public abstract class RelationalOwnedTypesTestBase : OwnedTypesTestBase
+    public abstract class RelationalOwnedTypesTestBase(RelationalModelBuilderFixture fixture) : OwnedTypesTestBase(fixture)
     {
-        protected RelationalOwnedTypesTestBase(RelationalModelBuilderFixture fixture)
-            : base(fixture)
-        {
-        }
-
         [ConditionalFact]
         public virtual void Can_use_table_splitting_with_owned_reference()
         {
@@ -2633,14 +2605,9 @@ public class RelationalModelBuilderTest : ModelBuilderTest
             => Wrap(StoredProcedureResultColumnBuilder.HasAnnotation(annotation, value));
     }
 
-    public abstract class TestTableValuedFunctionBuilder<TEntity> : DbFunctionBuilderBase
+    public abstract class TestTableValuedFunctionBuilder<TEntity>(IMutableDbFunction function) : DbFunctionBuilderBase(function)
         where TEntity : class
     {
-        protected TestTableValuedFunctionBuilder(IMutableDbFunction function)
-            : base(function)
-        {
-        }
-
         public new abstract TestTableValuedFunctionBuilder<TEntity> HasName(string name);
 
         public new abstract TestTableValuedFunctionBuilder<TEntity> HasSchema(string? schema);

--- a/test/EFCore.Relational.Specification.Tests/OptimisticConcurrencyRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/OptimisticConcurrencyRelationalTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>
-    : OptimisticConcurrencyTestBase<TFixture, TRowVersion>
+public abstract class OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>(TFixture fixture)
+    : OptimisticConcurrencyTestBase<TFixture, TRowVersion>(fixture)
     where TFixture : F1RelationalFixture<TRowVersion>, new()
 {
-    protected OptimisticConcurrencyRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual void Property_entry_original_value_is_set()
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsQueryRelationalTestBase.cs
@@ -6,11 +6,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 public abstract class
-    ComplexNavigationsCollectionsQueryRelationalTestBase<TFixture> : ComplexNavigationsCollectionsQueryTestBase<TFixture>
-    where TFixture : ComplexNavigationsQueryFixtureBase, new()
-{
-    protected ComplexNavigationsCollectionsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+    ComplexNavigationsCollectionsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsCollectionsQueryTestBase<TFixture>(fixture)
+    where TFixture : ComplexNavigationsQueryFixtureBase, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase.cs
@@ -6,15 +6,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 public abstract class
-    ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase<TFixture> : ComplexNavigationsCollectionsSharedTypeQueryTestBase<
-        TFixture>
+    ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsCollectionsSharedTypeQueryTestBase<
+        TFixture>(fixture)
     where TFixture : ComplexNavigationsSharedTypeQueryRelationalFixtureBase, new()
 {
-    protected ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
         => Assert.Equal(
             RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitQueryRelationalTestBase.cs
@@ -6,14 +6,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 public abstract class
-    ComplexNavigationsCollectionsSplitQueryRelationalTestBase<TFixture> : ComplexNavigationsCollectionsQueryTestBase<TFixture>
+    ComplexNavigationsCollectionsSplitQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsCollectionsQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
-    protected ComplexNavigationsCollectionsSplitQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
     {
         serverQueryExpression = base.RewriteServerQueryExpression(serverQueryExpression);

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase.cs
@@ -6,15 +6,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 public abstract class
-    ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase<TFixture> : ComplexNavigationsCollectionsSharedTypeQueryTestBase
-        <TFixture>
+    ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsCollectionsSharedTypeQueryTestBase
+        <TFixture>(fixture)
     where TFixture : ComplexNavigationsSharedTypeQueryRelationalFixtureBase, new()
 {
-    protected ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
         => Assert.Equal(
             RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ComplexNavigationsQueryRelationalTestBase<TFixture> : ComplexNavigationsQueryTestBase<TFixture>
+public abstract class ComplexNavigationsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
-    protected ComplexNavigationsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
         => AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryRelationalTestBase.cs
@@ -6,14 +6,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 public abstract class
-    ComplexNavigationsSharedTypeQueryRelationalTestBase<TFixture> : ComplexNavigationsSharedTypeQueryTestBase<TFixture>
+    ComplexNavigationsSharedTypeQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsSharedTypeQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsSharedTypeQueryRelationalFixtureBase, new()
 {
-    protected ComplexNavigationsSharedTypeQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
         => AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ComplexTypeQueryRelationalTestBase<TFixture> : ComplexTypeQueryTestBase<TFixture>
+public abstract class ComplexTypeQueryRelationalTestBase<TFixture>(TFixture fixture) : ComplexTypeQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexTypeQueryRelationalFixtureBase, new()
 {
-    protected ComplexTypeQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task Subquery_over_complex_type(bool async)
     {
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Subquery_over_complex_type(async));

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class FromSqlSprocQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class FromSqlSprocQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
 {
-    protected FromSqlSprocQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(false)]

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class GearsOfWarFromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class GearsOfWarFromSqlQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : GearsOfWarQueryRelationalFixture, new()
 {
-    protected GearsOfWarFromSqlQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void From_sql_queryable_simple_columns_out_of_order()

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class GearsOfWarQueryRelationalTestBase<TFixture> : GearsOfWarQueryTestBase<TFixture>
+public abstract class GearsOfWarQueryRelationalTestBase<TFixture>(TFixture fixture) : GearsOfWarQueryTestBase<TFixture>(fixture)
     where TFixture : GearsOfWarQueryFixtureBase, new()
 {
-    protected GearsOfWarQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Parameter_used_multiple_times_take_appropriate_inferred_type_mapping(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryRelationalTestBase.cs
@@ -4,14 +4,9 @@
 using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 namespace Microsoft.EntityFrameworkCore.Query;
-public abstract class JsonQueryRelationalTestBase<TFixture> : JsonQueryTestBase<TFixture>
+public abstract class JsonQueryRelationalTestBase<TFixture>(TFixture fixture) : JsonQueryTestBase<TFixture>(fixture)
     where TFixture : JsonQueryRelationalFixture, new()
 {
-    protected JsonQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task Project_json_reference_in_tracking_query_fails(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyNoTrackingQueryRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ManyToManyNoTrackingQueryRelationalTestBase<TFixture> : ManyToManyNoTrackingQueryTestBase<TFixture>
+public abstract class ManyToManyNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ManyToManyNoTrackingQueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
-    protected ManyToManyNoTrackingQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_skip_navigation_split(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ManyToManyQueryRelationalTestBase<TFixture> : ManyToManyQueryTestBase<TFixture>
+public abstract class ManyToManyQueryRelationalTestBase<TFixture>(TFixture fixture) : ManyToManyQueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
-    protected ManyToManyQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_skip_navigation_split(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/MappingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/MappingQueryTestBase.cs
@@ -8,15 +8,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class MappingQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class MappingQueryTestBase<TFixture>(MappingQueryTestBase<TFixture>.MappingQueryFixtureBase fixture)
+    : IClassFixture<TFixture>
     where TFixture : MappingQueryTestBase<TFixture>.MappingQueryFixtureBase, new()
 {
-    protected MappingQueryTestBase(MappingQueryFixtureBase fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected MappingQueryFixtureBase Fixture { get; }
+    protected MappingQueryFixtureBase Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void All_customers()

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindAggregateOperatorsQueryRelationalTestBase<TFixture> : NorthwindAggregateOperatorsQueryTestBase<TFixture>
+public abstract class NorthwindAggregateOperatorsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindAggregateOperatorsQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindAggregateOperatorsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task Last_when_no_order_by(bool async)
         => Assert.Equal(
             RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindFunctionsQueryRelationalTestBase<TFixture> : NorthwindFunctionsQueryTestBase<TFixture>
+public abstract class NorthwindFunctionsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindFunctionsQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindFunctionsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     // StartsWith with StringComparison not supported in relational databases, where the column collation is used to control comparison
     // semantics.
     public override Task String_StartsWith_with_StringComparison_Ordinal(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindGroupByQueryRelationalTestBase<TFixture> : NorthwindGroupByQueryTestBase<TFixture>
+public abstract class NorthwindGroupByQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindGroupByQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindGroupByQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindIncludeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindIncludeQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindIncludeQueryRelationalTestBase<TFixture> : NorthwindIncludeQueryTestBase<TFixture>
+public abstract class NorthwindIncludeQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindIncludeQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task Include_collection_with_last_no_orderby(bool async)
         => Assert.Equal(
             RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindJoinQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindJoinQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindJoinQueryRelationalTestBase<TFixture> : NorthwindJoinQueryTestBase<TFixture>
+public abstract class NorthwindJoinQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindJoinQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindJoinQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindKeylessEntitiesQueryRelationalTestBase<TFixture> : NorthwindKeylessEntitiesQueryTestBase<TFixture>
+public abstract class NorthwindKeylessEntitiesQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindKeylessEntitiesQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindKeylessEntitiesQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Projecting_collection_correlated_with_keyless_entity_throws(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindMiscellaneousQueryRelationalTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindMiscellaneousQueryRelationalTestBase<TFixture> : NorthwindMiscellaneousQueryTestBase<TFixture>
+public abstract class NorthwindMiscellaneousQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindMiscellaneousQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindMiscellaneousQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_collection_split(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindNavigationsQueryRelationalTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindNavigationsQueryRelationalTestBase<TFixture> : NorthwindNavigationsQueryTestBase<TFixture>
+public abstract class NorthwindNavigationsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindNavigationsQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindNavigationsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Where_subquery_on_navigation_client_eval(bool async)
         => AssertTranslationFailed(() => base.Where_subquery_on_navigation_client_eval(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSelectQueryRelationalTestBase<TFixture> : NorthwindSelectQueryTestBase<TFixture>
+public abstract class NorthwindSelectQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindSelectQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindSelectQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
         => AssertTranslationFailed(() => base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSetOperationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSetOperationsQueryRelationalTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSetOperationsQueryRelationalTestBase<TFixture> : NorthwindSetOperationsQueryTestBase<TFixture>
+public abstract class NorthwindSetOperationsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindSetOperationsQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindSetOperationsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task Collection_projection_after_set_operation_fails_if_distinct(bool async)
     {
         var message = (await Assert.ThrowsAsync<InvalidOperationException>(

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSplitIncludeNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSplitIncludeNoTrackingQueryTestBase.cs
@@ -11,17 +11,13 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSplitIncludeNoTrackingQueryTestBase<TFixture> : NorthwindIncludeNoTrackingQueryTestBase<TFixture>
+public abstract class NorthwindSplitIncludeNoTrackingQueryTestBase<TFixture>(TFixture fixture)
+    : NorthwindIncludeNoTrackingQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly MethodInfo _asSplitIncludeMethodInfo
         = typeof(RelationalQueryableExtensions)
             .GetTypeInfo().GetDeclaredMethod(nameof(RelationalQueryableExtensions.AsSplitQuery));
-
-    protected NorthwindSplitIncludeNoTrackingQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     public override async Task Include_closes_reader(bool async)
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSplitIncludeQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSplitIncludeQueryTestBase.cs
@@ -11,17 +11,12 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSplitIncludeQueryTestBase<TFixture> : NorthwindIncludeQueryTestBase<TFixture>
+public abstract class NorthwindSplitIncludeQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly MethodInfo _asSplitIncludeMethodInfo
         = typeof(RelationalQueryableExtensions)
             .GetTypeInfo().GetDeclaredMethod(nameof(RelationalQueryableExtensions.AsSplitQuery));
-
-    protected NorthwindSplitIncludeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     public override async Task Include_closes_reader(bool async)
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindWhereQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindWhereQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindWhereQueryRelationalTestBase<TFixture> : NorthwindWhereQueryTestBase<TFixture>
+public abstract class NorthwindWhereQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindWhereQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindWhereQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Where_bool_client_side_negated(bool async)
         => AssertTranslationFailed(() => base.Where_bool_client_side_negated(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -17,14 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NullSemanticsQueryFixtureBase, new()
 {
-    protected NullSemanticsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Rewrite_compare_int_with_int(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
@@ -7,12 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
 {
-    protected OperatorsData ExpectedData { get; init; }
-
-    protected OperatorsQueryTestBase()
-    {
-        ExpectedData = OperatorsData.Instance;
-    }
+    protected OperatorsData ExpectedData { get; init; } = OperatorsData.Instance;
 
     protected override string StoreName
         => "OperatorsTest";

--- a/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class OptionalDependentQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class OptionalDependentQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : OptionalDependentQueryFixtureBase, new()
 {
-    protected OptionalDependentQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_projection_entity_with_all_optional(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class OwnedQueryRelationalTestBase<TFixture> : OwnedQueryTestBase<TFixture>
+public abstract class OwnedQueryRelationalTestBase<TFixture>(TFixture fixture) : OwnedQueryTestBase<TFixture>(fixture)
     where TFixture : OwnedQueryRelationalTestBase<TFixture>.RelationalOwnedQueryFixture, new()
 {
-    protected OwnedQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Contains_over_owned_collection(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_over_owned_collection(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -9,15 +9,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class QueryNoClientEvalTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class QueryNoClientEvalTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
 {
-    protected QueryNoClientEvalTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Throws_when_where()

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : NorthwindDbFunctionsQueryTestBase<TFixture>
+public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : NorthwindDbFunctionsQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
 {
-    protected NorthwindDbFunctionsQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);

--- a/test/EFCore.Relational.Specification.Tests/Query/SpatialQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SpatialQueryRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class SpatialQueryRelationalTestBase<TFixture> : SpatialQueryTestBase<TFixture>
+public abstract class SpatialQueryRelationalTestBase<TFixture>(TFixture fixture) : SpatialQueryTestBase<TFixture>(fixture)
     where TFixture : SpatialQueryFixtureBase, new()
 {
-    protected SpatialQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
         => new RelationalQueryAsserter(
             fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);

--- a/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -11,15 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class SqlExecutorTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class SqlExecutorTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryRelationalFixture<SqlExecutorModelCustomizer>, new()
 {
-    protected SqlExecutorTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(false)]
@@ -333,11 +328,5 @@ public class SqlExecutorModelCustomizer : NoopModelCustomizer
         configurationBuilder.DefaultTypeMapping<City>().HasConversion<CityToStringConverter>();
     }
 
-    private sealed class CityToStringConverter : ValueConverter<City, string>
-    {
-        public CityToStringConverter()
-            : base(value => value.Name, value => new City { Name = value })
-        {
-        }
-    }
+    private sealed class CityToStringConverter() : ValueConverter<City, string>(value => value.Name, value => new City { Name = value });
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPCGearsOfWarQueryRelationalTestBase<TFixture> : GearsOfWarQueryRelationalTestBase<TFixture>
+public abstract class TPCGearsOfWarQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : GearsOfWarQueryRelationalTestBase<TFixture>(fixture)
     where TFixture : TPCGearsOfWarQueryRelationalFixture, new()
 {
-    protected TPCGearsOfWarQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Project_discriminator_columns(bool async)
         => AssertUnableToTranslateEFProperty(() => base.Project_discriminator_columns(async));
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyNoTrackingQueryRelationalTestBase.cs
@@ -5,11 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPCManyToManyNoTrackingQueryRelationalTestBase<TFixture> : ManyToManyNoTrackingQueryRelationalTestBase<TFixture>
-    where TFixture : TPCManyToManyQueryRelationalFixture, new()
-{
-    protected TPCManyToManyNoTrackingQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPCManyToManyNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ManyToManyNoTrackingQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPCManyToManyQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyQueryRelationalTestBase.cs
@@ -5,11 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPCManyToManyQueryRelationalTestBase<TFixture> : ManyToManyQueryRelationalTestBase<TFixture>
-    where TFixture : TPCManyToManyQueryRelationalFixture, new()
-{
-    protected TPCManyToManyQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPCManyToManyQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ManyToManyQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPCManyToManyQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCRelationshipsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCRelationshipsQueryTestBase.cs
@@ -7,11 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPCRelationshipsQueryTestBase<TFixture> : InheritanceRelationshipsQueryRelationalTestBase<TFixture>
-    where TFixture : TPCRelationshipsQueryRelationalFixture, new()
-{
-    protected TPCRelationshipsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPCRelationshipsQueryTestBase<TFixture>(TFixture fixture)
+    : InheritanceRelationshipsQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPCRelationshipsQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPTGearsOfWarQueryRelationalTestBase<TFixture> : GearsOfWarQueryRelationalTestBase<TFixture>
+public abstract class TPTGearsOfWarQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : GearsOfWarQueryRelationalTestBase<TFixture>(fixture)
     where TFixture : TPTGearsOfWarQueryRelationalFixture, new()
 {
-    protected TPTGearsOfWarQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Project_discriminator_columns(bool async)
         => AssertUnableToTranslateEFProperty(() => base.Project_discriminator_columns(async));
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyNoTrackingQueryRelationalTestBase.cs
@@ -5,11 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPTManyToManyNoTrackingQueryRelationalTestBase<TFixture> : ManyToManyNoTrackingQueryRelationalTestBase<TFixture>
-    where TFixture : TPTManyToManyQueryRelationalFixture, new()
-{
-    protected TPTManyToManyNoTrackingQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPTManyToManyNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ManyToManyNoTrackingQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPTManyToManyQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyQueryRelationalTestBase.cs
@@ -5,11 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPTManyToManyQueryRelationalTestBase<TFixture> : ManyToManyQueryRelationalTestBase<TFixture>
-    where TFixture : TPTManyToManyQueryRelationalFixture, new()
-{
-    protected TPTManyToManyQueryRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPTManyToManyQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ManyToManyQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPTManyToManyQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTRelationshipsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTRelationshipsQueryTestBase.cs
@@ -7,11 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPTRelationshipsQueryTestBase<TFixture> : InheritanceRelationshipsQueryRelationalTestBase<TFixture>
-    where TFixture : TPTRelationshipsQueryRelationalFixture, new()
-{
-    protected TPTRelationshipsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-}
+public abstract class TPTRelationshipsQueryTestBase<TFixture>(TFixture fixture)
+    : InheritanceRelationshipsQueryRelationalTestBase<TFixture>(fixture)
+    where TFixture : TPTRelationshipsQueryRelationalFixture, new();

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -7,15 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class UdfDbFunctionTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class UdfDbFunctionTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : SharedStoreFixtureBase<DbContext>, new()
 {
-    protected UdfDbFunctionTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected UDFSqlContext CreateContext()
         => (UDFSqlContext)Fixture.CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/RelationalServiceCollectionExtensionsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/RelationalServiceCollectionExtensionsTestBase.cs
@@ -5,13 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class RelationalServiceCollectionExtensionsTestBase : EntityFrameworkServiceCollectionExtensionsTestBase
+public abstract class RelationalServiceCollectionExtensionsTestBase(TestHelpers testHelpers)
+    : EntityFrameworkServiceCollectionExtensionsTestBase(testHelpers)
 {
-    protected RelationalServiceCollectionExtensionsTestBase(TestHelpers testHelpers)
-        : base(testHelpers)
-    {
-    }
-
     public override void Required_services_are_registered_with_expected_lifetimes()
         => LifetimeTest(EntityFrameworkServicesBuilder.CoreServices, EntityFrameworkRelationalServicesBuilder.RelationalServices);
 }

--- a/test/EFCore.Relational.Specification.Tests/StoreGeneratedFixupRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/StoreGeneratedFixupRelationalTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class StoreGeneratedFixupRelationalTestBase<TFixture> : StoreGeneratedFixupTestBase<TFixture>
+public abstract class StoreGeneratedFixupRelationalTestBase<TFixture>(TFixture fixture) : StoreGeneratedFixupTestBase<TFixture>(fixture)
     where TFixture : StoreGeneratedFixupRelationalTestBase<TFixture>.StoreGeneratedFixupRelationalFixtureBase, new()
 {
-    protected StoreGeneratedFixupRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class StoreGeneratedFixupRelationalFixtureBase : StoreGeneratedFixupFixtureBase
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)

--- a/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
@@ -8,13 +8,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TPTTableSplittingTestBase : TableSplittingTestBase
+public abstract class TPTTableSplittingTestBase(ITestOutputHelper testOutputHelper) : TableSplittingTestBase(testOutputHelper)
 {
-    protected TPTTableSplittingTestBase(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     public override Task Can_use_optional_dependents_with_shared_concurrency_tokens()
         // TODO: Issue #22060
         => Task.CompletedTask;

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -5,13 +5,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 #nullable disable
 
-public abstract class NorthwindRelationalContext : NorthwindContext
+public abstract class NorthwindRelationalContext(DbContextOptions options) : NorthwindContext(options)
 {
-    protected NorthwindRelationalContext(DbContextOptions options)
-        : base(options)
-    {
-    }
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentData.cs
@@ -7,14 +7,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.OptionalDependent;
 
 public class OptionalDependentData : ISetSource
 {
-    public OptionalDependentData()
-    {
-        EntitiesAllOptional = CreateEntitiesAllOptional();
-        EntitiesSomeRequired = CreateEntitiesSomeRequired();
-    }
-
-    public IReadOnlyList<OptionalDependentEntityAllOptional> EntitiesAllOptional { get; }
-    public IReadOnlyList<OptionalDependentEntitySomeRequired> EntitiesSomeRequired { get; }
+    public IReadOnlyList<OptionalDependentEntityAllOptional> EntitiesAllOptional { get; } = CreateEntitiesAllOptional();
+    public IReadOnlyList<OptionalDependentEntitySomeRequired> EntitiesSomeRequired { get; } = CreateEntitiesSomeRequired();
 
     public static IReadOnlyList<OptionalDependentEntityAllOptional> CreateEntitiesAllOptional()
     {

--- a/test/EFCore.Relational.Specification.Tests/TransactionInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionInterceptionTestBase.cs
@@ -7,13 +7,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TransactionInterceptionTestBase : InterceptionTestBase
+public abstract class TransactionInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture) : InterceptionTestBase(fixture)
 {
-    protected TransactionInterceptionTestBase(InterceptionFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false)]
     [InlineData(true)]

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -12,15 +12,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>, IAsyncLifetime
+public abstract class TransactionTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>, IAsyncLifetime
     where TFixture : TransactionTestBase<TFixture>.TransactionFixtureBase, new()
 {
-    protected TransactionTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; set; }
+    protected TFixture Fixture { get; set; } = fixture;
 
     [ConditionalTheory]
     [InlineData(true)]

--- a/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TwoDatabasesTestBase
+public abstract class TwoDatabasesTestBase(FixtureBase fixture)
 {
-    protected FixtureBase Fixture { get; }
-
-    protected TwoDatabasesTestBase(FixtureBase fixture)
-    {
-        Fixture = fixture;
-    }
+    protected FixtureBase Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Can_query_from_one_connection_string_and_save_changes_to_another()

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class JsonUpdateTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : JsonUpdateFixtureBase, new()
 {
-    public TFixture Fixture { get; }
-
-    protected JsonUpdateTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
+    public TFixture Fixture { get; } = fixture;
 
     public JsonQueryContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFixture>, IAsyncLifetime
+public abstract class StoreValueGenerationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>, IAsyncLifetime
     where TFixture : StoreValueGenerationFixtureBase
 {
-    protected StoreValueGenerationTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     #region Single operation
 
     [ConditionalTheory]
@@ -363,7 +358,7 @@ public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFi
         bool withSameEntityType)
         => 1;
 
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected StoreValueGenerationContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/Update/UpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/UpdatesRelationalTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public abstract class UpdatesRelationalTestBase<TFixture> : UpdatesTestBase<TFixture>
+public abstract class UpdatesRelationalTestBase<TFixture>(TFixture fixture) : UpdatesTestBase<TFixture>(fixture)
     where TFixture : UpdatesRelationalTestBase<TFixture>.UpdatesRelationalFixture
 {
-    protected UpdatesRelationalTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual Task SaveChanges_works_for_entities_also_mapped_to_view()
         => ExecuteWithStrategyInTransactionAsync(

--- a/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
@@ -632,17 +632,11 @@ public class RelationalDatabaseFacadeExtensionsTest
         Assert.Equal(["Branston"], commandBuilder.Parameters);
     }
 
-    private class ThudContext : DbContext
-    {
-        public ThudContext()
-            : base(
-                FakeRelationalTestHelpers.Instance.CreateOptions(
-                    FakeRelationalTestHelpers.Instance.CreateServiceProvider(
-                        new ServiceCollection()
-                            .AddScoped<IRawSqlCommandBuilder, TestRawSqlCommandBuilder>())))
-        {
-        }
-    }
+    private class ThudContext() : DbContext(
+        FakeRelationalTestHelpers.Instance.CreateOptions(
+            FakeRelationalTestHelpers.Instance.CreateServiceProvider(
+                new ServiceCollection()
+                    .AddScoped<IRawSqlCommandBuilder, TestRawSqlCommandBuilder>())));
 
     private class TestRawSqlCommandBuilder(
         IRelationalCommandBuilderFactory relationalCommandBuilderFactory) : IRawSqlCommandBuilder

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalEventIdTest.cs
@@ -121,13 +121,8 @@ public class RelationalEventIdTest : EventIdTestBase
             => throw new NotImplementedException();
     }
 
-    private class FakeSqlExpression : SqlExpression
+    private class FakeSqlExpression() : SqlExpression(typeof(object), null)
     {
-        public FakeSqlExpression()
-            : base(typeof(object), null)
-        {
-        }
-
         public override Expression Quote()
             => throw new NotSupportedException();
 
@@ -180,13 +175,7 @@ public class RelationalEventIdTest : EventIdTestBase
             => throw new NotImplementedException();
     }
 
-    private class FakeMigrationCommand : MigrationCommand
-    {
-        public FakeMigrationCommand()
-            : base(new FakeRelationalCommand(), null, new FakeRelationalCommandDiagnosticsLogger())
-        {
-        }
-    }
+    private class FakeMigrationCommand() : MigrationCommand(new FakeRelationalCommand(), null, new FakeRelationalCommandDiagnosticsLogger());
 
     private class FakeRelationalCommand : IRelationalCommand
     {

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -3843,26 +3843,17 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
         entityType.SetDiscriminatorValue(entityType.Name);
     }
 
-    public class TestDecimalToLongConverter : ValueConverter<decimal, long>
+    public class TestDecimalToLongConverter() : ValueConverter<decimal, long>(convertToProviderExpression, convertFromProviderExpression)
     {
         private static readonly Expression<Func<decimal, long>> convertToProviderExpression = d => (long)(d * 100);
         private static readonly Expression<Func<long, decimal>> convertFromProviderExpression = l => l / 100m;
-
-        public TestDecimalToLongConverter()
-            : base(convertToProviderExpression, convertFromProviderExpression)
-        {
-        }
     }
 
-    public class TestDecimalToDecimalConverter : ValueConverter<decimal, decimal>
+    public class TestDecimalToDecimalConverter()
+        : ValueConverter<decimal, decimal>(convertToProviderExpression, convertFromProviderExpression)
     {
         private static readonly Expression<Func<decimal, decimal>> convertToProviderExpression = d => d * 100m;
         private static readonly Expression<Func<decimal, decimal>> convertFromProviderExpression = l => l / 100m;
-
-        public TestDecimalToDecimalConverter()
-            : base(convertToProviderExpression, convertFromProviderExpression)
-        {
-        }
     }
 
     private class BaseTestMethods

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -9811,12 +9811,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
 
     protected class ApplicationUser
     {
-        private readonly SomeOwnedEntity _ownedEntity;
-
-        public ApplicationUser()
-        {
-            _ownedEntity = null!;
-        }
+        private readonly SomeOwnedEntity _ownedEntity = null!;
 
         public virtual long Id { get; set; }
 
@@ -10060,13 +10055,8 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             upOps => Assert.Empty(upOps),
             downOps => Assert.Empty(downOps));
 
-    private class RightmostValueComparer : ValueComparer<byte[]>
+    private class RightmostValueComparer() : ValueComparer<byte[]>(false)
     {
-        public RightmostValueComparer()
-            : base(false)
-        {
-        }
-
         public override bool Equals(byte[] left, byte[] right)
             => object.Equals(left[^1], right[^1]);
     }

--- a/test/EFCore.Relational.Tests/Storage/RelationalGeometryTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalGeometryTypeMappingTest.cs
@@ -40,12 +40,6 @@ public class RelationalGeometryTypeMappingTest
         protected override int GetSrid(object value)
             => throw new NotImplementedException();
 
-        private class NullValueConverter : ValueConverter<TGeometry, TGeometry>
-        {
-            public NullValueConverter()
-                : base(t => t, t => t)
-            {
-            }
-        }
+        private class NullValueConverter() : ValueConverter<TGeometry, TGeometry>(t => t, t => t);
     }
 }

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -8,24 +8,15 @@ namespace Microsoft.EntityFrameworkCore.Storage;
 
 public abstract class RelationalTypeMappingTest
 {
-    protected class FakeValueConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    protected class FakeValueConverter<TModel, TProvider>()
+        : ValueConverter<TModel, TProvider>(_ => (TProvider)(object)_, _ => (TModel)(object)_)
     {
-        public FakeValueConverter()
-            : base(_ => (TProvider)(object)_, _ => (TModel)(object)_)
-        {
-        }
-
         public override Type ModelClrType { get; } = typeof(TModel);
         public override Type ProviderClrType { get; } = typeof(TProvider);
     }
 
-    protected class FakeValueComparer<T> : ValueComparer<T>
+    protected class FakeValueComparer<T>() : ValueComparer<T>(false)
     {
-        public FakeValueComparer()
-            : base(false)
-        {
-        }
-
         public override Type Type { get; } = typeof(T);
     }
 

--- a/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
@@ -70,17 +70,12 @@ public class BatchExecutorTest
         return connection;
     }
 
-    private class TestContext : DbContext
+    private class TestContext() : DbContext(FakeRelationalTestHelpers.Instance.CreateOptions(_serviceProvider))
     {
         private static readonly IServiceProvider _serviceProvider
             = FakeRelationalOptionsExtension.AddEntityFrameworkRelationalDatabase(
                     new ServiceCollection())
                 .BuildServiceProvider(validateScopes: true);
-
-        public TestContext()
-            : base(FakeRelationalTestHelpers.Instance.CreateOptions(_serviceProvider))
-        {
-        }
 
         public DbSet<Foo> Foos { get; set; }
         public DbSet<Bar> Bars { get; set; }

--- a/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
@@ -10,14 +10,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ApiConsistencyTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ApiConsistencyTestBase<TFixture>.ApiConsistencyFixtureBase, new()
 {
-    protected ApiConsistencyTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     protected const BindingFlags PublicInstance
         = BindingFlags.Instance | BindingFlags.Public;
 
@@ -35,7 +30,7 @@ public abstract class ApiConsistencyTestBase<TFixture> : IClassFixture<TFixture>
             && firstParam.Name == "original"
             && firstParam.ParameterType == method.DeclaringType;
 
-    protected virtual TFixture Fixture { get; }
+    protected virtual TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public void Fluent_api_methods_should_not_return_void()

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -10,15 +10,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class BuiltInDataTypesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : BuiltInDataTypesTestBase<TFixture>.BuiltInDataTypesFixtureBase, new()
 {
-    protected BuiltInDataTypesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected DbContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
 
-public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTestBase<TFixture>
+public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture>(TFixture fixture) : BulkUpdatesTestBase<TFixture>(fixture)
     where TFixture : InheritanceBulkUpdatesFixtureBase, new()
 {
-    protected FiltersInheritanceBulkUpdatesTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_where_hierarchy(bool async)

--- a/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class CompositeKeyEndToEndTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class CompositeKeyEndToEndTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : CompositeKeyEndToEndTestBase<TFixture>.CompositeKeyEndToEndFixtureBase
 {
-    protected CompositeKeyEndToEndTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    private TFixture Fixture { get; }
+    private TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual async Task Can_use_two_non_generated_integers_as_composite_key_end_to_end()

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorDisabledTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorDisabledTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ConcurrencyDetectorDisabledTestBase<TFixture> : ConcurrencyDetectorTestBase<TFixture>
+public abstract class ConcurrencyDetectorDisabledTestBase<TFixture>(TFixture fixture) : ConcurrencyDetectorTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
-    protected ConcurrencyDetectorDisabledTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task SaveChanges(bool async)

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorEnabledTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorEnabledTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ConcurrencyDetectorEnabledTestBase<TFixture> : ConcurrencyDetectorTestBase<TFixture>
+public abstract class ConcurrencyDetectorEnabledTestBase<TFixture>(TFixture fixture) : ConcurrencyDetectorTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
-    protected ConcurrencyDetectorEnabledTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task SaveChanges(bool async)

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -11,15 +11,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ConcurrencyDetectorTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class ConcurrencyDetectorTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
-    protected ConcurrencyDetectorTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
@@ -3,14 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ConvertToProviderTypesTestBase<TFixture> : BuiltInDataTypesTestBase<TFixture>
+public abstract class ConvertToProviderTypesTestBase<TFixture>(TFixture fixture) : BuiltInDataTypesTestBase<TFixture>(fixture)
     where TFixture : BuiltInDataTypesTestBase<TFixture>.BuiltInDataTypesFixtureBase, new()
 {
-    protected ConvertToProviderTypesTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual void Equals_method_over_enum_works()
     {

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestBase<TFixture>
+public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : BuiltInDataTypesTestBase<TFixture>(fixture)
     where TFixture : BuiltInDataTypesTestBase<TFixture>.BuiltInDataTypesFixtureBase, new()
 {
-    protected CustomConvertersTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual async Task Can_query_and_update_with_nullable_converter_on_unique_index()
     {
@@ -766,14 +761,9 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
 
     public class Dashboard
     {
-        public Dashboard()
-        {
-            Layouts = [];
-        }
-
         public int Id { get; set; }
         public string Name { get; set; }
-        public List<Layout> Layouts { get; set; }
+        public List<Layout> Layouts { get; set; } = [];
     }
 
     public class Layout
@@ -1447,24 +1437,12 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
             }
         }
 
-        private class UrlSchemeRemover : ValueConverter<string, string>
-        {
-            public UrlSchemeRemover()
-                : base(x => x.Remove(0, 7), x => "http://" + x)
-            {
-            }
-        }
+        private class UrlSchemeRemover() : ValueConverter<string, string>(x => x.Remove(0, 7), x => "http://" + x);
 
-        private class RolesToStringConveter : ValueConverter<ICollection<Roles>, string>
-        {
-            public RolesToStringConveter()
-                : base(
-                    v => string.Join(";", v.Select(f => f.ToString())),
-                    v => v.Length > 0
-                        ? v.Split(new[] { ';' }).Select(f => (Roles)Enum.Parse(typeof(Roles), f)).ToList()
-                        : new List<Roles>())
-            {
-            }
-        }
+        private class RolesToStringConveter() : ValueConverter<ICollection<Roles>, string>(
+            v => string.Join(";", v.Select(f => f.ToString())),
+            v => v.Length > 0
+                ? v.Split(new[] { ';' }).Select(f => (Roles)Enum.Parse(typeof(Roles), f)).ToList()
+                : new List<Roles>());
     }
 }

--- a/test/EFCore.Specification.Tests/DataBindingTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataBindingTestBase.cs
@@ -10,15 +10,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class DataBindingTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class DataBindingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : F1FixtureBase<byte[]>, new()
 {
-    protected DataBindingTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected const int TotalCount = 40;
 

--- a/test/EFCore.Specification.Tests/EntityFrameworkServiceCollectionExtensionsTestBase.cs
+++ b/test/EFCore.Specification.Tests/EntityFrameworkServiceCollectionExtensionsTestBase.cs
@@ -5,15 +5,8 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class EntityFrameworkServiceCollectionExtensionsTestBase
+public abstract class EntityFrameworkServiceCollectionExtensionsTestBase(TestHelpers testHelpers)
 {
-    private readonly TestHelpers _testHelpers;
-
-    protected EntityFrameworkServiceCollectionExtensionsTestBase(TestHelpers testHelpers)
-    {
-        _testHelpers = testHelpers;
-    }
-
     [ConditionalFact]
     public void Calling_AddEntityFramework_explicitly_does_not_change_services()
     {
@@ -77,5 +70,5 @@ public abstract class EntityFrameworkServiceCollectionExtensionsTestBase
     }
 
     private IServiceCollection AddServices(IServiceCollection serviceCollection)
-        => _testHelpers.AddProviderServices(serviceCollection);
+        => testHelpers.AddProviderServices(serviceCollection);
 }

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -12,15 +12,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class FieldMappingTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : FieldMappingTestBase<TFixture>.FieldMappingFixtureBase, new()
 {
-    protected FieldMappingTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected static AsyncLocal<bool> _isSeeding = new();
 

--- a/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : FieldsOnlyLoadTestBase<TFixture>.FieldsOnlyLoadFixtureBase
 {
-    protected FieldsOnlyLoadTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged)]

--- a/test/EFCore.Specification.Tests/FindTestBase.cs
+++ b/test/EFCore.Specification.Tests/FindTestBase.cs
@@ -9,15 +9,10 @@ using System.ComponentModel.DataAnnotations.Schema;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    public abstract class FindTestBase<TFixture> : IClassFixture<TFixture>
+    public abstract class FindTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
         where TFixture : FindTestBase<TFixture>.FindFixtureBase
     {
-        protected FindTestBase(TFixture fixture)
-        {
-            Fixture = fixture;
-        }
-
-        protected TFixture Fixture { get; }
+        protected TFixture Fixture { get; } = fixture;
 
         protected abstract TestFinder Finder { get; }
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -14,15 +14,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
-    protected GraphUpdatesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     public abstract class GraphUpdatesFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
     {

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
@@ -5,15 +5,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
-    protected ProxyGraphUpdatesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected abstract bool DoesLazyLoading { get; }
     protected abstract bool DoesChangeTracking { get; }

--- a/test/EFCore.Specification.Tests/InterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/InterceptionTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class InterceptionTestBase
+public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture)
 {
-    protected InterceptionTestBase(InterceptionFixtureBase fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected InterceptionFixtureBase Fixture { get; }
+    protected InterceptionFixtureBase Fixture { get; } = fixture;
 
     protected class Singularity
     {

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -4054,13 +4054,7 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
         public int Id { get; init; }
     }
 
-    protected class DddIdConverter : ValueConverter<DddId, int>
-    {
-        public DddIdConverter()
-            : base(v => v.Id, v => new DddId { Id = v })
-        {
-        }
-    }
+    protected class DddIdConverter() : ValueConverter<DddId, int>(v => v.Id, v => new DddId { Id = v });
 
     public enum Enum8 : sbyte
     {
@@ -4126,28 +4120,16 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
         Max = ulong.MaxValue
     }
 
-    public class CustomCollectionConverter<T, TElement> : ValueConverter<T, string>
-        where T : class, IList<TElement>
-    {
-        public CustomCollectionConverter()
-            : base(
-                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                v => JsonSerializer.Deserialize<T>(v, (JsonSerializerOptions?)null)!)
-        {
-        }
-    }
+    public class CustomCollectionConverter<T, TElement>() : ValueConverter<T, string>(
+        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+        v => JsonSerializer.Deserialize<T>(v, (JsonSerializerOptions?)null)!)
+        where T : class, IList<TElement>;
 
-    public class CustomCollectionComparer<T, TElement> : ValueComparer<T>
-        where T : class, IList<TElement>
-    {
-        public CustomCollectionComparer()
-            : base(
-                (c1, c2) => c1!.SequenceEqual(c2!),
-                c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v!.GetHashCode())),
-                c => (T)(object)c.ToList())
-        {
-        }
-    }
+    public class CustomCollectionComparer<T, TElement>() : ValueComparer<T>(
+        (c1, c2) => c1!.SequenceEqual(c2!),
+        c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v!.GetHashCode())),
+        c => (T)(object)c.ToList())
+        where T : class, IList<TElement>;
 
     public sealed class JsonGeoJsonReaderWriter : JsonValueReaderWriter<Geometry>
     {

--- a/test/EFCore.Specification.Tests/KeysWithConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/KeysWithConvertersTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : KeysWithConvertersTestBase<TFixture>.KeysWithConvertersFixtureBase, new()
 {
-    protected KeysWithConvertersTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected DbContext CreateContext()
         => Fixture.CreateContext();
@@ -7073,21 +7068,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; }
     }
 
-    protected class OwnerIntStructKey
+    protected class OwnerIntStructKey(IntStructKey id, OwnedIntStructKey owned)
     {
         public OwnerIntStructKey(IntStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerIntStructKey(IntStructKey id, OwnedIntStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public IntStructKey Id { get; set; }
-        public OwnedIntStructKey Owned { get; set; }
+        public IntStructKey Id { get; set; } = id;
+        public OwnedIntStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedIntStructKey(int position)
@@ -7095,21 +7084,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerBytesStructKey
+    protected class OwnerBytesStructKey(BytesStructKey id, OwnedBytesStructKey owned)
     {
         public OwnerBytesStructKey(BytesStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerBytesStructKey(BytesStructKey id, OwnedBytesStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public BytesStructKey Id { get; set; }
-        public OwnedBytesStructKey Owned { get; set; }
+        public BytesStructKey Id { get; set; } = id;
+        public OwnedBytesStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedBytesStructKey(int position)
@@ -7117,21 +7100,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerComparableIntStructKey
+    protected class OwnerComparableIntStructKey(ComparableIntStructKey id, OwnedComparableIntStructKey owned)
     {
         public OwnerComparableIntStructKey(ComparableIntStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerComparableIntStructKey(ComparableIntStructKey id, OwnedComparableIntStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public ComparableIntStructKey Id { get; set; }
-        public OwnedComparableIntStructKey Owned { get; set; }
+        public ComparableIntStructKey Id { get; set; } = id;
+        public OwnedComparableIntStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedComparableIntStructKey(int position)
@@ -7139,21 +7116,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerComparableBytesStructKey
+    protected class OwnerComparableBytesStructKey(ComparableBytesStructKey id, OwnedComparableBytesStructKey owned)
     {
         public OwnerComparableBytesStructKey(ComparableBytesStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerComparableBytesStructKey(ComparableBytesStructKey id, OwnedComparableBytesStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public ComparableBytesStructKey Id { get; set; }
-        public OwnedComparableBytesStructKey Owned { get; set; }
+        public ComparableBytesStructKey Id { get; set; } = id;
+        public OwnedComparableBytesStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedComparableBytesStructKey(int position)
@@ -7161,21 +7132,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerGenericComparableIntStructKey
+    protected class OwnerGenericComparableIntStructKey(GenericComparableIntStructKey id, OwnedGenericComparableIntStructKey owned)
     {
         public OwnerGenericComparableIntStructKey(GenericComparableIntStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerGenericComparableIntStructKey(GenericComparableIntStructKey id, OwnedGenericComparableIntStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public GenericComparableIntStructKey Id { get; set; }
-        public OwnedGenericComparableIntStructKey Owned { get; set; }
+        public GenericComparableIntStructKey Id { get; set; } = id;
+        public OwnedGenericComparableIntStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedGenericComparableIntStructKey(int position)
@@ -7183,21 +7148,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerGenericComparableBytesStructKey
+    protected class OwnerGenericComparableBytesStructKey(GenericComparableBytesStructKey id, OwnedGenericComparableBytesStructKey owned)
     {
         public OwnerGenericComparableBytesStructKey(GenericComparableBytesStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerGenericComparableBytesStructKey(GenericComparableBytesStructKey id, OwnedGenericComparableBytesStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public GenericComparableBytesStructKey Id { get; set; }
-        public OwnedGenericComparableBytesStructKey Owned { get; set; }
+        public GenericComparableBytesStructKey Id { get; set; } = id;
+        public OwnedGenericComparableBytesStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedGenericComparableBytesStructKey(int position)
@@ -7205,23 +7164,17 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerStructuralComparableBytesStructKey
+    protected class OwnerStructuralComparableBytesStructKey(
+        StructuralComparableBytesStructKey id,
+        OwnedStructuralComparableBytesStructKey owned)
     {
         public OwnerStructuralComparableBytesStructKey(StructuralComparableBytesStructKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerStructuralComparableBytesStructKey(
-            StructuralComparableBytesStructKey id,
-            OwnedStructuralComparableBytesStructKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public StructuralComparableBytesStructKey Id { get; set; }
-        public OwnedStructuralComparableBytesStructKey Owned { get; set; }
+        public StructuralComparableBytesStructKey Id { get; set; } = id;
+        public OwnedStructuralComparableBytesStructKey Owned { get; set; } = owned;
     }
 
     protected class OwnedStructuralComparableBytesStructKey(int position)
@@ -7229,21 +7182,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerIntClassKey
+    protected class OwnerIntClassKey(IntClassKey id, OwnedIntClassKey owned)
     {
         public OwnerIntClassKey(IntClassKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerIntClassKey(IntClassKey id, OwnedIntClassKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public IntClassKey Id { get; set; }
-        public OwnedIntClassKey Owned { get; set; }
+        public IntClassKey Id { get; set; } = id;
+        public OwnedIntClassKey Owned { get; set; } = owned;
     }
 
     protected class OwnedIntClassKey(int position)
@@ -7251,21 +7198,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerBareIntClassKey
+    protected class OwnerBareIntClassKey(BareIntClassKey id, OwnedBareIntClassKey owned)
     {
         public OwnerBareIntClassKey(BareIntClassKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerBareIntClassKey(BareIntClassKey id, OwnedBareIntClassKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public BareIntClassKey Id { get; set; }
-        public OwnedBareIntClassKey Owned { get; set; }
+        public BareIntClassKey Id { get; set; } = id;
+        public OwnedBareIntClassKey Owned { get; set; } = owned;
     }
 
     protected class OwnedBareIntClassKey(int position)
@@ -7273,21 +7214,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerComparableIntClassKey
+    protected class OwnerComparableIntClassKey(ComparableIntClassKey id, OwnedComparableIntClassKey owned)
     {
         public OwnerComparableIntClassKey(ComparableIntClassKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerComparableIntClassKey(ComparableIntClassKey id, OwnedComparableIntClassKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public ComparableIntClassKey Id { get; set; }
-        public OwnedComparableIntClassKey Owned { get; set; }
+        public ComparableIntClassKey Id { get; set; } = id;
+        public OwnedComparableIntClassKey Owned { get; set; } = owned;
     }
 
     protected class OwnedComparableIntClassKey(int position)
@@ -7295,21 +7230,15 @@ public abstract class KeysWithConvertersTestBase<TFixture> : IClassFixture<TFixt
         public int Position { get; set; } = position;
     }
 
-    protected class OwnerGenericComparableIntClassKey
+    protected class OwnerGenericComparableIntClassKey(GenericComparableIntClassKey id, OwnedGenericComparableIntClassKey owned)
     {
         public OwnerGenericComparableIntClassKey(GenericComparableIntClassKey id)
+            : this(id, null)
         {
-            Id = id;
         }
 
-        public OwnerGenericComparableIntClassKey(GenericComparableIntClassKey id, OwnedGenericComparableIntClassKey owned)
-        {
-            Id = id;
-            Owned = owned;
-        }
-
-        public GenericComparableIntClassKey Id { get; set; }
-        public OwnedGenericComparableIntClassKey Owned { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = id;
+        public OwnedGenericComparableIntClassKey Owned { get; set; } = owned;
     }
 
     protected class OwnedGenericComparableIntClassKey(int position)

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -12,15 +12,10 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class LazyLoadProxyTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : LazyLoadProxyTestBase<TFixture>.LoadFixtureBase
 {
-    protected LazyLoadProxyTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory] // Issue #32390
     [InlineData(false)]

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -10,15 +10,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
+public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : LoadTestBase<TFixture>.LoadFixtureBase
 {
-    protected LoadTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, false)]

--- a/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ManyToManyFieldsLoadTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ManyToManyFieldsLoadTestBase<TFixture>.ManyToManyFieldsLoadFixtureBase
 {
-    protected ManyToManyFieldsLoadTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
@@ -992,7 +987,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture> : IClassFixture<TFi
     {
     }
 
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     public abstract class ManyToManyFieldsLoadFixtureBase : ManyToManyFieldsQueryFixtureBase
     {

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -6,14 +6,9 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<TFixture>
+public abstract partial class ManyToManyLoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ManyToManyLoadTestBase<TFixture>.ManyToManyLoadFixtureBase
 {
-    protected ManyToManyLoadTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
@@ -1484,7 +1479,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
     }
 
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected virtual bool ExpectLazyLoading
         => false;

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract partial class ManyToManyTrackingTestBase<TFixture> : IClassFixture<TFixture>
+public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ManyToManyTrackingTestBase<TFixture>.ManyToManyTrackingFixtureBase
 {
     [ConditionalTheory]
@@ -5922,12 +5922,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture> : IClassFixtu
     private ICollection<TEntity> CreateCollection<TEntity>()
         => RequiresDetectChanges ? new List<TEntity>() : new ObservableCollection<TEntity>();
 
-    protected ManyToManyTrackingTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<ManyToManyContext, Task> testOperation,

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexType.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexType.cs
@@ -673,21 +673,9 @@ public abstract partial class ModelBuilderTest
             Assert.True(strange.GetProviderValueComparer().IsDefault());
         }
 
-        protected  class UTF8StringToBytesConverter : StringToBytesConverter
-        {
-            public UTF8StringToBytesConverter()
-                : base(Encoding.UTF8)
-            {
-            }
-        }
+        protected class UTF8StringToBytesConverter() : StringToBytesConverter(Encoding.UTF8);
 
-        protected class CustomValueComparer<T> : ValueComparer<T>
-        {
-            public CustomValueComparer()
-                : base(false)
-            {
-            }
-        }
+        protected class CustomValueComparer<T>() : ValueComparer<T>(false);
 
         [ConditionalFact]
         public virtual void Properties_can_have_value_converter_set_inline()
@@ -821,21 +809,10 @@ public abstract partial class ModelBuilderTest
             return obj;
         }
 
-        private class ExpandoObjectConverter : ValueConverter<ExpandoObject, string>
-        {
-            public ExpandoObjectConverter()
-                : base(v => (string)((IDictionary<string, object>)v)["Value"], v => DeserializeExpandoObject(v))
-            {
-            }
-        }
+        private class ExpandoObjectConverter() : ValueConverter<ExpandoObject, string>(
+            v => (string)((IDictionary<string, object>)v)["Value"], v => DeserializeExpandoObject(v));
 
-        private class ExpandoObjectComparer : ValueComparer<ExpandoObject>
-        {
-            public ExpandoObjectComparer()
-                : base((v1, v2) => v1.SequenceEqual(v2), v => v.GetHashCode())
-            {
-            }
-        }
+        private class ExpandoObjectComparer() : ValueComparer<ExpandoObject>((v1, v2) => v1.SequenceEqual(v2), v => v.GetHashCode());
 
         [ConditionalFact]
         public virtual void Properties_can_have_value_converter_configured_by_type()
@@ -932,13 +909,8 @@ public abstract partial class ModelBuilderTest
             Assert.IsType<CustomValueComparer<string>>(wierd.GetProviderValueComparer());
         }
 
-        private class WrappedStringToStringConverter : ValueConverter<WrappedString, string>
-        {
-            public WrappedStringToStringConverter()
-                : base(v => v.Value, v => new WrappedString { Value = v })
-            {
-            }
-        }
+        private class WrappedStringToStringConverter()
+            : ValueConverter<WrappedString, string>(v => v.Value, v => new WrappedString { Value = v });
 
         [ConditionalFact]
         public virtual void Value_converter_type_is_checked()

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToMany.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToMany.cs
@@ -9,13 +9,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public abstract partial class ModelBuilderTest
 {
-    public abstract class ManyToManyTestBase : ModelBuilderTestBase
+    public abstract class ManyToManyTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
     {
-        protected ManyToManyTestBase(ModelBuilderFixtureBase fixture)
-            : base(fixture)
-        {
-        }
-
         [ConditionalFact]
         public virtual void Discovers_navigations()
         {

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonRelationship.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonRelationship.cs
@@ -965,21 +965,9 @@ public abstract partial class ModelBuilderTest
             Assert.True(strange.GetProviderValueComparer()?.IsDefault());
         }
 
-        protected class UTF8StringToBytesConverter : StringToBytesConverter
-        {
-            public UTF8StringToBytesConverter()
-                : base(Encoding.UTF8)
-            {
-            }
-        }
+        protected class UTF8StringToBytesConverter() : StringToBytesConverter(Encoding.UTF8);
 
-        protected class CustomValueComparer<T> : ValueComparer<T>
-        {
-            public CustomValueComparer()
-                : base(false)
-            {
-            }
-        }
+        protected class CustomValueComparer<T>() : ValueComparer<T>(false);
 
         [ConditionalFact]
         public virtual void Properties_can_have_value_converter_set_inline()
@@ -1097,21 +1085,10 @@ public abstract partial class ModelBuilderTest
             return obj;
         }
 
-        private class ExpandoObjectConverter : ValueConverter<ExpandoObject, string>
-        {
-            public ExpandoObjectConverter()
-                : base(v => (string)((IDictionary<string, object>)v!)["Value"], v => DeserializeExpandoObject(v))
-            {
-            }
-        }
+        private class ExpandoObjectConverter() : ValueConverter<ExpandoObject, string>(
+            v => (string)((IDictionary<string, object>)v!)["Value"], v => DeserializeExpandoObject(v));
 
-        private class ExpandoObjectComparer : ValueComparer<ExpandoObject>
-        {
-            public ExpandoObjectComparer()
-                : base((v1, v2) => v1!.SequenceEqual(v2!), v => v.GetHashCode())
-            {
-            }
-        }
+        private class ExpandoObjectComparer() : ValueComparer<ExpandoObject>((v1, v2) => v1!.SequenceEqual(v2!), v => v.GetHashCode());
 
         [ConditionalFact]
         public virtual void Properties_can_have_value_converter_configured_by_type()
@@ -1207,13 +1184,8 @@ public abstract partial class ModelBuilderTest
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
         }
 
-        private class WrappedStringToStringConverter : ValueConverter<WrappedString, string>
-        {
-            public WrappedStringToStringConverter()
-                : base(v => v.Value!, v => new WrappedString { Value = v })
-            {
-            }
-        }
+        private class WrappedStringToStringConverter()
+            : ValueConverter<WrappedString, string>(v => v.Value!, v => new WrappedString { Value = v });
 
         [ConditionalFact]
         public virtual void Throws_for_conflicting_base_configurations_by_type()

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
@@ -2106,12 +2106,6 @@ public abstract partial class ModelBuilderTest
             public override ValueGenerator Create(IProperty property, ITypeBase entityType)
                 => new CustomValueGenerator();
         }
-        private class CustomValueComparer<T> : ValueComparer<T>
-        {
-            public CustomValueComparer()
-                : base(false)
-            {
-            }
-        }
+        private class CustomValueComparer<T>() : ValueComparer<T>(false);
     }
 }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
@@ -1035,12 +1035,7 @@ public abstract partial class ModelBuilderTest
 
     protected class ManyToManyNavPrincipal
     {
-        private readonly List<NavDependent> _randomField;
-
-        public ManyToManyNavPrincipal()
-        {
-            _randomField = [];
-        }
+        private readonly List<NavDependent> _randomField = [];
 
         public int Id { get; set; }
         public string? Name { get; set; }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public abstract partial class ModelBuilderTest
 {
-    public abstract class ModelBuilderTestBase
+    public abstract class ModelBuilderTestBase(ModelBuilderFixtureBase fixture)
     {
-        protected ModelBuilderTestBase(ModelBuilderFixtureBase fixture)
-        {
-            Fixture = fixture;
-        }
-
-        protected virtual ModelBuilderFixtureBase Fixture { get; }
+        protected virtual ModelBuilderFixtureBase Fixture { get; } = fixture;
 
         protected abstract TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder>? configure = null);
 

--- a/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
+++ b/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
@@ -10,15 +10,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class NotificationEntitiesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NotificationEntitiesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NotificationEntitiesTestBase<TFixture>.NotificationEntitiesFixtureBase, new()
 {
-    protected NotificationEntitiesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected virtual TFixture Fixture { get; }
+    protected virtual TFixture Fixture { get; } = fixture;
 
     [ConditionalFact] // Issue #4020
     public virtual void Include_brings_entities_referenced_from_already_tracked_notification_entities_as_Unchanged()

--- a/test/EFCore.Specification.Tests/OverzealousInitializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/OverzealousInitializationTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class OverzealousInitializationTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class OverzealousInitializationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : OverzealousInitializationTestBase<TFixture>.OverzealousInitializationFixtureBase, new()
 {
-    protected OverzealousInitializationTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
     [ConditionalFact]
     public virtual void Fixup_ignores_eagerly_initialized_reference_navs()
     {
@@ -84,7 +79,7 @@ public abstract class OverzealousInitializationTestBase<TFixture> : IClassFixtur
         }
     }
 
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected AlbumViewerContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -8,15 +8,10 @@ using System.Globalization;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class PropertyValuesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : PropertyValuesTestBase<TFixture>.PropertyValuesFixtureBase, new()
 {
-    protected PropertyValuesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual Task Scalar_current_values_can_be_accessed_as_a_property_dictionary()

--- a/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
@@ -621,28 +621,19 @@ public abstract class AdHocNavigationsQueryTestBase : NonSharedModelTestBase
             return SaveChangesAsync();
         }
 
-        public class Blog
+        public class Blog(List<Post> posts1, CustomCollection posts2, HashSet<Post> posts3)
         {
             public Blog()
+                : this([], [], [])
             {
-                Posts1 = [];
-                Posts2 = [];
-                Posts3 = [];
-            }
-
-            public Blog(List<Post> posts1, CustomCollection posts2, HashSet<Post> posts3)
-            {
-                Posts1 = posts1;
-                Posts2 = posts2;
-                Posts3 = posts3;
             }
 
             public int Id { get; set; }
             public string Name { get; set; }
 
-            public List<Post> Posts1 { get; }
-            public CustomCollection Posts2 { get; }
-            public HashSet<Post> Posts3 { get; }
+            public List<Post> Posts1 { get; } = posts1;
+            public CustomCollection Posts2 { get; } = posts2;
+            public HashSet<Post> Posts3 { get; } = posts3;
         }
 
         public class Post

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
@@ -7,16 +7,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
     protected ComplexNavigationsContext CreateContext()
         => Fixture.CreateContext();
-
-    protected ComplexNavigationsCollectionsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
         => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryTestBase.cs
@@ -4,14 +4,10 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class
-    ComplexNavigationsCollectionsSharedTypeQueryTestBase<TFixture> : ComplexNavigationsCollectionsQueryTestBase<TFixture>
+    ComplexNavigationsCollectionsSharedTypeQueryTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsCollectionsQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsSharedTypeQueryFixtureBase, new()
 {
-    protected ComplexNavigationsCollectionsSharedTypeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task Multiple_complex_includes_self_ref(bool async)
         => Assert.Equal(
             CoreStrings.InvalidIncludeExpression("e.OneToOne_Optional_Self1"),

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -9,16 +9,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
     protected ComplexNavigationsContext CreateContext()
         => Fixture.CreateContext();
-
-    protected ComplexNavigationsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
         => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
@@ -3,14 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ComplexNavigationsSharedTypeQueryTestBase<TFixture> : ComplexNavigationsQueryTestBase<TFixture>
+public abstract class ComplexNavigationsSharedTypeQueryTestBase<TFixture>(TFixture fixture)
+    : ComplexNavigationsQueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsSharedTypeQueryFixtureBase, new()
 {
-    protected ComplexNavigationsSharedTypeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override Task Join_navigation_self_ref(bool async)
         => AssertTranslationFailed(() => base.Join_navigation_self_ref(async));
 

--- a/test/EFCore.Specification.Tests/Query/CompositeKeysQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompositeKeysQueryTestBase.cs
@@ -5,16 +5,11 @@ using Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class CompositeKeysQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class CompositeKeysQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : CompositeKeysQueryFixtureBase, new()
 {
     protected CompositeKeysContext CreateContext()
         => Fixture.CreateContext();
-
-    protected CompositeKeysQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
         => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : Ef6GroupByTestBase<TFixture>.Ef6GroupByFixtureBase, new()
 {
-    protected Ef6GroupByTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_is_optimized_when_projecting_group_key(bool async)

--- a/test/EFCore.Specification.Tests/Query/FilteredQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FilteredQueryTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class FilteredQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class FilteredQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : class, IQueryFixtureBase, new()
 {
-    protected FilteredQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public Task AssertFilteredQuery<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,

--- a/test/EFCore.Specification.Tests/Query/FiltersInheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersInheritanceQueryTestBase.cs
@@ -9,14 +9,9 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 // ReSharper disable ConvertMethodToExpressionBody
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class FiltersInheritanceQueryTestBase<TFixture> : FilteredQueryTestBase<TFixture>
+public abstract class FiltersInheritanceQueryTestBase<TFixture>(TFixture fixture) : FilteredQueryTestBase<TFixture>(fixture)
     where TFixture : InheritanceQueryFixtureBase, new()
 {
-    protected FiltersInheritanceQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Can_use_of_type_animal(bool async)

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -11,14 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : FunkyDataQueryTestBase<TFixture>.FunkyDataQueryFixtureBase, new()
 {
-    protected FunkyDataQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task String_contains_on_argument_with_wildcard_constant(bool async)

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -24,14 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : GearsOfWarQueryFixtureBase, new()
 {
-    protected GearsOfWarQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
         => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings())
             .Visit(expectedQueryExpression);

--- a/test/EFCore.Specification.Tests/Query/IncludeOneToOneTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeOneToOneTestBase.cs
@@ -7,15 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class IncludeOneToOneTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class IncludeOneToOneTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : IncludeOneToOneTestBase<TFixture>.OneToOneQueryFixtureBase, new()
 {
-    protected IncludeOneToOneTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    public TFixture Fixture { get; }
+    public TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Include_address()

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
@@ -8,14 +8,9 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 // ReSharper disable StringEndsWithIsCultureSpecific
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class InheritanceQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class InheritanceQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : InheritanceQueryFixtureBase, new()
 {
-    protected InheritanceQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Can_query_when_shared_column(bool async)

--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class InheritanceRelationshipsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : InheritanceRelationshipsQueryFixtureBase, new()
 {
-    protected InheritanceRelationshipsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact]
     public virtual void Changes_in_derived_related_entities_are_detected()
     {

--- a/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : JsonQueryFixtureBase, new()
 {
-    protected JsonQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owner_entity(bool async)

--- a/test/EFCore.Specification.Tests/Query/ManyToManyNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyNoTrackingQueryTestBase.cs
@@ -7,17 +7,12 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ManyToManyNoTrackingQueryTestBase<TFixture> : ManyToManyQueryTestBase<TFixture>
+public abstract class ManyToManyNoTrackingQueryTestBase<TFixture>(TFixture fixture) : ManyToManyQueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
     private static readonly MethodInfo _asNoTrackingMethodInfo
         = typeof(EntityFrameworkQueryableExtensions)
             .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking));
-
-    protected ManyToManyNoTrackingQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     protected override bool IgnoreEntryCount
         => true;

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class ManyToManyQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
-    protected ManyToManyQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Skip_navigation_all(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -11,14 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindAggregateOperatorsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindAsNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAsNoTrackingQueryTestBase.cs
@@ -7,14 +7,9 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable AccessToDisposedClosure
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindAsNoTrackingQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindAsNoTrackingQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindAsNoTrackingQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false, false)]
     [InlineData(false, true)]

--- a/test/EFCore.Specification.Tests/Query/NorthwindAsTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAsTrackingQueryTestBase.cs
@@ -6,15 +6,10 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindAsTrackingQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NorthwindAsTrackingQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindAsTrackingQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(false)]

--- a/test/EFCore.Specification.Tests/Query/NorthwindChangeTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindChangeTrackingQueryTestBase.cs
@@ -6,15 +6,10 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindChangeTrackingQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NorthwindChangeTrackingQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindChangeTrackingQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Entity_reverts_when_state_set_to_unchanged()

--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -11,15 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindCompiledQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindCompiledQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void DbSet_query()

--- a/test/EFCore.Specification.Tests/Query/NorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindDbFunctionsQueryTestBase.cs
@@ -6,14 +6,9 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindDbFunctionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindDbFunctionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindDbFunctionsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Like_literal(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
@@ -7,15 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindEFPropertyIncludeQueryTestBase<TFixture> : NorthwindIncludeQueryTestBase<TFixture>
+public abstract class NorthwindEFPropertyIncludeQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly IncludeRewritingExpressionVisitor _includeRewritingExpressionVisitor = new();
-
-    protected NorthwindEFPropertyIncludeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -19,14 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 // ReSharper disable once UnusedTypeParameter
-public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindFunctionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindFunctionsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindGroupByQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
@@ -12,17 +12,12 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture> : NorthwindIncludeQueryTestBase<TFixture>
+public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly MethodInfo _asNoTrackingMethodInfo
         = typeof(EntityFrameworkQueryableExtensions)
             .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking));
-
-    protected NorthwindIncludeNoTrackingQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     // Include with cycles are not allowed in no tracking query.
     public override async Task Include_multi_level_reference_and_collection_predicate(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -12,14 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindIncludeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_and_collection_order_by(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindJoinQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
@@ -6,14 +6,9 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindKeylessEntitiesQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -10,14 +10,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindMiscellaneousQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -9,14 +9,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindNavigationsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindNavigationsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
@@ -10,14 +10,9 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable StringStartsWithIsCultureSpecific
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindQueryFiltersQueryTestBase<TFixture> : FilteredQueryTestBase<TFixture>
+public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixture) : FilteredQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NorthwindQueryFiltersCustomizer>, new()
 {
-    protected NorthwindQueryFiltersQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Count_query(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryTaggingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryTaggingQueryTestBase.cs
@@ -7,15 +7,10 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable AccessToDisposedClosure
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class NorthwindQueryTaggingQueryTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NorthwindQueryTaggingQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindQueryTaggingQueryTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Single_query_tag()

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -10,14 +10,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSelectQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindSelectQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindSetOperationsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindSetOperationsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
@@ -13,15 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NorthwindStringIncludeQueryTestBase<TFixture> : NorthwindIncludeQueryTestBase<TFixture>
+public abstract class NorthwindStringIncludeQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly IncludeRewritingExpressionVisitor _includeRewritingExpressionVisitor = new();
-
-    protected NorthwindStringIncludeQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -11,14 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 // ReSharper disable RedundantBoolCompare
 // ReSharper disable InconsistentNaming
 
-public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
-    protected NorthwindWhereQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NullKeysTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NullKeysTestBase.cs
@@ -7,15 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NullKeysTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NullKeysTestBase<TFixture>.NullKeysFixtureBase, new()
 {
-    protected NullKeysTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected virtual TFixture Fixture { get; }
+    protected virtual TFixture Fixture { get; } = fixture;
 
     protected DbContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -896,13 +896,8 @@ public abstract class OwnedEntityQueryTestBase : NonSharedModelTestBase
         Assert.Equal("IM Free shipping", owner.OwnedEntity.SupplierData.AdditionalSupplierData);
     }
 
-    protected abstract class MyContext26592Base : DbContext
+    protected abstract class MyContext26592Base(DbContextOptions options) : DbContext(options)
     {
-        protected MyContext26592Base(DbContextOptions options)
-            : base(options)
-        {
-        }
-
         public DbSet<Company> Companies { get; set; }
         public DbSet<Owner> Owners { get; set; }
 

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -3,14 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : PrimitiveCollectionsQueryTestBase<TFixture>.PrimitiveCollectionsQueryFixtureBase, new()
 {
-    protected PrimitiveCollectionsQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Inline_collection_of_ints_Contains(bool async)

--- a/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -7,15 +7,10 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class QueryFilterFuncletizationTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class QueryFilterFuncletizationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : QueryFilterFuncletizationFixtureBase, new()
 {
-    protected QueryFilterFuncletizationTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected QueryFilterFuncletizationContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
@@ -10,14 +10,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class SpatialQueryTestBase<TFixture> : QueryTestBase<TFixture>
+public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : SpatialQueryFixtureBase, new()
 {
-    protected SpatialQueryTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected virtual bool AssertDistances
         => true;
 

--- a/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
@@ -5,13 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class QueryExpressionInterceptionTestBase : InterceptionTestBase
+public abstract class QueryExpressionInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture)
+    : InterceptionTestBase(fixture)
 {
-    protected QueryExpressionInterceptionTestBase(InterceptionFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false, false)]
     [InlineData(true, false)]

--- a/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
@@ -5,13 +5,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
+public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture) : InterceptionTestBase(fixture)
 {
-    protected SaveChangesInterceptionTestBase(InterceptionFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false, false, false)]
     [InlineData(true, false, false)]

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -689,29 +689,12 @@ namespace TestNamespace
     protected virtual int ExpectedComplexTypeProperties
         => 14;
 
-    public class CustomValueComparer<T> : ValueComparer<T>
-    {
-        public CustomValueComparer()
-            : base(false)
-        {
-        }
-    }
+    public class CustomValueComparer<T>() : ValueComparer<T>(false);
 
-    public class ManyTypesIdConverter : ValueConverter<ManyTypesId, int>
-    {
-        public ManyTypesIdConverter()
-            : base(v => v.Id, v => new ManyTypesId(v))
-        {
-        }
-    }
+    public class ManyTypesIdConverter() : ValueConverter<ManyTypesId, int>(v => v.Id, v => new ManyTypesId(v));
 
-    public class NullIntToNullStringConverter : ValueConverter<int?, string?>
-    {
-        public NullIntToNullStringConverter()
-            : base(v => v == null ? null : v.ToString()!, v => v == null || v == "<null>" ? null : int.Parse(v), convertsNulls: true)
-        {
-        }
-    }
+    public class NullIntToNullStringConverter() : ValueConverter<int?, string?>(
+        v => v == null ? null : v.ToString()!, v => v == null || v == "<null>" ? null : int.Parse(v), convertsNulls: true);
 
     public abstract class AbstractBase
     {
@@ -1150,15 +1133,9 @@ namespace TestNamespace
         public PrincipalDerived<DependentBase<TKey>>? Principal { get; set; }
     }
 
-    public class DependentDerived<TKey> : DependentBase<TKey>
+    public class DependentDerived<TKey>(TKey id, string data) : DependentBase<TKey>(id)
     {
-        public DependentDerived(TKey id, string data)
-            : base(id)
-        {
-            Data = data;
-        }
-
-        private string? Data { get; set; }
+        private string? Data { get; set; } = data;
 
         public string? GetData()
             => Data;

--- a/test/EFCore.Specification.Tests/SeedingTestBase.cs
+++ b/test/EFCore.Specification.Tests/SeedingTestBase.cs
@@ -54,14 +54,9 @@ public abstract class SeedingTestBase
     protected virtual KeylessSeedingContext CreateKeylessContextWithEmptyDatabase()
         => new(TestStore.AddProviderOptions(new DbContextOptionsBuilder()).Options);
 
-    protected abstract class SeedingContext : DbContext
+    protected abstract class SeedingContext(string testId) : DbContext
     {
-        public string TestId { get; }
-
-        protected SeedingContext(string testId)
-        {
-            TestId = testId;
-        }
+        public string TestId { get; } = testId;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Seed>().HasData(

--- a/test/EFCore.Specification.Tests/SerializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/SerializationTestBase.cs
@@ -11,15 +11,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SerializationTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : F1FixtureBase<byte[]>, new()
 {
-    protected SerializationTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalTheory]
     [InlineData(false, false, false)]

--- a/test/EFCore.Specification.Tests/SingletonInterceptorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/SingletonInterceptorsTestBase.cs
@@ -47,13 +47,8 @@ public abstract class SingletonInterceptorsTestBase<TContext> : NonSharedModelTe
         public string Value { get; set; } = value;
     }
 
-    public abstract class LibraryContext : PoolableDbContext
+    public abstract class LibraryContext(DbContextOptions options) : PoolableDbContext(options)
     {
-        protected LibraryContext(DbContextOptions options)
-            : base(options)
-        {
-        }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Book>(

--- a/test/EFCore.Specification.Tests/SpatialTestBase.cs
+++ b/test/EFCore.Specification.Tests/SpatialTestBase.cs
@@ -8,15 +8,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SpatialTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class SpatialTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : SpatialFixtureBase, new()
 {
-    protected SpatialTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected virtual TFixture Fixture { get; }
+    protected virtual TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual void Values_are_copied_into_change_tracker()

--- a/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -9,18 +9,13 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class StoreGeneratedFixupTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : StoreGeneratedFixupTestBase<TFixture>.StoreGeneratedFixupFixtureBase, new()
 {
     protected static readonly Guid Guid77 = new("{DE390D36-DAAC-4C8B-91F7-E9F5DAA7EF01}");
     protected static readonly Guid Guid78 = new("{4C80406F-49AF-4D85-AFFB-75C146A98A70}");
 
-    protected StoreGeneratedFixupTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual Task Add_dependent_then_principal_one_to_many_FK_set_both_navs_set()
@@ -4233,15 +4228,10 @@ public abstract class StoreGeneratedFixupTestBase<TFixture> : IClassFixture<TFix
 
     protected class CategoryPN
     {
-        public CategoryPN()
-        {
-            Products = new List<ProductPN>();
-        }
-
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public ICollection<ProductPN> Products { get; }
+        public ICollection<ProductPN> Products { get; } = new List<ProductPN>();
     }
 
     protected class ProductPN
@@ -4270,15 +4260,10 @@ public abstract class StoreGeneratedFixupTestBase<TFixture> : IClassFixture<TFix
 
     protected class Category
     {
-        public Category()
-        {
-            Products = new List<Product>();
-        }
-
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public ICollection<Product> Products { get; }
+        public ICollection<Product> Products { get; } = new List<Product>();
     }
 
     protected class Product

--- a/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -7,15 +7,10 @@ using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class StoreGeneratedTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : StoreGeneratedTestBase<TFixture>.StoreGeneratedFixtureBase, new()
 {
-    protected StoreGeneratedTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     [ConditionalFact]
     public virtual async Task Value_generation_works_for_common_GUID_conversions()
@@ -1891,26 +1886,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public int Value { get; set; }
     }
 
-    protected class WrappedIntClassConverter : ValueConverter<WrappedIntClass, int>
-    {
-        public WrappedIntClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntClassConverter() : ValueConverter<WrappedIntClass, int>(
+        v => v.Value,
+        v => new WrappedIntClass { Value = v });
 
-    protected class WrappedIntClassComparer : ValueComparer<WrappedIntClass?>
-    {
-        public WrappedIntClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntClassComparer() : ValueComparer<WrappedIntClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntClass { Value = v.Value });
 
     protected class WrappedIntClassValueGenerator : ValueGenerator<WrappedIntClass>
     {
@@ -1926,15 +1909,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public int Value { get; set; }
     }
 
-    protected class WrappedIntStructConverter : ValueConverter<WrappedIntStruct, int>
-    {
-        public WrappedIntStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntStructConverter() : ValueConverter<WrappedIntStruct, int>(
+        v => v.Value,
+        v => new WrappedIntStruct { Value = v });
 
     protected class WrappedIntStructValueGenerator : ValueGenerator<WrappedIntStruct>
     {
@@ -1950,15 +1927,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public int Value { get; set; }
     }
 
-    protected class WrappedIntRecordConverter : ValueConverter<WrappedIntRecord, int>
-    {
-        public WrappedIntRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntRecordConverter() : ValueConverter<WrappedIntRecord, int>(
+        v => v.Value,
+        v => new WrappedIntRecord { Value = v });
 
     protected class WrappedIntRecordValueGenerator : ValueGenerator<WrappedIntRecord>
     {
@@ -1974,26 +1945,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public int Value { get; set; }
     }
 
-    protected class WrappedIntKeyClassConverter : ValueConverter<WrappedIntKeyClass, int>
-    {
-        public WrappedIntKeyClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyClassConverter() : ValueConverter<WrappedIntKeyClass, int>(
+        v => v.Value,
+        v => new WrappedIntKeyClass { Value = v });
 
-    protected class WrappedIntKeyClassComparer : ValueComparer<WrappedIntKeyClass?>
-    {
-        public WrappedIntKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntKeyClassComparer() : ValueComparer<WrappedIntKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntKeyClass { Value = v.Value });
 
     public struct WrappedIntKeyStruct
     {
@@ -2012,30 +1971,18 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
             => !left.Equals(right);
     }
 
-    protected class WrappedIntKeyStructConverter : ValueConverter<WrappedIntKeyStruct, int>
-    {
-        public WrappedIntKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyStructConverter() : ValueConverter<WrappedIntKeyStruct, int>(
+        v => v.Value,
+        v => new WrappedIntKeyStruct { Value = v });
 
     public record WrappedIntKeyRecord
     {
         public int Value { get; set; }
     }
 
-    protected class WrappedIntKeyRecordConverter : ValueConverter<WrappedIntKeyRecord, int>
-    {
-        public WrappedIntKeyRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntKeyRecordConverter() : ValueConverter<WrappedIntKeyRecord, int>(
+        v => v.Value,
+        v => new WrappedIntKeyRecord { Value = v });
 
     protected class WrappedIntClassPrincipal
     {
@@ -2574,26 +2521,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringClassConverter : ValueConverter<WrappedStringClass, string>
-    {
-        public WrappedStringClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringClassConverter() : ValueConverter<WrappedStringClass, string>(
+        v => v.Value!,
+        v => new WrappedStringClass { Value = v });
 
-    protected class WrappedStringClassComparer : ValueComparer<WrappedStringClass?>
-    {
-        public WrappedStringClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedStringClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedStringClassComparer() : ValueComparer<WrappedStringClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedStringClass { Value = v.Value });
 
     protected class WrappedStringClassValueGenerator : ValueGenerator<WrappedStringClass>
     {
@@ -2609,15 +2544,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringStructConverter : ValueConverter<WrappedStringStruct, string>
-    {
-        public WrappedStringStructConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringStructConverter() : ValueConverter<WrappedStringStruct, string>(
+        v => v.Value!,
+        v => new WrappedStringStruct { Value = v });
 
     protected class WrappedStringStructValueGenerator : ValueGenerator<WrappedStringStruct>
     {
@@ -2633,15 +2562,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringRecordConverter : ValueConverter<WrappedStringRecord, string>
-    {
-        public WrappedStringRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringRecordConverter() : ValueConverter<WrappedStringRecord, string>(
+        v => v.Value!,
+        v => new WrappedStringRecord { Value = v });
 
     protected class WrappedStringRecordValueGenerator : ValueGenerator<WrappedStringRecord>
     {
@@ -2657,26 +2580,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringKeyClassConverter : ValueConverter<WrappedStringKeyClass, string>
-    {
-        public WrappedStringKeyClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyClassConverter() : ValueConverter<WrappedStringKeyClass, string>(
+        v => v.Value!,
+        v => new WrappedStringKeyClass { Value = v });
 
-    protected class WrappedStringKeyClassComparer : ValueComparer<WrappedStringKeyClass?>
-    {
-        public WrappedStringKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedStringKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedStringKeyClassComparer() : ValueComparer<WrappedStringKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedStringKeyClass { Value = v.Value });
 
     public struct WrappedStringKeyStruct
     {
@@ -2695,30 +2606,18 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
             => !left.Equals(right);
     }
 
-    protected class WrappedStringKeyStructConverter : ValueConverter<WrappedStringKeyStruct, string>
-    {
-        public WrappedStringKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedStringKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyStructConverter() : ValueConverter<WrappedStringKeyStruct, string>(
+        v => v.Value,
+        v => new WrappedStringKeyStruct { Value = v });
 
     public record WrappedStringKeyRecord
     {
         public string? Value { get; set; }
     }
 
-    protected class WrappedStringKeyRecordConverter : ValueConverter<WrappedStringKeyRecord, string>
-    {
-        public WrappedStringKeyRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedStringKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedStringKeyRecordConverter() : ValueConverter<WrappedStringKeyRecord, string>(
+        v => v.Value!,
+        v => new WrappedStringKeyRecord { Value = v });
 
     protected class WrappedStringClassPrincipal
     {
@@ -3132,26 +3031,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidClassConverter : ValueConverter<WrappedGuidClass, Guid>
-    {
-        public WrappedGuidClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidClassConverter() : ValueConverter<WrappedGuidClass, Guid>(
+        v => v.Value,
+        v => new WrappedGuidClass { Value = v });
 
-    protected class WrappedGuidClassComparer : ValueComparer<WrappedGuidClass?>
-    {
-        public WrappedGuidClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value.GetHashCode() : 0,
-                v => v == null ? null : new WrappedGuidClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedGuidClassComparer() : ValueComparer<WrappedGuidClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value.GetHashCode() : 0,
+        v => v == null ? null : new WrappedGuidClass { Value = v.Value });
 
     protected class WrappedGuidClassValueGenerator : ValueGenerator<WrappedGuidClass>
     {
@@ -3167,15 +3054,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidStructConverter : ValueConverter<WrappedGuidStruct, Guid>
-    {
-        public WrappedGuidStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidStructConverter() : ValueConverter<WrappedGuidStruct, Guid>(
+        v => v.Value,
+        v => new WrappedGuidStruct { Value = v });
 
     protected class WrappedGuidStructValueGenerator : ValueGenerator<WrappedGuidStruct>
     {
@@ -3191,15 +3072,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidRecordConverter : ValueConverter<WrappedGuidRecord, Guid>
-    {
-        public WrappedGuidRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidRecordConverter() : ValueConverter<WrappedGuidRecord, Guid>(
+        v => v.Value,
+        v => new WrappedGuidRecord { Value = v });
 
     protected class WrappedGuidRecordValueGenerator : ValueGenerator<WrappedGuidRecord>
     {
@@ -3215,26 +3090,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidKeyClassConverter : ValueConverter<WrappedGuidKeyClass, Guid>
-    {
-        public WrappedGuidKeyClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyClassConverter() : ValueConverter<WrappedGuidKeyClass, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyClass { Value = v });
 
-    protected class WrappedGuidKeyClassComparer : ValueComparer<WrappedGuidKeyClass?>
-    {
-        public WrappedGuidKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value.GetHashCode() : 0,
-                v => v == null ? null : new WrappedGuidKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedGuidKeyClassComparer() : ValueComparer<WrappedGuidKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value.GetHashCode() : 0,
+        v => v == null ? null : new WrappedGuidKeyClass { Value = v.Value });
 
     public struct WrappedGuidKeyStruct
     {
@@ -3253,30 +3116,18 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
             => !left.Equals(right);
     }
 
-    protected class WrappedGuidKeyStructConverter : ValueConverter<WrappedGuidKeyStruct, Guid>
-    {
-        public WrappedGuidKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyStructConverter() : ValueConverter<WrappedGuidKeyStruct, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyStruct { Value = v });
 
     public record WrappedGuidKeyRecord
     {
         public Guid Value { get; set; }
     }
 
-    protected class WrappedGuidKeyRecordConverter : ValueConverter<WrappedGuidKeyRecord, Guid>
-    {
-        public WrappedGuidKeyRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedGuidKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedGuidKeyRecordConverter() : ValueConverter<WrappedGuidKeyRecord, Guid>(
+        v => v.Value,
+        v => new WrappedGuidKeyRecord { Value = v });
 
     protected class WrappedGuidClassPrincipal
     {
@@ -3675,26 +3526,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriClassConverter : ValueConverter<WrappedUriClass, Uri>
-    {
-        public WrappedUriClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriClassConverter() : ValueConverter<WrappedUriClass, Uri>(
+        v => v.Value!,
+        v => new WrappedUriClass { Value = v });
 
-    protected class WrappedUriClassComparer : ValueComparer<WrappedUriClass?>
-    {
-        public WrappedUriClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedUriClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedUriClassComparer() : ValueComparer<WrappedUriClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedUriClass { Value = v.Value });
 
     protected class WrappedUriClassValueGenerator : ValueGenerator<WrappedUriClass>
     {
@@ -3710,15 +3549,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Uri Value { get; set; }
     }
 
-    protected class WrappedUriStructConverter : ValueConverter<WrappedUriStruct, Uri>
-    {
-        public WrappedUriStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedUriStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriStructConverter() : ValueConverter<WrappedUriStruct, Uri>(
+        v => v.Value,
+        v => new WrappedUriStruct { Value = v });
 
     protected class WrappedUriStructValueGenerator : ValueGenerator<WrappedUriStruct>
     {
@@ -3734,15 +3567,9 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriRecordConverter : ValueConverter<WrappedUriRecord, Uri>
-    {
-        public WrappedUriRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriRecordConverter() : ValueConverter<WrappedUriRecord, Uri>(
+        v => v.Value!,
+        v => new WrappedUriRecord { Value = v });
 
     protected class WrappedUriRecordValueGenerator : ValueGenerator<WrappedUriRecord>
     {
@@ -3758,26 +3585,14 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriKeyClassConverter : ValueConverter<WrappedUriKeyClass, Uri>
-    {
-        public WrappedUriKeyClassConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyClassConverter() : ValueConverter<WrappedUriKeyClass, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyClass { Value = v });
 
-    protected class WrappedUriKeyClassComparer : ValueComparer<WrappedUriKeyClass?>
-    {
-        public WrappedUriKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
-                v => v != null ? v.Value!.GetHashCode() : 0,
-                v => v == null ? null : new WrappedUriKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedUriKeyClassComparer() : ValueComparer<WrappedUriKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value!.Equals(v2.Value)),
+        v => v != null ? v.Value!.GetHashCode() : 0,
+        v => v == null ? null : new WrappedUriKeyClass { Value = v.Value });
 
     public struct WrappedUriKeyStruct
     {
@@ -3799,30 +3614,18 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
             => !left.Equals(right);
     }
 
-    protected class WrappedUriKeyStructConverter : ValueConverter<WrappedUriKeyStruct, Uri>
-    {
-        public WrappedUriKeyStructConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyStructConverter() : ValueConverter<WrappedUriKeyStruct, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyStruct { Value = v });
 
     public record WrappedUriKeyRecord
     {
         public Uri? Value { get; set; }
     }
 
-    protected class WrappedUriKeyRecordConverter : ValueConverter<WrappedUriKeyRecord, Uri>
-    {
-        public WrappedUriKeyRecordConverter()
-            : base(
-                v => v.Value!,
-                v => new WrappedUriKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedUriKeyRecordConverter() : ValueConverter<WrappedUriKeyRecord, Uri>(
+        v => v.Value!,
+        v => new WrappedUriKeyRecord { Value = v });
 
     protected class WrappedUriClassPrincipal
     {

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Country.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Country.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 public class Country
 {
-    public Country()
-    {
-        Animals = new List<Animal>();
-    }
-
     public int Id { get; set; }
     public string Name { get; set; }
 
-    public IList<Animal> Animals { get; set; }
+    public IList<Animal> Animals { get; set; } = new List<Animal>();
     public IList<Plant> Plants { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Eagle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Eagle.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 public class Eagle : Bird
 {
-    public Eagle()
-    {
-        Prey = new List<Bird>();
-    }
-
     public EagleGroup Group { get; set; }
 
-    public ICollection<Bird> Prey { get; set; }
+    public ICollection<Bird> Prey { get; set; } = new List<Bird>();
 }
 
 public enum EagleGroup

--- a/test/EFCore.Specification.Tests/TestModels/MonsterContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MonsterContext.cs
@@ -3,13 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels;
 
-public abstract class MonsterContext : PoolableDbContext
+public abstract class MonsterContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    protected MonsterContext(DbContextOptions options)
-        : base(options)
-    {
-    }
-
     public abstract IQueryable<ICustomer> Customers { get; }
     public abstract IQueryable<IBarcode> Barcodes { get; }
     public abstract IQueryable<IIncorrectScan> IncorrectScans { get; }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/Album.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/Album.cs
@@ -37,10 +37,5 @@ public class Album
 
     [ScaffoldColumn(false)]
     [Required]
-    public DateTime Created { get; set; }
-
-    public Album()
-    {
-        Created = DateTime.UtcNow;
-    }
+    public DateTime Created { get; set; } = DateTime.UtcNow;
 }

--- a/test/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
@@ -26,12 +26,7 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class BackOrderLine : OrderLine, IBackOrderLine
     {
-        public BackOrderLine()
-        {
-            ETA = DateTime.Now;
-        }
-
-        public DateTime ETA { get; set; }
+        public DateTime ETA { get; set; } = DateTime.Now;
 
         public int SupplierId { get; set; }
         public virtual ISupplier Supplier { get; set; }
@@ -71,11 +66,6 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class ComputerDetail : IComputerDetail
     {
-        public ComputerDetail()
-        {
-            Dimensions = new Dimensions();
-        }
-
         public int ComputerDetailId { get; set; }
         public string Manufacturer { get; set; }
         public string Model { get; set; }
@@ -83,7 +73,7 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public string Specifications { get; set; }
         public DateTime PurchaseDate { get; set; }
 
-        public IDimensions Dimensions { get; set; }
+        public IDimensions Dimensions { get; set; } = new Dimensions();
 
         public virtual IComputer Computer { get; set; }
     }
@@ -105,19 +95,12 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class ContactDetails : IContactDetails
     {
-        public ContactDetails()
-        {
-            HomePhone = new Phone();
-            WorkPhone = new Phone();
-            MobilePhone = new Phone();
-        }
-
         public bool Active { get; set; }
         public string Email { get; set; }
 
-        public IPhone HomePhone { get; set; }
-        public IPhone WorkPhone { get; set; }
-        public IPhone MobilePhone { get; set; }
+        public IPhone HomePhone { get; set; } = new Phone();
+        public IPhone WorkPhone { get; set; } = new Phone();
+        public IPhone MobilePhone { get; set; } = new Phone();
     }
 
     public class CustomerInfo : ICustomerInfo
@@ -174,14 +157,9 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class License : ILicense
     {
-        public License()
-        {
-            LicenseClass = "C";
-        }
-
         public string Name { get; set; }
         public string LicenseNumber { get; set; }
-        public string LicenseClass { get; set; }
+        public string LicenseClass { get; set; } = "C";
         public string Restrictions { get; set; }
         public DateTime ExpirationDate { get; set; }
         public LicenseState? State { get; set; }
@@ -205,14 +183,9 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class OrderLine : IOrderLine
     {
-        public OrderLine()
-        {
-            Quantity = 1;
-        }
-
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public int Quantity { get; set; }
+        public int Quantity { get; set; } = 1;
         public string ConcurrencyToken { get; set; }
 
         public virtual IAnOrder Order { get; set; }
@@ -221,11 +194,6 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class AnOrder : IAnOrder
     {
-        public AnOrder()
-        {
-            Concurrency = new ConcurrencyInfo();
-        }
-
         public void InitializeCollections()
         {
             OrderLines ??= new HashSet<IOrderLine>();
@@ -236,7 +204,7 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public int AlternateId { get; set; }
         public int? CustomerId { get; set; }
 
-        public IConcurrencyInfo Concurrency { get; set; }
+        public IConcurrencyInfo Concurrency { get; set; } = new ConcurrencyInfo();
 
         public virtual ICustomer Customer { get; set; }
         public virtual ICollection<IOrderLine> OrderLines { get; set; }
@@ -294,12 +262,6 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class Product : IProduct
     {
-        public Product()
-        {
-            ComplexConcurrency = new ConcurrencyInfo();
-            NestedComplexConcurrency = new AuditInfo();
-        }
-
         public void InitializeCollections()
         {
             Suppliers ??= new HashSet<ISupplier>();
@@ -314,8 +276,8 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public string BaseConcurrency { get; set; }
 
         public IDimensions Dimensions { get; set; }
-        public IConcurrencyInfo ComplexConcurrency { get; set; }
-        public IAuditInfo NestedComplexConcurrency { get; set; }
+        public IConcurrencyInfo ComplexConcurrency { get; set; } = new ConcurrencyInfo();
+        public IAuditInfo NestedComplexConcurrency { get; set; } = new AuditInfo();
 
         public virtual ICollection<ISupplier> Suppliers { get; set; }
         public virtual ICollection<IDiscontinuedProduct> Replaces { get; set; }
@@ -437,26 +399,14 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class AuditInfo : IAuditInfo
     {
-        public AuditInfo()
-        {
-            Concurrency = new ConcurrencyInfo();
-            ModifiedDate = DateTime.Now;
-        }
-
-        public DateTime ModifiedDate { get; set; }
+        public DateTime ModifiedDate { get; set; } = DateTime.Now;
         public string ModifiedBy { get; set; }
 
-        public IConcurrencyInfo Concurrency { get; set; }
+        public IConcurrencyInfo Concurrency { get; set; } = new ConcurrencyInfo();
     }
 
     public class Customer : ICustomer
     {
-        public Customer()
-        {
-            ContactInfo = new ContactDetails();
-            Auditing = new AuditInfo();
-        }
-
         public void InitializeCollections()
         {
             Orders ??= new HashSet<IAnOrder>();
@@ -467,8 +417,8 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public int? HusbandId { get; set; }
         public string Name { get; set; }
 
-        public IContactDetails ContactInfo { get; set; }
-        public IAuditInfo Auditing { get; set; }
+        public IContactDetails ContactInfo { get; set; } = new ContactDetails();
+        public IAuditInfo Auditing { get; set; } = new AuditInfo();
 
         public virtual ICollection<IAnOrder> Orders { get; set; }
         public virtual ICollection<ILogin> Logins { get; set; }
@@ -499,13 +449,8 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
     public class Phone : IPhone
     {
-        public Phone()
-        {
-            Extension = "None";
-        }
-
         public string PhoneNumber { get; set; }
-        public string Extension { get; set; }
+        public string Extension { get; set; } = "None";
         public PhoneType PhoneType { get; set; }
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Person.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Person.cs
@@ -5,24 +5,18 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 
-public class Person
+public class Person(string name, Person? parent)
 {
     protected Person()
+        : this(null!, null)
     {
-        Name = null!;
-    }
-
-    public Person(string name, Person? parent)
-    {
-        Name = name;
-        Parent = parent;
     }
 
     public int PersonId { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = name;
     public int? ParentId { get; set; }
     public string? Country { get; set; }
     public string? ZipCode { get; set; }
-    public Person? Parent { get; set; }
+    public Person? Parent { get; set; } = parent;
     public Address? Address { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
@@ -5,36 +5,31 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration;
 
 #nullable disable
 
-public class ProceduralQueryExpressionGenerator
+public class ProceduralQueryExpressionGenerator(DbContext context)
 {
-    private readonly List<ExpressionMutator> _mutators;
+    private readonly List<ExpressionMutator> _mutators =
+    [
+        new AppendSelectConstantExpressionMutator(context),
+        new AppendSelectIdentityExpressionMutator(context),
+        new AppendSelectPropertyExpressionMutator(context),
+        new AppendOrderByIdentityExpressionMutator(context),
+        new AppendOrderByPropertyExpressionMutator(context),
+        new AppendThenByIdentityExpressionMutator(context),
+        new AppendTakeExpressionMutator(context),
+        new StringConcatWithSelfExpressionMutator(context),
+        new InjectCoalesceExpressionMutator(context),
+        new InjectStringFunctionExpressionMutator(context),
+        new InjectJoinWithSelfExpressionMutator(context),
+        new InjectOrderByPropertyExpressionMutator(context),
+        new InjectThenByPropertyExpressionMutator(context),
+        new AppendCorrelatedCollectionExpressionMutator(context),
+        new AppendIncludeToExistingExpressionMutator(context),
+        new InjectIncludeExpressionMutator(context),
+        new InjectWhereExpressionMutator(context)
+    ];
 
     // used to hard code the seed used for test generation
     public static readonly int? Seed = null;
-
-    public ProceduralQueryExpressionGenerator(DbContext context)
-    {
-        _mutators =
-        [
-            new AppendSelectConstantExpressionMutator(context),
-            new AppendSelectIdentityExpressionMutator(context),
-            new AppendSelectPropertyExpressionMutator(context),
-            new AppendOrderByIdentityExpressionMutator(context),
-            new AppendOrderByPropertyExpressionMutator(context),
-            new AppendThenByIdentityExpressionMutator(context),
-            new AppendTakeExpressionMutator(context),
-            new StringConcatWithSelfExpressionMutator(context),
-            new InjectCoalesceExpressionMutator(context),
-            new InjectStringFunctionExpressionMutator(context),
-            new InjectJoinWithSelfExpressionMutator(context),
-            new InjectOrderByPropertyExpressionMutator(context),
-            new InjectThenByPropertyExpressionMutator(context),
-            new AppendCorrelatedCollectionExpressionMutator(context),
-            new AppendIncludeToExistingExpressionMutator(context),
-            new InjectIncludeExpressionMutator(context),
-            new InjectWhereExpressionMutator(context)
-        ];
-    }
 
     public Expression Generate(Expression expression, Random random)
     {

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
@@ -3,16 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-public class TestLogger<TDefinitions> : TestLogger
+public class TestLogger<TDefinitions>(LoggingDefinitions definitions) : TestLogger(definitions)
     where TDefinitions : LoggingDefinitions, new()
 {
     public TestLogger()
-        : base(new TDefinitions())
-    {
-    }
-
-    public TestLogger(LoggingDefinitions definitions)
-        : base(definitions)
+        : this(new TDefinitions())
     {
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLogger``.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLogger``.cs
@@ -3,17 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-public class TestLogger<TCategory, TDefinitions> : TestLogger<TDefinitions>, IDiagnosticsLogger<TCategory>
+public class TestLogger<TCategory, TDefinitions>(LoggingDefinitions definitions)
+    : TestLogger<TDefinitions>(definitions), IDiagnosticsLogger<TCategory>
     where TCategory : LoggerCategory<TCategory>, new()
     where TDefinitions : LoggingDefinitions, new()
 {
     public TestLogger()
-        : base(new TDefinitions())
-    {
-    }
-
-    public TestLogger(LoggingDefinitions definitions)
-        : base(definitions)
+        : this(new TDefinitions())
     {
     }
 }

--- a/test/EFCore.Specification.Tests/Update/UpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/Update/UpdatesTestBase.cs
@@ -9,15 +9,10 @@ using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Update;
 
-public abstract class UpdatesTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class UpdatesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : UpdatesTestBase<TFixture>.UpdatesFixtureBase
 {
-    protected UpdatesTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     public static IEnumerable<object[]> IsAsyncData = new object[][] { [false], [true] };
 

--- a/test/EFCore.Specification.Tests/ValueConvertersEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/ValueConvertersEndToEndTestBase.cs
@@ -8,15 +8,10 @@ using System.Text.Json;
 // ReSharper disable StaticMemberInGenericType
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ValueConvertersEndToEndTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class ValueConvertersEndToEndTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ValueConvertersEndToEndTestBase<TFixture>.ValueConvertersEndToEndFixtureBase, new()
 {
-    protected ValueConvertersEndToEndTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     private static readonly DateTimeOffset _dateTimeOffset1 = new(1973, 9, 3, 12, 10, 0, new TimeSpan(7, 0, 0));
     private static readonly DateTimeOffset _dateTimeOffset2 = new(1973, 9, 3, 12, 10, 0, new TimeSpan(8, 0, 0));
@@ -883,53 +878,23 @@ public abstract class ValueConvertersEndToEndTestBase<TFixture> : IClassFixture<
                 });
     }
 
-    protected class NullStringToNonNullStringConverter : ValueConverter<string?, string>
-    {
-        public NullStringToNonNullStringConverter()
-            : base(v => v ?? "<null>", v => v == "<null>" ? null : v, convertsNulls: true)
-        {
-        }
-    }
+    protected class NullStringToNonNullStringConverter() : ValueConverter<string?, string>(
+        v => v ?? "<null>", v => v == "<null>" ? null : v, convertsNulls: true);
 
-    protected class NonNullStringToNullStringConverter : ValueConverter<string, string?>
-    {
-        public NonNullStringToNullStringConverter()
-            : base(v => v == "<null>" ? null : v, v => v ?? "<null>", convertsNulls: true)
-        {
-        }
-    }
+    protected class NonNullStringToNullStringConverter() : ValueConverter<string, string?>(
+        v => v == "<null>" ? null : v, v => v ?? "<null>", convertsNulls: true);
 
-    protected class NullIntToNonNullStringConverter : ValueConverter<int?, string>
-    {
-        public NullIntToNonNullStringConverter()
-            : base(v => v == null ? "<null>" : v.ToString()!, v => v == "<null>" ? null : int.Parse(v), convertsNulls: true)
-        {
-        }
-    }
+    protected class NullIntToNonNullStringConverter() : ValueConverter<int?, string>(
+        v => v == null ? "<null>" : v.ToString()!, v => v == "<null>" ? null : int.Parse(v), convertsNulls: true);
 
-    protected class NullIntToNullStringConverter : ValueConverter<int?, string?>
-    {
-        public NullIntToNullStringConverter()
-            : base(v => v == null ? null : v.ToString()!, v => v == null || v == "<null>" ? null : int.Parse(v), convertsNulls: true)
-        {
-        }
-    }
+    protected class NullIntToNullStringConverter() : ValueConverter<int?, string?>(
+        v => v == null ? null : v.ToString()!, v => v == null || v == "<null>" ? null : int.Parse(v), convertsNulls: true);
 
-    protected class NonNullIntToNonNullStringConverter : ValueConverter<int, string>
-    {
-        public NonNullIntToNonNullStringConverter()
-            : base(v => v.ToString()!, v => v == "<null>" ? 0 : int.Parse(v), convertsNulls: true)
-        {
-        }
-    }
+    protected class NonNullIntToNonNullStringConverter() : ValueConverter<int, string>(
+        v => v.ToString()!, v => v == "<null>" ? 0 : int.Parse(v), convertsNulls: true);
 
-    protected class NonNullIntToNullStringConverter : ValueConverter<int, string?>
-    {
-        public NonNullIntToNullStringConverter()
-            : base(v => v.ToString()!, v => v == null ? 0 : int.Parse(v), convertsNulls: true)
-        {
-        }
-    }
+    protected class NonNullIntToNullStringConverter() : ValueConverter<int, string?>(
+        v => v.ToString()!, v => v == null ? 0 : int.Parse(v), convertsNulls: true);
 
     protected enum TheExperience : ushort
     {
@@ -938,45 +903,21 @@ public abstract class ValueConvertersEndToEndTestBase<TFixture> : IClassFixture<
         Mitch
     }
 
-    protected class ListOfIntToJsonConverter : ValueConverter<List<int>, string>
-    {
-        public ListOfIntToJsonConverter()
-            : base(
-                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions?)null)!)
-        {
-        }
-    }
+    protected class ListOfIntToJsonConverter() : ValueConverter<List<int>, string>(
+        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+        v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions?)null)!);
 
-    protected class ListOfIntComparer : ValueComparer<List<int>?>
-    {
-        public ListOfIntComparer()
-            : base(
-                (c1, c2) => (c1 == null && c2 == null) || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
-                c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                c => c == null ? null : c.ToList())
-        {
-        }
-    }
+    protected class ListOfIntComparer() : ValueComparer<List<int>?>(
+        (c1, c2) => (c1 == null && c2 == null) || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
+        c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+        c => c == null ? null : c.ToList());
 
-    protected class EnumerableOfIntToJsonConverter : ValueConverter<IEnumerable<int>, string>
-    {
-        public EnumerableOfIntToJsonConverter()
-            : base(
-                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions?)null)!)
-        {
-        }
-    }
+    protected class EnumerableOfIntToJsonConverter() : ValueConverter<IEnumerable<int>, string>(
+        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+        v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions?)null)!);
 
-    protected class EnumerableOfIntComparer : ValueComparer<IEnumerable<int>?>
-    {
-        public EnumerableOfIntComparer()
-            : base(
-                (c1, c2) => (c1 == null && c2 == null) || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
-                c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                c => c == null ? null : c.ToList())
-        {
-        }
-    }
+    protected class EnumerableOfIntComparer() : ValueComparer<IEnumerable<int>?>(
+        (c1, c2) => (c1 == null && c2 == null) || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
+        c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+        c => c == null ? null : c.ToList());
 }

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -14,15 +14,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixture>
+public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : WithConstructorsTestBase<TFixture>.WithConstructorsFixtureBase, new()
 {
-    protected WithConstructorsTestBase(TFixture fixture)
-    {
-        Fixture = fixture;
-    }
-
-    protected TFixture Fixture { get; }
+    protected TFixture Fixture { get; } = fixture;
 
     protected DbContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
@@ -8,13 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class CommandInterceptionSqlServerTestBase : CommandInterceptionTestBase
+public abstract class CommandInterceptionSqlServerTestBase(CommandInterceptionSqlServerTestBase.InterceptionSqlServerFixtureBase fixture)
+    : CommandInterceptionTestBase(fixture)
 {
-    protected CommandInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task<string> Intercept_query_passively(bool async, bool inject)
     {
         AssertSql(
@@ -106,13 +102,8 @@ SELECT [s].[Id], [s].[Type] FROM [Singularity] AS [s]
         return interceptor.CommandText;
     }
 
-    protected class StatisticsCommandInterceptor : CommandInterceptorBase
+    protected class StatisticsCommandInterceptor() : CommandInterceptorBase(DbCommandMethod.ExecuteReader)
     {
-        public StatisticsCommandInterceptor()
-            : base(DbCommandMethod.ExecuteReader)
-        {
-        }
-
         public override InterceptionResult<DbDataReader> ReaderExecuting(
             DbCommand command,
             CommandEventData eventData,

--- a/test/EFCore.SqlServer.FunctionalTests/ConnectionInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConnectionInterceptionSqlServerTest.cs
@@ -6,13 +6,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ConnectionInterceptionSqlServerTestBase : ConnectionInterceptionTestBase
+public abstract class ConnectionInterceptionSqlServerTestBase(
+    ConnectionInterceptionSqlServerTestBase.InterceptionSqlServerFixtureBase fixture)
+    : ConnectionInterceptionTestBase(fixture)
 {
-    protected ConnectionInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
     {
         protected override string StoreName

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -135,26 +135,15 @@ public class F1SqlServerFixture : F1SqlServerFixtureBase<byte[]>
             .IsRowVersion();
     }
 
-    private class BinaryVersionConverter : ValueConverter<List<byte>, byte[]>
-    {
-        public BinaryVersionConverter()
-            : base(
-                v => v == null ? null : v.ToArray(),
-                v => v == null ? null : v.ToList())
-        {
-        }
-    }
+    private class BinaryVersionConverter() : ValueConverter<List<byte>, byte[]>(
+        v => v == null ? null : v.ToArray(),
+        v => v == null ? null : v.ToList());
 
-    private class BinaryVersionComparer : ValueComparer<List<byte>>
+    private class BinaryVersionComparer() : ValueComparer<List<byte>>(
+        (l, r) => (l == null && r == null) || (l != null && r != null && l.SequenceEqual(r)),
+        v => CalculateHashCode(v),
+        v => v == null ? null : v.ToList())
     {
-        public BinaryVersionComparer()
-            : base(
-                (l, r) => (l == null && r == null) || (l != null && r != null && l.SequenceEqual(r)),
-                v => CalculateHashCode(v),
-                v => v == null ? null : v.ToList())
-        {
-        }
-
         private static int CalculateHashCode(List<byte> source)
         {
             if (source == null)

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class GraphUpdatesSqlServerTestBase<TFixture> : GraphUpdatesTestBase<TFixture>
+public abstract class GraphUpdatesSqlServerTestBase<TFixture>(TFixture fixture) : GraphUpdatesTestBase<TFixture>(fixture)
     where TFixture : GraphUpdatesSqlServerTestBase<TFixture>.GraphUpdatesSqlServerFixtureBase, new()
 {
-    protected GraphUpdatesSqlServerTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalFact] // Issue #32638
     public virtual void Key_and_index_properties_use_appropriate_comparer()
     {

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/ProxyGraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/ProxyGraphUpdatesSqlServerTest.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public abstract class ProxyGraphUpdatesSqlServerTest
 {
-    public abstract class ProxyGraphUpdatesSqlServerTestBase<TFixture> : ProxyGraphUpdatesTestBase<TFixture>
+    public abstract class ProxyGraphUpdatesSqlServerTestBase<TFixture>(TFixture fixture) : ProxyGraphUpdatesTestBase<TFixture>(fixture)
         where TFixture : ProxyGraphUpdatesSqlServerTestBase<TFixture>.ProxyGraphUpdatesSqlServerFixtureBase, new()
     {
-        protected ProxyGraphUpdatesSqlServerTestBase(TFixture fixture)
-            : base(fixture)
-        {
-        }
-
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToManyTrackingRelationalTestBase<TFixture>
+public abstract class ManyToManyTrackingSqlServerTestBase<TFixture>(TFixture fixture)
+    : ManyToManyTrackingRelationalTestBase<TFixture>(fixture)
     where TFixture : ManyToManyTrackingSqlServerTestBase<TFixture>.ManyToManyTrackingSqlServerFixtureBase
 {
-    protected ManyToManyTrackingSqlServerTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected override Dictionary<string, DeleteBehavior> CustomDeleteBehaviors { get; } = new()
     {
         { "EntityBranch.RootSkipShared", DeleteBehavior.ClientCascade },

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -9,7 +9,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-public class SqlServerMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
+public class SqlServerMigrationsSqlGeneratorTest() : MigrationsSqlGeneratorTestBase(
+    SqlServerTestHelpers.Instance,
+    new ServiceCollection().AddEntityFrameworkSqlServerNetTopologySuite(),
+    SqlServerTestHelpers.Instance.AddProviderOptions(
+        ((IRelationalDbContextOptionsBuilderInfrastructure)
+            new SqlServerDbContextOptionsBuilder(new DbContextOptionsBuilder()).UseNetTopologySuite())
+        .OptionsBuilder).Options)
 {
     [ConditionalFact]
     public void CreateIndexOperation_unique_online()
@@ -1282,15 +1288,4 @@ ALTER TABLE [Person] ADD DEFAULT N'' FOR [Name];
                 pb.Property<string>("Culture").HasColumnName("Culture");
                 pb.HasKey("FirstName", "LastName");
             });
-
-    public SqlServerMigrationsSqlGeneratorTest()
-        : base(
-            SqlServerTestHelpers.Instance,
-            new ServiceCollection().AddEntityFrameworkSqlServerNetTopologySuite(),
-            SqlServerTestHelpers.Instance.AddProviderOptions(
-                ((IRelationalDbContextOptionsBuilderInfrastructure)
-                    new SqlServerDbContextOptionsBuilder(new DbContextOptionsBuilder()).UseNetTopologySuite())
-                .OptionsBuilder).Options)
-    {
-    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -106,15 +106,10 @@ public class OptimisticConcurrencySqlServerTest(F1SqlServerFixture fixture) : Op
         => Row_version_with_table_splitting<StreetCircuitTpc, CityTpc, List<byte>>(updateDependentFirst, Mapping.Tpc, "BinaryVersion");
 }
 
-public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersion>
-    : OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>
+public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersion>(TFixture fixture)
+    : OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>(fixture)
     where TFixture : F1RelationalFixture<TRowVersion>, new()
 {
-    protected OptimisticConcurrencySqlServerTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     protected enum Mapping
     {
         Tph,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
@@ -5,14 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class TPCInheritanceQuerySqlServerTestBase<TFixture> : TPCInheritanceQueryTestBase<TFixture>
+public abstract class TPCInheritanceQuerySqlServerTestBase<TFixture>(TFixture fixture, ITestOutputHelper testOutputHelper)
+    : TPCInheritanceQueryTestBase<TFixture>(fixture, testOutputHelper)
     where TFixture : TPCInheritanceQuerySqlServerFixtureBase, new()
 {
-    protected TPCInheritanceQuerySqlServerTestBase(TFixture fixture, ITestOutputHelper testOutputHelper)
-        : base(fixture, testOutputHelper)
-    {
-    }
-
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType().BaseType);

--- a/test/EFCore.SqlServer.FunctionalTests/QueryExpressionInterceptionSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryExpressionInterceptionSqlServerTestBase.cs
@@ -7,13 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class QueryExpressionInterceptionSqlServerTestBase : QueryExpressionInterceptionTestBase
+public abstract class QueryExpressionInterceptionSqlServerTestBase(
+    QueryExpressionInterceptionSqlServerTestBase.InterceptionSqlServerFixtureBase fixture)
+    : QueryExpressionInterceptionTestBase(fixture)
 {
-    protected QueryExpressionInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.SqlServer.FunctionalTests/SaveChangesInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SaveChangesInterceptionSqlServerTest.cs
@@ -7,13 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SaveChangesInterceptionSqlServerTestBase : SaveChangesInterceptionTestBase
+public abstract class SaveChangesInterceptionSqlServerTestBase(
+    SaveChangesInterceptionSqlServerTestBase.InterceptionSqlServerFixtureBase fixture)
+    : SaveChangesInterceptionTestBase(fixture)
 {
-    protected SaveChangesInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [InlineData(false, false, false)]
     [InlineData(true, false, false)]

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -764,13 +764,9 @@ public class SqlServerConfigPatternsTest
             Assert.IsType<SqlServerRetryingExecutionStrategy>(context.Database.CreateExecutionStrategy());
         }
 
-        private class NorthwindContext : DbContext
+        private class NorthwindContext(DbContextOptions options) : DbContext(options)
         {
             public DbSet<Customer> Customers { get; set; }
-
-            public NorthwindContext(DbContextOptions options)
-                : base(options)
-            { }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
                 => ConfigureModel(modelBuilder);

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerServiceCollectionExtensionsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerServiceCollectionExtensionsTest.cs
@@ -5,10 +5,4 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class SqlServerServiceCollectionExtensionsTest : RelationalServiceCollectionExtensionsTestBase
-{
-    public SqlServerServiceCollectionExtensionsTest()
-        : base(SqlServerTestHelpers.Instance)
-    {
-    }
-}
+public class SqlServerServiceCollectionExtensionsTest() : RelationalServiceCollectionExtensionsTestBase(SqlServerTestHelpers.Instance);

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTestBase.cs
@@ -1744,17 +1744,8 @@ END");
                     v => new NeedsConverter(v.Value)))
             .HasDefaultValue(new NeedsConverter(999));
 
-    public abstract class ContextBase : DbContext
+    public abstract class ContextBase(string databaseName, Action<ModelBuilder> builder) : DbContext
     {
-        private readonly string _databaseName;
-        private readonly Action<ModelBuilder> _modelBuilder;
-
-        protected ContextBase(string databaseName, Action<ModelBuilder> modelBuilder)
-        {
-            _databaseName = databaseName;
-            _modelBuilder = modelBuilder;
-        }
-
         public DbSet<Blog> Blogs { get; set; }
         public DbSet<BlogWithSpatial> SpatialBlogs { get; set; }
         public DbSet<NullableKeyBlog> NullableKeyBlogs { get; set; }
@@ -1763,13 +1754,13 @@ END");
         public DbSet<ConcurrentBlog> ConcurrentBlogs { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => _modelBuilder(modelBuilder);
+            => builder(modelBuilder);
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .EnableServiceProviderCaching(false)
                 .UseSqlServer(
-                    SqlServerTestStore.CreateConnectionString(_databaseName),
+                    SqlServerTestStore.CreateConnectionString(databaseName),
                     b => b.UseNetTopologySuite().ApplyConfiguration());
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
@@ -6,39 +6,22 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGeneratedTestBase<TFixture>
+public abstract class StoreGeneratedSqlServerTestBase<TFixture>(TFixture fixture) : StoreGeneratedTestBase<TFixture>(fixture)
     where TFixture : StoreGeneratedSqlServerTestBase<TFixture>.StoreGeneratedSqlServerFixtureBase, new()
 {
-    protected StoreGeneratedSqlServerTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public class WrappedIntHiLoClass
     {
         public int Value { get; set; }
     }
 
-    protected class WrappedIntHiLoClassConverter : ValueConverter<WrappedIntHiLoClass, int>
-    {
-        public WrappedIntHiLoClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoClassConverter() : ValueConverter<WrappedIntHiLoClass, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoClass { Value = v });
 
-    protected class WrappedIntHiLoClassComparer : ValueComparer<WrappedIntHiLoClass?>
-    {
-        public WrappedIntHiLoClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntHiLoClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntHiLoClassComparer() : ValueComparer<WrappedIntHiLoClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntHiLoClass { Value = v.Value });
 
     protected class WrappedIntHiLoClassValueGenerator : ValueGenerator<WrappedIntHiLoClass>
     {
@@ -54,15 +37,9 @@ public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGenerated
         public int Value { get; set; }
     }
 
-    protected class WrappedIntHiLoStructConverter : ValueConverter<WrappedIntHiLoStruct, int>
-    {
-        public WrappedIntHiLoStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoStructConverter() : ValueConverter<WrappedIntHiLoStruct, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoStruct { Value = v });
 
     protected class WrappedIntHiLoStructValueGenerator : ValueGenerator<WrappedIntHiLoStruct>
     {
@@ -78,15 +55,9 @@ public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGenerated
         public int Value { get; set; }
     }
 
-    protected class WrappedIntHiLoRecordConverter : ValueConverter<WrappedIntHiLoRecord, int>
-    {
-        public WrappedIntHiLoRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoRecordConverter() : ValueConverter<WrappedIntHiLoRecord, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoRecord { Value = v });
 
     protected class WrappedIntHiLoRecordValueGenerator : ValueGenerator<WrappedIntHiLoRecord>
     {
@@ -102,26 +73,14 @@ public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGenerated
         public int Value { get; set; }
     }
 
-    protected class WrappedIntHiLoKeyClassConverter : ValueConverter<WrappedIntHiLoKeyClass, int>
-    {
-        public WrappedIntHiLoKeyClassConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoKeyClass { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoKeyClassConverter() : ValueConverter<WrappedIntHiLoKeyClass, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoKeyClass { Value = v });
 
-    protected class WrappedIntHiLoKeyClassComparer : ValueComparer<WrappedIntHiLoKeyClass?>
-    {
-        public WrappedIntHiLoKeyClassComparer()
-            : base(
-                (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
-                v => v != null ? v.Value : 0,
-                v => v == null ? null : new WrappedIntHiLoKeyClass { Value = v.Value })
-        {
-        }
-    }
+    protected class WrappedIntHiLoKeyClassComparer() : ValueComparer<WrappedIntHiLoKeyClass?>(
+        (v1, v2) => (v1 == null && v2 == null) || (v1 != null && v2 != null && v1.Value.Equals(v2.Value)),
+        v => v != null ? v.Value : 0,
+        v => v == null ? null : new WrappedIntHiLoKeyClass { Value = v.Value });
 
     public struct WrappedIntHiLoKeyStruct
     {
@@ -140,30 +99,18 @@ public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGenerated
             => !left.Equals(right);
     }
 
-    protected class WrappedIntHiLoKeyStructConverter : ValueConverter<WrappedIntHiLoKeyStruct, int>
-    {
-        public WrappedIntHiLoKeyStructConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoKeyStruct { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoKeyStructConverter() : ValueConverter<WrappedIntHiLoKeyStruct, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoKeyStruct { Value = v });
 
     public record WrappedIntHiLoKeyRecord
     {
         public int Value { get; set; }
     }
 
-    protected class WrappedIntHiLoKeyRecordConverter : ValueConverter<WrappedIntHiLoKeyRecord, int>
-    {
-        public WrappedIntHiLoKeyRecordConverter()
-            : base(
-                v => v.Value,
-                v => new WrappedIntHiLoKeyRecord { Value = v })
-        {
-        }
-    }
+    protected class WrappedIntHiLoKeyRecordConverter() : ValueConverter<WrappedIntHiLoKeyRecord, int>(
+        v => v.Value,
+        v => new WrappedIntHiLoKeyRecord { Value = v });
 
     protected class WrappedIntHiLoClassPrincipal
     {

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionInterceptionSqlServerTest.cs
@@ -5,13 +5,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TransactionInterceptionSqlServerTestBase : TransactionInterceptionTestBase
+public abstract class TransactionInterceptionSqlServerTestBase(
+    TransactionInterceptionSqlServerTestBase.InterceptionSqlServerFixtureBase fixture)
+    : TransactionInterceptionTestBase(fixture)
 {
-    protected TransactionInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
     {
         protected override string StoreName

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationWithoutOutputSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationWithoutOutputSqlServerTestBase.cs
@@ -7,14 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public abstract class StoreValueGenerationWithoutOutputSqlServerTestBase<TFixture> : StoreValueGenerationTestBase<TFixture>
+public abstract class StoreValueGenerationWithoutOutputSqlServerTestBase<TFixture>(TFixture fixture)
+    : StoreValueGenerationTestBase<TFixture>(fixture)
     where TFixture : StoreValueGenerationWithoutOutputSqlServerFixture
 {
-    protected StoreValueGenerationWithoutOutputSqlServerTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Three_Add_use_batched_inserts(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/ValueConvertersEndToEndSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ValueConvertersEndToEndSqlServerTest.cs
@@ -181,13 +181,8 @@ WHERE CAST(DATALENGTH(CAST(N'' AS nvarchar(max))) AS int) = 1
         public string Value { get; init; }
     }
 
-    private class WrappedStringToStringConverter : ValueConverter<WrappedString, string>
-    {
-        public WrappedStringToStringConverter()
-            : base(v => v.Value, v => new WrappedString { Value = v })
-        {
-        }
-    }
+    private class WrappedStringToStringConverter()
+        : ValueConverter<WrappedString, string>(v => v.Value, v => new WrappedString { Value = v });
 
     [ConditionalFact]
     public virtual void Fixed_length_hints_are_respected()

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsAnnotationProviderTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsAnnotationProviderTest.cs
@@ -7,12 +7,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
 
 public class SqlServerMigrationsAnnotationProviderTest
 {
-    private readonly SqlServerAnnotationProvider _annotations;
-
-    public SqlServerMigrationsAnnotationProviderTest()
-    {
-        _annotations = new SqlServerAnnotationProvider(new RelationalAnnotationProviderDependencies());
-    }
+    private readonly SqlServerAnnotationProvider _annotations = new(new RelationalAnnotationProviderDependencies());
 
     [ConditionalFact]
     public void For_property_handles_identity_annotations()

--- a/test/EFCore.Sqlite.FunctionalTests/CommandInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CommandInterceptionSqliteTest.cs
@@ -5,13 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class CommandInterceptionSqliteTestBase : CommandInterceptionTestBase
+public abstract class CommandInterceptionSqliteTestBase(CommandInterceptionSqliteTestBase.InterceptionSqliteFixtureBase fixture)
+    : CommandInterceptionTestBase(fixture)
 {
-    protected CommandInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public override async Task<string> Intercept_query_passively(bool async, bool inject)
     {
         AssertSql(

--- a/test/EFCore.Sqlite.FunctionalTests/ConnectionInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConnectionInterceptionSqliteTest.cs
@@ -3,13 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ConnectionInterceptionSqliteTestBase : ConnectionInterceptionTestBase
+public abstract class ConnectionInterceptionSqliteTestBase(ConnectionInterceptionSqliteTestBase.InterceptionSqliteFixtureBase fixture)
+    : ConnectionInterceptionTestBase(fixture)
 {
-    protected ConnectionInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     protected override DbContextOptionsBuilder ConfigureProvider(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.UseSqlite();
 

--- a/test/EFCore.Sqlite.FunctionalTests/FieldMappingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/FieldMappingSqliteTest.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public abstract class FieldMappingSqliteTest
 {
-    public abstract class FieldMappingSqliteTestBase<TFixture> : FieldMappingTestBase<TFixture>
+    public abstract class FieldMappingSqliteTestBase<TFixture>(TFixture fixture) : FieldMappingTestBase<TFixture>(fixture)
         where TFixture : FieldMappingSqliteTestBase<TFixture>.FieldMappingSqliteFixtureBase, new()
     {
-        protected FieldMappingSqliteTestBase(TFixture fixture)
-            : base(fixture)
-        {
-        }
-
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 

--- a/test/EFCore.Sqlite.FunctionalTests/FindSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/FindSqliteTest.cs
@@ -5,13 +5,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class FindSqliteTest : FindTestBase<FindSqliteTest.FindSqliteFixture>
+public abstract class FindSqliteTest(FindSqliteTest.FindSqliteFixture fixture) : FindTestBase<FindSqliteTest.FindSqliteFixture>(fixture)
 {
-    protected FindSqliteTest(FindSqliteFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public class FindSqliteTestSet(FindSqliteFixture fixture) : FindSqliteTest(fixture)
     {
         protected override TestFinder Finder { get; } = new FindViaSetFinder();

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTestBase.cs
@@ -5,14 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class GraphUpdatesSqliteTestBase<TFixture> : GraphUpdatesTestBase<TFixture>
+public abstract class GraphUpdatesSqliteTestBase<TFixture>(TFixture fixture) : GraphUpdatesTestBase<TFixture>(fixture)
     where TFixture : GraphUpdatesSqliteTestBase<TFixture>.GraphUpdatesSqliteFixtureBase, new()
 {
-    protected GraphUpdatesSqliteTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
     public override Task Update_principal_with_shadow_key_owned_collection_throws(bool async)
         => Task.CompletedTask;

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/ProxyGraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/ProxyGraphUpdatesSqliteTest.cs
@@ -8,14 +8,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public class ProxyGraphUpdatesSqliteTest
 {
-    public abstract class ProxyGraphUpdatesSqliteTestBase<TFixture> : ProxyGraphUpdatesTestBase<TFixture>
+    public abstract class ProxyGraphUpdatesSqliteTestBase<TFixture>(TFixture fixture) : ProxyGraphUpdatesTestBase<TFixture>(fixture)
         where TFixture : ProxyGraphUpdatesSqliteTestBase<TFixture>.ProxyGraphUpdatesSqliteFixtureBase, new()
     {
-        protected ProxyGraphUpdatesSqliteTestBase(TFixture fixture)
-            : base(fixture)
-        {
-        }
-
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 

--- a/test/EFCore.Sqlite.FunctionalTests/ManyToManyLoadSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ManyToManyLoadSqliteTestBase.cs
@@ -7,14 +7,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class ManyToManyLoadSqliteTestBase<TFixture> : ManyToManyLoadTestBase<TFixture>
+public abstract class ManyToManyLoadSqliteTestBase<TFixture>(TFixture fixture) : ManyToManyLoadTestBase<TFixture>(fixture)
     where TFixture : ManyToManyLoadSqliteTestBase<TFixture>.ManyToManyLoadSqliteFixtureBase
 {
-    protected ManyToManyLoadSqliteTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public class ManyToManyLoadSqliteFixtureBase : ManyToManyLoadFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
@@ -9,7 +9,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-public class SqliteMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
+public class SqliteMigrationsSqlGeneratorTest() : MigrationsSqlGeneratorTestBase(
+    SqliteTestHelpers.Instance,
+    new ServiceCollection().AddEntityFrameworkSqliteNetTopologySuite(),
+    SqliteTestHelpers.Instance.AddProviderOptions(
+        ((IRelationalDbContextOptionsBuilderInfrastructure)
+            new SqliteDbContextOptionsBuilder(new DbContextOptionsBuilder()).UseNetTopologySuite())
+        .OptionsBuilder).Options)
 {
     [ConditionalFact]
     public virtual void It_lifts_foreign_key_additions()
@@ -1176,16 +1182,5 @@ GO
 
 PRAGMA foreign_keys = 1;
 """);
-    }
-
-    public SqliteMigrationsSqlGeneratorTest()
-        : base(
-            SqliteTestHelpers.Instance,
-            new ServiceCollection().AddEntityFrameworkSqliteNetTopologySuite(),
-            SqliteTestHelpers.Instance.AddProviderOptions(
-                ((IRelationalDbContextOptionsBuilderInfrastructure)
-                    new SqliteDbContextOptionsBuilder(new DbContextOptionsBuilder()).UseNetTopologySuite())
-                .OptionsBuilder).Options)
-    {
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
@@ -9,15 +9,10 @@ public class OptimisticConcurrencyULongSqliteTest(F1ULongSqliteFixture fixture) 
 
 public class OptimisticConcurrencySqliteTest(F1SqliteFixture fixture) : OptimisticConcurrencySqliteTestBase<F1SqliteFixture, byte[]>(fixture);
 
-public abstract class OptimisticConcurrencySqliteTestBase<TFixture, TRowVersion>
-    : OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>
+public abstract class OptimisticConcurrencySqliteTestBase<TFixture, TRowVersion>(TFixture fixture)
+    : OptimisticConcurrencyRelationalTestBase<TFixture, TRowVersion>(fixture)
     where TFixture : F1RelationalFixture<TRowVersion>, new()
 {
-    protected OptimisticConcurrencySqliteTestBase(TFixture fixture)
-        : base(fixture)
-    {
-    }
-
     public override void Property_entry_original_value_is_set()
     {
         base.Property_entry_original_value_is_set();

--- a/test/EFCore.Sqlite.FunctionalTests/QueryExpressionInterceptionSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/QueryExpressionInterceptionSqliteTestBase.cs
@@ -5,13 +5,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class QueryExpressionInterceptionSqliteTestBase : QueryExpressionInterceptionTestBase
+public abstract class QueryExpressionInterceptionSqliteTestBase(
+    QueryExpressionInterceptionSqliteTestBase.InterceptionSqliteFixtureBase fixture)
+    : QueryExpressionInterceptionTestBase(fixture)
 {
-    protected QueryExpressionInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.Sqlite.FunctionalTests/SaveChangesInterceptionSqliteTestBase.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SaveChangesInterceptionSqliteTestBase.cs
@@ -5,13 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SaveChangesInterceptionSqliteTestBase : SaveChangesInterceptionTestBase
+public abstract class SaveChangesInterceptionSqliteTestBase(SaveChangesInterceptionSqliteTestBase.InterceptionSqliteFixtureBase fixture)
+    : SaveChangesInterceptionTestBase(fixture)
 {
-    protected SaveChangesInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
     {
         protected override string StoreName

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteServiceCollectionExtensionsTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteServiceCollectionExtensionsTest.cs
@@ -5,10 +5,4 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class SqliteServiceCollectionExtensionsTest : RelationalServiceCollectionExtensionsTestBase
-{
-    public SqliteServiceCollectionExtensionsTest()
-        : base(SqliteTestHelpers.Instance)
-    {
-    }
-}
+public class SqliteServiceCollectionExtensionsTest() : RelationalServiceCollectionExtensionsTestBase(SqliteTestHelpers.Instance);

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteValueGenerationScenariosTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteValueGenerationScenariosTest.cs
@@ -619,15 +619,8 @@ public class SqliteValueGenerationScenariosTest
         public byte[] Timestamp { get; set; }
     }
 
-    public abstract class ContextBase : DbContext
+    public abstract class ContextBase(string databaseName) : DbContext
     {
-        private readonly string _databaseName;
-
-        protected ContextBase(string databaseName)
-        {
-            _databaseName = databaseName;
-        }
-
         public DbSet<Blog> Blogs { get; set; }
         public DbSet<NullableKeyBlog> NullableKeyBlogs { get; set; }
         public DbSet<FullNameBlog> FullNameBlogs { get; set; }
@@ -649,6 +642,6 @@ public class SqliteValueGenerationScenariosTest
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .EnableServiceProviderCaching(false)
-                .UseSqlite($"DataSource = {_databaseName}.db");
+                .UseSqlite($"DataSource = {databaseName}.db");
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/TransactionInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TransactionInterceptionSqliteTest.cs
@@ -5,13 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TransactionInterceptionSqliteTestBase : TransactionInterceptionTestBase
+public abstract class TransactionInterceptionSqliteTestBase(TransactionInterceptionSqliteTestBase.InterceptionSqliteFixtureBase fixture)
+    : TransactionInterceptionTestBase(fixture)
 {
-    protected TransactionInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
-        : base(fixture)
-    {
-    }
-
     public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
     {
         protected override string StoreName

--- a/test/EFCore.Tests/ChangeTracking/FindEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/FindEntryTest.cs
@@ -2279,12 +2279,7 @@ public class FindEntryTest
 
     private class FindContext : DbContext
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        public FindContext()
-        {
-            _serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
-        }
+        private readonly IServiceProvider _serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -2408,12 +2403,7 @@ public class FindEntryTest
 
     private class FindContextShared : DbContext
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        public FindContextShared()
-        {
-            _serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
-        }
+        private readonly IServiceProvider _serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
@@ -3535,15 +3535,10 @@ public class FixupCompositeTest
 
     private class CategoryPN
     {
-        public CategoryPN()
-        {
-            Products = new List<ProductPN>();
-        }
-
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public ICollection<ProductPN> Products { get; }
+        public ICollection<ProductPN> Products { get; } = new List<ProductPN>();
     }
 
     private class ProductPN
@@ -3572,15 +3567,10 @@ public class FixupCompositeTest
 
     private class Category
     {
-        public Category()
-        {
-            Products = new List<Product>();
-        }
-
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public ICollection<Product> Products { get; }
+        public ICollection<Product> Products { get; } = new List<Product>();
     }
 
     private class Product

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -3447,14 +3447,9 @@ public class FixupTest
 
     private class CategoryPN
     {
-        public CategoryPN()
-        {
-            Products = new List<ProductPN>();
-        }
-
         public int Id { get; set; }
 
-        public ICollection<ProductPN> Products { get; }
+        public ICollection<ProductPN> Products { get; } = new List<ProductPN>();
     }
 
     private class ProductPN

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -1536,14 +1536,9 @@ public class ShadowFkFixupTest
 
     private class CategoryPN
     {
-        public CategoryPN()
-        {
-            Products = new List<ProductPN>();
-        }
-
         public int Id { get; set; }
 
-        public ICollection<ProductPN> Products { get; }
+        public ICollection<ProductPN> Products { get; } = new List<ProductPN>();
     }
 
     private class ProductPN
@@ -1563,29 +1558,19 @@ public class ShadowFkFixupTest
 
     private class Category
     {
-        public Category()
-        {
-            Products = new List<Product>();
-        }
-
         public int Id { get; set; }
 
-        public ICollection<Product> Products { get; }
+        public ICollection<Product> Products { get; } = new List<Product>();
     }
 
     private class Product
     {
-        public Product()
-        {
-            SpecialOffers = new List<SpecialOffer>();
-        }
-
         public int Id { get; set; }
 
         public Category Category { get; set; }
 
         // ReSharper disable once CollectionNeverUpdated.Local
-        public ICollection<SpecialOffer> SpecialOffers { get; }
+        public ICollection<SpecialOffer> SpecialOffers { get; } = new List<SpecialOffer>();
     }
 
     private class SpecialOffer

--- a/test/EFCore.Tests/ChangeTracking/TrackGraphTestBase.cs
+++ b/test/EFCore.Tests/ChangeTracking/TrackGraphTestBase.cs
@@ -1369,21 +1369,11 @@ public abstract class TrackGraphTestBase
 
     private class OfThis : AreMade;
 
-    private class EarlyLearningCenter : DbContext
+    private class EarlyLearningCenter(string databaseName, IServiceProvider serviceProvider) : DbContext
     {
-        private readonly string _databaseName;
-        private readonly IServiceProvider _serviceProvider;
-
         public EarlyLearningCenter(string databaseName)
+            : this(databaseName, InMemoryTestHelpers.Instance.CreateServiceProvider())
         {
-            _databaseName = databaseName;
-            _serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
-        }
-
-        public EarlyLearningCenter(string databaseName, IServiceProvider serviceProvider)
-        {
-            _databaseName = databaseName;
-            _serviceProvider = serviceProvider;
         }
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
@@ -1452,8 +1442,8 @@ public abstract class TrackGraphTestBase
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseInternalServiceProvider(_serviceProvider)
-                .UseInMemoryDatabase(_databaseName);
+                .UseInternalServiceProvider(serviceProvider)
+                .UseInMemoryDatabase(databaseName);
     }
 
     public class KeyValueEntityTracker(bool updateExistingEntities)

--- a/test/EFCore.Tests/ChangeTracking/ValueComparerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ValueComparerTest.cs
@@ -5,13 +5,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
 public class ValueComparerTest
 {
-    protected class FakeValueComparer : ValueComparer<double>
-    {
-        public FakeValueComparer()
-            : base(false)
-        {
-        }
-    }
+    protected class FakeValueComparer() : ValueComparer<double>(false);
 
     private class Foo
     {

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -1335,12 +1335,7 @@ public partial class DbContextTest
 
     public class FakeServiceProvider : IServiceProvider, IDisposable
     {
-        private readonly IServiceProvider _realProvider;
-
-        public FakeServiceProvider()
-        {
-            _realProvider = new ServiceCollection().AddEntityFrameworkInMemoryDatabase().BuildServiceProvider(validateScopes: true);
-        }
+        private readonly IServiceProvider _realProvider = new ServiceCollection().AddEntityFrameworkInMemoryDatabase().BuildServiceProvider(validateScopes: true);
 
         public bool Disposed { get; set; }
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -126,13 +126,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
             modelBuilder);
     }
 
-    public class CustomValueComparer<T> : ValueComparer<T> // Doesn't implement IComparer
-    {
-        public CustomValueComparer()
-            : base(false)
-        {
-        }
-    }
+    public class CustomValueComparer<T>() : ValueComparer<T>(false); // Doesn't implement IComparer
 
     [ConditionalFact]
     public virtual void Detects_unique_index_property_which_cannot_be_compared()

--- a/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -382,13 +382,7 @@ public class InternalPropertyBuilderTest
         Assert.Null(metadata[CoreAnnotationNames.ValueConverterType]);
     }
 
-    private class UTF8StringToBytesConverter : StringToBytesConverter
-    {
-        public UTF8StringToBytesConverter()
-            : base(Encoding.UTF8)
-        {
-        }
-    }
+    private class UTF8StringToBytesConverter() : StringToBytesConverter(Encoding.UTF8);
 
     [ConditionalFact]
     public void Can_only_override_lower_or_equal_source_ValueComparer()
@@ -416,13 +410,7 @@ public class InternalPropertyBuilderTest
         Assert.Null(metadata[CoreAnnotationNames.ValueComparerType]);
     }
 
-    private class CustomValueComparer<T> : ValueComparer<T>
-    {
-        public CustomValueComparer()
-            : base(false)
-        {
-        }
-    }
+    private class CustomValueComparer<T>() : ValueComparer<T>(false);
 
     [ConditionalFact]
     public void Can_only_override_lower_or_equal_source_ProviderValueComparer()

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -419,13 +419,7 @@ public class PropertyTest
 
     private class NonDerivedValueComparer;
 
-    private abstract class AbstractValueComparer : ValueComparer<string>
-    {
-        public AbstractValueComparer()
-            : base(false)
-        {
-        }
-    }
+    private abstract class AbstractValueComparer() : ValueComparer<string>(false);
 
     private class StaticValueComparer : ValueComparer<string>
     {

--- a/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
+++ b/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
@@ -15,31 +15,26 @@ public class NavigationExpandingExpressionVisitorTests
             => null;
     }
 
-    private class TestNavigationExpandingExpressionVisitor : NavigationExpandingExpressionVisitor
+    private class TestNavigationExpandingExpressionVisitor() : NavigationExpandingExpressionVisitor(
+        null,
+        new QueryCompilationContext(
+            new QueryCompilationContextDependencies(
+                model: null,
+                queryTranslationPreprocessorFactory: null,
+                queryableMethodTranslatingExpressionVisitorFactory: null,
+                queryTranslationPostprocessorFactory: null,
+                shapedQueryCompilingExpressionVisitorFactory: null,
+                liftableConstantFactory: null,
+                liftableConstantProcessor: null,
+                new ExecutionStrategyTest.TestExecutionStrategy(new MyDemoContext()),
+                new CurrentDbContext(new MyDemoContext()),
+                contextOptions: null,
+                logger: null,
+                new TestInterceptors()
+            ), async: false),
+        null,
+        null)
     {
-        public TestNavigationExpandingExpressionVisitor()
-            : base(
-                null,
-                new QueryCompilationContext(
-                    new QueryCompilationContextDependencies(
-                        model: null,
-                        queryTranslationPreprocessorFactory: null,
-                        queryableMethodTranslatingExpressionVisitorFactory: null,
-                        queryTranslationPostprocessorFactory: null,
-                        shapedQueryCompilingExpressionVisitorFactory: null,
-                        liftableConstantFactory: null,
-                        liftableConstantProcessor: null,
-                        new ExecutionStrategyTest.TestExecutionStrategy(new MyDemoContext()),
-                        new CurrentDbContext(new MyDemoContext()),
-                        contextOptions: null,
-                        logger: null,
-                        new TestInterceptors()
-                    ), async: false),
-                null,
-                null)
-        {
-        }
-
         public Expression TestVisitExtension(Expression extensionExpression)
             => base.VisitExtension(extensionExpression);
     }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteTransactionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteTransactionTest.cs
@@ -96,22 +96,13 @@ public class SqliteTransactionTest
         }
     }
 
-    private class FakeCommand : SqliteCommand
+    private class FakeCommand(FakeConnection connection, SqliteCommand realCommand) : SqliteCommand
     {
-        private readonly FakeConnection _connection;
-        private readonly SqliteCommand _realCommand;
-
-        public FakeCommand(FakeConnection connection, SqliteCommand realCommand)
-        {
-            _connection = connection;
-            _realCommand = realCommand;
-        }
-
         public override int ExecuteNonQuery()
         {
-            var result = _realCommand.ExecuteNonQuery();
+            var result = realCommand.ExecuteNonQuery();
 
-            if (_connection.SimulateFailureOnRollback && CommandText.Contains("ROLLBACK"))
+            if (connection.SimulateFailureOnRollback && CommandText.Contains("ROLLBACK"))
             {
                 throw new SqliteException("Simulated failure", 1);
             }
@@ -120,25 +111,25 @@ public class SqliteTransactionTest
         }
 
         [AllowNull]
-        public override string CommandText { get => _realCommand.CommandText; set => _realCommand.CommandText = value; }
-        public override int CommandTimeout { get => _realCommand.CommandTimeout; set => _realCommand.CommandTimeout = value; }
-        public override CommandType CommandType { get => _realCommand.CommandType; set => _realCommand.CommandType = value; }
-        public override bool DesignTimeVisible { get => _realCommand.DesignTimeVisible; set => _realCommand.DesignTimeVisible = value; }
+        public override string CommandText { get => realCommand.CommandText; set => realCommand.CommandText = value; }
+        public override int CommandTimeout { get => realCommand.CommandTimeout; set => realCommand.CommandTimeout = value; }
+        public override CommandType CommandType { get => realCommand.CommandType; set => realCommand.CommandType = value; }
+        public override bool DesignTimeVisible { get => realCommand.DesignTimeVisible; set => realCommand.DesignTimeVisible = value; }
 
         public override UpdateRowSource UpdatedRowSource
         {
-            get => _realCommand.UpdatedRowSource;
-            set => _realCommand.UpdatedRowSource = value;
+            get => realCommand.UpdatedRowSource;
+            set => realCommand.UpdatedRowSource = value;
         }
 
         public override void Cancel()
-            => _realCommand.Cancel();
+            => realCommand.Cancel();
 
         public override object? ExecuteScalar()
-            => _realCommand.ExecuteScalar();
+            => realCommand.ExecuteScalar();
 
         public override void Prepare()
-            => _realCommand.Prepare();
+            => realCommand.Prepare();
     }
 
     private class FakeConnection(string connectionString) : SqliteConnection(connectionString)


### PR DESCRIPTION
Completely automated change; we already had primary constructor in various places, but not everywhere/systematic. Doing this now before we branch for 10, to avoid conflicts when backporting patches later.