### PR TITLE
[release/9.0] Always include generated files in the compilation

### DIFF
--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -114,15 +114,14 @@ For Publish:
     <Delete Files="$(EFGeneratedSourcesPublishFile)"
             Condition="'$(_EFGenerationStage)'=='publish'"/>
 
-    <CallTarget Targets="Build"/>
-
-    <!-- The files are written after the build to indicate that they are up to date with the assembly used for code generation -->
     <WriteLinesToFile File="$(EFGeneratedSourcesBuildFile)"
                       Lines="$(_EFGeneratedFiles)"
                       Condition="'$(_EFGenerationStage)'=='build'"/>
     <WriteLinesToFile File="$(EFGeneratedSourcesPublishFile)"
                       Lines="$(_EFGeneratedFiles)"
                       Condition="'$(_EFGenerationStage)'=='publish'"/>
+
+    <CallTarget Targets="Build"/>
   </Target>
 
   <Target Name="_EFValidateProperties"
@@ -135,11 +134,11 @@ For Publish:
   <Target Name="_EFReadGeneratedFilesList"
           BeforeTargets="_EFProcessGeneratedFiles;_EFCleanGeneratedFiles">
     <ReadLinesFromFile File="$(EFGeneratedSourcesBuildFile)"
-                       Condition="Exists($(EFGeneratedSourcesBuildFile))">
+                       Condition="Exists('$(EFGeneratedSourcesBuildFile)')">
       <Output TaskParameter="Lines" ItemName="_ReadGeneratedFiles"/>
     </ReadLinesFromFile>
     <ReadLinesFromFile File="$(EFGeneratedSourcesPublishFile)"
-                       Condition="Exists($(EFGeneratedSourcesPublishFile))">
+                       Condition="Exists('$(EFGeneratedSourcesPublishFile)')">
       <Output TaskParameter="Lines" ItemName="_ReadGeneratedFiles"/>
     </ReadLinesFromFile>
 
@@ -185,12 +184,15 @@ For Publish:
                    @(_DebugSymbolsIntermediatePath);
                    $(NonExistentFile);
                    @(CustomAdditionalCompileOutputs)">
+    <CallTarget Targets="_EFRemoveGeneratedFiles" />
+    <Delete Files="$(EFGeneratedSourcesBuildFile)" />
+    <Delete Files="$(EFGeneratedSourcesPublishFile)" />
+  </Target>
+
+  <Target Name="_EFRemoveGeneratedFiles">
     <ItemGroup>
       <Compile Remove="@(_EFGeneratedFiles)" />
     </ItemGroup>
-
-    <Delete Files="$(EFGeneratedSourcesBuildFile)" />
-    <Delete Files="$(EFGeneratedSourcesPublishFile)" />
   </Target>
 
   <!-- Go through the dependencies to check whether they need code generated for Native AOT -->


### PR DESCRIPTION
Fixes #33710

### Description

When publishing for NativeAOT EF Tasks would generate the compiled model, but then remove the files from compilation in `_EFPrepareForCompile`, because the contained `ItemGroup` is evaluated even when the target is skipped.

Additionally, the list of the generated files was being written after compilation, so the files weren't being included in the compilation.

### Customer impact

Publishing with NativeAOT doesn't work unless the compiled model is included manually in the project.

### How found
 
During validation

### Regression

No, new feature.

### Testing

Verified manually.

### Risk

Low. Code is executed only in build-time. And only affects the NativeAOT experimental support.