### PR TITLE
Add missing Model Builder API

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
@@ -64,19 +64,7 @@ public class CosmosDatabaseCreator : IDatabaseCreator
             InsertData();
         }
 
-        var coreOptionsExtension =
-            _contextOptions.FindExtension<CoreOptionsExtension>()
-            ?? new CoreOptionsExtension();
-
-        var seed = coreOptionsExtension.Seeder;
-        if (seed != null)
-        {
-            seed(_currentContext.Context, created);
-        }
-        else if (coreOptionsExtension.AsyncSeeder != null)
-        {
-            throw new InvalidOperationException(CoreStrings.MissingSeeder);
-        }
+        SeedData(created);
 
         return created;
     }
@@ -104,19 +92,7 @@ public class CosmosDatabaseCreator : IDatabaseCreator
             await InsertDataAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var coreOptionsExtension =
-            _contextOptions.FindExtension<CoreOptionsExtension>()
-            ?? new CoreOptionsExtension();
-
-        var seedAsync = coreOptionsExtension.AsyncSeeder;
-        if (seedAsync != null)
-        {
-            await seedAsync(_currentContext.Context, created, cancellationToken).ConfigureAwait(false);
-        }
-        else if (coreOptionsExtension.Seeder != null)
-        {
-            throw new InvalidOperationException(CoreStrings.MissingSeeder);
-        }
+        await SeedDataAsync(created, cancellationToken).ConfigureAwait(false);
 
         return created;
     }
@@ -221,6 +197,52 @@ public class CosmosDatabaseCreator : IDatabaseCreator
         }
 
         return updateAdapter;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void SeedData(bool created)
