### PR TITLE
[release/9.0] Acquire the migrations database lock in a transaction.

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -80,6 +80,7 @@ public static class RelationalEventId
         PendingModelChangesWarning,
         NonTransactionalMigrationOperationWarning,
         AcquiringMigrationLock,
+        MigrationsUserTransactionWarning,
 
         // Query events
         QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
@@ -763,6 +764,19 @@ public static class RelationalEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId AcquiringMigrationLock = MakeMigrationsId(Id.AcquiringMigrationLock);
+
+    /// <summary>
+    ///     A migration lock is being acquired.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="EventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId MigrationsUserTransactionWarning = MakeMigrationsId(Id.MigrationsUserTransactionWarning);
 
     private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
 

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -2426,6 +2426,36 @@ public static class RelationalLoggerExtensions
     }
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.MigrationsUserTransactionWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    public static void MigrationsUserTransactionWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics)
+    {
+        var definition = RelationalResources.LogMigrationsUserTransaction(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new EventData(
+                definition,
+                MigrationsUserTransactionWarning);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string MigrationsUserTransactionWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition)definition;
+        return d.GenerateMessage();
+    }
+
+    /// <summary>
     ///     Logs for the <see cref="RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning" /> event.
     /// </summary>
     /// <param name="diagnostics">The diagnostics logger to use.</param>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -374,6 +374,15 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogMigrationsUserTransactionWarning;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogKeyHasDefaultValue;
 
     /// <summary>

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -197,16 +197,19 @@ public abstract class HistoryRepository : IHistoryRepository
     /// <summary>
     ///     Gets an exclusive lock on the database.
     /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    public abstract IDisposable GetDatabaseLock();
+    public abstract IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction);
 
     /// <summary>
     ///     Gets an exclusive lock on the database.
     /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public abstract Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default);
+    public abstract Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(
+        IDbContextTransaction transaction, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Configures the entity type mapped to the history table.

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -128,14 +128,15 @@ public abstract class HistoryRepository : IHistoryRepository
     /// </summary>
     /// <returns><see langword="true" /> if the table already exists, <see langword="false" /> otherwise.</returns>
     public virtual bool Exists()
-        => InterpretExistsResult(
-            Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalar(
-                new RelationalCommandParameterObject(
-                    Dependencies.Connection,
-                    null,
-                    null,
-                    Dependencies.CurrentContext.Context,
-                    Dependencies.CommandLogger, CommandSource.Migrations)));
+        => Dependencies.DatabaseCreator.Exists()
+            && InterpretExistsResult(
+                Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalar(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        null,
+                        Dependencies.CurrentContext.Context,
+                        Dependencies.CommandLogger, CommandSource.Migrations)));
 
     /// <summary>
     ///     Checks whether or not the history table exists.
@@ -147,15 +148,16 @@ public abstract class HistoryRepository : IHistoryRepository
     /// </returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual async Task<bool> ExistsAsync(CancellationToken cancellationToken = default)
-        => InterpretExistsResult(
-            await Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalarAsync(
-                new RelationalCommandParameterObject(
-                    Dependencies.Connection,
-                    null,
-                    null,
-                    Dependencies.CurrentContext.Context,
-                    Dependencies.CommandLogger, CommandSource.Migrations),
-                cancellationToken).ConfigureAwait(false));
+        => await Dependencies.DatabaseCreator.ExistsAsync(cancellationToken).ConfigureAwait(false)
+            && InterpretExistsResult(
+                await Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalarAsync(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        null,
+                        Dependencies.CurrentContext.Context,
+                        Dependencies.CommandLogger, CommandSource.Migrations),
+                    cancellationToken).ConfigureAwait(false));
 
     /// <summary>
     ///     Interprets the result of executing <see cref="ExistsSql" />.

--- a/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
@@ -59,7 +59,8 @@ public sealed record HistoryRepositoryDependencies
         IRelationalTypeMappingSource typeMappingSource,
         ICurrentDbContext currentContext,
         IModelRuntimeInitializer modelRuntimeInitializer,
-        IRelationalCommandDiagnosticsLogger commandLogger)
+        IRelationalCommandDiagnosticsLogger commandLogger,
+        IDiagnosticsLogger<DbLoggerCategory.Migrations> migrationsLogger)
     {
         DatabaseCreator = databaseCreator;
         RawSqlCommandBuilder = rawSqlCommandBuilder;
@@ -75,6 +76,7 @@ public sealed record HistoryRepositoryDependencies
         CurrentContext = currentContext;
         ModelRuntimeInitializer = modelRuntimeInitializer;
         CommandLogger = commandLogger;
+        MigrationsLogger = migrationsLogger;
     }
 
     /// <summary>
