### PR TITLE
(RC2) Fix ESCAPE clause for Azure Synapse. (#34463)

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -297,20 +297,8 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                         // (but SqlNullabilityProcess will convert this to a true constant if the instance is non-nullable)
                         "" => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant("%")),
 
-                        string s => s.Any(IsLikeWildChar)
-                            ? _sqlExpressionFactory.Like(
-                                translatedInstance,
-                                _sqlExpressionFactory.Constant(
-                                    methodType switch
-                                    {
-                                        StartsEndsWithContains.StartsWith => EscapeLikePattern(s) + '%',
-                                        StartsEndsWithContains.EndsWith => '%' + EscapeLikePattern(s),
-                                        StartsEndsWithContains.Contains => $"%{EscapeLikePattern(s)}%",
-
-                                        _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
-                                    }),
-                                _sqlExpressionFactory.Constant(LikeEscapeString))
-                            : _sqlExpressionFactory.Like(
+                        string s when !s.Any(IsLikeWildChar)
+                            => _sqlExpressionFactory.Like(
                                 translatedInstance,
                                 _sqlExpressionFactory.Constant(
                                     methodType switch
@@ -322,6 +310,24 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                                         _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
                                     })),
 
+                        // Azure Synapse does not support ESCAPE clause in LIKE
+                        // fallback to translation like with column/expression
+                        string s when _sqlServerSingletonOptions.EngineType == SqlServerEngineType.AzureSynapse
+                            => TranslateWithoutLike(patternIsNonEmptyConstantString: true),
+
+                        string s => _sqlExpressionFactory.Like(
+                            translatedInstance,
+                            _sqlExpressionFactory.Constant(
+                                methodType switch
+                                {
+                                    StartsEndsWithContains.StartsWith => EscapeLikePattern(s) + '%',
+                                    StartsEndsWithContains.EndsWith => '%' + EscapeLikePattern(s),
+                                    StartsEndsWithContains.Contains => $"%{EscapeLikePattern(s)}%",
+
+                                    _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
+                                }),
+                            _sqlExpressionFactory.Constant(LikeEscapeString)),
+
                         _ => throw new UnreachableException()
                     };
 
@@ -329,7 +335,10 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                 }
 
                 case SqlParameterExpression patternParameter