+    {
+        var coreOptionsExtension =
+                    _contextOptions.FindExtension<CoreOptionsExtension>()
+                    ?? new CoreOptionsExtension();
+
+        var seed = coreOptionsExtension.Seeder;
+        if (seed != null)
+        {
+            seed(_currentContext.Context, created);
+        }
+        else if (coreOptionsExtension.AsyncSeeder != null)
+        {
+            throw new InvalidOperationException(CoreStrings.MissingSeeder);
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual async Task SeedDataAsync(bool created, CancellationToken cancellationToken = default)
+    {
+        var coreOptionsExtension =
+            _contextOptions.FindExtension<CoreOptionsExtension>()
+            ?? new CoreOptionsExtension();
+
+        var seedAsync = coreOptionsExtension.AsyncSeeder;
+        if (seedAsync != null)
+        {
+            await seedAsync(_currentContext.Context, created, cancellationToken).ConfigureAwait(false);
+        }
+        else if (coreOptionsExtension.Seeder != null)
+        {
+            throw new InvalidOperationException(CoreStrings.MissingSeeder);
+        }
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -141,6 +141,111 @@ public static class SqlServerEntityTypeBuilderExtensions
         => entityTypeBuilder.CanSetAnnotation(SqlServerAnnotationNames.MemoryOptimized, memoryOptimized, fromDataAnnotation);
 
     /// <summary>
+    ///     Sets a value indicating whether to use the SQL OUTPUT clause when saving changes to the table.
+    ///     The OUTPUT clause is incompatible with certain SQL Server features, such as tables with triggers.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlOutputClause">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionEntityTypeBuilder? UseSqlOutputClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlOutputClause,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanUseSqlOutputClause(useSqlOutputClause, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.UseSqlOutputClause(useSqlOutputClause, fromDataAnnotation);
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    ///     Sets a value indicating whether to use the SQL OUTPUT clause when saving changes to the table.
+    ///     The OUTPUT clause is incompatible with certain SQL Server features, such as tables with triggers.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlOutputClause">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionEntityTypeBuilder? UseSqlOutputClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlOutputClause,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanUseSqlOutputClause(useSqlOutputClause, storeObject, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.UseSqlOutputClause(useSqlOutputClause, storeObject, fromDataAnnotation);
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether this entity type can be configured to use the SQL OUTPUT clause
+    ///     using the specified configuration source.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlOutputClause">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanUseSqlOutputClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlOutputClause,
+        bool fromDataAnnotation = false)
+        => entityTypeBuilder.CanSetAnnotation(
+            SqlServerAnnotationNames.UseSqlOutputClause,
+            useSqlOutputClause,
+            fromDataAnnotation);
+
+    /// <summary>
+    ///     Returns a value indicating whether this entity type can be configured to use the SQL OUTPUT clause
+    ///     using the specified configuration source.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlOutputClause">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanUseSqlOutputClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlOutputClause,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => StoreObjectIdentifier.Create(entityTypeBuilder.Metadata, storeObject.StoreObjectType) == storeObject
+            ? entityTypeBuilder.CanSetAnnotation(
+                SqlServerAnnotationNames.UseSqlOutputClause,
+                useSqlOutputClause,
+                fromDataAnnotation)
+            : entityTypeBuilder.Metadata.GetOrCreateMappingFragment(storeObject, fromDataAnnotation).Builder.CanSetAnnotation(
+                SqlServerAnnotationNames.UseSqlOutputClause,
+                useSqlOutputClause,
+                fromDataAnnotation);
+
+    /// <summary>
     ///     Configures the table as temporal.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -343,6 +344,18 @@ public static class SqlServerEntityTypeExtensions
     /// <returns>The configuration source for the memory-optimized setting.</returns>
     public static ConfigurationSource? GetUseSqlOutputClauseConfigurationSource(this IConventionEntityType entityType)
         => entityType.FindAnnotation(SqlServerAnnotationNames.UseSqlOutputClause)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Gets the configuration source for whether to use the SQL OUTPUT clause when saving changes to the table.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <returns>The configuration source for the memory-optimized setting.</returns>
+    public static ConfigurationSource? GetUseSqlOutputClauseConfigurationSource(
+        this IConventionEntityType entityType, in StoreObjectIdentifier storeObject)
+        => StoreObjectIdentifier.Create(entityType, storeObject.StoreObjectType) == storeObject
+            ? entityType.GetUseSqlOutputClauseConfigurationSource()
+            : (entityType.FindMappingFragment(storeObject)?.GetUseSqlOutputClauseConfigurationSource());
 
     /// <summary>
     ///     Returns a value indicating whether to use the SQL OUTPUT clause when saving changes to the specified table.

--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeMappingFragmentExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeMappingFragmentExtensions.cs
@@ -27,7 +27,7 @@ public static class SqlServerEntityTypeMappingFragmentExtensions
     /// <param name="fragment">The entity type mapping fragment.</param>
     /// <param name="useSqlOutputClause">The value to set.</param>
     public static void UseSqlOutputClause(this IMutableEntityTypeMappingFragment fragment, bool? useSqlOutputClause)
-        => fragment.SetAnnotation(SqlServerAnnotationNames.UseSqlOutputClause, useSqlOutputClause);
+        => fragment.SetOrRemoveAnnotation(SqlServerAnnotationNames.UseSqlOutputClause, useSqlOutputClause);
 
     /// <summary>
     ///     Sets whether to use the SQL OUTPUT clause when saving changes to the associated table.
@@ -41,7 +41,7 @@ public static class SqlServerEntityTypeMappingFragmentExtensions
         this IConventionEntityTypeMappingFragment fragment,
         bool? useSqlOutputClause,
         bool fromDataAnnotation = false)
-        => (bool?)fragment.SetAnnotation(SqlServerAnnotationNames.UseSqlOutputClause, useSqlOutputClause, fromDataAnnotation)?.Value;
+        => (bool?)fragment.SetOrRemoveAnnotation(SqlServerAnnotationNames.UseSqlOutputClause, useSqlOutputClause, fromDataAnnotation)?.Value;
 
     /// <summary>
     ///     Gets the configuration source for the setting whether to use the SQL OUTPUT clause when saving changes to the associated table.

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeBuilderExtensions.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Entity type builder extension methods for Sqlite-specific metadata.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+///     <see href="https://aka.ms/efcore-docs-sqlite">Accessing Sqlite databases with EF Core</see> for more information and examples.
+/// </remarks>
+public static class SqliteEntityTypeBuilderExtensions
+{
+    /// <summary>
+    ///     Sets a value indicating whether to use the SQL RETURNING clause when saving changes to the table.
+    ///     The RETURNING clause is incompatible with certain Sqlite features, such as virtual tables or tables with AFTER triggers.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlReturningClause">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionEntityTypeBuilder? UseSqlReturningClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlReturningClause,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanUseSqlReturningClause(useSqlReturningClause, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.UseSqlReturningClause(useSqlReturningClause, fromDataAnnotation);
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    ///     Sets a value indicating whether to use the SQL RETURNING clause when saving changes to the table.
+    ///     The RETURNING clause is incompatible with certain Sqlite features, such as virtual tables or tables with AFTER triggers.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlReturningClause">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionEntityTypeBuilder? UseSqlReturningClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlReturningClause,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanUseSqlReturningClause(useSqlReturningClause, storeObject, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.UseSqlReturningClause(useSqlReturningClause, storeObject, fromDataAnnotation);
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether this entity type can be configured to use the SQL RETURNING clause
+    ///     using the specified configuration source.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlReturningClause">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanUseSqlReturningClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlReturningClause,
+        bool fromDataAnnotation = false)
+        => entityTypeBuilder.CanSetAnnotation(
+            SqliteAnnotationNames.UseSqlReturningClause,
+            useSqlReturningClause,
+            fromDataAnnotation);
+
+    /// <summary>
+    ///     Returns a value indicating whether this entity type can be configured to use the SQL RETURNING clause
+    ///     using the specified configuration source.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="useSqlReturningClause">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanUseSqlReturningClause(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        bool? useSqlReturningClause,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => StoreObjectIdentifier.Create(entityTypeBuilder.Metadata, storeObject.StoreObjectType) == storeObject
+            ? entityTypeBuilder.CanSetAnnotation(
+                SqliteAnnotationNames.UseSqlReturningClause,
+                useSqlReturningClause,
+                fromDataAnnotation)
+            : entityTypeBuilder.Metadata.GetOrCreateMappingFragment(storeObject, fromDataAnnotation).Builder.CanSetAnnotation(
+                SqliteAnnotationNames.UseSqlReturningClause,
+                useSqlReturningClause,
+                fromDataAnnotation);
+}

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeExtensions.cs
@@ -78,6 +78,18 @@ public static class SqliteEntityTypeExtensions
         => entityType.FindAnnotation(SqliteAnnotationNames.UseSqlReturningClause)?.GetConfigurationSource();
 
     /// <summary>
