### PR TITLE
API review updates:

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -406,11 +405,11 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder AlwaysCreateShadowIdProperty(
+    public static EntityTypeBuilder HasShadowId(
         this EntityTypeBuilder entityTypeBuilder,
         bool? alwaysCreate = true)
     {
-        entityTypeBuilder.Metadata.SetAlwaysCreateShadowIdProperty(alwaysCreate);
+        entityTypeBuilder.Metadata.SetHasShadowId(alwaysCreate);
 
         return entityTypeBuilder;
     }
@@ -430,11 +429,11 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder<TEntity> AlwaysCreateShadowIdProperty<TEntity>(
+    public static EntityTypeBuilder<TEntity> HasShadowId<TEntity>(
         this EntityTypeBuilder<TEntity> entityTypeBuilder,
         bool? alwaysCreate = true)
         where TEntity : class
-        => (EntityTypeBuilder<TEntity>)AlwaysCreateShadowIdProperty((EntityTypeBuilder)entityTypeBuilder, alwaysCreate);
+        => (EntityTypeBuilder<TEntity>)HasShadowId((EntityTypeBuilder)entityTypeBuilder, alwaysCreate);
 
     /// <summary>
     ///     Forces model building to always create a "__id" shadow property mapped to the JSON "id". This was the default
@@ -451,17 +450,17 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
-    public static IConventionEntityTypeBuilder? AlwaysCreateShadowIdProperty(
+    public static IConventionEntityTypeBuilder? HasShadowId(
         this IConventionEntityTypeBuilder entityTypeBuilder,
         bool? alwaysCreate,
         bool fromDataAnnotation = false)
     {
-        if (!entityTypeBuilder.CanSetAlwaysCreateShadowIdProperty(alwaysCreate, fromDataAnnotation))
+        if (!entityTypeBuilder.CanSetShadowId(alwaysCreate, fromDataAnnotation))
         {
             return null;
         }
 
-        entityTypeBuilder.Metadata.SetAlwaysCreateShadowIdProperty(alwaysCreate, fromDataAnnotation);
+        entityTypeBuilder.Metadata.SetHasShadowId(alwaysCreate, fromDataAnnotation);
 
         return entityTypeBuilder;
     }
@@ -481,14 +480,14 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the configuration can be applied.</returns>
-    public static bool CanSetAlwaysCreateShadowIdProperty(
+    public static bool CanSetShadowId(
         this IConventionEntityTypeBuilder entityTypeBuilder,
         bool? alwaysCreate,
         bool fromDataAnnotation = false)
     {
         Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
-        return entityTypeBuilder.CanSetAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty, alwaysCreate, fromDataAnnotation);
+        return entityTypeBuilder.CanSetAnnotation(CosmosAnnotationNames.HasShadowId, alwaysCreate, fromDataAnnotation);
     }
 
     /// <summary>
@@ -504,7 +503,7 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder IncludeDiscriminatorInJsonId(
+    public static EntityTypeBuilder HasDiscriminatorInJsonId(
         this EntityTypeBuilder entityTypeBuilder,
         bool? includeDiscriminator = true)
     {
@@ -512,8 +511,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.EntityTypeName
-                    : DiscriminatorInKeyBehavior.None);
+                    ? IdDiscriminatorMode.EntityType
+                    : IdDiscriminatorMode.None);
 
         return entityTypeBuilder;
     }
@@ -540,8 +539,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.RootEntityTypeName
-                    : DiscriminatorInKeyBehavior.None);
+                    ? IdDiscriminatorMode.RootEntityType
+                    : IdDiscriminatorMode.None);
 
         return entityTypeBuilder;
     }
@@ -559,10 +558,10 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder<TEntity> IncludeDiscriminatorInJsonId<TEntity>(
+    public static EntityTypeBuilder<TEntity> HasDiscriminatorInJsonId<TEntity>(
         this EntityTypeBuilder<TEntity> entityTypeBuilder, bool? includeDiscriminator = true)
         where TEntity : class
-        => (EntityTypeBuilder<TEntity>)IncludeDiscriminatorInJsonId((EntityTypeBuilder)entityTypeBuilder, includeDiscriminator);
+        => (EntityTypeBuilder<TEntity>)HasDiscriminatorInJsonId((EntityTypeBuilder)entityTypeBuilder, includeDiscriminator);
 
     /// <summary>
     ///     Includes the discriminator value of the root entity type in the JSON "id" value. This allows types with the same
@@ -597,10 +596,10 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
-    public static IConventionEntityTypeBuilder? IncludeDiscriminatorInJsonId(
+    public static IConventionEntityTypeBuilder? HasDiscriminatorInJsonId(
         this IConventionEntityTypeBuilder entityTypeBuilder, bool? includeDiscriminator, bool fromDataAnnotation = false)
     {
-        if (!entityTypeBuilder.CanSetIncludeDiscriminatorInJsonId(includeDiscriminator, fromDataAnnotation))
+        if (!entityTypeBuilder.CanSetDiscriminatorInJsonId(includeDiscriminator, fromDataAnnotation))
         {
             return null;
         }
@@ -609,8 +608,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.EntityTypeName
-                    : DiscriminatorInKeyBehavior.None, fromDataAnnotation);
+                    ? IdDiscriminatorMode.EntityType
+                    : IdDiscriminatorMode.None, fromDataAnnotation);
 
         return entityTypeBuilder;
     }
@@ -642,8 +641,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.EntityTypeName
-                    : DiscriminatorInKeyBehavior.None, fromDataAnnotation);
+                    ? IdDiscriminatorMode.EntityType
+                    : IdDiscriminatorMode.None, fromDataAnnotation);
 
         return entityTypeBuilder;
     }
