### PR TITLE
Associate the DatabaseRoot with the scoped options instance and not the singleton options.

### DIFF
--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -53,7 +53,8 @@ public static class InMemoryServiceCollectionExtensions
             .TryAddProviderSpecificServices(
                 b => b
                     .TryAddSingleton<IInMemorySingletonOptions, InMemorySingletonOptions>()
-                    .TryAddSingleton<IInMemoryStoreCache, InMemoryStoreCache>()
+                    .TryAddScoped<IInMemoryStoreProvider, InMemoryStoreProvider>()
+                    .TryAddSingleton<IInMemoryDatabaseRootCache, InMemoryDatabaseRootCache>()
                     .TryAddSingleton<IInMemoryTableFactory, InMemoryTableFactory>()
                     .TryAddScoped<IInMemoryDatabase, InMemoryDatabase>());
 

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -38,6 +38,7 @@ public class InMemoryOptionsExtension : IDbContextOptionsExtension
     protected InMemoryOptionsExtension(InMemoryOptionsExtension copyFrom)
     {
         _storeName = copyFrom._storeName;
+        _nullabilityCheckEnabled = copyFrom._nullabilityCheckEnabled;
         _databaseRoot = copyFrom._databaseRoot;
     }
 
@@ -170,6 +171,11 @@ public class InMemoryOptionsExtension : IDbContextOptionsExtension
 
                     builder.Append("StoreName=").Append(Extension._storeName).Append(' ');
 
+                    if (Extension._databaseRoot is { } root)
+                    {
+                        builder.Append("DatabaseRoot=").Append(root.GetHashCode()).Append(' ');
+                    }
+
                     if (!Extension._nullabilityCheckEnabled)
                     {
                         builder.Append("NullabilityChecksEnabled ");
@@ -185,22 +191,16 @@ public class InMemoryOptionsExtension : IDbContextOptionsExtension
         public override int GetServiceProviderHashCode()
         {
             var hashCode = new HashCode();
-            hashCode.Add(Extension._databaseRoot);
             hashCode.Add(Extension._nullabilityCheckEnabled);
             return hashCode.ToHashCode();
         }
 
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             => other is ExtensionInfo otherInfo
-                && Extension._databaseRoot == otherInfo.Extension._databaseRoot
                 && Extension._nullabilityCheckEnabled == otherInfo.Extension._nullabilityCheckEnabled;
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-        {
-            debugInfo["InMemoryDatabase:DatabaseRoot"]
-                = (Extension._databaseRoot?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
-            debugInfo["InMemoryDatabase:NullabilityChecksEnabled"]
+            => debugInfo["InMemoryDatabase:NullabilityChecksEnabled"]
                 = (!Extension._nullabilityCheckEnabled).GetHashCode().ToString(CultureInfo.InvariantCulture);
-        }
     }
 }

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
@@ -23,7 +23,6 @@ public class InMemorySingletonOptions : IInMemorySingletonOptions
 
         if (inMemoryOptions != null)
         {
-            DatabaseRoot = inMemoryOptions.DatabaseRoot;
             IsNullabilityCheckEnabled = inMemoryOptions.IsNullabilityCheckEnabled;
         }
     }