+    ///     Gets the configuration source for whether to use the SQL RETURNING clause when saving changes to the table.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <param name="storeObject">The identifier of the table-like store object.</param>
+    /// <returns>The configuration source for the memory-optimized setting.</returns>
+    public static ConfigurationSource? GetUseSqlReturningClauseConfigurationSource(
+        this IConventionEntityType entityType, in StoreObjectIdentifier storeObject)
+        => StoreObjectIdentifier.Create(entityType, storeObject.StoreObjectType) == storeObject
+            ? entityType.GetUseSqlReturningClauseConfigurationSource()
+            : (entityType.FindMappingFragment(storeObject)?.GetUseSqlReturningClauseConfigurationSource());
+
+    /// <summary>
     ///     Returns a value indicating whether to use the SQL RETURNING clause when saving changes to the table.
     ///     The RETURNING clause is incompatible with certain Sqlite features, such as virtual tables or tables with AFTER triggers.
     /// </summary>

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeMappingFragmentExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteEntityTypeMappingFragmentExtensions.cs
@@ -27,7 +27,7 @@ public static class SqliteEntityTypeMappingFragmentExtensions
     /// <param name="fragment">The entity type mapping fragment.</param>
     /// <param name="useSqlReturningClause">The value to set.</param>
     public static void UseSqlReturningClause(this IMutableEntityTypeMappingFragment fragment, bool? useSqlReturningClause)
-        => fragment.SetAnnotation(SqliteAnnotationNames.UseSqlReturningClause, useSqlReturningClause);
+        => fragment.SetOrRemoveAnnotation(SqliteAnnotationNames.UseSqlReturningClause, useSqlReturningClause);
 
     /// <summary>
     ///     Sets a value indicating whether to use the SQL RETURNING clause when saving changes to the table.
@@ -41,7 +41,7 @@ public static class SqliteEntityTypeMappingFragmentExtensions
         this IConventionEntityTypeMappingFragment fragment,
         bool? useSqlReturningClause,
         bool fromDataAnnotation = false)