-                    when patternParameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal):
+                    when patternParameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal)
+                        // Azure Synapse does not support ESCAPE clause in LIKE
+                        // fall through to translation like with column/expression
+                        && _sqlServerSingletonOptions.EngineType != SqlServerEngineType.AzureSynapse:
                 {
                     // The pattern is a parameter, register a runtime parameter that will contain the rewritten LIKE pattern, where
                     // all special characters have been escaped.
@@ -356,23 +365,29 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                 default:
                     // The pattern is a column or a complex expression; the possible special characters in the pattern cannot be escaped,
                     // preventing us from translating to LIKE.
-                    translation = methodType switch
-                    {
-                        // For StartsWith/EndsWith, use LEFT or RIGHT instead to extract substring and compare:
-                        // WHERE instance IS NOT NULL AND pattern IS NOT NULL AND LEFT(instance, LEN(pattern)) = pattern
-                        // This is less efficient than LIKE (i.e. StartsWith does an index scan instead of seek), but we have no choice.
-                        // Note that we compensate for the case where both the instance and the pattern are null (null.StartsWith(null)); a
-                        // simple equality would yield true in that case, but we want false. We technically
-                        StartsEndsWithContains.StartsWith or StartsEndsWithContains.EndsWith
-                            => _sqlExpressionFactory.AndAlso(
-                                _sqlExpressionFactory.IsNotNull(translatedInstance),
-                                _sqlExpressionFactory.AndAlso(
-                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
-                                    _sqlExpressionFactory.Equal(
-                                        _sqlExpressionFactory.Function(
-                                            methodType is StartsEndsWithContains.StartsWith ? "LEFT" : "RIGHT",
-                                            new[]
-                                            {
+                    translation = TranslateWithoutLike();
+                    return true;
+            }
+
+            SqlExpression TranslateWithoutLike(bool patternIsNonEmptyConstantString = false)
+            {
+                return methodType switch
+                {
+                    // For StartsWith/EndsWith, use LEFT or RIGHT instead to extract substring and compare:
+                    // WHERE instance IS NOT NULL AND pattern IS NOT NULL AND LEFT(instance, LEN(pattern)) = pattern
+                    // This is less efficient than LIKE (i.e. StartsWith does an index scan instead of seek), but we have no choice.
+                    // Note that we compensate for the case where both the instance and the pattern are null (null.StartsWith(null)); a
+                    // simple equality would yield true in that case, but we want false. We technically
+                    StartsEndsWithContains.StartsWith or StartsEndsWithContains.EndsWith
+                        => _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(translatedInstance),
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                _sqlExpressionFactory.Equal(
+                                    _sqlExpressionFactory.Function(
+                                        methodType is StartsEndsWithContains.StartsWith ? "LEFT" : "RIGHT",
+                                        new[]
+                                        {
                                                 translatedInstance,
                                                 _sqlExpressionFactory.Function(
                                                     "LEN",
@@ -380,37 +395,44 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                                                     nullable: true,
                                                     argumentsPropagateNullability: new[] { true },
                                                     typeof(int))
-                                            },
-                                            nullable: true,
-                                            argumentsPropagateNullability: new[] { true, true },
-                                            typeof(string),
-                                            stringTypeMapping),
-                                        translatedPattern))),
+                                        },
+                                        nullable: true,
+                                        argumentsPropagateNullability: new[] { true, true },
+                                        typeof(string),
+                                        stringTypeMapping),
+                                    translatedPattern))),
 
-                        // For Contains, just use CHARINDEX and check if the result is greater than 0.
-                        // Add a check to return null when the pattern is an empty string (and the string isn't null)
-                        StartsEndsWithContains.Contains
-                            => _sqlExpressionFactory.AndAlso(
-                                _sqlExpressionFactory.IsNotNull(translatedInstance),
-                                _sqlExpressionFactory.AndAlso(
-                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
-                                    _sqlExpressionFactory.OrElse(
-                                        _sqlExpressionFactory.GreaterThan(
-                                            _sqlExpressionFactory.Function(
-                                                "CHARINDEX",
-                                                new[] { translatedPattern, translatedInstance },
-                                                nullable: true,
-                                                argumentsPropagateNullability: new[] { true, true },
-                                                typeof(int)),
-                                            _sqlExpressionFactory.Constant(0)),
-                                        _sqlExpressionFactory.Like(
-                                            translatedPattern,
-                                            _sqlExpressionFactory.Constant(string.Empty, stringTypeMapping))))),
+                    // For Contains, just use CHARINDEX and check if the result is greater than 0.
+                    StartsEndsWithContains.Contains when patternIsNonEmptyConstantString
+                        => _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(translatedInstance),
+                            CharIndexGreaterThanZero()),
 
-                        _ => throw new UnreachableException()
-                    };
+                    // For Contains, just use CHARINDEX and check if the result is greater than 0.
+                    // Add a check to return null when the pattern is an empty string (and the string isn't null)
+                    StartsEndsWithContains.Contains
+                        => _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(translatedInstance),
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                _sqlExpressionFactory.OrElse(
+                                    CharIndexGreaterThanZero(),
+                                    _sqlExpressionFactory.Like(
+                                        translatedPattern,
+                                        _sqlExpressionFactory.Constant(string.Empty, stringTypeMapping))))),
 