@@ -39,15 +38,6 @@ public class InMemorySingletonOptions : IInMemorySingletonOptions
         var inMemoryOptions = options.FindExtension<InMemoryOptionsExtension>();
 
         if (inMemoryOptions != null
-            && DatabaseRoot != inMemoryOptions.DatabaseRoot)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.SingletonOptionChanged(
-                    nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
-                    nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
-        }
-
-        if (inMemoryOptions != null
             && IsNullabilityCheckEnabled != inMemoryOptions.IsNullabilityCheckEnabled)
         {
             throw new InvalidOperationException(
@@ -56,14 +46,6 @@ public class InMemorySingletonOptions : IInMemorySingletonOptions
                     nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
         }
     }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual InMemoryDatabaseRoot? DatabaseRoot { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
 /// </summary>
 public class InMemoryQueryContextFactory : IQueryContextFactory
 {
-    private readonly IInMemoryStore _store;
+    private readonly IInMemoryStoreProvider _storeProvider;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,10 +23,9 @@ public class InMemoryQueryContextFactory : IQueryContextFactory
     /// </summary>
     public InMemoryQueryContextFactory(
         QueryContextDependencies dependencies,
-        IInMemoryStoreCache storeCache,
-        IDbContextOptions contextOptions)
+        IInMemoryStoreProvider storeProvider)
     {
-        _store = storeCache.GetStore(contextOptions);
+        _storeProvider = storeProvider;
         Dependencies = dependencies;
     }
 
@@ -42,5 +41,5 @@ public class InMemoryQueryContextFactory : IQueryContextFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual QueryContext Create()
-        => new InMemoryQueryContext(Dependencies, _store);
+        => new InMemoryQueryContext(Dependencies, _storeProvider.Store);
 }

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryDatabaseRootCache.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryDatabaseRootCache.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
-
 namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 
 /// <summary>
@@ -11,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public static class InMemoryStoreCacheExtensions
+public interface IInMemoryDatabaseRootCache
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,6 +17,5 @@ public static class InMemoryStoreCacheExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static IInMemoryStore GetStore(this IInMemoryStoreCache storeCache, IDbContextOptions options)
-        => storeCache.GetStore(options.Extensions.OfType<InMemoryOptionsExtension>().First().StoreName);
+    InMemoryDatabaseRoot SharedRoot { get; }
 }

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryStoreProvider.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryStoreProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public interface IInMemoryStoreCache
+public interface IInMemoryStoreProvider
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -17,5 +17,5 @@ public interface IInMemoryStoreCache
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IInMemoryStore GetStore(string name);
+    IInMemoryStore Store { get; }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabaseRootCache.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabaseRootCache.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
+namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -9,13 +9,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Singleton" /> and multiple registrations
-///     are allowed. This means a single instance of each service is used by many <see cref="DbContext" />
-///     instances. The implementation must be thread-safe.
-///     This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
-/// </remarks>
-public interface IInMemorySingletonOptions : ISingletonOptions
+public class InMemoryDatabaseRootCache : IInMemoryDatabaseRootCache
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,5 +17,5 @@ public interface IInMemorySingletonOptions : ISingletonOptions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IsNullabilityCheckEnabled { get; }
+    public InMemoryDatabaseRoot SharedRoot { get; } = new();
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabaseRootExtensions.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabaseRootExtensions.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
+using System.Collections.Concurrent;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -9,13 +11,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Singleton" /> and multiple registrations
-///     are allowed. This means a single instance of each service is used by many <see cref="DbContext" />
-///     instances. The implementation must be thread-safe.
-///     This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
-/// </remarks>
-public interface IInMemorySingletonOptions : ISingletonOptions
+public static class InMemoryDatabaseRootExtensions
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,5 +19,13 @@ public interface IInMemorySingletonOptions : ISingletonOptions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IsNullabilityCheckEnabled { get; }
+    public static IInMemoryStore GetStore(this InMemoryDatabaseRoot root, string name, IInMemoryTableFactory tableFactory)
+    {
+        var instance = (ConcurrentDictionary<string, IInMemoryStore>)
+            LazyInitializer.EnsureInitialized(
+                ref root.Instance,
+                () => new ConcurrentDictionary<string, IInMemoryStore>());
+
+        return instance.GetOrAdd(name, static (_, f) => new InMemoryStore(f), tableFactory);
+    }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStoreProvider.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStoreProvider.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
@@ -12,10 +11,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class InMemoryStoreCache : IInMemoryStoreCache
+public class InMemoryStoreProvider : IInMemoryStoreProvider
 {
+    private readonly IDbContextOptions _options;
+    private readonly IInMemoryDatabaseRootCache _databaseRootCache;
     private readonly IInMemoryTableFactory _tableFactory;
-    private readonly ConcurrentDictionary<string, IInMemoryStore> _namedStores;
+    private IInMemoryStore? _store;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,24 +24,11 @@ public class InMemoryStoreCache : IInMemoryStoreCache
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public InMemoryStoreCache(
-        IInMemoryTableFactory tableFactory,
-        IInMemorySingletonOptions? options)
+    public InMemoryStoreProvider(IDbContextOptions options, IInMemoryDatabaseRootCache databaseRootCache, IInMemoryTableFactory tableFactory)
     {
+        _options = options;
+        _databaseRootCache = databaseRootCache;
         _tableFactory = tableFactory;
-
-        if (options?.DatabaseRoot != null)
-        {
-            LazyInitializer.EnsureInitialized(
-                ref options.DatabaseRoot.Instance,
-                () => new ConcurrentDictionary<string, IInMemoryStore>());
-
-            _namedStores = (ConcurrentDictionary<string, IInMemoryStore>)options.DatabaseRoot.Instance;
-        }
-        else
-        {
-            _namedStores = new ConcurrentDictionary<string, IInMemoryStore>();
-        }
     }
 
     /// <summary>
@@ -49,6 +37,19 @@ public class InMemoryStoreCache : IInMemoryStoreCache
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IInMemoryStore GetStore(string name)
-        => _namedStores.GetOrAdd(name, _ => new InMemoryStore(_tableFactory));
+    public IInMemoryStore Store
+        => LazyInitializer.EnsureInitialized(ref _store, InitializeStore);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual IInMemoryStore InitializeStore()
+    {
+        var extension = _options.Extensions.OfType<InMemoryOptionsExtension>().First();
+        var root = extension.DatabaseRoot ?? _databaseRootCache.SharedRoot;
+        return root.GetStore(extension.StoreName, _tableFactory);
+    }
 }

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -163,39 +163,6 @@ public class GlobalDatabaseTest
     }
 
     [ConditionalFact]
