### PR TITLE
Split UseSqlServer/UseAzureSql/UseAzureSynapse builders

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseSqlServer(
         this DbContextOptionsBuilder optionsBuilder,
@@ -57,7 +57,7 @@ public static class SqlServerDbContextOptionsExtensions
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseSqlServer(
         this DbContextOptionsBuilder optionsBuilder,
@@ -88,7 +88,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseSqlServer(
         this DbContextOptionsBuilder optionsBuilder,
@@ -116,7 +116,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseSqlServer(
         this DbContextOptionsBuilder optionsBuilder,
@@ -151,7 +151,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseSqlServer<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
@@ -171,7 +171,7 @@ public static class SqlServerDbContextOptionsExtensions
     /// <typeparam name="TContext">The type of context to be configured.</typeparam>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseSqlServer<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
@@ -198,7 +198,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseSqlServer<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
@@ -229,7 +229,7 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseSqlServer<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
@@ -257,17 +257,17 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSql(
         this DbContextOptionsBuilder optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
     {
         var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder);
         extension = extension
             .WithEngineType(SqlServerEngineType.AzureSql);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSqlOptionsAction);
     }
 
     /// <summary>
@@ -280,19 +280,19 @@ public static class SqlServerDbContextOptionsExtensions
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSql(
         this DbContextOptionsBuilder optionsBuilder,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
     {
         var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder);
         extension = (SqlServerOptionsExtension)extension
             .WithEngineType(SqlServerEngineType.AzureSql)
             .WithConnectionString(connectionString);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSqlOptionsAction);
     }
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
@@ -311,13 +311,13 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSql(
         this DbContextOptionsBuilder optionsBuilder,
         DbConnection connection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
-        => UseAzureSql(optionsBuilder, connection, false, sqlServerOptionsAction);
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
+        => UseAzureSql(optionsBuilder, connection, false, azureSqlOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -339,13 +339,13 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSql(
         this DbContextOptionsBuilder optionsBuilder,
         DbConnection connection,
         bool contextOwnsConnection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
     {
         Check.NotNull(connection, nameof(connection));
 
@@ -354,7 +354,7 @@ public static class SqlServerDbContextOptionsExtensions
             .WithEngineType(SqlServerEngineType.AzureSql)
             .WithConnection(connection, contextOwnsConnection);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSqlOptionsAction);
     }
 
     /// <summary>
@@ -374,14 +374,14 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSql<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSql(
-            (DbContextOptionsBuilder)optionsBuilder, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, azureSqlOptionsAction);
 
     /// <summary>
     ///     Configures the context to connect to a Azure SQL database.
@@ -394,15 +394,15 @@ public static class SqlServerDbContextOptionsExtensions
     /// <typeparam name="TContext">The type of context to be configured.</typeparam>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSql<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSql(
-            (DbContextOptionsBuilder)optionsBuilder, connectionString, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connectionString, azureSqlOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -421,15 +421,15 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSql<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         DbConnection connection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSql(
-            (DbContextOptionsBuilder)optionsBuilder, connection, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connection, azureSqlOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -452,16 +452,16 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSql<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         DbConnection connection,
         bool contextOwnsConnection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSql(
-            (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, azureSqlOptionsAction);
 
     /// <summary>
     ///     Configures the context to connect to a Azure Synapse database, but without initially setting any
@@ -480,17 +480,17 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSynapse(
         this DbContextOptionsBuilder optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
     {
         var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder);
         extension = extension
             .WithEngineType(SqlServerEngineType.AzureSynapse);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSynapseOptionsAction);
     }
 
     /// <summary>
@@ -503,19 +503,19 @@ public static class SqlServerDbContextOptionsExtensions
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSynapse(
         this DbContextOptionsBuilder optionsBuilder,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
     {
         var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder);
         extension = (SqlServerOptionsExtension)extension
             .WithEngineType(SqlServerEngineType.AzureSynapse)
             .WithConnectionString(connectionString);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSynapseOptionsAction);
     }
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
@@ -534,13 +534,13 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSynapse(
         this DbContextOptionsBuilder optionsBuilder,
         DbConnection connection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
-        => UseAzureSynapse(optionsBuilder, connection, false, sqlServerOptionsAction);
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
+        => UseAzureSynapse(optionsBuilder, connection, false, azureSynapseOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -562,13 +562,13 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder UseAzureSynapse(
         this DbContextOptionsBuilder optionsBuilder,
         DbConnection connection,
         bool contextOwnsConnection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
     {
         Check.NotNull(connection, nameof(connection));
 
@@ -577,7 +577,7 @@ public static class SqlServerDbContextOptionsExtensions
             .WithEngineType(SqlServerEngineType.AzureSynapse)
             .WithConnection(connection, contextOwnsConnection);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, azureSynapseOptionsAction);
     }
 
     /// <summary>
@@ -597,14 +597,14 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSynapse<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSynapse(
-            (DbContextOptionsBuilder)optionsBuilder, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, azureSynapseOptionsAction);
 
     /// <summary>
     ///     Configures the context to connect to a Azure Synapse database.
@@ -617,15 +617,15 @@ public static class SqlServerDbContextOptionsExtensions
     /// <typeparam name="TContext">The type of context to be configured.</typeparam>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSynapse<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSynapse(
-            (DbContextOptionsBuilder)optionsBuilder, connectionString, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connectionString, azureSynapseOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -644,15 +644,15 @@ public static class SqlServerDbContextOptionsExtensions
     ///     state then EF will open and close the connection as needed. The caller owns the connection and is
     ///     responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSynapse<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         DbConnection connection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSynapse(
-            (DbContextOptionsBuilder)optionsBuilder, connection, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connection, azureSynapseOptionsAction);
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
@@ -675,16 +675,16 @@ public static class SqlServerDbContextOptionsExtensions
     ///     dispose it in the same way it would dispose a connection created by EF. If <see langword="false" />, then the caller still
     ///     owns the connection and is responsible for its disposal.
     /// </param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseAzureSynapse<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         DbConnection connection,
         bool contextOwnsConnection,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAzureSynapse(
-            (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, azureSynapseOptionsAction);
 
     /// <summary>
     ///     Configures the context to connect to any of SQL Server, Azure SQL, Azure Synapse databases, but without initially setting any
@@ -703,14 +703,14 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlEngineOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder ConfigureSqlEngine(
         this DbContextOptionsBuilder optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<SqlEngineDbContextOptionsBuilder>? sqlEngineOptionsAction = null)
     {
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder));
-        return ApplyConfiguration(optionsBuilder, sqlServerOptionsAction);
+        return ApplyConfiguration(optionsBuilder, sqlEngineOptionsAction);
     }
 
     /// <summary>
@@ -730,14 +730,14 @@ public static class SqlServerDbContextOptionsExtensions
     ///     </para>
     /// </remarks>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlEngineOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse configuration.</param>
     /// <returns>The options builder so that further configuration can be chained.</returns>
     public static DbContextOptionsBuilder<TContext> ConfigureSqlEngine<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        Action<SqlEngineDbContextOptionsBuilder>? sqlEngineOptionsAction = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)ConfigureSqlEngine(
-            (DbContextOptionsBuilder)optionsBuilder, sqlServerOptionsAction);
+            (DbContextOptionsBuilder)optionsBuilder, sqlEngineOptionsAction);
 
     private static T GetOrCreateExtension<T>(DbContextOptionsBuilder optionsBuilder)
         where T : RelationalOptionsExtension, new()
@@ -751,6 +751,45 @@ public static class SqlServerDbContextOptionsExtensions
         ConfigureWarnings(optionsBuilder);
 
         sqlServerOptionsAction?.Invoke(new SqlServerDbContextOptionsBuilder(optionsBuilder));
+
+        var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder).ApplyDefaults(optionsBuilder.Options);
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        return optionsBuilder;
+    }
+    private static DbContextOptionsBuilder ApplyConfiguration(
+        DbContextOptionsBuilder optionsBuilder,
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction)
+    {
+        ConfigureWarnings(optionsBuilder);
+
+        azureSqlOptionsAction?.Invoke(new AzureSqlDbContextOptionsBuilder(optionsBuilder));
+
+        var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder).ApplyDefaults(optionsBuilder.Options);
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        return optionsBuilder;
+    }
+    private static DbContextOptionsBuilder ApplyConfiguration(
+        DbContextOptionsBuilder optionsBuilder,
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction)
+    {
+        ConfigureWarnings(optionsBuilder);
+
+        azureSynapseOptionsAction?.Invoke(new AzureSynapseDbContextOptionsBuilder(optionsBuilder));
+
+        var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder).ApplyDefaults(optionsBuilder.Options);
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        return optionsBuilder;
+    }
+    private static DbContextOptionsBuilder ApplyConfiguration(
+        DbContextOptionsBuilder optionsBuilder,
+        Action<SqlEngineDbContextOptionsBuilder>? sqlEngineOptionsAction)
+    {
+        ConfigureWarnings(optionsBuilder);
+
+        sqlEngineOptionsAction?.Invoke(new SqlEngineDbContextOptionsBuilder(optionsBuilder));
 
         var extension = GetOrCreateExtension<SqlServerOptionsExtension>(optionsBuilder).ApplyDefaults(optionsBuilder.Options);
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -52,7 +52,7 @@ public static class SqlServerServiceCollectionExtensions
     /// <typeparam name="TContext">The type of context to be registered.</typeparam>
     /// <param name="serviceCollection">The <see cref="IServiceCollection" /> to add services to.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server specific configuration.</param>
     /// <param name="optionsAction">An optional action to configure the <see cref="DbContextOptions" /> for the context.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
     public static IServiceCollection AddSqlServer<TContext>(
@@ -126,20 +126,20 @@ public static class SqlServerServiceCollectionExtensions
     /// <typeparam name="TContext">The type of context to be registered.</typeparam>
     /// <param name="serviceCollection">The <see cref="IServiceCollection" /> to add services to.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSqlOptionsAction">An optional action to allow additional Azure SQL specific configuration.</param>
     /// <param name="optionsAction">An optional action to configure the <see cref="DbContextOptions" /> for the context.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
     public static IServiceCollection AddAzureSql<TContext>(
         this IServiceCollection serviceCollection,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null,
+        Action<AzureSqlDbContextOptionsBuilder>? azureSqlOptionsAction = null,
         Action<DbContextOptionsBuilder>? optionsAction = null)
         where TContext : DbContext
         => serviceCollection.AddDbContext<TContext>(
             (_, options) =>
             {
                 optionsAction?.Invoke(options);
-                options.UseAzureSql(connectionString, sqlServerOptionsAction);
+                options.UseAzureSql(connectionString, azureSqlOptionsAction);
             });
 
     /// <summary>
@@ -200,20 +200,20 @@ public static class SqlServerServiceCollectionExtensions
     /// <typeparam name="TContext">The type of context to be registered.</typeparam>
     /// <param name="serviceCollection">The <see cref="IServiceCollection" /> to add services to.</param>
     /// <param name="connectionString">The connection string of the database to connect to.</param>
-    /// <param name="sqlServerOptionsAction">An optional action to allow additional SQL Server, Azure SQL, Azure Synapse specific configuration.</param>
+    /// <param name="azureSynapseOptionsAction">An optional action to allow additional Azure Synapse specific configuration.</param>
     /// <param name="optionsAction">An optional action to configure the <see cref="DbContextOptions" /> for the context.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
     public static IServiceCollection AddAzureSynapse<TContext>(
         this IServiceCollection serviceCollection,
         string? connectionString,
-        Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null,
+        Action<AzureSynapseDbContextOptionsBuilder>? azureSynapseOptionsAction = null,
         Action<DbContextOptionsBuilder>? optionsAction = null)
         where TContext : DbContext
         => serviceCollection.AddDbContext<TContext>(
             (_, options) =>
             {
                 optionsAction?.Invoke(options);
-                options.UseAzureSynapse(connectionString, sqlServerOptionsAction);
+                options.UseAzureSynapse(connectionString, azureSynapseOptionsAction);
             });
 
     /// <summary>

--- a/src/EFCore.SqlServer/Infrastructure/AzureSqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/AzureSqlDbContextOptionsBuilder.cs
@@ -6,21 +6,21 @@ using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
-///     Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
+///     Allows Azure SQL specific configuration to be performed on <see cref="DbContextOptions" />.
 /// </summary>
 /// <remarks>
 ///     Instances of this class are returned from a call to 
-///     <see cref="O:SqlServerDbContextOptionsExtensions.UseSqlServer" />
+///     <see cref="O:SqlServerDbContextOptionsExtensions.UseAzureSql" /> 
 ///     and it is not designed to be directly constructed in your application code.
 /// </remarks>
-public class SqlServerDbContextOptionsBuilder
-    : RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>
+public class AzureSqlDbContextOptionsBuilder
+    : RelationalDbContextOptionsBuilder<AzureSqlDbContextOptionsBuilder, SqlServerOptionsExtension>
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="SqlServerDbContextOptionsBuilder" /> class.
+    ///     Initializes a new instance of the <see cref="AzureSqlDbContextOptionsBuilder" /> class.
     /// </summary>
     /// <param name="optionsBuilder">The options builder.</param>
-    public SqlServerDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+    public AzureSqlDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
         : base(optionsBuilder)
     {
     }
@@ -30,7 +30,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure SQL. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -41,7 +41,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure()
+    public virtual AzureSqlDbContextOptionsBuilder EnableRetryOnFailure()
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
     /// <summary>
@@ -49,7 +49,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure SQL. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -60,7 +60,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
+    public virtual AzureSqlDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount));
 
     /// <summary>
