### PR TITLE
[release/8.0] Update FK ElementType when the FK properties change.

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -802,6 +802,14 @@ public class InternalPropertyBuilder
             {
                 Metadata.SetValueConverter((Type?)null, configurationSource);
             }
+
+            if (elementType == null
+                && CanSetConversion((Type?)null, configurationSource)
+                && !ElementTypeChangedConvention.UseOldBehavior33704)
+            {
+                Metadata.RemoveAnnotation(CoreAnnotationNames.ValueConverter);
+            }
+
             return new InternalElementTypeBuilder(Metadata.GetElementType()!, ModelBuilder);
         }
 

--- a/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -13,181 +13,181 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
     {
         public override void Can_set_composite_key_for_primitive_collection_on_an_entity_with_fields()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(EntityWithFields), "CollectionCompanyId"),
+                CoreStrings.PropertyNotMapped("int[]", nameof(EntityWithFields), "CollectionCompanyId"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_composite_key_for_primitive_collection_on_an_entity_with_fields()).Message);
 
         public override void Access_mode_can_be_overridden_at_entity_and_primitive_collection_levels()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<string>", nameof(CollectionQuarks), "Down"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Access_mode_can_be_overridden_at_entity_and_primitive_collection_levels()).Message);
 
         public override void Can_set_custom_value_generator_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(CollectionQuarks), "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_custom_value_generator_for_primitive_collections()).Message);
 
         public override void Can_set_element_type_annotation()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(Customer), "Notes"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_element_type_annotation()).Message);
 
         public override void Can_set_max_length_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("string[]", nameof(CollectionQuarks), "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_max_length_for_primitive_collections()).Message);
 
         public override void Can_set_primitive_collection_annotation()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(Customer), "Notes"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_primitive_collection_annotation()).Message);
 
         public override void Can_set_primitive_collection_annotation_by_type()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(Customer), "Notes"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_primitive_collection_annotation_by_type()).Message);
 
         public override void Can_set_primitive_collection_annotation_when_no_clr_property()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(Customer), "Notes"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_primitive_collection_annotation_when_no_clr_property()).Message);
 
         public override void Can_set_sentinel_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(CollectionQuarks), "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_sentinel_for_primitive_collections()).Message);
 
         public override void Can_set_unicode_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(CollectionQuarks), "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_unicode_for_primitive_collections()).Message);
 
         public override void Element_types_are_nullable_by_default_if_the_type_is_nullable()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_are_nullable_by_default_if_the_type_is_nullable()).Message);
 
         public override void Element_types_can_be_made_required()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_be_made_required()).Message);
 
         public override void Element_types_can_have_custom_type_value_converter_type_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("int[]", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_custom_type_value_converter_type_set()).Message);
 
         public override void Element_types_can_have_max_length()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_max_length()).Message);
 
         public override void Element_types_can_have_non_generic_value_converter_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("int[]", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_non_generic_value_converter_set()).Message);
 
         public override void Element_types_can_have_precision_and_scale()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<decimal?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_precision_and_scale()).Message);
 
         public override void Element_types_can_have_provider_type_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_provider_type_set()).Message);
 
         public override void Element_types_can_have_unicode_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_can_have_unicode_set()).Message);
 
         public override void Element_types_have_default_precision_and_scale()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<decimal?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_have_default_precision_and_scale()).Message);
 
         public override void Element_types_have_default_unicode()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<decimal?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_have_default_unicode()).Message);
 
         public override void Element_types_have_no_max_length_by_default()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int?>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Element_types_have_no_max_length_by_default()).Message);
 
         public override void Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()).Message);
 
         public override void Primitive_collections_can_be_made_optional()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_optional()).Message);
 
         public override void Primitive_collections_can_be_made_required()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_required()).Message);
 
         public override void Primitive_collections_can_be_set_to_generate_values_on_Add()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", nameof(CollectionQuarks), "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_set_to_generate_values_on_Add()).Message);
 
         public override void Primitive_collections_can_have_access_mode_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_have_access_mode_set()).Message);
 
         public override void Primitive_collections_can_have_field_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<string>", nameof(CollectionQuarks), "Down"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_have_field_set()).Message);
 
         public override void Primitive_collections_can_have_value_converter_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_have_value_converter_set()).Message);
 
         public override void Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()).Message);
 
         public override void Value_converter_type_on_primitive_collection_is_checked()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Up"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<int>", nameof(CollectionQuarks), "Up"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Value_converter_type_on_primitive_collection_is_checked()).Message);
 
@@ -425,7 +425,7 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
 
         public override void Primitive_collections_can_be_made_concurrency_tokens()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_concurrency_tokens()).Message);
 
@@ -437,97 +437,97 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
     {
         public override void Access_mode_can_be_overridden_at_entity_and_property_levels()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Down"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Access_mode_can_be_overridden_at_entity_and_property_levels()).Message);
 
         public override void Can_add_shadow_primitive_collections_when_they_have_been_ignored()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Shadow"),
+                CoreStrings.PropertyNotMapped("string[]", "ComplexProperties.Customer#Customer", "Shadow"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_add_shadow_primitive_collections_when_they_have_been_ignored()).Message);
 
         public override void Can_call_PrimitiveCollection_on_a_field()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(EntityWithFields), "CollectionId"),