-    public void Throws_changing_global_store_in_OnConfiguring_when_UseInternalServiceProvider()
-    {
-        using (var context = new ChangeSdlCacheContext(false))
-        {
-            Assert.NotNull(context.Model);
-        }
-
-        using (var context = new ChangeSdlCacheContext(true))
-        {
-            Assert.Equal(
-                CoreStrings.SingletonOptionChanged(
-                    nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
-                    nameof(DbContextOptionsBuilder.UseInternalServiceProvider)),
-                Assert.Throws<InvalidOperationException>(() => context.Model).Message);
-        }
-    }
-
-    private class ChangeSdlCacheContext(bool on) : DbContext
-    {
-        private static readonly IServiceProvider _serviceProvider
-            = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .BuildServiceProvider(validateScopes: true);
-
-        private readonly bool _on = on;
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseInternalServiceProvider(_serviceProvider)
-                .UseInMemoryDatabase(nameof(ChangeSdlCacheContext), _on ? _databaseRoot : null);
-    }
-
-    [ConditionalFact]
     public void Throws_changing_nullability_checks_in_OnConfiguring_when_UseInternalServiceProvider()
     {
         using (var context = new ChangeNullabilityChecksCacheContext(false))
@@ -225,7 +192,7 @@ public class GlobalDatabaseTest
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseInternalServiceProvider(_serviceProvider)
-                .UseInMemoryDatabase(nameof(ChangeSdlCacheContext), b => b.EnableNullChecks(_on));
+                .UseInMemoryDatabase(nameof(ChangeNullabilityChecksCacheContext), b => b.EnableNullChecks(_on));
     }
 
     private class BooFooContext(DbContextOptions options) : DbContext(options)

--- a/test/EFCore.InMemory.FunctionalTests/TestUtilities/InMemoryTestStore.cs
+++ b/test/EFCore.InMemory.FunctionalTests/TestUtilities/InMemoryTestStore.cs
@@ -41,7 +41,7 @@ public class InMemoryTestStore(string name = null, bool shared = true) : TestSto
 
     public override Task CleanAsync(DbContext context)
     {
-        context.GetService<IInMemoryStoreCache>().GetStore(Name).Clear();
+        context.GetService<IInMemoryStoreProvider>().Store.Clear();
         return context.Database.EnsureCreatedAsync();
     }
 }

