### PR TITLE
Cosmos: strip implicit casts to allow vector search over arrays

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -828,7 +828,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
                 when operand.Type.IsInterface && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)
                 // We strip out implicit conversions, e.g. float[] -> ReadOnlyMemory<float> (for vector search)
                 || (unaryExpression.Method is { IsSpecialName: true, Name: "op_Implicit" }
-                    && IsRom(unaryExpression.Type.UnwrapNullableType()))
+                    && IsReadOnlyMemory(unaryExpression.Type.UnwrapNullableType()))
                 || unaryExpression.Type.UnwrapNullableType() == operand.Type
                 || unaryExpression.Type.UnwrapNullableType() == typeof(Enum)
                 // Object convert needs to be converted to explicit cast when mismatching types
@@ -839,7 +839,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
             _ => QueryCompilationContext.NotTranslatedExpression
         };
 
-        static bool IsRom(Type type)
+        static bool IsReadOnlyMemory(Type type)
             => type is { IsGenericType: true, IsGenericTypeDefinition: false }
                 && type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>);
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -820,13 +820,18 @@ public class CosmosSqlTranslatingExpressionVisitor(
             ExpressionType.Negate or ExpressionType.NegateChecked
                 => sqlExpressionFactory.Negate(sqlOperand!),
 
-            ExpressionType.Convert or ExpressionType.ConvertChecked
-                when operand.Type.IsInterface
-                && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)
+            // Convert nodes can be an explicit user gesture in the query, or they may get introduced by the compiler (e.g. when a Child is
+            // passed as an argument for a parameter of type Parent). The latter type should generally get stripped out as a pure C#/LINQ
+            // artifact that shouldn't affect translation, but the latter may be an indication from the user that they want to apply a
+            // type change.
+            ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs
+                when operand.Type.IsInterface && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)
+                // We strip out implicit conversions, e.g. float[] -> ReadOnlyMemory<float> (for vector search)
+                || unaryExpression.Method is { IsSpecialName: true, Name: "op_Implicit"}
                 || unaryExpression.Type.UnwrapNullableType() == operand.Type
                 || unaryExpression.Type.UnwrapNullableType() == typeof(Enum)
                 // Object convert needs to be converted to explicit cast when mismatching types
-                // But we let is pass here since we don't have explicit cast mechanism here and in some cases object convert is due to value types
+                // But we let it pass here since we don't have explicit cast mechanism here and in some cases object convert is due to value types
                 || unaryExpression.Type == typeof(object)
                 => sqlOperand!,
 

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 
@@ -63,7 +64,8 @@ public class CosmosVectorTypeMapping : CosmosTypeMapping
         : this(
             new CoreTypeMappingParameters(
                 mapping.ClrType,
-                converter: mapping.Converter,
+                // This is a hack to allow both arrays and ROM types without different function overloads or type mappings.
+                converter: mapping.Converter?.GetType() == typeof(BytesToStringConverter) ? null : mapping.Converter,
                 mapping.Comparer,
                 mapping.KeyComparer,
                 elementMapping: mapping.ElementTypeMapping,
@@ -114,4 +116,35 @@ public class CosmosVectorTypeMapping : CosmosTypeMapping
     /// </summary>
     protected override CoreTypeMapping Clone(CoreTypeMappingParameters parameters)
         => new CosmosVectorTypeMapping(parameters, VectorType);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override JToken? GenerateJToken(object? value)
+    {
+        // This is a hack to allow both arrays and ROM types without different function overloads or type mappings.
+        var type = value?.GetType();
+        if (type?.IsArray is false)
+        {
+            if (type == typeof(ReadOnlyMemory<byte>))
+            {
+                value = ((ReadOnlyMemory<byte>)value!).ToArray();
+            }
+            else if (type == typeof(ReadOnlyMemory<sbyte>))
+            {
+                value = ((ReadOnlyMemory<sbyte>)value!).ToArray();
+            }
+            else if (type == typeof(ReadOnlyMemory<float>))
+            {
+                value = ((ReadOnlyMemory<float>)value!).ToArray();
+            }
+        }
+
+        return value == null
+            ? null
+            : JToken.FromObject(value, CosmosClientWrapper.Serializer);
+    }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
@@ -99,16 +99,19 @@ FROM root c
         await using var context = CreateContext();
         var inputVector = new byte[] { 2, 1, 4, 3, 5, 2, 5, 7, 3, 1 };
 
-        // See Issue #34402
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => context.Set<Book>().Select(e => EF.Functions.VectorDistance(e.BytesArray, inputVector)).ToListAsync());
+        var booksFromStore = await context
+            .Set<Book>()
+            .Select(e => EF.Functions.VectorDistance(e.BytesArray, inputVector))
+            .ToListAsync();
 
-        // Assert.Equal(3, booksFromStore.Count);
-        // Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
+        Assert.Equal(3, booksFromStore.Count);
+        Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
 
         AssertSql(
             """
-SELECT VALUE c["BytesArray"]
+@__inputVector_1='[2,1,4,3,5,2,5,7,3,1]'
+
+SELECT VALUE VectorDistance(c["Bytes"], @__inputVector_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 FROM root c
 """);
     }