-                    return true;
+                    _ => throw new UnreachableException()
+                };
+
+                SqlExpression CharIndexGreaterThanZero()
+                    => _sqlExpressionFactory.GreaterThan(
+                        _sqlExpressionFactory.Function(
+                            "CHARINDEX",
+                            new[] { translatedPattern, translatedInstance },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(int)),
+                        _sqlExpressionFactory.Constant(0));
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQueryAzureSynapseTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQueryAzureSynapseTest.cs
@@ -5,9 +5,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class FunkyDataQuerySqlServerTest : FunkyDataQuerySqlServerBaseTest<FunkyDataQuerySqlServerTest.FunkyDataQuerySqlServerFixture>
+public class FunkyDataQueryAzureSynapseTest : FunkyDataQuerySqlServerBaseTest<FunkyDataQueryAzureSynapseTest.FunkyDataQueryAzureSynapseFixture>
 {
-    public FunkyDataQuerySqlServerTest(FunkyDataQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+    public FunkyDataQueryAzureSynapseTest(FunkyDataQueryAzureSynapseFixture fixture, ITestOutputHelper testOutputHelper)
         : base(fixture, testOutputHelper)
     {
     }
@@ -20,46 +20,46 @@ public class FunkyDataQuerySqlServerTest : FunkyDataQuerySqlServerBaseTest<Funky
             """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%\%B%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND CHARINDEX(N'%B', [f].[FirstName]) > 0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%a\_%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND CHARINDEX(N'a_', [f].[FirstName]) > 0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%\_Ba\_%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND CHARINDEX(N'_Ba_', [f].[FirstName]) > 0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE N'%\%B\%a\%r%' ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR CHARINDEX(N'%B%a%r', [f].[FirstName]) <= 0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -71,60 +71,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_contains='%\%B%' (Size = 4000)
+@__prm1_0='%B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0 OR @__prm1_0 LIKE N'')
 """,
-            //
-            """
-@__prm2_0_contains='%a\_%' (Size = 4000)
+                //
+                """
+@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0 OR @__prm2_0 LIKE N'')
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
-@__prm4_0_contains='%' (Size = 4000)
+                //
+                """
+@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0 OR @__prm4_0 LIKE N'')
 """,
-            //
-            """
-@__prm5_0_contains='%\_Ba\_%' (Size = 4000)
+                //
+                """
+@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0 OR @__prm5_0 LIKE N'')
 """,
-            //
-            """
-@__prm6_0_contains='%\%B\%a\%r%' (Size = 4000)
+                //
+                """
+@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@__prm6_0, [f].[FirstName]) <= 0 AND @__prm6_0 NOT LIKE N'')
 """,