@@ -68,7 +68,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure SQL. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -80,7 +80,7 @@ public class SqlServerDbContextOptionsBuilder
     ///     </para>
     /// </remarks>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
+    public virtual AzureSqlDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, errorNumbersToAdd));
 
     /// <summary>
@@ -88,7 +88,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure SQL. It is pre-configured with
     ///         error numbers for transient errors that can be retried, but additional error numbers can also be supplied.
     ///     </para>
     ///     <para>
@@ -99,33 +99,24 @@ public class SqlServerDbContextOptionsBuilder
     /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
     /// <param name="maxRetryDelay">The maximum delay between retries.</param>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(
+    public virtual AzureSqlDbContextOptionsBuilder EnableRetryOnFailure(
         int maxRetryCount,
         TimeSpan maxRetryDelay,
         IEnumerable<int>? errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
 
     /// <summary>
-    ///     Sets the SQL Server compatibility level that EF Core will use when interacting with the database. This allows configuring EF
-    ///     Core to work with older (or newer) versions of SQL Server. Defaults to <c>150</c> (SQL Server 2019).
+    ///     Sets the Azure SQL compatibility level that EF Core will use when interacting with the database. This allows configuring EF
+    ///     Core to work with older (or newer) versions of Azure SQL. Defaults to <c>160</c>.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
-    ///     <see href="https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level">
-    ///         SQL Server
-    ///         documentation on compatibility level
+    ///     <see href="https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-database-scoped-configuration-transact-sql">
+    ///         Azure SQL documentation on compatibility level
     ///     </see>
     ///     for more information and examples.
     /// </remarks>
     /// <param name="compatibilityLevel"><see langword="false" /> to have null resource</param>
-    public virtual SqlServerDbContextOptionsBuilder UseCompatibilityLevel(int compatibilityLevel)
-        => WithOption(e => e.WithSqlServerCompatibilityLevel(compatibilityLevel));
-
-    /// <summary>
-    ///     Configures the context to use defaults optimized for Azure SQL, including retries on errors.
-    /// </summary>
-    /// <param name="enable">Whether the defaults should be enabled.</param>
-    [Obsolete("Use UseAzureSql instead of UseSqlServer with UseAzureSqlDefaults.")]
-    public virtual SqlServerDbContextOptionsBuilder UseAzureSqlDefaults(bool enable = true)
-        => WithOption(e => e.WithLegacyAzureSql(enable));
+    public virtual AzureSqlDbContextOptionsBuilder UseCompatibilityLevel(int compatibilityLevel)
+        => WithOption(e => e.WithAzureSqlCompatibilityLevel(compatibilityLevel));
 }

