### PR TITLE
better perf in SupportedMethods calculation in SqlServerConvertTransl…

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerConvertTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerConvertTranslator.cs
@@ -41,14 +41,7 @@ public class SqlServerConvertTranslator : IMethodCallTranslator
         typeof(object)
     ];
 
-    private static readonly MethodInfo[] SupportedMethods
-        = TypeMapping.Keys
-            .SelectMany(
-                t => typeof(Convert).GetTypeInfo().GetDeclaredMethods(t)
-                    .Where(
-                        m => m.GetParameters().Length == 1
-                            && SupportedTypes.Contains(m.GetParameters().First().ParameterType)))
-            .ToArray();
+    private static readonly MethodInfo[] SupportedMethods;
 
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
@@ -61,6 +54,22 @@ public class SqlServerConvertTranslator : IMethodCallTranslator
     public SqlServerConvertTranslator(ISqlExpressionFactory sqlExpressionFactory)
     {
         _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    static SqlServerConvertTranslator()
+    {
+        var convertInfo = typeof(Convert).GetTypeInfo();
+        SupportedMethods = TypeMapping.Keys
+            .SelectMany(
+                name => convertInfo.GetDeclaredMethods(name)
+                    .Where(
+                        method =>
+                        {
+                            var parameters = method.GetParameters();
+                            return parameters.Length == 1
+                                && SupportedTypes.Contains(parameters[0].ParameterType);
+                        }))
+            .ToArray();
     }
 
     /// <summary>


### PR DESCRIPTION
 * take `typeof(Convert).GetTypeInfo()` outside the loop
 * avoid linq `.First().` and use index
 * cache `GetParameters`