### PR TITLE
API review fixes

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -50,7 +50,7 @@ public interface ISqlExpressionFactory
         SqlExpression left,
         SqlExpression right,
         CoreTypeMapping? typeMapping,
-        SqlExpression? existingExpr = null);
+        SqlExpression? existingExpression = null);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -320,14 +320,14 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
         SqlExpression left,
         SqlExpression right,
         CoreTypeMapping? typeMapping,
-        SqlExpression? existingExpr = null)
+        SqlExpression? existingExpression = null)
     {
         switch (operatorType)
         {
             case ExpressionType.AndAlso:
-                return ApplyTypeMapping(AndAlso(left, right, existingExpr), typeMapping);
+                return ApplyTypeMapping(AndAlso(left, right, existingExpression), typeMapping);
             case ExpressionType.OrElse:
-                return ApplyTypeMapping(OrElse(left, right, existingExpr), typeMapping);
+                return ApplyTypeMapping(OrElse(left, right, existingExpression), typeMapping);
         }
 
         if (!SqlBinaryExpression.IsValidOperator(operatorType))
@@ -424,7 +424,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     public virtual SqlExpression AndAlso(SqlExpression left, SqlExpression right)
         => MakeBinary(ExpressionType.AndAlso, left, right, null)!;
 
-    private SqlExpression AndAlso(SqlExpression left, SqlExpression right, SqlExpression? existingExpr)
+    private SqlExpression AndAlso(SqlExpression left, SqlExpression right, SqlExpression? existingExpression)
     {
         // false && x -> false
         // x && true -> x
@@ -450,11 +450,11 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
             // the case in which left and right are the same expression is handled above
             return Constant(false);
         }
-        if (existingExpr is SqlBinaryExpression { OperatorType: ExpressionType.AndAlso } binaryExpr
+        if (existingExpression is SqlBinaryExpression { OperatorType: ExpressionType.AndAlso } binaryExpr
             && left == binaryExpr.Left
             && right == binaryExpr.Right)
         {
-            return existingExpr;
+            return existingExpression;
         }
 
         return new SqlBinaryExpression(ExpressionType.AndAlso, left, right, typeof(bool), null);
@@ -469,7 +469,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     public virtual SqlExpression OrElse(SqlExpression left, SqlExpression right)
         => MakeBinary(ExpressionType.OrElse, left, right, null)!;
 
-    private SqlExpression OrElse(SqlExpression left, SqlExpression right, SqlExpression? existingExpr)
+    private SqlExpression OrElse(SqlExpression left, SqlExpression right, SqlExpression? existingExpression)
     {
         // true || x -> true
         // x || false -> x
@@ -496,11 +496,11 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
             // the case in which left and right are the same expression is handled above
             return Constant(true);
         }
-        if (existingExpr is SqlBinaryExpression { OperatorType: ExpressionType.OrElse } binaryExpr
+        if (existingExpression is SqlBinaryExpression { OperatorType: ExpressionType.OrElse } binaryExpr
             && left == binaryExpr.Left
             && right == binaryExpr.Right)
         {
-            return existingExpr;
+            return existingExpression;
         }
 
         return new SqlBinaryExpression(ExpressionType.OrElse, left, right, typeof(bool), null);

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
-using Microsoft.EntityFrameworkCore.Query.Design;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Query.Design;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 

--- a/src/EFCore.Design/Query/IPrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/IPrecompiledQueryCodeGenerator.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using static Microsoft.EntityFrameworkCore.Query.Internal.PrecompiledQueryCodeGenerator;
 
-namespace Microsoft.EntityFrameworkCore.Migrations.Design;
+namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
 ///     Used to generate code for precompiled queries.

--- a/src/EFCore.Design/Query/IPrecompiledQueryCodeGeneratorSelector.cs
+++ b/src/EFCore.Design/Query/IPrecompiledQueryCodeGeneratorSelector.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.EntityFrameworkCore.Query.Design;
+namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
 ///     Selects an <see cref="IPrecompiledQueryCodeGenerator" /> service for a given programming language.

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGeneratorSelector.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGeneratorSelector.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Design.Internal;
-using Microsoft.EntityFrameworkCore.Query.Design;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -41,14 +41,14 @@ public interface ISqlExpressionFactory
     /// <param name="operand">A <see cref="SqlExpression" /> to apply unary operator on.</param>
     /// <param name="type">The type of the created expression.</param>
     /// <param name="typeMapping">A type mapping to be assigned to the created expression.</param>
-    /// <param name="existingExpr">An optional expression that can be re-used if it matches the new expression.</param>
+    /// <param name="existingExpression">An optional expression that can be re-used if it matches the new expression.</param>
     /// <returns>A <see cref="SqlExpression" /> with the given arguments.</returns>
     SqlExpression? MakeUnary(
         ExpressionType operatorType,
         SqlExpression operand,
         Type type,
         RelationalTypeMapping? typeMapping = null,
-        SqlExpression? existingExpr = null);
+        SqlExpression? existingExpression = null);
 
     /// <summary>
     ///     Creates a new <see cref="SqlExpression" /> with the given arguments.
@@ -57,14 +57,14 @@ public interface ISqlExpressionFactory
     /// <param name="left">The left operand of binary operation.</param>
     /// <param name="right">The right operand of binary operation.</param>
     /// <param name="typeMapping">A type mapping to be assigned to the created expression.</param>
-    /// <param name="existingExpr">An optional expression that can be re-used if it matches the new expression.</param>
+    /// <param name="existingExpression">An optional expression that can be re-used if it matches the new expression.</param>
     /// <returns>A <see cref="SqlExpression" /> with the given arguments.</returns>
     SqlExpression? MakeBinary(
         ExpressionType operatorType,
         SqlExpression left,
         SqlExpression right,
         RelationalTypeMapping? typeMapping,
-        SqlExpression? existingExpr = null);
+        SqlExpression? existingExpression = null);
 
     // Comparison
     /// <summary>
@@ -250,13 +250,13 @@ public interface ISqlExpressionFactory
     /// <param name="operand">An expression to compare with <see cref="CaseWhenClause.Test" /> in <paramref name="whenClauses" />.</param>
     /// <param name="whenClauses">A list of <see cref="CaseWhenClause" /> to compare or evaluate and get result from.</param>
     /// <param name="elseResult">A value to return if no <paramref name="whenClauses" /> matches, if any.</param>
-    /// <param name="existingExpr">An optional expression that can be re-used if it matches the new expression.</param>
+    /// <param name="existingExpression">An optional expression that can be re-used if it matches the new expression.</param>
     /// <returns>An expression representing a CASE statement in a SQL tree.</returns>
     SqlExpression Case(
         SqlExpression? operand,
         IReadOnlyList<CaseWhenClause> whenClauses,
         SqlExpression? elseResult,
-        SqlExpression? existingExpr = null);
+        SqlExpression? existingExpression = null);
 
     /// <summary>
     ///     Creates a new <see cref="CaseExpression" /> which represent a CASE statement in a SQL tree.


### PR DESCRIPTION
API review (#33220):

* Rename existingExpr in ISqlExpressionFactory.Case to existingExpression
* Move IPrecompiledQueryCodeGenerator/IPrecompiledQueryCodeGeneratorSelector to Microsoft.EntityFrameworkCore.Query (in the Design package)

Also some cleanup of RelationalTypeMappingPostprocessor