### PR TITLE
Update SDK to 9.0.100-preview.7.24407.12

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,7 +14,7 @@
   
   <ItemGroup>
     <FrameworkReference Update="Microsoft.NETCore.App"
-                        Condition="'$(TargetFramework)' == 'net9.0'"
+                        Condition="'$(TargetFramework)' == 'net9.0' and '$(StabilizePackageVersion)' != 'true'"
                         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
                         TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.5.24307.3",
+    "version": "9.0.100-preview.7.24407.12",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
   "tools": {
-    "dotnet": "9.0.100-preview.5.24307.3",
+    "dotnet": "9.0.100-preview.7.24407.12",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimewinx64Version)"


### PR DESCRIPTION
Change `FrameworkReference` condition to avoid requiring specific patch versions of the runtime for servicing releases, see https://github.com/dotnet/efcore/issues/32782