### PR TITLE
(RC2) Cosmos: strip implicit casts to allow vector search over arrays

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 
@@ -63,7 +64,8 @@ public class CosmosVectorTypeMapping : CosmosTypeMapping
         : this(
             new CoreTypeMappingParameters(
                 mapping.ClrType,
-                converter: mapping.Converter,
+                // This is a hack to allow both arrays and ROM types without different function overloads or type mappings.
+                converter: mapping.Converter?.GetType() == typeof(BytesToStringConverter) ? null : mapping.Converter,
                 mapping.Comparer,
                 mapping.KeyComparer,
                 elementMapping: mapping.ElementTypeMapping,
@@ -114,4 +116,35 @@ public class CosmosVectorTypeMapping : CosmosTypeMapping
     /// </summary>
     protected override CoreTypeMapping Clone(CoreTypeMappingParameters parameters)
         => new CosmosVectorTypeMapping(parameters, VectorType);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override JToken? GenerateJToken(object? value)
+    {
+        // This is a hack to allow both arrays and ROM types without different function overloads or type mappings.
+        var type = value?.GetType();
+        if (type?.IsArray is false)
+        {
+            if (type == typeof(ReadOnlyMemory<byte>))
+            {
+                value = ((ReadOnlyMemory<byte>)value!).ToArray();
+            }
+            else if (type == typeof(ReadOnlyMemory<sbyte>))
+            {
+                value = ((ReadOnlyMemory<sbyte>)value!).ToArray();
+            }
+            else if (type == typeof(ReadOnlyMemory<float>))
+            {
+                value = ((ReadOnlyMemory<float>)value!).ToArray();
+            }
+        }
+
+        return value == null
+            ? null
+            : JToken.FromObject(value, CosmosClientWrapper.Serializer);
+    }
 }


### PR DESCRIPTION
Port of #34437

Fixes #34402

### Description

Cosmos vector search was merged as an experimental feature in EF9. This PR adds support of array types in addition to `ReadOnlyMemory<>` types.

### Customer impact

Allow customers to use vector search with array properties.

### How found

Known bug on vector search implementation.

### Regression

No.

### Testing

Tests added and run using the preview SDK.

### Risk

Low.
