### PR TITLE
[release/8.0] Find the discriminator property even if it is not string

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
@@ -15,6 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 public abstract class InternalTypeBaseBuilder : AnnotatableBuilder<TypeBase, InternalModelBuilder>,
     IConventionTypeBaseBuilder
 {
+    private static readonly bool UseOldBehavior34201 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue34201", out var enabled34201) && enabled34201;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -204,6 +207,7 @@ public abstract class InternalTypeBaseBuilder : AnnotatableBuilder<TypeBase, Int
                 || (memberInfo is PropertyInfo propertyInfo && propertyInfo.IsIndexerProperty()))
             {
                 if (existingProperty.GetTypeConfigurationSource() is ConfigurationSource existingTypeConfigurationSource
+                    && (typeConfigurationSource != null || UseOldBehavior34201)
                     && !typeConfigurationSource.Overrides(existingTypeConfigurationSource))
                 {
                     return null;

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -8646,7 +8646,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                         x.Property<string>("Name");
                         x.Property<int>("Discriminator");
 
-                        x.HasDiscriminator<int>("Discriminator")
+                        x.HasDiscriminator()
                             .HasValue(1)
                             .HasValue<Eagle>(2);
 


### PR DESCRIPTION
Fixes #34201

**Description**
When the discriminator property has the default name, but a non-default type then `HasDiscriminator()` returns `null`. This can be considered a regression, because after https://github.com/dotnet/efcore/pull/33622 the model snapshot always contains this line for affected models, so this issue now impacts many more users.

**Customer impact**
For affected models, all migration operations throw an exception. The workaround is to rename all non-string discriminators, but this is impractical for large models.

**How found**
Customer reported on 8.0.7

**Regression**
Yes, from 8.0.6

**Testing**
Test added.

**Risk**
Low. Quirk added.