--- a/src/EFCore.SqlServer/Infrastructure/AzureSynapseDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/AzureSynapseDbContextOptionsBuilder.cs
@@ -6,21 +6,21 @@ using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
-///     Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
+///     Allows Azure Synapse specific configuration to be performed on <see cref="DbContextOptions" />.
 /// </summary>
 /// <remarks>
 ///     Instances of this class are returned from a call to 
-///     <see cref="O:SqlServerDbContextOptionsExtensions.UseSqlServer" />
+///     <see cref="O:SqlServerDbContextOptionsExtensions.UseAzureSynapse" /> 
 ///     and it is not designed to be directly constructed in your application code.
 /// </remarks>
-public class SqlServerDbContextOptionsBuilder
-    : RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>
+public class AzureSynapseDbContextOptionsBuilder
+    : RelationalDbContextOptionsBuilder<AzureSynapseDbContextOptionsBuilder, SqlServerOptionsExtension>
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="SqlServerDbContextOptionsBuilder" /> class.
+    ///     Initializes a new instance of the <see cref="AzureSynapseDbContextOptionsBuilder" /> class.
     /// </summary>
     /// <param name="optionsBuilder">The options builder.</param>
-    public SqlServerDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+    public AzureSynapseDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
         : base(optionsBuilder)
     {
     }