@@ -119,17 +122,20 @@ FROM root c
         await using var context = CreateContext();
         var inputVector = new[] { 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f, 0.86f, -0.78f };
 
-        // See Issue #34402
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => context.Set<Book>()
-                .Select(e => EF.Functions.VectorDistance(e.SinglesArray, inputVector, false, DistanceFunction.DotProduct)).ToListAsync());
+        var booksFromStore = await context
+            .Set<Book>()
+            .Select(
+                e => EF.Functions.VectorDistance(e.SinglesArray, inputVector, false, DistanceFunction.DotProduct))
+            .ToListAsync();
 
-        // Assert.Equal(3, booksFromStore.Count);
-        // Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
+        Assert.Equal(3, booksFromStore.Count);
+        Assert.All(booksFromStore, s => Assert.NotEqual(0.0, s));
 
         AssertSql(
             """
-SELECT VALUE c["SinglesArray"]
+@__inputVector_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
+
+SELECT VALUE VectorDistance(c["Singles"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
 FROM root c
 """);
     }
@@ -207,14 +213,20 @@ ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine
         await using var context = CreateContext();
         var inputVector = new byte[] { 2, 1, 4, 6, 5, 2, 5, 7, 3, 1 };
 
-        // See Issue #34402
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => context.Set<Book>().OrderBy(e => EF.Functions.VectorDistance(e.BytesArray, inputVector)).ToListAsync());
+        var booksFromStore = await context
+            .Set<Book>()
+            .OrderBy(e => EF.Functions.VectorDistance(e.BytesArray, inputVector))
+            .ToListAsync();
 
-        // Assert.Equal(3, booksFromStore.Count);
-
+        Assert.Equal(3, booksFromStore.Count);
         AssertSql(
-);
+            """
+@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+
+SELECT VALUE c
+FROM root c
+ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+""");
     }
 
     [ConditionalFact]
@@ -223,13 +235,20 @@ ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine
         await using var context = CreateContext();
         var inputVector = new[] { 0.33f, -0.52f, 0.45f, -0.67f, 0.89f, -0.34f, 0.86f, -0.78f };
 
-        // See Issue #34402
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => context.Set<Book>().OrderBy(e => EF.Functions.VectorDistance(e.SinglesArray, inputVector)).ToListAsync());
+        var booksFromStore = await context
+            .Set<Book>()
+            .OrderBy(e => EF.Functions.VectorDistance(e.SinglesArray, inputVector))
+            .ToListAsync();
 
-        // Assert.Equal(3, booksFromStore.Count);
+        Assert.Equal(3, booksFromStore.Count);
+        AssertSql(
+            """
+@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
 
-        AssertSql();
+SELECT VALUE c
+FROM root c
+ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
+""");
     }
 
     [ConditionalFact]

--- a/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
@@ -109,9 +109,9 @@ FROM root c
 
         AssertSql(
             """
-@__inputVector_1='[2,1,4,3,5,2,5,7,3,1]'
+@__p_1='[2,1,4,3,5,2,5,7,3,1]'
 
-SELECT VALUE VectorDistance(c["Bytes"], @__inputVector_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+SELECT VALUE VectorDistance(c["BytesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 FROM root c
 """);
     }
@@ -133,9 +133,9 @@ FROM root c
 
         AssertSql(
             """
-@__inputVector_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
+@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
 
-SELECT VALUE VectorDistance(c["Singles"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
+SELECT VALUE VectorDistance(c["SinglesArray"], @__p_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
 FROM root c
 """);
     }
@@ -225,7 +225,7 @@ ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+ORDER BY VectorDistance(c["BytesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 """);
     }
 
@@ -247,7 +247,7 @@ ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine',
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
+ORDER BY VectorDistance(c["SinglesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
 """);
     }
 


### PR DESCRIPTION
This is a targeted fix to Cosmos, to strip convert nodes out which represent implicit conversions.

I think we need to revisit our general casting/conversion strategy (across both Cosmos and relational), but this specific change makes sense to me...

@ajcvickers can you verify that all vector search tests now pass?