@@ -663,7 +662,7 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the configuration can be applied.</returns>
-    public static bool CanSetIncludeDiscriminatorInJsonId(
+    public static bool CanSetDiscriminatorInJsonId(
         this IConventionEntityTypeBuilder entityTypeBuilder,
         bool? includeDiscriminator,
         bool fromDataAnnotation = false)
@@ -675,8 +674,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.EntityTypeName
-                    : DiscriminatorInKeyBehavior.None, fromDataAnnotation);
+                    ? IdDiscriminatorMode.EntityType
+                    : IdDiscriminatorMode.None, fromDataAnnotation);
     }
 
 
@@ -707,8 +706,8 @@ public static class CosmosEntityTypeBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.RootEntityTypeName
-                    : DiscriminatorInKeyBehavior.None, fromDataAnnotation);
+                    ? IdDiscriminatorMode.RootEntityType
+                    : IdDiscriminatorMode.None, fromDataAnnotation);
     }
 
     /// <summary>

--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -354,11 +353,11 @@ public static class CosmosEntityTypeExtensions
     ///     <see langword="true" /> to force __id creation, <see langword="false" /> to not force __id creation,
     ///     <see langword="null" /> to revert to the default setting.
     /// .</returns>
-    public static bool? GetAlwaysCreateShadowIdProperty(this IReadOnlyEntityType entityType)
+    public static bool? GetHasShadowId(this IReadOnlyEntityType entityType)
         => (entityType.BaseType != null
-                ? entityType.GetRootType().GetAlwaysCreateShadowIdProperty()
-                : (bool?)entityType[CosmosAnnotationNames.AlwaysCreateShadowIdProperty])
-            ?? entityType.Model.GetAlwaysCreateShadowIdProperty();
+                ? entityType.GetRootType().GetHasShadowId()
+                : (bool?)entityType[CosmosAnnotationNames.HasShadowId])
+            ?? entityType.Model.GetHasShadowIds();
 
     /// <summary>
     ///     Forces model building to always create a "__id" shadow property mapped to the JSON "id". This was the default
@@ -369,8 +368,8 @@ public static class CosmosEntityTypeExtensions
     ///     <see langword="true" /> to force __id creation, <see langword="false" /> to not force __id creation,
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
-    public static void SetAlwaysCreateShadowIdProperty(this IMutableEntityType entityType, bool? alwaysCreate)
-        => entityType.SetOrRemoveAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty, alwaysCreate);
+    public static void SetHasShadowId(this IMutableEntityType entityType, bool? alwaysCreate)
+        => entityType.SetOrRemoveAnnotation(CosmosAnnotationNames.HasShadowId, alwaysCreate);
 
     /// <summary>
     ///     Forces model building to always create a "__id" shadow property mapped to the JSON "id". This was the default
@@ -382,31 +381,31 @@ public static class CosmosEntityTypeExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    public static bool? SetAlwaysCreateShadowIdProperty(
+    public static bool? SetHasShadowId(
         this IConventionEntityType entityType,
         bool? alwaysCreate,
         bool fromDataAnnotation = false)
         => (bool?)entityType.SetOrRemoveAnnotation(
-            CosmosAnnotationNames.AlwaysCreateShadowIdProperty, alwaysCreate, fromDataAnnotation)?.Value;
+            CosmosAnnotationNames.HasShadowId, alwaysCreate, fromDataAnnotation)?.Value;
 
     /// <summary>
-    ///     Gets the <see cref="ConfigurationSource" /> for <see cref="GetAlwaysCreateShadowIdProperty"/>.
+    ///     Gets the <see cref="ConfigurationSource" /> for <see cref="GetHasShadowId"/>.
     /// </summary>
     /// <param name="entityType">The entity typer.</param>
     /// <returns>The <see cref="ConfigurationSource" />.</returns>
-    public static ConfigurationSource? GetAlwaysCreateShadowIdPropertyConfigurationSource(this IConventionEntityType entityType)
-        => entityType.FindAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty)?.GetConfigurationSource();
+    public static ConfigurationSource? GetHasShadowIdConfigurationSource(this IConventionEntityType entityType)
+        => entityType.FindAnnotation(CosmosAnnotationNames.HasShadowId)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns a value indicating whether the entity type discriminator should be included in the JSON "id" value.
     ///     Prior to EF Core 9, it was always included. Starting with EF Core 9, it is not included by default.
     /// </summary>
     /// <param name="entityType">The entity type.</param>
-    /// <returns>The <see cref="DiscriminatorInKeyBehavior"/> or <see langword="null" /> if not set.</returns>
-    public static DiscriminatorInKeyBehavior? GetDiscriminatorInKey(this IReadOnlyEntityType entityType)
+    /// <returns>The <see cref="IdDiscriminatorMode"/> or <see langword="null" /> if not set.</returns>
+    public static IdDiscriminatorMode? GetDiscriminatorInKey(this IReadOnlyEntityType entityType)
         => (entityType.BaseType != null
                 ? entityType.GetRootType().GetDiscriminatorInKey()
-                : (DiscriminatorInKeyBehavior?)entityType[CosmosAnnotationNames.DiscriminatorInKey])
+                : (IdDiscriminatorMode?)entityType[CosmosAnnotationNames.DiscriminatorInKey])
             ?? entityType.Model.GetDiscriminatorInKey();
 
     /// <summary>