@@ -146,4 +148,9 @@ public sealed record HistoryRepositoryDependencies
     ///     The command logger
     /// </summary>
     public IRelationalCommandDiagnosticsLogger CommandLogger { get; init; }
+
+    /// <summary>
+    ///     The migrations logger
+    /// </summary>
+    public IDiagnosticsLogger<DbLoggerCategory.Migrations> MigrationsLogger { get; init; }
 }

--- a/src/EFCore.Relational/Migrations/IHistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/IHistoryRepository.cs
@@ -75,18 +75,20 @@ public interface IHistoryRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Gets an exclusive lock on the database.
+    ///     Acquires an exclusive lock on the database.
     /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    IDisposable GetDatabaseLock();
+    IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction);
 
     /// <summary>
-    ///     Gets an exclusive lock on the database.
+    ///     Acquires an exclusive lock on the database asynchronously.
     /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default);
+    Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Generates a SQL script that will create the history table.

--- a/src/EFCore.Relational/Migrations/IHistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/IHistoryRepository.cs
@@ -50,11 +50,43 @@ public interface IHistoryRepository
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
-    ///     A task that represents the asynchronous operation. The task result contains
-    ///     <see langword="true" /> if the table already exists, <see langword="false" /> otherwise.
+    ///     A task that represents the asynchronous operation.
     /// </returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     Task CreateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Creates the history table if it doesn't exist.
+    /// </summary>
+    /// <returns><see langword="true" /> if the table was created, <see langword="false" /> otherwise.</returns>
+    bool CreateIfNotExists()
+    {
+        if (!Exists())
+        {
+            Create();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    ///     Creates the history table.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation. The task result contains
+    ///     <see langword="true" /> if the table was created, <see langword="false" /> otherwise.
+    /// </returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    async Task<bool> CreateIfNotExistsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await ExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await CreateAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        return false;
+    }
 
     /// <summary>
     ///     Queries the history table for all migrations that have been applied.
@@ -75,20 +107,23 @@ public interface IHistoryRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     The condition under witch the lock is released implicitly.
+    /// </summary>
+    LockReleaseBehavior LockReleaseBehavior { get; }
+
+    /// <summary>
     ///     Acquires an exclusive lock on the database.
     /// </summary>
-    /// <param name="transaction">The transaction currently in use.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction);
+    IMigrationsDatabaseLock AcquireDatabaseLock();
 
     /// <summary>
     ///     Acquires an exclusive lock on the database asynchronously.
     /// </summary>
-    /// <param name="transaction">The transaction currently in use.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default);
+    Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Generates a SQL script that will create the history table.

--- a/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
@@ -33,11 +33,41 @@ public interface IMigrationCommandExecutor
     /// </summary>
     /// <param name="migrationCommands">The commands to execute.</param>
     /// <param name="connection">The connection to use.</param>
+    /// <param name="executionState">The state of the current migration execution.</param>
+    /// <param name="executeInTransaction">Indicates whether the commands should be executed in a transaction.</param>
+    void ExecuteNonQuery(
+        IReadOnlyList<MigrationCommand> migrationCommands,
+        IRelationalConnection connection,
+        MigrationExecutionState executionState,
+        bool executeInTransaction);
+
+    /// <summary>
+    ///     Executes the given commands using the given database connection.
+    /// </summary>
+    /// <param name="migrationCommands">The commands to execute.</param>
+    /// <param name="connection">The connection to use.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     Task ExecuteNonQueryAsync(
         IEnumerable<MigrationCommand> migrationCommands,
         IRelationalConnection connection,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Executes the given commands using the given database connection.
+    /// </summary>
+    /// <param name="migrationCommands">The commands to execute.</param>
+    /// <param name="connection">The connection to use.</param>
+    /// <param name="executionState">The state of the current migration execution.</param>
+    /// <param name="executeInTransaction">Indicates whether the commands should be executed in a transaction.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task ExecuteNonQueryAsync(
+        IReadOnlyList<MigrationCommand> migrationCommands,
+        IRelationalConnection connection,
+        MigrationExecutionState executionState,
+        bool executeInTransaction,
         CancellationToken cancellationToken = default);
 }

--- a/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
+
 namespace Microsoft.EntityFrameworkCore.Migrations;
 
 /// <summary>
@@ -34,12 +36,17 @@ public interface IMigrationCommandExecutor
     /// <param name="migrationCommands">The commands to execute.</param>
     /// <param name="connection">The connection to use.</param>
     /// <param name="executionState">The state of the current migration execution.</param>
