### PR TITLE
(RC2) Downgrade to LTS SqlClient

### DIFF
--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of #32915

### Description

We develop with the latest SqlClient package so that we have a better chance of catching regressions. However, we cannot release with this package because it has an open-ended support policy that may end before .NET 9/EF9 support ends. Therefore, we revert to the latest LTS package before release.

See [SqlClient driver support lifecycle](https://learn.microsoft.com/en-us/sql/connect/ado-net/sqlclient-driver-support-lifecycle?view=sql-server-ver16)

### Customer impact

Customer's get an LTS dependency by default. They can manually update to the non-LTS package.

### How found

N/A

### Regression

N/A

### Testing

All tests pass with LTS version.

### Risk

Low.