@@ -414,7 +413,7 @@ public static class CosmosEntityTypeExtensions
     /// </summary>
     /// <param name="entityType">The entity type.</param>
     /// <param name="behavior">The behavior to use, or <see langword="null" /> to reset the behavior to the default.</param>
-    public static void SetDiscriminatorInKey(this IMutableEntityType entityType, DiscriminatorInKeyBehavior? behavior)
+    public static void SetDiscriminatorInKey(this IMutableEntityType entityType, IdDiscriminatorMode? behavior)
         => entityType.SetOrRemoveAnnotation(CosmosAnnotationNames.DiscriminatorInKey, behavior);
 
     /// <summary>
@@ -423,9 +422,9 @@ public static class CosmosEntityTypeExtensions
     /// <param name="entityType">The entity type.</param>
     /// <param name="behavior">The behavior to use, or <see langword="null" /> to reset the behavior to the default.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    public static DiscriminatorInKeyBehavior? SetDiscriminatorInKey(
-        this IConventionEntityType entityType, DiscriminatorInKeyBehavior? behavior, bool fromDataAnnotation = false)
-        => (DiscriminatorInKeyBehavior?)entityType.SetOrRemoveAnnotation(
+    public static IdDiscriminatorMode? SetDiscriminatorInKey(
+        this IConventionEntityType entityType, IdDiscriminatorMode? behavior, bool fromDataAnnotation = false)
+        => (IdDiscriminatorMode?)entityType.SetOrRemoveAnnotation(
             CosmosAnnotationNames.DiscriminatorInKey, behavior, fromDataAnnotation)?.Value;
 
     /// <summary>

--- a/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -118,9 +117,9 @@ public static class CosmosModelBuilderExtensions
     ///     <see langword="true" /> to force __id creation, <see langword="false" /> to not force __id creation,
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
-    public static ModelBuilder AlwaysCreateShadowIdProperties(this ModelBuilder modelBuilder, bool? alwaysCreate = true)
+    public static ModelBuilder HasShadowIds(this ModelBuilder modelBuilder, bool? alwaysCreate = true)
     {
-        modelBuilder.Model.SetAlwaysCreateShadowIdProperty(alwaysCreate);
+        modelBuilder.Model.SetHasShadowIds(alwaysCreate);
 
         return modelBuilder;
     }
@@ -138,7 +137,7 @@ public static class CosmosModelBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static ModelBuilder IncludeDiscriminatorInJsonId(
+    public static ModelBuilder HasDiscriminatorInJsonIds(
         this ModelBuilder modelBuilder,
         bool? includeDiscriminator = true)
     {
@@ -146,8 +145,8 @@ public static class CosmosModelBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.EntityTypeName
-                    : DiscriminatorInKeyBehavior.None);
+                    ? IdDiscriminatorMode.EntityType
+                    : IdDiscriminatorMode.None);
 
         return modelBuilder;
     }
@@ -174,8 +173,8 @@ public static class CosmosModelBuilderExtensions
             includeDiscriminator == null
                 ? null
                 : includeDiscriminator.Value
-                    ? DiscriminatorInKeyBehavior.RootEntityTypeName
-                    : DiscriminatorInKeyBehavior.None);
+                    ? IdDiscriminatorMode.RootEntityType
+                    : IdDiscriminatorMode.None);
 
         return modelBuilder;
     }

--- a/src/EFCore.Cosmos/Extensions/CosmosModelExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosModelExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Metadata;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -64,8 +63,8 @@ public static class CosmosModelExtensions
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The configured value.</returns>
-    public static bool? GetAlwaysCreateShadowIdProperty(this IReadOnlyModel model)
-        => (bool?)model[CosmosAnnotationNames.AlwaysCreateShadowIdProperty];
+    public static bool? GetHasShadowIds(this IReadOnlyModel model)
+        => (bool?)model[CosmosAnnotationNames.HasShadowId];
 
     /// <summary>
     ///     Forces model building to always create a "__id" shadow property mapped to the JSON "id". This was the default
@@ -76,8 +75,8 @@ public static class CosmosModelExtensions
     ///     <see langword="true" /> to force __id creation, <see langword="false" /> to not force __id creation,
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
-    public static void SetAlwaysCreateShadowIdProperty(this IMutableModel model, bool? alwaysCreate)
-        => model.SetOrRemoveAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty, alwaysCreate);
+    public static void SetHasShadowIds(this IMutableModel model, bool? alwaysCreate)
+        => model.SetOrRemoveAnnotation(CosmosAnnotationNames.HasShadowId, alwaysCreate);
 
     /// <summary>
     ///     Forces model building to always create a "__id" shadow property mapped to the JSON "id". This was the default
@@ -89,36 +88,36 @@ public static class CosmosModelExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    public static bool? SetAlwaysCreateShadowIdProperty(
+    public static bool? SetHasShadowIds(
         this IConventionModel model,
         bool? alwaysCreate,
         bool fromDataAnnotation = false)
-        => (bool?)model.SetOrRemoveAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty, alwaysCreate, fromDataAnnotation)?.Value;
+        => (bool?)model.SetOrRemoveAnnotation(CosmosAnnotationNames.HasShadowId, alwaysCreate, fromDataAnnotation)?.Value;
 
     /// <summary>
     ///     Gets the <see cref="ConfigurationSource" />