-    /// <param name="executeInTransaction">Indicates whether the commands should be executed in a transaction.</param>
-    void ExecuteNonQuery(
+    /// <param name="commitTransaction">
+    ///     Indicates whether the transaction started by this call should be commited.
+    ///     If <see langword="false" />, the transaction will be made available in <paramref name="executionState"/>.
+    /// </param>
+    /// <param name="isolationLevel">The isolation level for the transaction.</param>
+    int ExecuteNonQuery(
         IReadOnlyList<MigrationCommand> migrationCommands,
         IRelationalConnection connection,
         MigrationExecutionState executionState,
-        bool executeInTransaction);
+        bool commitTransaction,
+        IsolationLevel isolationLevel = IsolationLevel.Unspecified);
 
     /// <summary>
     ///     Executes the given commands using the given database connection.
@@ -60,14 +67,19 @@ public interface IMigrationCommandExecutor
     /// <param name="migrationCommands">The commands to execute.</param>
     /// <param name="connection">The connection to use.</param>
     /// <param name="executionState">The state of the current migration execution.</param>
-    /// <param name="executeInTransaction">Indicates whether the commands should be executed in a transaction.</param>
+    /// <param name="commitTransaction">
+    ///     Indicates whether the transaction started by this call should be commited.
+    ///     If <see langword="false" />, the transaction will be made available in <paramref name="executionState"/>.
+    /// </param>
+    /// <param name="isolationLevel">The isolation level for the transaction.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    Task ExecuteNonQueryAsync(
+    Task<int> ExecuteNonQueryAsync(
         IReadOnlyList<MigrationCommand> migrationCommands,
         IRelationalConnection connection,
         MigrationExecutionState executionState,
-        bool executeInTransaction,
+        bool commitTransaction,
+        IsolationLevel isolationLevel = IsolationLevel.Unspecified,
         CancellationToken cancellationToken = default);
 }

--- a/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
@@ -46,7 +46,7 @@ public interface IMigrationCommandExecutor
         IRelationalConnection connection,
         MigrationExecutionState executionState,
         bool commitTransaction,
-        IsolationLevel isolationLevel = IsolationLevel.Unspecified);
+        IsolationLevel? isolationLevel = null);
 
     /// <summary>
     ///     Executes the given commands using the given database connection.
@@ -80,6 +80,6 @@ public interface IMigrationCommandExecutor
         IRelationalConnection connection,
         MigrationExecutionState executionState,
         bool commitTransaction,
-        IsolationLevel isolationLevel = IsolationLevel.Unspecified,
+        IsolationLevel? isolationLevel = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+///     Represents an exclusive lock on the database that is used to ensure that only one migration application can be run at a time.
+/// </summary>
+/// <remarks>
+///     Database providers typically implement this.
+/// </remarks>
+public interface IMigrationsDatabaseLock : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    ///     Acquires an exclusive lock on the database again, if the current one was already released.
+    /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
+    /// <returns>An object that can be disposed to release the lock.</returns>
+    IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction);
+
+    /// <summary>
+    ///     Acquires an exclusive lock on the database again, if the current one was already released.
+    /// </summary>
+    /// <param name="transaction">The transaction currently in use.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>An object that can be disposed to release the lock.</returns>
+    Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default);
+}

--- a/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
@@ -25,7 +25,7 @@ public interface IMigrationsDatabaseLock : IDisposable, IAsyncDisposable
     ///     <see langword="null"/> if there's no current transaction.
     /// </param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    IMigrationsDatabaseLock Refresh(bool connectionReopened, bool? transactionRestarted)