@@ -30,7 +30,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -41,7 +41,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure()
+    public virtual AzureSynapseDbContextOptionsBuilder EnableRetryOnFailure()
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
     /// <summary>
@@ -49,7 +49,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -60,7 +60,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
+    public virtual AzureSynapseDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount));
 
     /// <summary>
@@ -68,7 +68,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -80,7 +80,7 @@ public class SqlServerDbContextOptionsBuilder
     ///     </para>
     /// </remarks>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
+    public virtual AzureSynapseDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, errorNumbersToAdd));
 
     /// <summary>
@@ -88,7 +88,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried, but additional error numbers can also be supplied.
     ///     </para>
     ///     <para>
@@ -99,33 +99,24 @@ public class SqlServerDbContextOptionsBuilder
     /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
     /// <param name="maxRetryDelay">The maximum delay between retries.</param>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(
+    public virtual AzureSynapseDbContextOptionsBuilder EnableRetryOnFailure(
         int maxRetryCount,
         TimeSpan maxRetryDelay,
         IEnumerable<int>? errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
 
     /// <summary>
-    ///     Sets the SQL Server compatibility level that EF Core will use when interacting with the database. This allows configuring EF
-    ///     Core to work with older (or newer) versions of SQL Server. Defaults to <c>150</c> (SQL Server 2019).
+    ///     Sets the Azure Synapse compatibility level that EF Core will use when interacting with the database. This allows configuring EF
+    ///     Core to work with older (or newer) versions of Azure Synapse. Defaults to <c>30</c>.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
-    ///     <see href="https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level">
-    ///         SQL Server
-    ///         documentation on compatibility level
+    ///     <see href="https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-database-scoped-configuration-transact-sql">
+    ///         Azure Synapse documentation on compatibility level
     ///     </see>
     ///     for more information and examples.
     /// </remarks>
     /// <param name="compatibilityLevel"><see langword="false" /> to have null resource</param>
-    public virtual SqlServerDbContextOptionsBuilder UseCompatibilityLevel(int compatibilityLevel)
-        => WithOption(e => e.WithSqlServerCompatibilityLevel(compatibilityLevel));
-
-    /// <summary>
-    ///     Configures the context to use defaults optimized for Azure SQL, including retries on errors.
-    /// </summary>
-    /// <param name="enable">Whether the defaults should be enabled.</param>
-    [Obsolete("Use UseAzureSql instead of UseSqlServer with UseAzureSqlDefaults.")]
-    public virtual SqlServerDbContextOptionsBuilder UseAzureSqlDefaults(bool enable = true)
-        => WithOption(e => e.WithLegacyAzureSql(enable));
+    public virtual AzureSynapseDbContextOptionsBuilder UseCompatibilityLevel(int compatibilityLevel)
+        => WithOption(e => e.WithAzureSynapseCompatibilityLevel(compatibilityLevel));
 }

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -16,10 +16,10 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
 {
     private DbContextOptionsExtensionInfo? _info;
     private SqlServerEngineType _engineType;
-    private bool _legacyAzureSql;
     private int? _sqlServerCompatibilityLevel;
     private int? _azureSqlCompatibilityLevel;
     private int? _azureSynapseCompatibilityLevel;
+    private bool _useRetryStrategyByDefault;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -80,10 +80,10 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
         : base(copyFrom)
     {
         _engineType = copyFrom._engineType;
-        _legacyAzureSql = copyFrom._legacyAzureSql;
         _sqlServerCompatibilityLevel = copyFrom._sqlServerCompatibilityLevel;
         _azureSqlCompatibilityLevel = copyFrom._azureSqlCompatibilityLevel;
         _azureSynapseCompatibilityLevel = copyFrom._azureSynapseCompatibilityLevel;
+        _useRetryStrategyByDefault = copyFrom._useRetryStrategyByDefault;
     }
 
     /// <summary>
@@ -119,15 +119,6 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool LegacyAzureSql
-        => _legacyAzureSql;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public virtual int SqlServerCompatibilityLevel
         => _sqlServerCompatibilityLevel ?? SqlServerDefaultCompatibilityLevel;
 
@@ -148,6 +139,15 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
     /// </summary>
     public virtual int AzureSynapseCompatibilityLevel
         => _azureSynapseCompatibilityLevel ?? AzureSynapseDefaultCompatibilityLevel;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool UseRetryStrategyByDefault
+        => _useRetryStrategyByDefault;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -180,7 +180,7 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
         var clone = (SqlServerOptionsExtension)Clone();
 
         clone._engineType = SqlServerEngineType.SqlServer;
-        clone._legacyAzureSql = enable;
+        clone._useRetryStrategyByDefault = enable;
 
         return clone;
     }