--- a/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseTest.cs
+++ b/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseTest.cs
@@ -36,6 +36,24 @@ public class InMemoryDatabaseTest
     }
 
     [ConditionalFact]
+    public void Uses_different_stores_for_different_database_roots()
+    {
+        const string databaseName = nameof(Uses_different_stores_for_different_database_roots);
+
+        var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
+
+        var options1 = new DbContextOptionsBuilder().UseInMemoryDatabase(databaseName, new InMemoryDatabaseRoot()).Options;
+        var options2 = new DbContextOptionsBuilder().UseInMemoryDatabase(databaseName, new InMemoryDatabaseRoot()).Options;
+
+        var store1 = InMemoryTestHelpers.Instance.CreateContextServices(serviceProvider, options1)
+            .GetRequiredService<IInMemoryDatabase>();
+        var store2 = InMemoryTestHelpers.Instance.CreateContextServices(serviceProvider, options2)
+            .GetRequiredService<IInMemoryDatabase>();
+
+        Assert.NotSame(store1.Store, store2.Store);
+    }
+
+    [ConditionalFact]
     public void EnsureDatabaseCreated_returns_true_for_first_use_of_persistent_database_and_false_thereafter()
     {
         var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();

--- a/test/EFCore.Tests/DbContextTest.Services.cs
+++ b/test/EFCore.Tests/DbContextTest.Services.cs
@@ -980,7 +980,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContextWithOC1A())
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
@@ -990,7 +990,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC1A())
             {
                 // Singleton services not the same because service provider caching is off
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.NotSame(singleton[2], context.GetService<IMemoryCache>());
             }
@@ -1007,11 +1007,11 @@ namespace Microsoft.EntityFrameworkCore
             var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetService<ILoggerFactory>());
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var context = new ConstructorTestContextWithOC1B(loggerFactory, memoryCache))
             {
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
@@ -1022,7 +1022,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC1B(loggerFactory, memoryCache))
             {
                 // Singleton internal services not the same because service provider caching is off
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
             }
@@ -1040,7 +1040,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1051,7 +1051,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
                 // Singleton services not the same because service provider caching is off
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.NotSame(singleton[2], context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1076,11 +1076,11 @@ namespace Microsoft.EntityFrameworkCore
                 .UseMemoryCache(memoryCache)
                 .Options;
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1091,7 +1091,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1109,18 +1109,18 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContextWithOC2A(internalServiceProvider))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContextWithOC2A(internalServiceProvider))
             {
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
             }
         }
@@ -1142,20 +1142,20 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[2], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -1174,7 +1174,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1184,7 +1184,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.NotSame(singleton[2], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1210,11 +1210,11 @@ namespace Microsoft.EntityFrameworkCore
                 .EnableServiceProviderCaching(false)
                 .Options;
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1225,7 +1225,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1249,19 +1249,19 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContext1A(options))
             {
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -1279,7 +1279,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new DbContext(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
@@ -1288,7 +1288,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new DbContext(options))
             {
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -1315,11 +1315,11 @@ namespace Microsoft.EntityFrameworkCore
                 .ConfigureWarnings(w => w.Default(WarningBehavior.Throw))
                 .Options;
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var context = new DbContext(options))
             {
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1330,7 +1330,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new DbContext(options))
             {
-                Assert.Same(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
@@ -1354,19 +1354,19 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new DbContext(options))
             {
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new DbContext(options))
             {
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -1407,7 +1407,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Same(context1, serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>());
                 }
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -1425,7 +1425,7 @@ namespace Microsoft.EntityFrameworkCore
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
 
                 // Singleton services not the same because service provider caching is off
-                Assert.NotSame(singleton[0], context2.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context2.GetService<ILoggerFactory>());
                 Assert.NotSame(singleton[2], context2.GetService<IMemoryCache>());
             }
@@ -1445,7 +1445,7 @@ namespace Microsoft.EntityFrameworkCore
 
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var serviceScope = appServiceProvider
                        .GetRequiredService<IServiceScopeFactory>()
@@ -1453,7 +1453,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1B>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1466,7 +1466,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1B>();
 
                 // Singleton internal services not the same because service provider caching is off
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
             }
         }