-    ///     for <see cref="GetAlwaysCreateShadowIdProperty(Microsoft.EntityFrameworkCore.Metadata.IReadOnlyModel)"/>.
+    ///     for <see cref="GetHasShadowIds"/>.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The <see cref="ConfigurationSource" />.</returns>
-    public static ConfigurationSource? GetAlwaysCreateShadowIdPropertyConfigurationSource(this IConventionModel model)
-        => model.FindAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty)?.GetConfigurationSource();
+    public static ConfigurationSource? GetHasShadowIdsConfigurationSource(this IConventionModel model)
+        => model.FindAnnotation(CosmosAnnotationNames.HasShadowId)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns a value indicating whether the entity type discriminator should be included in the JSON "id" value.
     ///     Prior to EF Core 9, it was always included. Starting with EF Core 9, it is not included by default.
     /// </summary>
     /// <param name="model">The model.</param>
-    /// <returns>The <see cref="DiscriminatorInKeyBehavior"/> or <see langword="null" /> if not set.</returns>
-    public static DiscriminatorInKeyBehavior? GetDiscriminatorInKey(this IReadOnlyModel model)
-        => (DiscriminatorInKeyBehavior?)model[CosmosAnnotationNames.DiscriminatorInKey];
+    /// <returns>The <see cref="IdDiscriminatorMode"/> or <see langword="null" /> if not set.</returns>
+    public static IdDiscriminatorMode? GetDiscriminatorInKey(this IReadOnlyModel model)
+        => (IdDiscriminatorMode?)model[CosmosAnnotationNames.DiscriminatorInKey];
 
     /// <summary>
     ///     Includes the entity type discriminator in the JSON "id".
     /// </summary>
     /// <param name="model">The model.</param>
     /// <param name="behavior">The behavior to use, or <see langword="null" /> to reset the behavior to the default.</param>
-    public static void SetDiscriminatorInKey(this IMutableModel model, DiscriminatorInKeyBehavior? behavior)
+    public static void SetDiscriminatorInKey(this IMutableModel model, IdDiscriminatorMode? behavior)
         => model.SetOrRemoveAnnotation(CosmosAnnotationNames.DiscriminatorInKey, behavior);
 
     /// <summary>
@@ -127,16 +126,16 @@ public static class CosmosModelExtensions
     /// <param name="model">The model.</param>
     /// <param name="behavior">The behavior to use, or <see langword="null" /> to reset the behavior to the default.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    public static DiscriminatorInKeyBehavior? SetDiscriminatorInKey(
+    public static IdDiscriminatorMode? SetDiscriminatorInKey(
         this IConventionModel model,
-        DiscriminatorInKeyBehavior? behavior,
+        IdDiscriminatorMode? behavior,
         bool fromDataAnnotation = false)
-        => (DiscriminatorInKeyBehavior?)model.SetOrRemoveAnnotation(
+        => (IdDiscriminatorMode?)model.SetOrRemoveAnnotation(
             CosmosAnnotationNames.DiscriminatorInKey, behavior, fromDataAnnotation)?.Value;
 
     /// <summary>
     ///     Gets the <see cref="ConfigurationSource" />
-    ///     for <see cref="GetAlwaysCreateShadowIdProperty(Microsoft.EntityFrameworkCore.Metadata.IReadOnlyModel)"/>.
+    ///     for <see cref="GetDiscriminatorInKey"/>.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The <see cref="ConfigurationSource" />.</returns>

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -514,9 +514,9 @@ public class CosmosModelValidator : ModelValidator
             }
 
             if (!entityType.IsDocumentRoot()
-                && entityType.FindAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty) != null)
+                && entityType.FindAnnotation(CosmosAnnotationNames.HasShadowId) != null)
             {
-                throw new InvalidOperationException(CosmosStrings.AlwaysCreateShadowIdPropertyOnNonRoot(entityType.DisplayName()));
+                throw new InvalidOperationException(CosmosStrings.HasShadowIdOnNonRoot(entityType.DisplayName()));
             }
         }
     }

--- a/src/EFCore.Cosmos/Metadata/Conventions/ContextContainerConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/ContextContainerConvention.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
@@ -103,7 +104,7 @@ public class CosmosJsonIdConvention
         // the appropriate values into a single string for the JSON `id` property.
 
         // The line below requires: IModelAnnotationChangedConvention, IPropertyAnnotationChangedConvention
-        var alwaysCreateId = entityType.GetAlwaysCreateShadowIdProperty();
+        var alwaysCreateId = entityType.GetHasShadowId();
         if (alwaysCreateId != true)
         {
             // The line below requires:
@@ -228,9 +229,9 @@ public class CosmosJsonIdConvention
                 }
                 break;
 
-            case CosmosAnnotationNames.AlwaysCreateShadowIdProperty:
+            case CosmosAnnotationNames.HasShadowId:
                 if (oldAnnotation?.Value != null
-                    || !Equals(annotation?.Value, entityTypeBuilder.ModelBuilder.Metadata.GetAlwaysCreateShadowIdProperty()))
+                    || !Equals(annotation?.Value, entityTypeBuilder.ModelBuilder.Metadata.GetHasShadowIds()))
                 {
                     ProcessEntityType(entityTypeBuilder.Metadata, context);
                 }