-        => (bool?)fragment.SetAnnotation(SqliteAnnotationNames.UseSqlReturningClause, useSqlReturningClause, fromDataAnnotation)?.Value;
+        => (bool?)fragment.SetOrRemoveAnnotation(SqliteAnnotationNames.UseSqlReturningClause, useSqlReturningClause, fromDataAnnotation)?.Value;
 
     /// <summary>
     ///     Gets the configuration source for whether to use the SQL RETURNING clause when saving changes to the associated table.

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -335,6 +335,23 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
                 Check.NotEmpty(propertyNames, nameof(propertyNames)), ConfigurationSource.Explicit)!.Metadata);
 
     /// <summary>
+    ///     Configures an index on the specified properties and with the given name.
+    ///     If there is an existing index on the given list of properties and with
+    ///     the given name, then the existing index will be returned for configuration.
+    /// </summary>
+    /// <param name="propertyNames">The names of the properties that make up the index.</param>
+    /// <param name="name">The name to assign to the index.</param>
+    /// <returns>An object that can be used to configure the index.</returns>
+    public virtual IndexBuilder HasIndex(
+        string[] propertyNames,
+        string name)
+        => new(
+            DependentEntityType.Builder.HasIndex(
+                Check.NotEmpty(propertyNames, nameof(propertyNames)),
+                Check.NotEmpty(name, nameof(name)),
+                ConfigurationSource.Explicit)!.Metadata);
+
+    /// <summary>
     ///     Configures the relationship to the owner.
     /// </summary>
     /// <remarks>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -201,6 +201,32 @@ public class OwnedNavigationBuilder<
                 .Metadata);
 
     /// <summary>
+    ///     Configures an index on the specified properties with the given name.
+    ///     If there is an existing index on the given list of properties and with
+    ///     the given name, then the existing index will be returned for configuration.
+    /// </summary>
+    /// <param name="indexExpression">
+    ///     <para>
+    ///         A lambda expression representing the property(s) to be included in the index
+    ///         (<c>blog => blog.Url</c>).
+    ///     </para>
+    ///     <para>
+    ///         If the index is made up of multiple properties then specify an anonymous type including the
+    ///         properties (<c>post => new { post.Title, post.BlogId }</c>).
+    ///     </para>
+    /// </param>
+    /// <param name="name">The name to assign to the index.</param>
+    /// <returns>An object that can be used to configure the index.</returns>
+    public virtual IndexBuilder<TDependentEntity> HasIndex(
+        Expression<Func<TDependentEntity, object?>> indexExpression,
+        string name)
+        => new(
+            DependentEntityType.Builder.HasIndex(
+                Check.NotNull(indexExpression, nameof(indexExpression)).GetMemberAccessList(),
+                name,
+                ConfigurationSource.Explicit)!.Metadata);
+
+    /// <summary>
     ///     Configures an index on the specified properties. If there is an existing index on the given
     ///     set of properties, then the existing index will be returned for configuration.
     /// </summary>
@@ -210,6 +236,23 @@ public class OwnedNavigationBuilder<
         => new(
             DependentEntityType.Builder.HasIndex(
                 Check.NotEmpty(propertyNames, nameof(propertyNames)), ConfigurationSource.Explicit)!.Metadata);
+
+    /// <summary>
+    ///     Configures an index on the specified properties with the given name.
+    ///     If there is an existing index on the given list of properties and with
+    ///     the given name, then the existing index will be returned for configuration.
+    /// </summary>
+    /// <param name="propertyNames">The names of the properties that make up the index.</param>
+    /// <param name="name">The name to assign to the index.</param>
+    /// <returns>An object that can be used to configure the index.</returns>
+    public new virtual IndexBuilder<TDependentEntity> HasIndex(
+        string[] propertyNames,
+        string name)
+        => new(
+            DependentEntityType.Builder.HasIndex(
+                Check.NotEmpty(propertyNames, nameof(propertyNames)),
+                name,
+                ConfigurationSource.Explicit)!.Metadata);
 
     /// <summary>
     ///     Configures the relationship to the owner.

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -978,7 +978,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
 
         public override void Can_configure_owned_type_collection()
             => Assert.Equal(
-                CosmosStrings.IndexesExist(nameof(Order), "foo"),
+                CosmosStrings.IndexesExist(nameof(Order), "CustomerId"),
                 Assert.Throws<InvalidOperationException>(
                     base.Can_configure_owned_type_collection).Message);
 

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -503,6 +503,7 @@ public class CosmosTestStore : TestStore
     {
         var creator = (CosmosDatabaseCreator)context.GetService<IDatabaseCreator>();
         await creator.InsertDataAsync().ConfigureAwait(false);
+        await creator.SeedDataAsync(created: true).ConfigureAwait(false);
     }
 
     public override void Dispose()