-            //
-            """
-@__prm7_0_contains='%' (Size = 4000)
+                //
+                """
+@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@__prm7_0, [f].[FirstName]) <= 0 AND @__prm7_0 NOT LIKE N'')
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -164,46 +164,46 @@ WHERE [f].[FirstName] IS NULL OR [f0].[LastName] IS NULL OR (CHARINDEX([f0].[Las
             """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'\%B%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'%B')) = N'%B'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'\_B%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'_B')) = N'_B'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'\_Ba\_%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'_Ba_')) = N'_Ba_'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE N'\%B\%a\%r%' ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(N'%B%a%r')) <> N'%B%a%r'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -215,60 +215,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_startswith='\%B%' (Size = 4000)
+@__prm1_0='%B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
 """,
-            //
-            """
-@__prm2_0_startswith='\_B%' (Size = 4000)
+                //
+                """
+@__prm2_0='_B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
-@__prm4_0_startswith='%' (Size = 4000)
+                //
+                """
+@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0
 """,
-            //
-            """
-@__prm5_0_startswith='\_Ba\_%' (Size = 4000)
+                //
+                """
+@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0
 """,
-            //
-            """
-@__prm6_0_startswith='\%B\%a\%r%' (Size = 4000)
+                //
+                """
+@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
 """,
-            //
-            """
-@__prm7_0_startswith='%' (Size = 4000)
+                //
+                """
+@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -282,46 +282,46 @@ FROM [FunkyCustomers] AS [f]
             """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'\[%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'[')) = N'['
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'B\[%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'B[')) = N'B['
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'B[[a^')) = N'B[[a^'
 """,
-            //
-            """
-@__prm1_0_startswith='\[%' (Size = 4000)
+                //
+                """
+@__prm1_0='[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
 """,
-            //
-            """
-@__prm2_0_startswith='B\[%' (Size = 4000)
+                //
+                """
+@__prm2_0='B[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
 """,
-            //
-            """
-@__prm3_0_startswith='B\[\[a^%' (Size = 4000)
+                //
+                """
+@__prm3_0='B[[a^' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm3_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL AND [f].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName]
@@ -362,46 +362,46 @@ WHERE [f].[FirstName] IS NULL OR [f0].[LastName] IS NULL OR LEFT([f].[FirstName]
             """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%\%r' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(N'%r')) = N'%r'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%r\_' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(N'r_')) = N'r_'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE N'%\_r\_' ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(N'_r_')) = N'_r_'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE N'%a\%r\%' ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(N'a%r%')) <> N'a%r%'
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NULL
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -413,60 +413,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_endswith='%\%r' (Size = 4000)
+@__prm1_0='%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
 """,
-            //
-            """
-@__prm2_0_endswith='%r\_' (Size = 4000)
+                //
+                """
+@__prm2_0='r_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-            //
-            """
-@__prm4_0_endswith='%' (Size = 4000)
+                //
+                """
+@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0
 """,
-            //
-            """
-@__prm5_0_endswith='%\_r\_' (Size = 4000)
+                //
+                """
+@__prm5_0='_r_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0
 """,
-            //
-            """
-@__prm6_0_endswith='%a\%r\%' (Size = 4000)
+                //
+                """
+@__prm6_0='a%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
 """,
-            //
-            """
-@__prm7_0_endswith='%' (Size = 4000)
+                //
+                """
+@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
 """,
-            //
-            """
+                //
+                """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -580,21 +580,20 @@ ORDER BY [f].[Id]
 
         AssertSql(
             """
-@__s_0_contains='%B%' (Size = 4000)
-@__s_0_startswith='B%' (Size = 4000)
+@__s_0='B' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__s_0_contains ESCAPE N'\' OR [f].[LastName] LIKE @__s_0_startswith ESCAPE N'\'
+WHERE ([f].[FirstName] IS NOT NULL AND (CHARINDEX(@__s_0, [f].[FirstName]) > 0 OR @__s_0 LIKE N'')) OR ([f].[LastName] IS NOT NULL AND LEFT([f].[LastName], LEN(@__s_0)) = @__s_0)
 """);
     }
 
-    public class FunkyDataQuerySqlServerFixture : FunkyDataQueryFixtureBase, ITestSqlLoggerFactory
+    public class FunkyDataQueryAzureSynapseFixture : FunkyDataQueryFixtureBase, ITestSqlLoggerFactory
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;
 
         protected override ITestStoreFactory TestStoreFactory
-            => SqlServerTestStoreFactory.Instance;
+            => AzureSynapseTestStoreFactory.Instance;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerBaseTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerBaseTest.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#nullable disable
+
+public abstract class FunkyDataQuerySqlServerBaseTest<TFixture> : FunkyDataQueryTestBase<TFixture>
+    where TFixture : FunkyDataQueryTestBase<TFixture>.FunkyDataQueryFixtureBase, ITestSqlLoggerFactory, new()
+{
+    public FunkyDataQuerySqlServerBaseTest(TFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
+        => new RelationalQueryAsserter(
+            fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression);
+
+    protected override void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
+
+    protected void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStore.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0022 // Use block body for methods
+// ReSharper disable SuggestBaseTypeForParameter
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+public class AzureSynapseTestStore : SqlServerTestStore
+{
+    public new static async Task<AzureSynapseTestStore> GetNorthwindStoreAsync()
+        => (AzureSynapseTestStore)await SqlServerNorthwindTestStoreFactory.Instance
+            .GetOrCreate(SqlServerNorthwindTestStoreFactory.Name).InitializeAsync(null, (Func<DbContext>?)null);
+
+    public new static AzureSynapseTestStore GetOrCreate(string name)
+        => new(name);
+
+    public new static async Task<AzureSynapseTestStore> GetOrCreateInitializedAsync(string name)
+        => (AzureSynapseTestStore)await new AzureSynapseTestStore(name).InitializeSqlServerAsync(null, (Func<DbContext>?)null, null);
+
+    public new static AzureSynapseTestStore GetOrCreateWithInitScript(string name, string initScript)
+        => new(name, initScript: initScript);
+
+    public new static AzureSynapseTestStore GetOrCreateWithScriptPath(
+        string name,
+        string scriptPath,
+        bool? multipleActiveResultSets = null,
+        bool shared = true)
+        => new(name, scriptPath: scriptPath, multipleActiveResultSets: multipleActiveResultSets, shared: shared);
+
+    public new static AzureSynapseTestStore Create(string name, bool useFileName = false)
+        => new(name, useFileName, shared: false);
+
+    public new static async Task<AzureSynapseTestStore> CreateInitializedAsync(
+        string name,
+        bool useFileName = false,
+        bool? multipleActiveResultSets = null)
+        => (AzureSynapseTestStore)await new AzureSynapseTestStore(name, useFileName, shared: false, multipleActiveResultSets: multipleActiveResultSets)
+            .InitializeSqlServerAsync(null, (Func<DbContext>?)null, null);
+
+    protected AzureSynapseTestStore(string name, bool useFileName = false, bool? multipleActiveResultSets = null, string? initScript = null, string? scriptPath = null, bool shared = true)
+        : base(name, useFileName, multipleActiveResultSets, initScript, scriptPath, shared)
+    {
+    }
+
+    public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
+        => (UseConnectionString
+            ? builder.UseAzureSynapse(ConnectionString, b => b.ApplyConfiguration())
+            : builder.UseAzureSynapse(Connection, b => b.ApplyConfiguration()))
+            .ConfigureWarnings(b => b.Ignore(SqlServerEventId.SavepointsDisabledBecauseOfMARS));
+}

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStoreFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStoreFactory.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+public class AzureSynapseTestStoreFactory : RelationalTestStoreFactory
+{
+    public static AzureSynapseTestStoreFactory Instance { get; } = new();
+
+    protected AzureSynapseTestStoreFactory()
+    {
+    }
+
+    public override TestStore Create(string storeName)
+        => AzureSynapseTestStore.Create(storeName);
+
+    public override TestStore GetOrCreate(string storeName)
+        => AzureSynapseTestStore.GetOrCreate(storeName);
+
+    public override IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
+        => serviceCollection
+            .AddEntityFrameworkAzureSynapse();
+}

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDbContextOptionsBuilderExtensions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDbContextOptionsBuilderExtensions.cs
@@ -21,4 +21,38 @@ public static class SqlServerDbContextOptionsBuilderExtensions
 
         return optionsBuilder;
     }
+
+    public static AzureSqlDbContextOptionsBuilder ApplyConfiguration(this AzureSqlDbContextOptionsBuilder optionsBuilder)
+    {
+        var maxBatch = TestEnvironment.GetInt(nameof(SqlServerDbContextOptionsBuilder.MaxBatchSize));
+        if (maxBatch.HasValue)
+        {
+            optionsBuilder.MaxBatchSize(maxBatch.Value);
+        }
+
+        optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
+
+        optionsBuilder.ExecutionStrategy(d => new TestSqlServerRetryingExecutionStrategy(d));
+
+        optionsBuilder.CommandTimeout(SqlServerTestStore.CommandTimeout);
+
+        return optionsBuilder;
+    }
+
+    public static AzureSynapseDbContextOptionsBuilder ApplyConfiguration(this AzureSynapseDbContextOptionsBuilder optionsBuilder)
+    {
+        var maxBatch = TestEnvironment.GetInt(nameof(SqlServerDbContextOptionsBuilder.MaxBatchSize));
+        if (maxBatch.HasValue)
+        {
+            optionsBuilder.MaxBatchSize(maxBatch.Value);
+        }
+
+        optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
+
+        optionsBuilder.ExecutionStrategy(d => new TestSqlServerRetryingExecutionStrategy(d));
+
+        optionsBuilder.CommandTimeout(SqlServerTestStore.CommandTimeout);
+
+        return optionsBuilder;
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -50,7 +50,7 @@ public class SqlServerTestStore : RelationalTestStore
     private readonly string? _initScript;
     private readonly string? _scriptPath;
 
-    private SqlServerTestStore(
+    protected SqlServerTestStore(
         string name,
         bool useFileName = false,
         bool? multipleActiveResultSets = null,


### PR DESCRIPTION
Port of #34463

Fixes #33555

### Description

Fixes translation of `Contains`/`StartsWith`/`EndsWith` into SQL on Azure Synapse.

### Customer impact

Customers using Azure Synapse are unable to run queries using `Contains`/`StartsWith`/`EndsWith` because improper SQL is generated.

### How found

Reported by customer.

### Regression

Yes.

### Testing

Tests added.

### Risk

Low.