@@ -1497,7 +1497,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1518,7 +1518,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
 
@@ -1544,7 +1544,7 @@ namespace Microsoft.EntityFrameworkCore
             ILoggerFactory loggerFactory;
             IMemoryCache memoryCache;
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
             IDbContextOptions options;
 
             using (var serviceScope = appServiceProvider
@@ -1553,7 +1553,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
                 Assert.NotNull(memoryCache = context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
@@ -1568,7 +1568,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 // Singleton services not the same because service provider caching is off
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.NotSame(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1592,7 +1592,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1604,7 +1604,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
             }
         }
@@ -1632,7 +1632,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1645,7 +1645,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -1687,7 +1687,7 @@ namespace Microsoft.EntityFrameworkCore
                     ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC3A>()
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1702,7 +1702,7 @@ namespace Microsoft.EntityFrameworkCore
                     ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC3A>()
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -1726,7 +1726,7 @@ namespace Microsoft.EntityFrameworkCore
 
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
             IDbContextOptions options;
 
             using (var serviceScope = appServiceProvider
@@ -1735,7 +1735,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -1748,7 +1748,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.Same(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 if (singletonOptions)
                 {
@@ -1779,7 +1779,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1792,7 +1792,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -1810,7 +1810,7 @@ namespace Microsoft.EntityFrameworkCore
 
             ILoggerFactory loggerFactory;
             IMemoryCache memoryCache;
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
             IDbContextOptions options;
 
             using (var serviceScope = appServiceProvider
@@ -1819,7 +1819,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
                 Assert.NotNull(memoryCache = context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
@@ -1833,7 +1833,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.NotSame(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
@@ -1862,7 +1862,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1875,7 +1875,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -1901,7 +1901,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1914,7 +1914,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -1934,7 +1934,7 @@ namespace Microsoft.EntityFrameworkCore
 
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
             IDbContextOptions options;
 
             using (var serviceScope = appServiceProvider
@@ -1943,7 +1943,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -1956,7 +1956,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
-                Assert.Same(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
@@ -1979,7 +1979,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -1992,7 +1992,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -2015,7 +2015,7 @@ namespace Microsoft.EntityFrameworkCore
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
             IDbContextOptions options;
-            IInMemoryStoreCache singleton;
+            IInMemoryDatabaseRootCache singleton;
 
             using (var serviceScope = appServiceProvider
                        .GetRequiredService<IServiceScopeFactory>()
@@ -2023,7 +2023,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -2036,7 +2036,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
@@ -2062,7 +2062,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
@@ -2075,7 +2075,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
@@ -2111,7 +2111,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -2126,7 +2126,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
 
-                Assert.Same(singleton[0], context2.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
             }
@@ -2199,7 +2199,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -2214,7 +2214,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.Same(singleton[0], context2.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
             }
@@ -2257,7 +2257,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotSame(context1, context2);
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -2292,7 +2292,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
 
                 // Singleton services not the same because service provider caching is off
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.NotSame(singleton[2], context.GetService<IMemoryCache>());
 
@@ -2360,7 +2360,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotSame(context1, context2);
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -2379,7 +2379,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();
@@ -2418,7 +2418,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context1 = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -2433,7 +2433,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context2 = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.Same(singleton[0], context2.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
             }
@@ -2494,7 +2494,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context1 = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
@@ -2509,7 +2509,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context2 = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.Same(singleton[0], context2.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
             }
@@ -2550,7 +2550,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotSame(context1, context2);
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -2569,7 +2569,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();
@@ -2630,7 +2630,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotSame(context1, context2);
 
-                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -2649,7 +2649,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
-                Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
+                Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();


### PR DESCRIPTION
- Remove the DatabaseRoot from the InMemoryOptionsExtension service provider equality condition.
- Remove the DatabaseRoot from the InMemorySingletonOptions.
- Resolve the IInMemoryStore in a scoped service (IInMemoryStoreProvider) instead of a singleton service (IInMemoryStoreCache).
- Fall back to the DatabaseRoot stored in a singleton service (IInMemoryDatabaseRootCache) if the options does not specify one.

Fixes #34476 