@@ -230,14 +230,31 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
         return clone;
     }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlServerOptionsExtension WithUseRetryStrategyByDefault(bool enable)
+    {
+        var clone = (SqlServerOptionsExtension)Clone();
+
+        clone._useRetryStrategyByDefault = enable;
+
+        return clone;
+    }
+
     /// <inheritdoc />
     public virtual IDbContextOptionsExtension ApplyDefaults(IDbContextOptions options)
     {
         if (ExecutionStrategyFactory == null
-            && (EngineType == SqlServerEngineType.AzureSql || EngineType == SqlServerEngineType.AzureSynapse || LegacyAzureSql))
-        {
-            return WithExecutionStrategyFactory(c => new SqlServerRetryingExecutionStrategy(c));
-        }
+            && (EngineType == SqlServerEngineType.AzureSql
+                || EngineType == SqlServerEngineType.AzureSynapse
+                || UseRetryStrategyByDefault))
+            {
+                return WithExecutionStrategyFactory(c => new SqlServerRetryingExecutionStrategy(c));
+            }
 
         return this;
     }
@@ -313,11 +330,11 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
                         .Append(Extension._engineType)
                         .Append(' ');
 
-                    if (Extension._legacyAzureSql)
+                    if (Extension._useRetryStrategyByDefault)
                     {
                         builder
-                            .Append("LegacyAzureSql=")
-                            .Append(Extension._legacyAzureSql)
+                            .Append("UseRetryStrategyByDefault=")
+                            .Append(Extension._useRetryStrategyByDefault)
                             .Append(' ');
                     }
 