--- a/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
@@ -579,9 +579,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
             var expectedName = methodName.StartsWith("HasNo", StringComparison.Ordinal)
                 ? "CanRemove" + methodName[5..]
-                : methodName.StartsWith("Ignore", StringComparison.Ordinal)
-                    ? methodName
-                    : "CanSet"
+                : "CanSet"
                     + (methodName.StartsWith("Has", StringComparison.Ordinal)
                         || methodName.StartsWith("Use", StringComparison.Ordinal)
                             ? methodName[3..]
@@ -593,18 +591,33 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
             if (!methodLookup.TryGetValue(expectedName, out var canSetMethod))
             {
-                if (methodName.StartsWith("Has", StringComparison.Ordinal))
-                {
-                    var otherExpectedName = "CanHave" + methodName[3..];
-                    if (!methodLookup.TryGetValue(otherExpectedName, out canSetMethod))
-                    {
-                        return $"{declaringType.Name} expected to have a {expectedName} or {otherExpectedName} method";
-                    }
-                }
-                else
+                if (methodName.StartsWith("HasNo", StringComparison.Ordinal)
+                    || methodName.StartsWith("To", StringComparison.Ordinal)
+                    || methodName.StartsWith("With", StringComparison.Ordinal))
                 {
                     return $"{declaringType.Name} expected to have a {expectedName} method";
                 }
+
+                var otherExpectedName = "Can" + methodName;
+                if (methodName.StartsWith("Has", StringComparison.Ordinal))
+                {
+                    otherExpectedName = "CanHave" + methodName[3..];
+                }
+                else if (methodName.StartsWith("HasNo", StringComparison.Ordinal))
+                {
+                    otherExpectedName = "CanHaveNo" + methodName[3..];
+                }
+
+                if (!methodLookup.TryGetValue(otherExpectedName, out canSetMethod))
+                {
+                    return $"{declaringType.Name} expected to have a {expectedName} or {otherExpectedName} method";
+                }
+            }
+
+            if (canSetMethod.ReturnType != typeof(bool))
+            {
+                return $"{declaringType.Name}.{canSetMethod.Name}({Format(canSetMethod.GetParameters())})"
+                    + $" expected to have return type of 'bool'";
             }
 
             var parameterIndex = method.IsStatic ? 1 : 0;

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Generic.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Generic.cs
@@ -1407,8 +1407,14 @@ public abstract partial class ModelBuilderTest
         public override TestIndexBuilder<TDependentEntity> HasIndex(params string[] propertyNames)
             => new GenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(propertyNames));
 
+        public override TestIndexBuilder<TDependentEntity> HasIndex(string[] propertyNames, string name)
+            => new GenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(propertyNames, name));
+
         public override TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression)
             => new GenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(indexExpression));
+
+        public override TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression, string name)
+            => new GenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(indexExpression, name));
 
         public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string? ownerReference)
             => new GenericTestOwnershipBuilder<TEntity, TDependentEntity>(

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonGeneric.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.NonGeneric.cs
@@ -1482,10 +1482,18 @@ public abstract partial class ModelBuilderTest
         public override TestIndexBuilder<TDependentEntity> HasIndex(params string[] propertyNames)
             => new NonGenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(propertyNames));
 
+        public override TestIndexBuilder<TDependentEntity> HasIndex(string[] propertyNames, string name)
+            => new NonGenericTestIndexBuilder<TDependentEntity>(OwnedNavigationBuilder.HasIndex(propertyNames, name));
+
         public override TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression)
             => new NonGenericTestIndexBuilder<TDependentEntity>(
                 OwnedNavigationBuilder.HasIndex(
                     indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+
+        public override TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression, string name)
+            => new NonGenericTestIndexBuilder<TDependentEntity>(
+                OwnedNavigationBuilder.HasIndex(
+                    indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray(), name));
 
         public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string? ownerReference)
             => new NonGenericTestOwnershipBuilder<TEntity, TDependentEntity>(

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.cs
@@ -931,7 +931,10 @@ public abstract partial class ModelBuilderTest
             Expression<Func<TDependentEntity, object?>> propertyExpression);
 
         public abstract TestIndexBuilder<TDependentEntity> HasIndex(params string[] propertyNames);