+    IMigrationsDatabaseLock ReacquireIfNeeded(bool connectionReopened, bool? transactionRestarted)
     {
         if ((connectionReopened && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Connection)
                 || (transactionRestarted is true && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Transaction))
@@ -47,7 +47,7 @@ public interface IMigrationsDatabaseLock : IDisposable, IAsyncDisposable
     /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    async Task<IMigrationsDatabaseLock> RefreshAsync(
+    async Task<IMigrationsDatabaseLock> ReacquireIfNeededAsync(
         bool connectionReopened, bool? transactionRestarted, CancellationToken cancellationToken = default)
     {
         if ((connectionReopened && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Connection)

--- a/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationsDatabaseLock.cs
@@ -7,22 +7,56 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 ///     Represents an exclusive lock on the database that is used to ensure that only one migration application can be run at a time.
 /// </summary>
 /// <remarks>
-///     Database providers typically implement this.
+///     Typically only database providers implement this.
 /// </remarks>
 public interface IMigrationsDatabaseLock : IDisposable, IAsyncDisposable
 {
     /// <summary>
-    ///     Acquires an exclusive lock on the database again, if the current one was already released.
+    ///    The history repository.
     /// </summary>
-    /// <param name="transaction">The transaction currently in use.</param>
+    protected IHistoryRepository HistoryRepository { get; }
+
+    /// <summary>
+    ///     Acquires an exclusive lock on the database again if the current one was already released.
+    /// </summary>
+    /// <param name="connectionReopened">Indicates whether the connection was reopened.</param>
+    /// <param name="transactionRestarted">
+    ///     Indicates whether the transaction was restarted.
+    ///     <see langword="null"/> if there's no current transaction.
+    /// </param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction);
+    IMigrationsDatabaseLock Refresh(bool connectionReopened, bool? transactionRestarted)
+    {
+        if ((connectionReopened && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Connection)
+                || (transactionRestarted is true && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Transaction))
+        {
+            Dispose();
+            return HistoryRepository.AcquireDatabaseLock();
+        }
+
+        return this;
+    }
 
     /// <summary>
     ///     Acquires an exclusive lock on the database again, if the current one was already released.
     /// </summary>
-    /// <param name="transaction">The transaction currently in use.</param>
+    /// <param name="connectionReopened">Indicates whether the connection was reopened.</param>
+    /// <param name="transactionRestarted">
+    ///     Indicates whether the transaction was restarted.
+    ///     <see langword="null"/> if there's no current transaction.
+    /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>An object that can be disposed to release the lock.</returns>
-    Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default);
+    async Task<IMigrationsDatabaseLock> RefreshAsync(
+        bool connectionReopened, bool? transactionRestarted, CancellationToken cancellationToken = default)
+    {
+        if ((connectionReopened && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Connection)
+                || (transactionRestarted is true && HistoryRepository.LockReleaseBehavior == LockReleaseBehavior.Transaction))
+        {
+            await DisposeAsync().ConfigureAwait(false);
+            return await HistoryRepository.AcquireDatabaseLockAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return this;
+    }
 }

--- a/src/EFCore.Relational/Migrations/LockReleaseBehavior.cs
+++ b/src/EFCore.Relational/Migrations/LockReleaseBehavior.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+///     Represents the conditions under which a lock is released implicitly.
+/// </summary>
+public enum LockReleaseBehavior
+{
+    /// <summary>
+    ///     The lock is released when the transaction is committed or rolled back.
+    /// </summary>
+    Transaction,
+
+    /// <summary>
+    ///     The lock is released when the connection is closed.
+    /// </summary>
+    Connection,
+
+    /// <summary>
+    ///     The lock can only be released explicitly.
+    /// </summary>
+    Explicit
+}

--- a/src/EFCore.Relational/Migrations/MigrationExecutionState.cs
+++ b/src/EFCore.Relational/Migrations/MigrationExecutionState.cs
@@ -19,6 +19,11 @@ public sealed class MigrationExecutionState
     public string? CurrentMigrationId { get; set; }
 
     /// <summary>
+    ///    Indicates whether any migration operation was performed.
+    /// </summary>
+    public bool AnyOperationPerformed { get; set; }
+
+    /// <summary>
     ///     The database lock that is in use.
     /// </summary>
     public IMigrationsDatabaseLock? DatabaseLock { get; set; }

--- a/src/EFCore.Relational/Migrations/MigrationExecutionState.cs
+++ b/src/EFCore.Relational/Migrations/MigrationExecutionState.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+///     Contains the state of the current migration execution.
+/// </summary>
+public sealed class MigrationExecutionState
+{
+    /// <summary>
+    ///     The index of the last command that was committed to the database.
+    /// </summary>
+    public int LastCommittedCommandIndex { get; set; }
+
+    /// <summary>
+    ///     The id the migration that is currently being applied.
+    /// </summary>
+    public string? CurrentMigrationId { get; set; }
+
+    /// <summary>
+    ///     The database lock that is in use.
+    /// </summary>
+    public IMigrationsDatabaseLock? DatabaseLock { get; set; }
+
+    /// <summary>
+    ///     The transaction that is in use.
+    /// </summary>
+    public IDbContextTransaction? Transaction { get; set; }
+}

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -2130,7 +2130,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(
@@ -2256,7 +2256,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.RelationalStrings", typeof(RelationalResources).Assembly);
 
         /// <summary>
-        ///     Acquiring an exclusive lock for migration application. See https://aka.ms/efcore-docs-migrations for more information if this takes too long.
+        ///     Acquiring an exclusive lock for migration application. See https://aka.ms/efcore-docs-migrations-lock for more information if this takes too long.
         /// </summary>
         public static EventDefinition LogAcquiringMigrationLock(IDiagnosticsLogger logger)
         {
@@ -3422,6 +3422,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             }
 
             return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     A transaction was started before applying migrations. This prevents a database lock to be acquired and hence the database will not be protected from concurrent migration applications. The transactions and execution strategy are already managed by EF as needed. Remove the external transaction.
+        /// </summary>
+        public static EventDefinition LogMigrationsUserTransaction(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransactionWarning;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransactionWarning,
+                    logger,
+                    static logger => new EventDefinition(
+                        logger.Options,
+                        RelationalEventId.MigrationsUserTransactionWarning,
+                        LogLevel.Warning,
+                        "RelationalEventId.MigrationsUserTransactionWarning",
+                        level => LoggerMessage.Define(
+                            level,
+                            RelationalEventId.MigrationsUserTransactionWarning,
+                            _resourceManager.GetString("LogMigrationsUserTransaction")!)));
+            }
+
+            return (EventDefinition)definition;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -785,6 +785,10 @@
   <data name="LogMigrationAttributeMissingWarning" xml:space="preserve">
     <value>A [Migration] attribute isn't specified on the '{class}' class.</value>
     <comment>Warning RelationalEventId.MigrationAttributeMissingWarning string</comment>
+  </data>
+  <data name="LogMigrationsUserTransaction" xml:space="preserve">
+    <value>A transaction was started before applying migrations. This prevents a database lock to be acquired and hence the database will not be protected from concurrent migration applications. The transactions and execution strategy are already managed by EF as needed. Remove the external transaction.</value>
+    <comment>Warning RelationalEventId.MigrationsUserTransactionWarning</comment>
   </data>
   <data name="LogMultipleCollectionIncludeWarning" xml:space="preserve">
     <value>Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.</value>

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -116,7 +116,7 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
     ///     to incrementally update the schema. It is assumed that none of the tables exist in the database.
     /// </summary>
     public virtual void CreateTables()
-        => Dependencies.MigrationCommandExecutor.ExecuteNonQuery(GetCreateTablesCommands(), Dependencies.Connection);
+        => Dependencies.MigrationCommandExecutor.ExecuteNonQuery(GetCreateTablesCommands(), Dependencies.Connection, new MigrationExecutionState(), commitTransaction: true);
 
     /// <summary>
     ///     Asynchronously creates all tables for the current model in the database. No attempt is made
@@ -129,7 +129,7 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual Task CreateTablesAsync(CancellationToken cancellationToken = default)
         => Dependencies.MigrationCommandExecutor.ExecuteNonQueryAsync(
-            GetCreateTablesCommands(), Dependencies.Connection, cancellationToken);
+            GetCreateTablesCommands(), Dependencies.Connection, new MigrationExecutionState(), commitTransaction: true, cancellationToken: cancellationToken);
 
     /// <summary>
     ///     Gets the commands that will create all tables from the model.

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
 using System.Text;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
@@ -59,8 +60,10 @@ public class SqlServerHistoryRepository : HistoryRepository
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override IDisposable GetDatabaseLock()
+    public override IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
     {
+        Dependencies.MigrationsLogger.AcquiringMigrationLock();
+
         var dbLock = CreateMigrationDatabaseLock();
         int result;
         try
@@ -91,8 +94,10 @@ public class SqlServerHistoryRepository : HistoryRepository
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override async Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default)
+    public override async Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
     {
+        Dependencies.MigrationsLogger.AcquiringMigrationLock();
+
         var dbLock = CreateMigrationDatabaseLock();
         int result;
         try

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data;
 using System.Text;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
@@ -60,7 +59,15 @@ public class SqlServerHistoryRepository : HistoryRepository
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+    public override LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Connection;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override IMigrationsDatabaseLock AcquireDatabaseLock()
     {
         Dependencies.MigrationsLogger.AcquiringMigrationLock();
 
@@ -94,7 +101,7 @@ public class SqlServerHistoryRepository : HistoryRepository
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override async Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+    public override async Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default)
     {
         Dependencies.MigrationsLogger.AcquiringMigrationLock();
 
@@ -140,7 +147,8 @@ DECLARE @result int;
 EXEC @result = sp_releaseapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session';
 SELECT @result
 """),
-            CreateRelationalCommandParameters());
+            CreateRelationalCommandParameters(),
+            this);
 
     private RelationalCommandParameterObject CreateRelationalCommandParameters()
         => new(

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
@@ -19,7 +19,7 @@ public class SqlServerMigrationDatabaseLock(
     IRelationalCommand relationalCommand,
     RelationalCommandParameterObject relationalCommandParameters,
     CancellationToken cancellationToken = default)
-    : IDisposable, IAsyncDisposable
+    : IMigrationsDatabaseLock
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -38,4 +38,22 @@ public class SqlServerMigrationDatabaseLock(
     /// </summary>
     public async ValueTask DisposeAsync()
         => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction)
+        => this;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default)
+        => Task.FromResult((IMigrationsDatabaseLock)this);
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
@@ -18,9 +18,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
 public class SqlServerMigrationDatabaseLock(
     IRelationalCommand relationalCommand,
     RelationalCommandParameterObject relationalCommandParameters,
+    IHistoryRepository historyRepository,
     CancellationToken cancellationToken = default)
     : IMigrationsDatabaseLock
 {
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IHistoryRepository HistoryRepository => historyRepository;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -38,22 +47,4 @@ public class SqlServerMigrationDatabaseLock(
     /// </summary>
     public async ValueTask DisposeAsync()
         => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction)
-        => this;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default)
-        => Task.FromResult((IMigrationsDatabaseLock)this);
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationDatabaseLock.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
 public class SqlServerMigrationDatabaseLock(
-    IRelationalCommand relationalCommand,
+    IRelationalCommand releaseLockCommand,
     RelationalCommandParameterObject relationalCommandParameters,
     IHistoryRepository historyRepository,
     CancellationToken cancellationToken = default)
@@ -37,7 +37,7 @@ public class SqlServerMigrationDatabaseLock(
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public void Dispose()
-        => relationalCommand.ExecuteScalar(relationalCommandParameters);
+        => releaseLockCommand.ExecuteScalar(relationalCommandParameters);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,5 +46,5 @@ public class SqlServerMigrationDatabaseLock(
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public async ValueTask DisposeAsync()
-        => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
+        => await releaseLockCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
 }

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
@@ -139,8 +139,6 @@ SELECT COUNT(*) FROM "sqlite_master" WHERE "name" = {stringTypeMapping.GenerateS
                 retryDelay = retryDelay.Add(retryDelay);
             }
         }
-
-        throw new TimeoutException();
     }
 
     /// <summary>
@@ -180,8 +178,6 @@ SELECT COUNT(*) FROM "sqlite_master" WHERE "name" = {stringTypeMapping.GenerateS
                 retryDelay = retryDelay.Add(retryDelay);
             }
         }
-
-        throw new TimeoutException();
     }
 
     private IRelationalCommand CreateLockTableCommand()

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
@@ -104,7 +103,15 @@ SELECT COUNT(*) FROM "sqlite_master" WHERE "name" = {stringTypeMapping.GenerateS
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+    public override LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Explicit;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override IMigrationsDatabaseLock AcquireDatabaseLock()
     {
         Dependencies.MigrationsLogger.AcquiringMigrationLock();
 
@@ -143,7 +150,7 @@ SELECT COUNT(*) FROM "sqlite_master" WHERE "name" = {stringTypeMapping.GenerateS
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override async Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(
-        IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         Dependencies.MigrationsLogger.AcquiringMigrationLock();
 
@@ -212,7 +219,7 @@ DELETE FROM "{LockTableName}"
     }
 
     private SqliteMigrationDatabaseLock CreateMigrationDatabaseLock()
-        => new(CreateDeleteLockCommand(), CreateRelationalCommandParameters());
+        => new(CreateDeleteLockCommand(), CreateRelationalCommandParameters(), this);
 
     private RelationalCommandParameterObject CreateRelationalCommandParameters()
         => new(

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 
 /// <summary>
@@ -13,7 +14,7 @@ public class SqliteMigrationDatabaseLock(
     IRelationalCommand relationalCommand,
     RelationalCommandParameterObject relationalCommandParameters,
     CancellationToken cancellationToken = default)
-    : IDisposable, IAsyncDisposable
+    : IMigrationsDatabaseLock
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -32,4 +33,22 @@ public class SqliteMigrationDatabaseLock(
     /// </summary>
     public async ValueTask DisposeAsync()
         => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction)
+        => this;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default)
+        => Task.FromResult((IMigrationsDatabaseLock)this);
 }

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 
 /// <summary>
@@ -13,9 +12,18 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 public class SqliteMigrationDatabaseLock(
     IRelationalCommand relationalCommand,
     RelationalCommandParameterObject relationalCommandParameters,
+    IHistoryRepository historyRepository,
     CancellationToken cancellationToken = default)
     : IMigrationsDatabaseLock
 {
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IHistoryRepository HistoryRepository => historyRepository;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -33,22 +41,4 @@ public class SqliteMigrationDatabaseLock(
     /// </summary>
     public async ValueTask DisposeAsync()
         => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public IMigrationsDatabaseLock Reacquire(IDbContextTransaction? transaction)
-        => this;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public Task<IMigrationsDatabaseLock> ReacquireAsync(IDbContextTransaction? transaction, CancellationToken cancellationToken = default)
-        => Task.FromResult((IMigrationsDatabaseLock)this);
 }

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationDatabaseLock.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
 public class SqliteMigrationDatabaseLock(
-    IRelationalCommand relationalCommand,
+    IRelationalCommand releaseLockCommand,
     RelationalCommandParameterObject relationalCommandParameters,
     IHistoryRepository historyRepository,
     CancellationToken cancellationToken = default)
@@ -31,7 +31,7 @@ public class SqliteMigrationDatabaseLock(
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public void Dispose()
-        => relationalCommand.ExecuteScalar(relationalCommandParameters);
+        => releaseLockCommand.ExecuteScalar(relationalCommandParameters);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -40,5 +40,5 @@ public class SqliteMigrationDatabaseLock(
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public async ValueTask DisposeAsync()
-        => await relationalCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
+        => await releaseLockCommand.ExecuteScalarAsync(relationalCommandParameters, cancellationToken).ConfigureAwait(false);
 }

--- a/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
+++ b/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
@@ -222,10 +222,10 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
         public string GetCreateScript()
             => throw new NotImplementedException();
 
-        public IDisposable GetDatabaseLock()
+        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
             => throw new NotImplementedException();
 
-        public Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public string GetDeleteScript(string migrationId)
@@ -294,10 +294,10 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IDisposable GetDatabaseLock()
+        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
             => throw new NotImplementedException();
 
-        public Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public string GetDeleteScript(string migrationId)

--- a/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
+++ b/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
@@ -192,6 +192,8 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
 
     public class ExtensionHistoryRepository : IHistoryRepository
     {
+        public virtual LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Explicit;
+
         public void Create()
             => throw new NotImplementedException();
 
@@ -222,10 +224,10 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
         public string GetCreateScript()
             => throw new NotImplementedException();
 
-        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+        public IMigrationsDatabaseLock AcquireDatabaseLock()
             => throw new NotImplementedException();
 
-        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public string GetDeleteScript(string migrationId)
@@ -264,6 +266,8 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
 
     public class ContextHistoryRepository : IHistoryRepository
     {
+        public virtual LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Explicit;
+
         public bool Exists()
             => throw new NotImplementedException();
 
@@ -294,10 +298,10 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+        public IMigrationsDatabaseLock AcquireDatabaseLock()
             => throw new NotImplementedException();
 
-        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public string GetDeleteScript(string migrationId)

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -125,7 +125,8 @@ public class MigrationsScaffolderTest
                     services.GetRequiredService<IDatabaseProvider>(),
                     services.GetRequiredService<IMigrationsModelDiffer>(),
                     services.GetRequiredService<IDesignTimeModel>(),
-                    services.GetRequiredService<IDbContextOptions>())));
+                    services.GetRequiredService<IDbContextOptions>(),
+                    services.GetRequiredService<IExecutionStrategy>())));
     }
 
     // ReSharper disable once UnusedTypeParameter
@@ -182,10 +183,10 @@ public class MigrationsScaffolderTest
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IDisposable GetDatabaseLock()
+        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
             => throw new NotImplementedException();
 
-        public Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -144,6 +144,8 @@ public class MigrationsScaffolderTest
 
     private class MockHistoryRepository : IHistoryRepository
     {
+        public virtual LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Explicit;
+
         public string GetBeginIfExistsScript(string migrationId)
             => null;
 
@@ -183,10 +185,10 @@ public class MigrationsScaffolderTest
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+        public IMigrationsDatabaseLock AcquireDatabaseLock()
             => throw new NotImplementedException();
 
-        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
@@ -362,10 +362,10 @@ public class RelationalDatabaseFacadeExtensionsTest
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IDisposable GetDatabaseLock()
+        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
             => throw new NotImplementedException();
 
-        public Task<IAsyncDisposable> GetDatabaseLockAsync(CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Extensions/RelationalDatabaseFacadeExtensionsTest.cs
@@ -321,6 +321,8 @@ public class RelationalDatabaseFacadeExtensionsTest
 
     private class FakeHistoryRepository : IHistoryRepository
     {
+        public virtual LockReleaseBehavior LockReleaseBehavior => LockReleaseBehavior.Explicit;
+
         public List<HistoryRow> AppliedMigrations { get; set; }
 
         public IReadOnlyList<HistoryRow> GetAppliedMigrations()
@@ -362,10 +364,10 @@ public class RelationalDatabaseFacadeExtensionsTest
         public Task CreateAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public IMigrationsDatabaseLock AcquireDatabaseLock(IDbContextTransaction transaction)
+        public IMigrationsDatabaseLock AcquireDatabaseLock()
             => throw new NotImplementedException();
 
-        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(IDbContextTransaction transaction, CancellationToken cancellationToken = default)
+        public Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -1017,13 +1017,14 @@ DECLARE @result int;
 EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
 SELECT @result
 
-SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
-
-CREATE TABLE [__EFMigrationsHistory] (
-    [MigrationId] nvarchar(150) NOT NULL,
-    [ProductVersion] nvarchar(32) NOT NULL,
-    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-);
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
 
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 
@@ -1046,6 +1047,20 @@ BEGIN
 
     THROW 65536, 'Test', 0;
 END
+
+DECLARE @result int;
+EXEC @result = sp_releaseapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session';
+SELECT @result
+
+DECLARE @result int;
+EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
+SELECT @result
+
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
 
 IF OBJECT_ID(N'Blogs', N'U') IS NULL
 BEGIN
@@ -1110,13 +1125,14 @@ DECLARE @result int;
 EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
 SELECT @result
 
-SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
-
-CREATE TABLE [__EFMigrationsHistory] (
-    [MigrationId] nvarchar(150) NOT NULL,
-    [ProductVersion] nvarchar(32) NOT NULL,
-    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-);
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
 
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 
@@ -1139,6 +1155,20 @@ BEGIN
 
     THROW 65536, 'Test', 0;
 END
+
+DECLARE @result int;
+EXEC @result = sp_releaseapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session';
+SELECT @result
+
+DECLARE @result int;
+EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
+SELECT @result
+
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
 
 IF OBJECT_ID(N'Blogs', N'U') IS NULL
 BEGIN
@@ -2078,7 +2108,8 @@ DROP DATABASE TransactionSuppressed");
             public override MigrationsContext CreateContext()
             {
                 var options = AddOptions(TestStore.AddProviderOptions(new DbContextOptionsBuilder()))
-                    .UseSqlServer(TestStore.ConnectionString, b => b.ApplyConfiguration())
+                    .UseSqlServer(TestStore.ConnectionString, b => b
+                        .ApplyConfiguration())
                     .UseInternalServiceProvider(ServiceProvider)
                     .Options;
                 return new MigrationsContext(options);

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -1026,6 +1026,8 @@ BEGIN
     );
 END;
 
+SELECT 1
+
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 
 SELECT [MigrationId], [ProductVersion]
@@ -1055,6 +1057,8 @@ SELECT @result
 DECLARE @result int;
 EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
 SELECT @result
+
+SELECT 1
 
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 
@@ -1134,6 +1138,8 @@ BEGIN
     );
 END;
 
+SELECT 1
+
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 
 SELECT [MigrationId], [ProductVersion]
@@ -1163,6 +1169,8 @@ SELECT @result
 DECLARE @result int;
 EXEC @result = sp_getapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session', @LockMode = 'Exclusive';
 SELECT @result
+
+SELECT 1
 
 SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -43,6 +43,13 @@ public class TestSqlServerRetryingExecutionStrategy : SqlServerRetryingExecution
     {
     }
 
+    public TestSqlServerRetryingExecutionStrategy(
+        ExecutionStrategyDependencies dependencies,
+        IEnumerable<int> errorNumbersToAdd)
+        : base(dependencies, DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers.Concat(errorNumbersToAdd))
+    {
+    }
+
     protected override bool ShouldRetryOn(Exception exception)
     {
         if (base.ShouldRetryOn(exception))


### PR DESCRIPTION
Fixes #34439

### Description

The migrations database lock introduced in https://github.com/dotnet/efcore/pull/34115 doesn't work with providers that use a transaction-based lock implementation.

With this the lock can be acquired inside the transaction and all migrations are executed in a single transaction (when possible) to allow them to be covered by a single lock.

Additionally, the non-transaction based locks will be reacquired when retrying on a transient failure.

### Customer impact

Currently, the migrations database lock does not work on some providers. And they aren't reacquired when retrying on a transient failure for the other providers.

### How found

Reported by a provider maintainer.

### Regression

No, new feature.

### Testing

Tests added.

### Risk

Medium. It's a breaking change for providers from rc1, but it's unlikely that the existing implementations were working correctly.