@@ -353,7 +370,7 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {
             debugInfo["EngineType"] = Extension.EngineType.ToString();
-            debugInfo["LegacyAzureSql"] = Extension.LegacyAzureSql.ToString();
+            debugInfo["UseRetryStrategyByDefault"] = Extension.UseRetryStrategyByDefault.ToString();
 
             if (Extension.SqlServerCompatibilityLevel is int sqlServerCompatibilityLevel)
             {

--- a/src/EFCore.SqlServer/Infrastructure/SqlEngineDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlEngineDbContextOptionsBuilder.cs
@@ -45,6 +45,25 @@ public class SqlEngineDbContextOptionsBuilder
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
     /// <summary>
+    ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" /> unless it is configured explicitly.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This strategy is specifically tailored to SQL Server, Azure SQL, Azure Synapse. It is pre-configured with
+    ///         error numbers for transient errors that can be retried.
+    ///     </para>
+    ///     <para>
+    ///         Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-connection-resiliency">Connection resiliency and database retries</see>
+    ///         for more information and examples.
+    ///     </para>
+    /// </remarks>
+    public virtual SqlEngineDbContextOptionsBuilder TryEnableRetryOnFailure()
+        => WithOption(e => e.WithUseRetryStrategyByDefault(true));
+
+    /// <summary>
     ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.SqlServer/Infrastructure/SqlEngineDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlEngineDbContextOptionsBuilder.cs
@@ -6,21 +6,21 @@ using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
-///     Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
+///     Allows SQL Server, Azure SQL, Azure Synapse specific configuration to be performed on <see cref="DbContextOptions" />.
 /// </summary>
 /// <remarks>
 ///     Instances of this class are returned from a call to 
-///     <see cref="O:SqlServerDbContextOptionsExtensions.UseSqlServer" />
+///     <see cref="O:SqlServerDbContextOptionsExtensions.ConfigureSqlEngine" />
 ///     and it is not designed to be directly constructed in your application code.
 /// </remarks>
-public class SqlServerDbContextOptionsBuilder
-    : RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>
+public class SqlEngineDbContextOptionsBuilder
+    : RelationalDbContextOptionsBuilder<SqlEngineDbContextOptionsBuilder, SqlServerOptionsExtension>
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="SqlServerDbContextOptionsBuilder" /> class.
     /// </summary>
     /// <param name="optionsBuilder">The options builder.</param>
-    public SqlServerDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+    public SqlEngineDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
         : base(optionsBuilder)
     {
     }
@@ -30,7 +30,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to SQL Server, Azure SQL, Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -41,7 +41,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure()
+    public virtual SqlEngineDbContextOptionsBuilder EnableRetryOnFailure()
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
     /// <summary>
@@ -49,7 +49,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to SQL Server, Azure SQL, Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -60,7 +60,7 @@ public class SqlServerDbContextOptionsBuilder
     ///         for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
+    public virtual SqlEngineDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount));
 
     /// <summary>