+                CoreStrings.PropertyNotMapped("long[]", "ComplexProperties.EntityWithFields#EntityWithFields", "CollectionId"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_call_PrimitiveCollection_on_a_field()).Message);
 
         public override void Can_set_custom_value_generator_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_custom_value_generator_for_primitive_collections()).Message);
 
         public override void Can_set_max_length_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("string[]", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_max_length_for_primitive_collections()).Message);
 
         public override void Can_set_primitive_collection_annotation_when_no_clr_property()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Ints"),
+                CoreStrings.PropertyNotMapped("int[]", "ComplexProperties.Customer#Customer", "Ints"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_primitive_collection_annotation_when_no_clr_property()).Message);
 
         public override void Can_set_sentinel_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_sentinel_for_primitive_collections()).Message);
 
         public override void Can_set_unicode_for_primitive_collections()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Can_set_unicode_for_primitive_collections()).Message);
 
         public override void Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()).Message);
 
         public override void Primitive_collections_can_be_made_concurrency_tokens()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_concurrency_tokens()).Message);
 
         public override void Primitive_collections_can_be_made_optional()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_optional()).Message);
 
         public override void Primitive_collections_can_be_made_required()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("List<int>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_required()).Message);
 
         public override void Primitive_collections_can_be_set_to_generate_values_on_Add()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                CoreStrings.PropertyNotMapped("List<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Bottom"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_set_to_generate_values_on_Add()).Message);
 
         public override void Primitive_collections_can_have_field_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Down"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_have_field_set()).Message);
 
         public override void Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<int>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()).Message);
 
         public override void Properties_can_have_access_mode_set()
             => Assert.Equal(
-                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                CoreStrings.PropertyNotMapped("ObservableCollection<string>", "ComplexProperties.CollectionQuarks#CollectionQuarks", "Down"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Properties_can_have_access_mode_set()).Message);
 

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1076,11 +1076,12 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
-        public virtual void Can_configure_relationship_with_PK_ValueConverter()
+        public virtual void Can_configure_relationship_with_PK_ValueConverter_shadow_FK()
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<QueryResult>().Property(x => x.Id)
+            modelBuilder.Entity<QueryResult>()
+                .Property(x => x.Id)
                 .HasConversion(x => x.Id, x => new CustomId { Id = x });
 
             modelBuilder.Entity<ValueCategory>()
@@ -1089,8 +1090,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<QueryResult>()
                 .OwnsOne(q => q.Value)
-                .Property(x => x.CategoryId)
-                .HasConversion(x => x.Id, x => new CustomId { Id = x });
+                .Property(x => x.CategoryId);
 
             var model = modelBuilder.FinalizeModel();
 
@@ -1106,12 +1106,43 @@ public abstract partial class ModelBuilderTest
             var category = model.FindEntityType(typeof(ValueCategory));
             Assert.Null(category.FindProperty("TempId"));
 
-            var barNavigation = owned.GetDeclaredNavigations().Single(n => !n.ForeignKey.IsOwnership);
-            Assert.Same(category, barNavigation.TargetEntityType);
-            var fkProperty = barNavigation.ForeignKey.Properties.Single();
+            var categoryNavigation = owned.GetDeclaredNavigations().Single(n => !n.ForeignKey.IsOwnership);
+            Assert.Same(category, categoryNavigation.TargetEntityType);
+            var fkProperty = categoryNavigation.ForeignKey.Properties.Single();
             Assert.Equal("CategoryId", fkProperty.Name);
 
             Assert.Equal(3, model.GetEntityTypes().Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Can_configure_relationship_with_PK_ValueConverter()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<QueryResult>(eb =>
+            {
+                eb.Property(x => x.Id)
+                    .HasConversion(x => x.Id, x => new CustomId { Id = x });
+                eb.OwnsOne(q => q.Value)
+                    .WithOwner()
+                    .HasForeignKey(q => q.CategoryId);
+            });
+
+            modelBuilder.Ignore<ValueCategory>();
+
+            var model = modelBuilder.FinalizeModel();
+
+            var result = model.FindEntityType(typeof(QueryResult));
+            Assert.Null(result.FindProperty("TempId"));
+
+            var owned = result.GetDeclaredNavigations().Single().TargetEntityType;
+            Assert.Null(owned.FindProperty("TempId"));
+
+            var ownedPkProperty = owned.FindPrimaryKey().Properties.Single();
+            Assert.NotNull(ownedPkProperty.GetValueConverter());
+
+            Assert.Empty(owned.GetDeclaredNavigations().Where(n => !n.ForeignKey.IsOwnership));
+            Assert.Equal(2, model.GetEntityTypes().Count());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -809,9 +810,12 @@ public abstract partial class ModelBuilderTest
         public ValueCategory? Category { get; set; }
     }
 
-    protected class CustomId
+    protected class CustomId : IEnumerable<byte>
     {
         public int Id { get; set; }
+
+        public IEnumerator<byte> GetEnumerator() => throw new NotImplementedException();
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
     }
 
     protected class ValueCategory


### PR DESCRIPTION
Fixes #33704

### Description

In 8.0.0 we introduced a convention that configures properties as primitive collections, but it should avoid do that for properties that have been configured with a value conversion. However, in some cases a foreign key property can be configured as a primitive collection by the convention before the value conversion configuration is applied to the corresponding primary key. The solution is to enhance the convention logic to also handle this case.

Additionally, for Cosmos we were configuring properties as primitive collections even though they aren't supported.

### Customer impact

Affected models fail in model validation with an unhelpful exception. There is a workaround, but it isn't straightforward.

### How found
 
Customer reported

### Regression

Yes, from 7.0.x

### Testing

Tests added.

### Risk

Low. Quirk added.