+        public abstract TestIndexBuilder<TDependentEntity> HasIndex(string[] propertyNames, string name);
+
         public abstract TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression);
+        public abstract TestIndexBuilder<TDependentEntity> HasIndex(Expression<Func<TDependentEntity, object?>> indexExpression, string name);
 
         public abstract TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string? ownerReference);
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerApiConsistencyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerApiConsistencyTest.cs
@@ -31,6 +31,7 @@ public class SqlServerApiConsistencyTest(SqlServerApiConsistencyTest.SqlServerAp
             typeof(SqlServerEntityTypeBuilderExtensions),
             typeof(SqlServerServiceCollectionExtensions),
             typeof(SqlServerDbFunctionsExtensions),
+            typeof(SqlServerTableBuilderExtensions),
             typeof(OwnedNavigationTemporalPeriodPropertyBuilder),
             typeof(OwnedNavigationTemporalTableBuilder),
             typeof(OwnedNavigationTemporalTableBuilder<,>),

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataBuilderExtensionsTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -257,7 +256,7 @@ public class SqlServerMetadataBuilderExtensionsTest
     }
 
     [ConditionalFact]
-    public void Can_access_entity_type()
+    public void Can_change_entity_type_IsMemoryOptimized()
     {
         var typeBuilder = CreateBuilder().Entity(typeof(Splot));
 
@@ -278,6 +277,50 @@ public class SqlServerMetadataBuilderExtensionsTest
         Assert.NotNull(typeBuilder.IsMemoryOptimized(null, fromDataAnnotation: true));
         Assert.False(typeBuilder.Metadata.IsMemoryOptimized());
         Assert.Null(typeBuilder.Metadata.GetIsMemoryOptimizedConfigurationSource());
+    }
+
+    [ConditionalFact]
+    public void Can_change_entity_type_UseSqlOutputClause()
+    {
+        var typeBuilder = CreateBuilder().Entity(typeof(Splot));
+
+        Assert.Null(typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource());
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(true));
+        Assert.True(typeBuilder.Metadata.IsSqlOutputClauseUsed());
+        Assert.Equal(ConfigurationSource.Convention, typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource());
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(false, fromDataAnnotation: true));
+        Assert.False(typeBuilder.Metadata.IsSqlOutputClauseUsed());
+        Assert.Equal(ConfigurationSource.DataAnnotation, typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource());
+
+        Assert.Null(typeBuilder.UseSqlOutputClause(true));
+        Assert.False(typeBuilder.Metadata.IsSqlOutputClauseUsed());
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(false));
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(null, fromDataAnnotation: true));
+        Assert.True(typeBuilder.Metadata.IsSqlOutputClauseUsed());
+        Assert.Null(typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource());
+
+        var fragmentId = StoreObjectIdentifier.Table("Split");
+
+        Assert.Null(typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource(fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(true, fragmentId));
+        Assert.True(typeBuilder.Metadata.IsSqlOutputClauseUsed(fragmentId));
+        Assert.Equal(ConfigurationSource.Convention, typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource(fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(false, fragmentId, fromDataAnnotation: true));
+        Assert.False(typeBuilder.Metadata.IsSqlOutputClauseUsed(fragmentId));
+        Assert.Equal(ConfigurationSource.DataAnnotation, typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource(fragmentId));
+
+        Assert.Null(typeBuilder.UseSqlOutputClause(true, fragmentId));
+        Assert.False(typeBuilder.Metadata.IsSqlOutputClauseUsed(fragmentId));
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(false, fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlOutputClause(null, fragmentId, fromDataAnnotation: true));
+        Assert.True(typeBuilder.Metadata.IsSqlOutputClauseUsed(fragmentId));
+        Assert.Null(typeBuilder.Metadata.GetUseSqlOutputClauseConfigurationSource(fragmentId));
     }
 
     [ConditionalFact]

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteApiConsistencyTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteApiConsistencyTest.cs
@@ -22,7 +22,9 @@ public class SqliteApiConsistencyTest(SqliteApiConsistencyTest.SqliteApiConsiste
             typeof(SqliteServiceCollectionExtensions),
             typeof(SqliteDbContextOptionsBuilderExtensions),
             typeof(SqliteDbContextOptionsBuilder),
-            typeof(SqlitePropertyBuilderExtensions)
+            typeof(SqlitePropertyBuilderExtensions),
+            typeof(SqliteEntityTypeBuilderExtensions),
+            typeof(SqliteTableBuilderExtensions)
         ];
 
         public override
@@ -31,7 +33,8 @@ public class SqliteApiConsistencyTest(SqliteApiConsistencyTest.SqliteApiConsiste
                 Type MutableExtensions,
                 Type ConventionExtensions,
                 Type ConventionBuilderExtensions,
-                Type RuntimeExtensions)> MetadataExtensionTypes { get; }
+                Type RuntimeExtensions)> MetadataExtensionTypes
+        { get; }
             = new()
             {
                 {
@@ -40,6 +43,15 @@ public class SqliteApiConsistencyTest(SqliteApiConsistencyTest.SqliteApiConsiste
                         typeof(SqlitePropertyExtensions),
                         typeof(SqlitePropertyExtensions),
                         typeof(SqlitePropertyBuilderExtensions),
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyEntityType), (
+                        typeof(SqliteEntityTypeExtensions),
+                        typeof(SqliteEntityTypeExtensions),
+                        typeof(SqliteEntityTypeExtensions),
+                        typeof(SqliteEntityTypeBuilderExtensions),
                         null
                     )
                 }

--- a/test/EFCore.Sqlite.Tests/Metadata/Builders/SqliteMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/Metadata/Builders/SqliteMetadataBuilderExtensionsTest.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class SqliteMetadataBuilderExtensionsTest
+{
+    private IConventionModelBuilder CreateBuilder()
+        => new InternalModelBuilder(new Model());
+
+    [ConditionalFact]
+    public void Can_change_entity_type_UseSqlReturningClause()
+    {
+        var typeBuilder = CreateBuilder().Entity(typeof(Splot))!;
+
+        Assert.Null(typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource());
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(true));
+        Assert.True(typeBuilder.Metadata.IsSqlReturningClauseUsed());
+        Assert.Equal(ConfigurationSource.Convention, typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource());
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(false, fromDataAnnotation: true));
+        Assert.False(typeBuilder.Metadata.IsSqlReturningClauseUsed());
+        Assert.Equal(ConfigurationSource.DataAnnotation, typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource());
+
+        Assert.Null(typeBuilder.UseSqlReturningClause(true));
+        Assert.False(typeBuilder.Metadata.IsSqlReturningClauseUsed());
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(false));
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(null, fromDataAnnotation: true));
+        Assert.True(typeBuilder.Metadata.IsSqlReturningClauseUsed());
+        Assert.Null(typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource());
+
+        var fragmentId = StoreObjectIdentifier.Table("Split");
+
+        Assert.Null(typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource(fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(true, fragmentId));
+        Assert.True(typeBuilder.Metadata.IsSqlReturningClauseUsed(fragmentId));
+        Assert.Equal(ConfigurationSource.Convention, typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource(fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(false, fragmentId, fromDataAnnotation: true));
+        Assert.False(typeBuilder.Metadata.IsSqlReturningClauseUsed(fragmentId));
+        Assert.Equal(ConfigurationSource.DataAnnotation, typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource(fragmentId));
+
+        Assert.Null(typeBuilder.UseSqlReturningClause(true, fragmentId));
+        Assert.False(typeBuilder.Metadata.IsSqlReturningClauseUsed(fragmentId));
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(false, fragmentId));
+
+        Assert.NotNull(typeBuilder.UseSqlReturningClause(null, fragmentId, fromDataAnnotation: true));
+        Assert.True(typeBuilder.Metadata.IsSqlReturningClauseUsed(fragmentId));
+        Assert.Null(typeBuilder.Metadata.GetUseSqlReturningClauseConfigurationSource(fragmentId));
+    }
+
+    private class Splot;
+}


### PR DESCRIPTION
Add OwnedNavigationBuilder.HasIndex with name
Add IConventionEntityTypeBuilder API for UseSqlReturningClause and UseSqlOutputClause
Rename some `CanSet*` methods to `CanHave*`

Fixes #33739
Fixes #33287