@@ -68,7 +68,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to SQL Server, Azure SQL, Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried.
     ///     </para>
     ///     <para>
@@ -80,7 +80,7 @@ public class SqlServerDbContextOptionsBuilder
     ///     </para>
     /// </remarks>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
+    public virtual SqlEngineDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, errorNumbersToAdd));
 
     /// <summary>
@@ -88,7 +88,7 @@ public class SqlServerDbContextOptionsBuilder
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This strategy is specifically tailored to SQL Server. It is pre-configured with
+    ///         This strategy is specifically tailored to SQL Server, Azure SQL, Azure Synapse. It is pre-configured with
     ///         error numbers for transient errors that can be retried, but additional error numbers can also be supplied.
     ///     </para>
     ///     <para>
@@ -99,33 +99,9 @@ public class SqlServerDbContextOptionsBuilder
     /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
     /// <param name="maxRetryDelay">The maximum delay between retries.</param>
     /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
-    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(
+    public virtual SqlEngineDbContextOptionsBuilder EnableRetryOnFailure(
         int maxRetryCount,
         TimeSpan maxRetryDelay,
         IEnumerable<int>? errorNumbersToAdd)
         => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
-
-    /// <summary>
-    ///     Sets the SQL Server compatibility level that EF Core will use when interacting with the database. This allows configuring EF
-    ///     Core to work with older (or newer) versions of SQL Server. Defaults to <c>150</c> (SQL Server 2019).
-    /// </summary>
-    /// <remarks>
-    ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
-    ///     <see href="https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level">
-    ///         SQL Server
-    ///         documentation on compatibility level
-    ///     </see>
-    ///     for more information and examples.
-    /// </remarks>
-    /// <param name="compatibilityLevel"><see langword="false" /> to have null resource</param>
-    public virtual SqlServerDbContextOptionsBuilder UseCompatibilityLevel(int compatibilityLevel)
-        => WithOption(e => e.WithSqlServerCompatibilityLevel(compatibilityLevel));
-
-    /// <summary>
-    ///     Configures the context to use defaults optimized for Azure SQL, including retries on errors.
-    /// </summary>
-    /// <param name="enable">Whether the defaults should be enabled.</param>
-    [Obsolete("Use UseAzureSql instead of UseSqlServer with UseAzureSqlDefaults.")]
-    public virtual SqlServerDbContextOptionsBuilder UseAzureSqlDefaults(bool enable = true)
-        => WithOption(e => e.WithLegacyAzureSql(enable));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
@@ -4904,6 +4904,6 @@ ORDER BY [l].[Id], [s0].[Id], [s0].[Id0]
             => "ComplexNavigations160";
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(b => b.UseSqlServerCompatibilityLevel(160));
+            => base.AddOptions(builder).UseSqlServer(b => b.UseCompatibilityLevel(160));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
@@ -8526,6 +8526,6 @@ ORDER BY [l].[Id], [s0].[c], [s0].[Id0], [s0].[Id00]
             => "ComplexNavigationsOwned160";
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(b => b.UseSqlServerCompatibilityLevel(160));
+            => base.AddOptions(builder).UseSqlServer(b => b.UseCompatibilityLevel(160));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServer160Test.cs
@@ -1467,6 +1467,6 @@ WHERE RAND() >= 0.0E0
     public class Fixture160 : NorthwindQuerySqlServerFixture<NoopModelCustomizer>
     {
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(b => b.UseSqlServerCompatibilityLevel(160));
+            => base.AddOptions(builder).UseSqlServer(b => b.UseCompatibilityLevel(160));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServer160Test.cs
@@ -3008,6 +3008,6 @@ GROUP BY [o].[ProductID]
     public class Fixture160 : NorthwindQuerySqlServerFixture<NoopModelCustomizer>
     {
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(b => b.UseSqlServerCompatibilityLevel(160));
+            => base.AddOptions(builder).UseSqlServer(b => b.UseCompatibilityLevel(160));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
@@ -258,7 +258,7 @@ WHERE [b].[Name] IN (N'foo', N'bar')
             // TODO: Figure out if there's a nice way to continue using the retrying strategy
             var sqlServerOptionsBuilder = new SqlServerDbContextOptionsBuilder(builder);
             sqlServerOptionsBuilder
-                .UseSqlServerCompatibilityLevel(120)
+                .UseCompatibilityLevel(120)
                 .ExecutionStrategy(d => new NonRetryingExecutionStrategy(d));
             return builder;
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -1119,6 +1119,6 @@ END IN (N'one', N'two', N'three')
 
         // Compatibility level 120 (SQL Server 2014) doesn't support OPENJSON
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(o => o.UseSqlServerCompatibilityLevel(120));
+            => base.AddOptions(builder).UseSqlServer(o => o.UseCompatibilityLevel(120));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
@@ -1991,7 +1991,7 @@ END IN (
             => SqlServerTestStoreFactory.Instance;
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).UseSqlServer(b => b.UseSqlServerCompatibilityLevel(160));
+            => base.AddOptions(builder).UseSqlServer(b => b.UseCompatibilityLevel(160));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {


### PR DESCRIPTION
Follow-up PR from https://github.com/dotnet/efcore/pull/34052#issuecomment-2272350356.

On `ConfigureSqlEngine` I kept the method name the same - `EnableRetryOnFailure`. But we can discuss that. I don't remember either what was the name we decided before. But makes sense to me to keep it same as on the rest.