@@ -309,7 +310,7 @@ public class CosmosJsonIdConvention
     {
         switch (name)
         {
-            case CosmosAnnotationNames.AlwaysCreateShadowIdProperty:
+            case CosmosAnnotationNames.HasShadowId:
             case CosmosAnnotationNames.DiscriminatorInKey:
                 foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
                 {

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosManyToManyJoinEntityTypeConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosManyToManyJoinEntityTypeConvention.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosPartitionKeyInPrimaryKeyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosPartitionKeyInPrimaryKeyConvention.cs
@@ -8,18 +8,14 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
-///     A convention that adds partition key properties to the EF primary key.
+///     A convention that adds partition key properties to the EF primary key and adds the '__jObject' containing the JSON
+///     object returned by the store.
 /// </summary>
 /// <remarks>
-///     <para>
-///         This convention also adds the '__jObject' containing the JSON object returned by the store.
-///     </para>
-///     <para>
-///         See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see>, and
-///         <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
-///     </para>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see>, and
+///     <see href="https://aka.ms/efcore-docs-cosmos">Accessing Azure Cosmos DB with EF Core</see> for more information and examples.
 /// </remarks>
-public class CosmosKeyAugmenterConvention :
+public class CosmosPartitionKeyInPrimaryKeyConvention :
     IEntityTypeAddedConvention,
     IPropertyAnnotationChangedConvention,
     IForeignKeyOwnershipChangedConvention,
@@ -40,10 +36,10 @@ public class CosmosKeyAugmenterConvention :
     public static readonly string JObjectPropertyName = "__jObject";
 
     /// <summary>
-    ///     Creates a new instance of <see cref="CosmosKeyAugmenterConvention" />.
+    ///     Creates a new instance of <see cref="CosmosPartitionKeyInPrimaryKeyConvention" />.
     /// </summary>
     /// <param name="dependencies">Parameter object containing dependencies for this convention.</param>
-    public CosmosKeyAugmenterConvention(ProviderConventionSetBuilderDependencies dependencies)
+    public CosmosPartitionKeyInPrimaryKeyConvention(ProviderConventionSetBuilderDependencies dependencies)
     {
         Dependencies = dependencies;
     }

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosRelationshipDiscoveryConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosRelationshipDiscoveryConvention.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable once CheckNamespace
-
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosRuntimeModelConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosRuntimeModelConvention.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Conventions/ETagPropertyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/ETagPropertyConvention.cs
@@ -1,7 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions;
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
 ///     A convention that adds etag metadata on the concurrency token, if present.

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -50,7 +50,7 @@ public class CosmosConventionSetBuilder : ProviderConventionSetBuilder
 
         conventionSet.Add(new ContextContainerConvention(Dependencies));
         conventionSet.Add(new ETagPropertyConvention());
-        conventionSet.Add(new CosmosKeyAugmenterConvention(Dependencies));
+        conventionSet.Add(new CosmosPartitionKeyInPrimaryKeyConvention(Dependencies));
         conventionSet.Add(new CosmosJsonIdConvention(Dependencies, DefinitionFactory));
         conventionSet.Remove(typeof(ForeignKeyIndexConvention));
 

--- a/src/EFCore.Cosmos/Metadata/IdDiscriminatorMode.cs
+++ b/src/EFCore.Cosmos/Metadata/IdDiscriminatorMode.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata;
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
 ///    Defines the behavior for including discriminator values in the JSON "id" value.
 /// </summary>
-public enum DiscriminatorInKeyBehavior
+public enum IdDiscriminatorMode
 {
     /// <summary>
     ///     No discriminator value is included in the "id" value.
@@ -16,11 +17,11 @@ public enum DiscriminatorInKeyBehavior
     /// <summary>
     ///     The discriminator value of the entity type is included in the "id" value. This was the default behavior before EF Core 9.
     /// </summary>
-    EntityTypeName,
+    EntityType,
 
     /// <summary>
     ///     The discriminator value of the root entity type is included in the "id" value. This allows types with the same
     ///     primary key to be saved in the same container, while still allowing "ReadItem" to be used for lookups of an unknown type.
     /// </summary>
-    RootEntityTypeName
+    RootEntityType
 }

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
@@ -97,7 +97,7 @@ public static class CosmosAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public const string AlwaysCreateShadowIdProperty = Prefix + "AlwaysCreateShadowIdProperty";
+    public const string HasShadowId = Prefix + nameof(HasShadowId);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinitionFactory.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinitionFactory.cs
@@ -51,7 +51,7 @@ public class JsonIdDefinitionFactory : IJsonIdDefinitionFactory
 
         var includeDiscriminator = entityType.GetDiscriminatorInKey();
 
-        if (includeDiscriminator is DiscriminatorInKeyBehavior.EntityTypeName or DiscriminatorInKeyBehavior.RootEntityTypeName)
+        if (includeDiscriminator is IdDiscriminatorMode.EntityType or IdDiscriminatorMode.RootEntityType)
         {
             var discriminator = entityType.GetDiscriminatorValue();
             // If the discriminator is not part of the primary key already, then add it to the Cosmos `id`.
@@ -61,7 +61,7 @@ public class JsonIdDefinitionFactory : IJsonIdDefinitionFactory
                 if (!primaryKey.Properties.Contains(discriminatorProperty))
                 {
                     // Use the actual type for backwards compat, but the base type to allow lookup using ReadItem.
-                    return includeDiscriminator is DiscriminatorInKeyBehavior.EntityTypeName
+                    return includeDiscriminator is IdDiscriminatorMode.EntityType
                         ? new JsonIdDefinition(properties, entityType, false)
                         : new JsonIdDefinition(properties, entityType.GetRootType(), true);
                 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -24,14 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.Cosmos.Properties.CosmosStrings", typeof(CosmosStrings).Assembly);
 
         /// <summary>
-        ///     'AlwaysCreateShadowIdProperty' was called on a non-root entity type '{entityType}'. JSON 'id' configuration can only be made on the document root.
-        /// </summary>
-        public static string AlwaysCreateShadowIdPropertyOnNonRoot(object? entityType)
-            => string.Format(
-                GetString("AlwaysCreateShadowIdPropertyOnNonRoot", nameof(entityType)),
-                entityType);
-
-        /// <summary>
         ///     The time to live for analytical store was configured to '{ttl1}' on '{entityType1}', but on '{entityType2}' it was configured to '{ttl2}'. All entity types mapped to the same container '{container}' must be configured with the same time to live for analytical store.
         /// </summary>
         public static string AnalyticalTTLMismatch(object? ttl1, object? entityType1, object? entityType2, object? ttl2, object? container)
@@ -102,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 ttl1, entityType1, entityType2, ttl2, container);
 
         /// <summary>
-        ///     'IncludeDiscriminatorInJsonId' or 'IncludeRootDiscriminatorInJsonId' was called on a non-root entity type '{entityType}'. Discriminator configuration for the JSON 'id' property can only be made on the document root.
+        ///     'HasDiscriminatorInJsonId' or 'HasRootDiscriminatorInJsonId' was called on a non-root entity type '{entityType}'. Discriminator configuration for the JSON 'id' property can only be made on the document root.
         /// </summary>
         public static string DiscriminatorInKeyOnNonRoot(object? entityType)
             => string.Format(
@@ -138,6 +130,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         /// </summary>
         public static string ExceptNotSupported
             => GetString("ExceptNotSupported");
+
+        /// <summary>
+        ///     'HasShadowId' was called on a non-root entity type '{entityType}'. JSON 'id' configuration can only be made on the document root.
+        /// </summary>
+        public static string HasShadowIdOnNonRoot(object? entityType)
+            => string.Format(
+                GetString("HasShadowIdOnNonRoot", nameof(entityType)),
+                entityType);
 
         /// <summary>
         ///     The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AlwaysCreateShadowIdPropertyOnNonRoot" xml:space="preserve">
-    <value>'AlwaysCreateShadowIdProperty' was called on a non-root entity type '{entityType}'. JSON 'id' configuration can only be made on the document root.</value>
-  </data>
   <data name="AnalyticalTTLMismatch" xml:space="preserve">
     <value>The time to live for analytical store was configured to '{ttl1}' on '{entityType1}', but on '{entityType2}' it was configured to '{ttl2}'. All entity types mapped to the same container '{container}' must be configured with the same time to live for analytical store.</value>
   </data>
@@ -151,7 +148,7 @@
     <value>The default time to live was configured to '{ttl1}' on '{entityType1}', but on '{entityType2}' it was configured to '{ttl2}'. All entity types mapped to the same container '{container}' must be configured with the same default time to live.</value>
   </data>
   <data name="DiscriminatorInKeyOnNonRoot" xml:space="preserve">
-    <value>'IncludeDiscriminatorInJsonId' or 'IncludeRootDiscriminatorInJsonId' was called on a non-root entity type '{entityType}'. Discriminator configuration for the JSON 'id' property can only be made on the document root.</value>
+    <value>'HasDiscriminatorInJsonId' or 'HasRootDiscriminatorInJsonId' was called on a non-root entity type '{entityType}'. Discriminator configuration for the JSON 'id' property can only be made on the document root.</value>
   </data>
   <data name="DuplicateDiscriminatorValue" xml:space="preserve">
     <value>The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type mapped to the container '{container}' must have a unique discriminator value.</value>
@@ -164,6 +161,9 @@
   </data>
   <data name="ExceptNotSupported" xml:space="preserve">
     <value>The 'Except()' LINQ operator isn't supported by Cosmos.</value>
+  </data>
+  <data name="HasShadowIdOnNonRoot" xml:space="preserve">
+    <value>'HasShadowId' was called on a non-root entity type '{entityType}'. JSON 'id' configuration can only be made on the document root.</value>
   </data>
   <data name="IdNonStringStoreType" xml:space="preserve">
     <value>The type of the '{idProperty}' property on '{entityType}' is '{propertyType}'. All 'id' properties must be strings or have a string value converter.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -622,7 +622,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             IProperty property,
             Type type)
         {
-            if (property.Name == CosmosKeyAugmenterConvention.JObjectPropertyName)
+            if (property.Name == CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName)
             {
                 return _projectionBindings[jTokenExpression];
             }

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/EntityProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/EntityProjectionExpression.cs
@@ -118,7 +118,7 @@ public class EntityProjectionExpression : Expression, IPrintableExpression, IAcc
             // TODO: Remove once __jObject is translated to the access root in a better fashion and
             // would not otherwise be found to be non-translatable. See issues #17670 and #14121.
             // TODO: We shouldn't be returning null from here
-            && property.Name != CosmosKeyAugmenterConvention.JObjectPropertyName
+            && property.Name != CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName
             && expression.PropertyName?.Length is null or 0)
         {
             // Non-persisted property can't be translated

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -491,13 +491,13 @@ public class CosmosClientWrapper : ICosmosClientWrapper
             {
                 case EntityState.Modified:
                 {
-                    var jObjectProperty = entry.EntityType.FindProperty(CosmosKeyAugmenterConvention.JObjectPropertyName);
+                    var jObjectProperty = entry.EntityType.FindProperty(CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName);
                     enabledContentResponse = (jObjectProperty?.ValueGenerated & ValueGenerated.OnUpdate) == ValueGenerated.OnUpdate;
                     break;
                 }
                 case EntityState.Added:
                 {
-                    var jObjectProperty = entry.EntityType.FindProperty(CosmosKeyAugmenterConvention.JObjectPropertyName);
+                    var jObjectProperty = entry.EntityType.FindProperty(CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName);
                     enabledContentResponse = (jObjectProperty?.ValueGenerated & ValueGenerated.OnAdd) == ValueGenerated.OnAdd;
                     break;
                 }
@@ -536,7 +536,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
             entry.SetStoreGeneratedValue(etagProperty, response.Headers.ETag);
         }
 
-        var jObjectProperty = entry.EntityType.FindProperty(CosmosKeyAugmenterConvention.JObjectPropertyName);
+        var jObjectProperty = entry.EntityType.FindProperty(CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName);
         if (jObjectProperty is { ValueGenerated: ValueGenerated.OnAddOrUpdate }
             && response.Content != null)
         {

--- a/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
+++ b/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
@@ -36,7 +36,7 @@ public class DocumentSource
         _database = database;
         _entityType = entityType;
         _idProperty = entityType.GetProperties().FirstOrDefault(p => p.GetJsonPropertyName() == CosmosJsonIdConvention.IdPropertyJsonName);
-        _jObjectProperty = entityType.FindProperty(CosmosKeyAugmenterConvention.JObjectPropertyName);
+        _jObjectProperty = entityType.FindProperty(CosmosPartitionKeyInPrimaryKeyConvention.JObjectPropertyName);
     }
 
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
@@ -100,7 +100,7 @@ WHERE ((c["$type"] = "BuiltInDataTypes") AND (c["Id"] = 13))
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
 
             var shadowJObject = (Property)modelBuilder.Entity<BuiltInDataTypesShadow>().Property("__jObject").Metadata;
             shadowJObject.SetConfigurationSource(ConfigurationSource.Convention);

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -184,7 +184,7 @@ WHERE (c["$type"] IN ("Blog", "RssBlog") AND NOT((c["IndexerVisible"] = "Aye")))
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
 
             var shadowJObject = (Property)modelBuilder.Entity<BuiltInDataTypesShadow>().Property("__jObject").Metadata;
             shadowJObject.SetConfigurationSource(ConfigurationSource.Convention);

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -732,7 +732,7 @@ OFFSET 0 LIMIT 1
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
 
             modelBuilder.Entity<Vehicle>(
                 eb =>

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -1540,12 +1540,12 @@ OFFSET 0 LIMIT 1
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
 
             modelBuilder.Entity<Customer>(
                 cb =>
                 {
-                    cb.AlwaysCreateShadowIdProperty();
+                    cb.HasShadowId();
 
                     cb.HasPartitionKey(
                         c => new

--- a/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
@@ -39,7 +39,7 @@ public class F1CosmosFixture<TRowVersion> : F1FixtureBase<TRowVersion>
     {
         base.BuildModelExternal(modelBuilder);
 
-        modelBuilder.IncludeDiscriminatorInJsonId();
+        modelBuilder.HasDiscriminatorInJsonIds();
 
         modelBuilder.Entity<Engine>(
             b =>

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -199,7 +199,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
             modelBuilder.Entity<Customer>(
                 b =>
                 {
-                    b.HasAnnotation(CosmosAnnotationNames.AlwaysCreateShadowIdProperty, true);
+                    b.HasAnnotation(CosmosAnnotationNames.HasShadowId, true);
                     b.HasKey(CosmosJsonIdConvention.DefaultIdPropertyName);
 
                     b.Ignore(b => b.Details)
@@ -223,7 +223,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
             modelBuilder.Entity<Customer>().HasKey(CosmosJsonIdConvention.DefaultIdPropertyName);
 
             modelBuilder.Entity<Customer>()
@@ -304,7 +304,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
             modelBuilder.Entity<Customer>().HasKey(CosmosJsonIdConvention.DefaultIdPropertyName);
 
             modelBuilder.Entity<Customer>()
@@ -328,7 +328,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
             modelBuilder.Entity<Customer>().HasKey(nameof(Customer.AlternateKey), CosmosJsonIdConvention.DefaultIdPropertyName);
 
             modelBuilder.Entity<Customer>()
@@ -352,7 +352,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
 
             modelBuilder.Entity<Customer>().HasKey(
                 nameof(Customer.AlternateKey),
@@ -397,7 +397,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
 
             modelBuilder.Entity<Customer>().HasKey(
                 nameof(Customer.Title),
@@ -442,7 +442,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<Customer>().AlwaysCreateShadowIdProperty();
+            modelBuilder.Entity<Customer>().AlwaysHasShadowId();
 
             modelBuilder.Entity<Customer>().HasKey(
                 nameof(Customer.Title),

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
@@ -26,7 +26,7 @@ public static class CosmosTestModelBuilderExtensions
         return builder;
     }
 
-    public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> AlwaysCreateShadowIdProperty<TEntity>(
+    public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> AlwaysHasShadowId<TEntity>(
         this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
         bool? alwaysCreate = true)
         where TEntity : class
@@ -34,10 +34,10 @@ public static class CosmosTestModelBuilderExtensions
         switch (builder)
         {
             case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
-                genericBuilder.Instance.AlwaysCreateShadowIdProperty(alwaysCreate);
+                genericBuilder.Instance.HasShadowId(alwaysCreate);
                 break;
             case IInfrastructure<EntityTypeBuilder> nonGenericBuilder:
-                nonGenericBuilder.Instance.AlwaysCreateShadowIdProperty(alwaysCreate);
+                nonGenericBuilder.Instance.HasShadowId(alwaysCreate);
                 break;
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosFixture.cs
@@ -31,7 +31,7 @@ public class JsonQueryCosmosFixture : JsonQueryFixtureBase
 
         modelBuilder.Entity<JsonEntityBasic>()
             .ToContainer("JsonEntities")
-            .IncludeDiscriminatorInJsonId()
+            .HasDiscriminatorInJsonId()
             .HasDiscriminator<string>("Discriminator").HasValue("Basic");
 
         modelBuilder.Entity<EntityBasic>().ToContainer("EntitiesBasic");
@@ -81,12 +81,12 @@ public class JsonQueryCosmosFixture : JsonQueryFixtureBase
 
         modelBuilder.Entity<JsonEntityCustomNaming>()
             .ToContainer("JsonEntities")
-            .IncludeDiscriminatorInJsonId()
+            .HasDiscriminatorInJsonId()
             .HasDiscriminator<string>("Discriminator").HasValue("CustomNaming");
 
         modelBuilder.Entity<JsonEntitySingleOwned>()
             .ToContainer("JsonEntities")
-            .IncludeDiscriminatorInJsonId()
+            .HasDiscriminatorInJsonId()
             .HasDiscriminator<string>("Discriminator").HasValue("SingleOwned");
 
         modelBuilder.Entity<JsonEntitySingleOwned>().OwnsMany(
@@ -139,7 +139,7 @@ public class JsonQueryCosmosFixture : JsonQueryFixtureBase
 
         modelBuilder.Entity<JsonEntityAllTypes>()
             .ToContainer("JsonEntities")
-            .IncludeDiscriminatorInJsonId()
+            .HasDiscriminatorInJsonId()
             .HasDiscriminator<string>("Discriminator").HasValue("AllTypes");
 
         modelBuilder.Entity<JsonEntityAllTypes>().OwnsOne(
@@ -181,7 +181,7 @@ public class JsonQueryCosmosFixture : JsonQueryFixtureBase
 
         modelBuilder.Entity<JsonEntityConverters>()
             .ToContainer("JsonEntities")
-            .IncludeDiscriminatorInJsonId()
+            .HasDiscriminatorInJsonId()
             .HasDiscriminator<string>("Discriminator").HasValue("Converters");
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -1627,7 +1627,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
                 pb =>
                 {
                     pb.ToContainer("Planets");
-                    pb.IncludeDiscriminatorInJsonId();
+                    pb.HasDiscriminatorInJsonId();
                     pb.HasData(
                         new
                         {
@@ -1641,7 +1641,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
                 mb =>
                 {
                     mb.ToContainer("Planets");
-                    mb.IncludeDiscriminatorInJsonId();
+                    mb.HasDiscriminatorInJsonId();
                     mb.HasData(
                         new
                         {
@@ -1656,7 +1656,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
                 sb =>
                 {
                     sb.ToContainer("Planets");
-                    sb.IncludeDiscriminatorInJsonId();
+                    sb.HasDiscriminatorInJsonId();
                     sb.HasData(
                         new
                         {
@@ -1689,7 +1689,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
                 b =>
                 {
                     b.ToContainer("Bartons");
-                    b.IncludeDiscriminatorInJsonId();
+                    b.HasDiscriminatorInJsonId();
                     b.OwnsOne(
                         e => e.Throned, b => b.HasData(
                             new
@@ -1707,7 +1707,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
                 b =>
                 {
                     b.ToContainer("Bartons");
-                    b.IncludeDiscriminatorInJsonId();
+                    b.HasDiscriminatorInJsonId();
                     b.HasData(
                         new { Id = 1, BartonId = 1 });
                 });

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
@@ -967,7 +967,7 @@ OFFSET 0 LIMIT 2
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
         }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/QueryExpressionInterceptionWithDiagnosticsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/QueryExpressionInterceptionWithDiagnosticsCosmosTest.cs
@@ -36,7 +36,7 @@ public class QueryExpressionInterceptionWithDiagnosticsCosmosTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeDiscriminatorInJsonId();
+            modelBuilder.HasDiscriminatorInJsonIds();
         }
 
         protected override string StoreName

--- a/test/EFCore.Cosmos.Tests/ValueGeneration/IdValueGeneratorTest.cs
+++ b/test/EFCore.Cosmos.Tests/ValueGeneration/IdValueGeneratorTest.cs
@@ -10,7 +10,7 @@ public class IdValueGeneratorTest
     {
         var modelBuilder = CosmosTestHelpers.Instance.CreateConventionBuilder();
 
-        modelBuilder.IncludeDiscriminatorInJsonId();
+        modelBuilder.HasDiscriminatorInJsonIds();
 
         modelBuilder.Entity<Blog>().HasKey(p => new { p.OtherId, p.Id });
         modelBuilder.Entity<Post>().HasKey(p => new { p.OtherId, p.Id });


### PR DESCRIPTION
- Rename `AlwaysCreateShadowIdProperty` to `HasShadowId` and `HasShadowIds` (on the model builder)
- Rename `IncludeDiscriminatorInJsonId` to `HasDiscriminatorInJsonId` and `HasDiscriminatorInJsonIds`. Same for the related methods
- Rename `DiscriminatorInKeyBehavior` to `IdDiscriminatorMode` and move it to `Microsoft.EntityFrameworkCore.Metadata`
- Rename `DiscriminatorInKeyBehavior.(Root)EntityTypeName` to `(Root)EntityType`
- Move `ETagPropertyConvention` to `Microsoft.EntityFrameworkCore.Metadata.Conventions`
- Consider merging `CosmosKeyAugmenterConvention` with `CosmosKeyDiscoveryConvention`, otherwise propose a better name for it.
  - Tried it. Got messy. Renamed to `CosmosPartitionKeyInPrimaryKeyConvention`. I'm sure it will be dicussed again.
- Check why the obsolete methods on `RelationalSqlTranslatingExpressionVisitor` haven't been removed in the initial pass
  - Because it seems we didn't do the pass at the start of EF9
