### PR TITLE
Map directly to JSON id for types converted to string

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
@@ -84,13 +84,12 @@ public class CosmosJsonIdConvention
         {
             // If the entity type is not a keyed, root document in the container, then it doesn't have an `id` mapping, so
             // undo anything that was done by previous execution of this convention.
-            if (jsonIdProperty != null)
+            if (jsonIdProperty is not null)
             {
                 jsonIdProperty.Builder.ToJsonProperty(null);
-                entityType.Builder.HasNoProperty(jsonIdProperty);
             }
 
-            if (computedIdProperty != null
+            if (computedIdProperty is not null
                 && computedIdProperty != jsonIdProperty)
             {
                 entityType.Builder.HasNoProperty(computedIdProperty);
@@ -115,10 +114,17 @@ public class CosmosJsonIdConvention
             // - IDiscriminatorPropertySetConvention
             // - IEntityTypeBaseTypeChangedConvention
             var idDefinition = DefinitionFactory.Create((IEntityType)entityType)!;
-            var keyProperty = (IConventionProperty?)idDefinition.Properties.FirstOrDefault();
             if (idDefinition is { IncludesDiscriminator: false, Properties.Count: 1 })
             {
-                var clrType = keyProperty!.GetValueConverter()?.ProviderClrType ?? keyProperty.ClrType;
+                // If the property maps to a string in the JSON document, then we can use it directly, even if a value converter
+                // is applied. On the other hand, if it maps to a numeric or bool, then we need to duplicate this to preserve the
+                // non-string value for queries.
+                var keyProperty = (IConventionProperty)idDefinition.Properties.First();
+                var mapping = Dependencies.TypeMappingSource.FindMapping((IProperty)keyProperty);
+                var clrType = mapping?.Converter?.ProviderClrType
+                    ?? mapping?.ClrType
+                    ?? keyProperty!.ClrType;
+
                 if (clrType == typeof(string))
                 {
                     // We are at the point where we are going to map the `id` directly to the PK.

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosJsonIdConvention.cs
@@ -87,13 +87,13 @@ public class CosmosJsonIdConvention
             if (jsonIdProperty is not null)
             {
                 jsonIdProperty.Builder.ToJsonProperty(null);
+                entityType.Builder.RemoveUnusedImplicitProperties([jsonIdProperty]);
             }
 
             if (computedIdProperty is not null
                 && computedIdProperty != jsonIdProperty)
             {
-                entityType.Builder.HasNoProperty(computedIdProperty);
-            }
+                entityType.Builder.RemoveUnusedImplicitProperties([computedIdProperty]);            }
 
             return;
         }

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -700,12 +700,12 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         var entry = await context.AddAsync(item);
 
-        var id = entry.Property("__id").CurrentValue;
+        var id = entry.Property("Id").CurrentValue;
 
         Assert.NotNull(item.Id);
         Assert.NotNull(id);
 
-        Assert.Equal($"{item.Id}", id);
+        Assert.Equal(item.Id, id);
         Assert.Equal(EntityState.Added, entry.State);
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -537,6 +537,186 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
             Assert.DoesNotContain(entity.GetKeys(), k => k != entity.FindPrimaryKey());
         }
 
+        [ConditionalFact]
+        public virtual void Single_string_primary_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleStringKey>();
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleStringKey))!;
+
+            Assert.Equal(
+                [nameof(SingleStringKey.Id)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleStringKey.Id), "$type", nameof(SingleStringKey.Name), nameof(SingleStringKey.P1),
+                    nameof(SingleStringKey.P2), nameof(SingleStringKey.P3), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        [ConditionalFact] // Issue #34511
+        public virtual void Single_string_primary_key_with_single_partition_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleStringKey>().HasPartitionKey(e => e.P1);
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleStringKey))!;
+
+            Assert.Equal(
+                [nameof(SingleStringKey.Id), nameof(SingleStringKey.P1)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleStringKey.Id), nameof(SingleStringKey.P1), "$type", nameof(SingleStringKey.Name),
+                    nameof(SingleStringKey.P2), nameof(SingleStringKey.P3), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        [ConditionalFact] // Issue #34511
+        public virtual void Single_string_primary_key_with_hierarchical_partition_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleStringKey>().HasPartitionKey(e => new { e.P1, e.P2, e.P3 });
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleStringKey))!;
+
+            Assert.Equal(
+                [nameof(SingleStringKey.Id), nameof(SingleStringKey.P1), nameof(SingleStringKey.P2), nameof(SingleStringKey.P3)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleStringKey.Id), nameof(SingleStringKey.P1), nameof(SingleStringKey.P2), nameof(SingleStringKey.P3),
+                    "$type", nameof(SingleStringKey.Name), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        protected class SingleStringKey
+        {
+            public string Id { get; set; } = null!;
+            public string? Name { get; set; }
+            public string P1 { get; set; } = null!;
+            public string P2 { get; set; } = null!;
+            public string P3 { get; set; } = null!;
+        }
+
+        [ConditionalFact] // Issue #34554
+        public virtual void Single_GUID_primary_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleGuidKey>();
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleGuidKey))!;
+
+            Assert.Equal(
+                [nameof(SingleGuidKey.Id)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleGuidKey.Id), "$type", nameof(SingleGuidKey.Name), nameof(SingleGuidKey.P1),
+                    nameof(SingleGuidKey.P2), nameof(SingleGuidKey.P3), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        [ConditionalFact] // Issue #34554
+        public virtual void Single_GUID_primary_key_with_single_partition_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleGuidKey>().HasPartitionKey(e => e.P1);
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleGuidKey))!;
+
+            Assert.Equal(
+                [nameof(SingleGuidKey.Id), nameof(SingleGuidKey.P1)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleGuidKey.Id), nameof(SingleGuidKey.P1), "$type", nameof(SingleGuidKey.Name),
+                    nameof(SingleGuidKey.P2), nameof(SingleGuidKey.P3), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        [ConditionalFact] // Issue #34554
+        public virtual void Single_GUID_primary_key_with_hierarchical_partition_key_maps_to_JSON_id()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<SingleGuidKey>().HasPartitionKey(e => new { e.P1, e.P2, e.P3 });
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(SingleGuidKey))!;
+
+            Assert.Equal(
+                [nameof(SingleGuidKey.Id), nameof(SingleGuidKey.P1), nameof(SingleGuidKey.P2), nameof(SingleGuidKey.P3)],
+                entityType.FindPrimaryKey()!.Properties.Select(p => p.Name));
+
+            Assert.Equal(
+                [
+                    nameof(SingleGuidKey.Id), nameof(SingleGuidKey.P1), nameof(SingleGuidKey.P2), nameof(SingleGuidKey.P3),
+                    "$type", nameof(SingleGuidKey.Name), "__jObject"
+                ],
+                entityType.GetProperties().Select(p => p.Name));
+
+            Assert.Equal(1, entityType.GetKeys().Count());
+            Assert.Null(entityType.FindProperty("__id"));
+            Assert.Equal("id", entityType.FindProperty("Id")!.GetJsonPropertyName());
+        }
+
+        protected class SingleGuidKey
+        {
+            public Guid Id { get; set; }
+            public string? Name { get; set; }
+            public string P1 { get; set; } = null!;
+            public string P2 { get; set; } = null!;
+            public string P3 { get; set; } = null!;
+        }
+
         protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder>? configure = null)
             => new GenericTestModelBuilder(Fixture, configure);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
@@ -261,7 +261,7 @@ WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitio
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("HierarchicalPartitionKeyEntity", "DerivedHierarchicalPartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("HierarchicalPartitionKeyEntity", "DerivedHierarchicalPartitionKeyEntity") AND (c["Id"] = "31887258-bdf9-49b8-89b2-01b6aa741a4a"))
 """);
     }
 
@@ -286,7 +286,7 @@ WHERE c["$type"] IN ("OnlyHierarchicalPartitionKeyEntity", "DerivedOnlyHierarchi
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -312,7 +312,7 @@ WHERE c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartition
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -338,7 +338,7 @@ WHERE c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartition
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -365,7 +365,7 @@ OFFSET 0 LIMIT 2
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (1 = c["Id"]))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ("b29bced8-e1e5-420e-82d7-1c7a51703d34" = c["Id"]))
 """);
     }
 
@@ -391,7 +391,7 @@ WHERE c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartition
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -404,7 +404,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -428,7 +428,7 @@ WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitio
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["Id"] = 2)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["Id"] = "3307a33b-7f28-49ef-9857-48f4e3ebcaed")))
 """);
     }
 
@@ -468,7 +468,7 @@ WHERE (c["$type"] IN ("NoPartitionKeyEntity", "DerivedNoPartitionKeyEntity") AND
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -479,7 +479,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 999))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "50b66960-35be-40c5-bc3d-4c9f2799d4d1"))
 """);
     }
 
@@ -491,7 +491,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -504,7 +504,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -745,7 +745,10 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_hierarchical_partition_key_leaf();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], DerivedHierarchicalPartitionKeyEntity|11)""");
+        AssertSql(
+            """
+ReadItem(["PK1",1.0,true], DerivedHierarchicalPartitionKeyEntity|316c846c-787f-44b9-aadf-272f1658c5ff)
+""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key_leaf()
@@ -759,7 +762,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_constant_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant_leaf()
@@ -773,7 +776,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_parameter_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter_leaf()
@@ -787,7 +790,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_SingleAsync_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key_leaf()
@@ -801,7 +804,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_inverse_comparison_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key_leaf()
@@ -815,14 +818,14 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_EF_Property_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_leaf()
     {
         await base.ReadItem_with_WithPartitionKey_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key_leaf()
@@ -841,7 +844,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["Id"] = 22)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["Id"] = "11f8d1fd-7472-46f5-9e20-16af42b3b8d1")))
 """);
     }
 
@@ -875,7 +878,7 @@ WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKe
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c"))
 """);
     }
 
@@ -883,21 +886,21 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
     {
         await base.ReadItem_with_non_existent_id_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|999)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|b964beda-b4e1-4f5c-a729-0a35dae696fe)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking_leaf()
     {
         await base.ReadItem_with_AsNoTracking_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution_leaf()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_discriminator_mapping()
@@ -909,7 +912,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = "SinglePartitionKeyEntity")))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "SinglePartitionKeyEntity")))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -923,7 +926,7 @@ OFFSET 0 LIMIT 2
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
 """);
     }
 
@@ -938,7 +941,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -947,19 +950,18 @@ OFFSET 0 LIMIT 2
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping_leaf();
 
-        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], DerivedSinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping_leaf()
     {
         await base.ReadItem_with_single_explicit_incorrect_discriminator_mapping_leaf();
 
-        // No ReadItem because discriminator value is incorrect
         AssertSql(
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = "SinglePartitionKeyEntity")))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = "SinglePartitionKeyEntity")))
 """);
     }
 
@@ -974,7 +976,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND 
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
@@ -307,7 +307,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
             {
                 new HierarchicalPartitionKeyEntity
                 {
-                    Id = 1,
+                    Id = Guid.Parse("31887258-BDF9-49B8-89B2-01B6AA741A4A"),
                     PartitionKey1 = "PK1",
                     PartitionKey2 = 1,
                     PartitionKey3 = true,
@@ -315,7 +315,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                 },
                 new HierarchicalPartitionKeyEntity
                 {
-                    Id = 1,
+                    Id = Guid.Parse("31887258-BDF9-49B8-89B2-01B6AA741A4A"), // Same Id as previous; different partition.
                     PartitionKey1 = "PK2",
                     PartitionKey2 = 2,
                     PartitionKey3 = false,
@@ -323,7 +323,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                 },
                 new HierarchicalPartitionKeyEntity
                 {
-                    Id = 2,
+                    Id = Guid.Parse("BBA46A5D-BDB8-40F0-BA80-BA5731147B9A"), // Different Id.
                     PartitionKey1 = "PK1",
                     PartitionKey2 = 1,
                     PartitionKey3 = true,
@@ -331,7 +331,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                 },
                 new HierarchicalPartitionKeyEntity
                 {
-                    Id = 2,
+                    Id = Guid.Parse("BBA46A5D-BDB8-40F0-BA80-BA5731147B9A"), // Same Id as previous; different partition.
                     PartitionKey1 = "PK2",
                     PartitionKey2 = 2,
                     PartitionKey3 = false,
@@ -344,25 +344,25 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
             {
                 new SinglePartitionKeyEntity
                 {
-                    Id = 1,
+                    Id = Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34"),
                     PartitionKey = "PK1",
                     Payload = "Payload1"
                 },
                 new SinglePartitionKeyEntity
                 {
-                    Id = 1,
+                    Id = Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34"),
                     PartitionKey = "PK2",
                     Payload = "Payload2"
                 },
                 new SinglePartitionKeyEntity
                 {
-                    Id = 2,
+                    Id = Guid.Parse("3307A33B-7F28-49EF-9857-48F4E3EBCAED"),
                     PartitionKey = "PK1",
                     Payload = "Payload3"
                 },
                 new SinglePartitionKeyEntity
                 {
-                    Id = 2,
+                    Id = Guid.Parse("3307A33B-7F28-49EF-9857-48F4E3EBCAED"),
                     PartitionKey = "PK2",
                     Payload = "Payload4"
                 }
@@ -485,7 +485,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
 
 public class HierarchicalPartitionKeyEntity
 {
-    public int Id { get; set; }
+    public Guid Id { get; set; }
 
     public required string PartitionKey1 { get; set; }
     public int PartitionKey2 { get; set; }
@@ -496,7 +496,7 @@ public class HierarchicalPartitionKeyEntity
 
 public class SinglePartitionKeyEntity
 {
-    public int Id { get; set; }
+    public Guid Id { get; set; }
 
     public required string PartitionKey { get; set; }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryInheritanceFixtureBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryInheritanceFixtureBase.cs
@@ -133,7 +133,7 @@ public class ReadItemPartitionKeyQueryInheritanceFixtureBase : ReadItemPartition
             {
                 new DerivedHierarchicalPartitionKeyEntity
                 {
-                    Id = 11,
+                    Id = Guid.Parse("316C846C-787F-44B9-AADF-272F1658C5FF"),
                     PartitionKey1 = "PK1",
                     PartitionKey2 = 1,
                     PartitionKey3 = true,
@@ -142,7 +142,7 @@ public class ReadItemPartitionKeyQueryInheritanceFixtureBase : ReadItemPartition
                 },
                 new DerivedHierarchicalPartitionKeyEntity
                 {
-                    Id = 11,
+                    Id = Guid.Parse("316C846C-787F-44B9-AADF-272F1658C5FF"), // Same Id as previous; different partition.
                     PartitionKey1 = "PK2",
                     PartitionKey2 = 2,
                     PartitionKey3 = false,
@@ -151,7 +151,7 @@ public class ReadItemPartitionKeyQueryInheritanceFixtureBase : ReadItemPartition
                 },
                 new DerivedHierarchicalPartitionKeyEntity
                 {
-                    Id = 22,
+                    Id = Guid.Parse("C6E8E6D2-F33E-4695-9FA5-D0E9517EF04E"), // New Id.
                     PartitionKey1 = "PK1",
                     PartitionKey2 = 1,
                     PartitionKey3 = true,
@@ -160,7 +160,7 @@ public class ReadItemPartitionKeyQueryInheritanceFixtureBase : ReadItemPartition
                 },
                 new DerivedHierarchicalPartitionKeyEntity
                 {
-                    Id = 22,
+                    Id = Guid.Parse("C6E8E6D2-F33E-4695-9FA5-D0E9517EF04E"), // Same Id as previous; different partition.
                     PartitionKey1 = "PK2",
                     PartitionKey2 = 2,
                     PartitionKey3 = false,
@@ -174,28 +174,28 @@ public class ReadItemPartitionKeyQueryInheritanceFixtureBase : ReadItemPartition
             {
                 new DerivedSinglePartitionKeyEntity
                 {
-                    Id = 11,
+                    Id = Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C"),
                     PartitionKey = "PK1",
                     Payload = "Payload1",
                     DerivedPayload = "DerivedPayload1"
                 },
                 new DerivedSinglePartitionKeyEntity
                 {
-                    Id = 11,
+                    Id = Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C"),
                     PartitionKey = "PK2",
                     Payload = "Payload2",
                     DerivedPayload = "DerivedPayload2"
                 },
                 new DerivedSinglePartitionKeyEntity
                 {
-                    Id = 22,
+                    Id = Guid.Parse("11F8D1FD-7472-46F5-9E20-16AF42B3B8D1"),
                     PartitionKey = "PK1",
                     Payload = "Payload3",
                     DerivedPayload = "DerivedPayload3"
                 },
                 new DerivedSinglePartitionKeyEntity
                 {
-                    Id = 22,
+                    Id = Guid.Parse("11F8D1FD-7472-46F5-9E20-16AF42B3B8D1"),
                     PartitionKey = "PK2",
                     Payload = "Payload4",
                     DerivedPayload = "DerivedPayload4"

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryInheritanceTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryInheritanceTestBase.cs
@@ -154,7 +154,11 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
         return AssertQuery(
             async: true,
             ss => ss.Set<DerivedHierarchicalPartitionKeyEntity>()
-                .Where(e => e.Id == 11 && e.PartitionKey1 == "PK1" && e.PartitionKey2 == partitionKey2 && e.PartitionKey3));
+                .Where(
+                    e => e.Id == Guid.Parse("316C846C-787F-44B9-AADF-272F1658C5FF")
+                        && e.PartitionKey1 == "PK1"
+                        && e.PartitionKey2 == partitionKey2
+                        && e.PartitionKey3));
     }
 
     [ConditionalFact]
@@ -172,7 +176,8 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
     public virtual Task ReadItem_with_single_partition_key_constant_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11 && e.PartitionKey == "PK1"));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>()
+                .Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_only_single_partition_key_constant_leaf()
@@ -187,7 +192,8 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
 
         return AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11 && e.PartitionKey == partitionKey));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -207,7 +213,8 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
 
         return AssertSingle(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11 && e.PartitionKey == partitionKey));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -224,7 +231,8 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
     public virtual Task ReadItem_with_inverse_comparison_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => 11 == e.Id && "PK1" == e.PartitionKey));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>()
+                .Where(e => Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") == e.Id && "PK1" == e.PartitionKey));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_inverse_comparison_with_only_partition_key_leaf()
@@ -237,15 +245,17 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
         => AssertQuery(
             async: true,
             ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(
-                e => EF.Property<int>(e, nameof(DerivedSinglePartitionKeyEntity.Id)) == 11
+                e => EF.Property<Guid>(e, nameof(DerivedSinglePartitionKeyEntity.Id)) == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")
                     && EF.Property<string>(e, nameof(DerivedSinglePartitionKeyEntity.PartitionKey)) == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_WithPartitionKey_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().WithPartitionKey("PK1").Where(e => e.Id == 11),
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.PartitionKey == "PK1").Where(e => e.Id == 11));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().WithPartitionKey("PK1")
+                .Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")),
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.PartitionKey == "PK1")
+                .Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_WithPartitionKey_with_only_partition_key_leaf()
@@ -261,7 +271,7 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
 
         return AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11 && e.Id == 22 && e.PartitionKey == partitionKey),
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.Id == Guid.Parse("11F8D1FD-7472-46F5-9E20-16AF42B3B8D1") && e.PartitionKey == partitionKey),
             assertEmpty: true);
     }
 
@@ -287,27 +297,29 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
     public virtual Task ReadItem_is_not_used_without_partition_key_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_non_existent_id_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 999 && e.PartitionKey == "PK1"),
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>()
+                .Where(e => e.Id == Guid.Parse("B964BEDA-B4E1-4F5C-A729-0A35DAE696FE") && e.PartitionKey == "PK1"),
             assertEmpty: true);
 
     [ConditionalFact]
     public virtual Task ReadItem_with_AsNoTracking_leaf()
         => AssertQuery(
             async: true,
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().AsNoTracking().Where(e => e.Id == 11 && e.PartitionKey == "PK1"));
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().AsNoTracking().Where(
+                e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_AsNoTrackingWithIdentityResolution_leaf()
         => AssertQuery(
             async: true,
             ss => ss.Set<DerivedSinglePartitionKeyEntity>().AsNoTrackingWithIdentityResolution()
-                .Where(e => e.Id == 11 && e.PartitionKey == "PK1"));
+                .Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_single_explicit_discriminator_mapping_leaf()
@@ -318,11 +330,11 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
             async: true,
             ss => ss.Set<DerivedSinglePartitionKeyEntity>()
                 .Where(
-                    e => e.Id == 11
+                    e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")
                         && EF.Property<string>(e, "$type") == nameof(DerivedSinglePartitionKeyEntity)
                         && e.PartitionKey == partitionKey),
             ss => ss.Set<DerivedSinglePartitionKeyEntity>()
-                .Where(e => e.Id == 11 && e.PartitionKey == partitionKey));
+                .Where(e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -334,7 +346,7 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
             async: true,
             ss => ss.Set<DerivedSinglePartitionKeyEntity>()
                 .Where(
-                    e => e.Id == 11
+                    e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")
                         && EF.Property<string>(e, "$type") == nameof(SinglePartitionKeyEntity)
                         && e.PartitionKey == partitionKey),
             ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => false),
@@ -350,7 +362,11 @@ public abstract class ReadItemPartitionKeyQueryInheritanceTestBase<TFixture> : R
         return AssertSingle(
             async: true,
             ss => ss.Set<DerivedSinglePartitionKeyEntity>()
-                .Where(e => e.Id == 11 && EF.Property<string>(e, "$type") == discriminator && e.PartitionKey == partitionKey),
-            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(e => e.Id == 11 && e.PartitionKey == partitionKey));
+                .Where(
+                    e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C")
+                        && EF.Property<string>(e, "$type") == discriminator
+                        && e.PartitionKey == partitionKey),
+            ss => ss.Set<DerivedSinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("188D3253-81BE-4A87-B58F-A2BD07E6B98C") && e.PartitionKey == partitionKey));
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
@@ -236,7 +236,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_hierarchical_partition_key();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], 1)""");
+        AssertSql("""ReadItem(["PK1",1.0,true], 31887258-bdf9-49b8-89b2-01b6aa741a4a)""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key()
@@ -250,7 +250,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_single_partition_key_constant();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant()
@@ -264,7 +264,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_single_partition_key_parameter();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter()
@@ -278,7 +278,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_SingleAsync();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key()
@@ -292,7 +292,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_inverse_comparison();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key()
@@ -306,14 +306,14 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_EF_Property();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey()
     {
         await base.ReadItem_with_WithPartitionKey();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key()
@@ -332,7 +332,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["Id"] = 2)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["id"] = "3307a33b-7f28-49ef-9857-48f4e3ebcaed")))
 """);
     }
 
@@ -366,7 +366,7 @@ WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitio
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -374,21 +374,21 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_non_existent_id();
 
-        AssertSql("""ReadItem(["PK1"], 999)""");
+        AssertSql("""ReadItem(["PK1"], 50b66960-35be-40c5-bc3d-4c9f2799d4d1)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking()
     {
         await base.ReadItem_with_AsNoTracking();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_shared_container()
@@ -618,7 +618,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_hierarchical_partition_key_leaf();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], 11)""");
+        AssertSql("""ReadItem(["PK1",1.0,true], 316c846c-787f-44b9-aadf-272f1658c5ff)""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key_leaf()
@@ -632,7 +632,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_constant_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant_leaf()
@@ -646,7 +646,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_parameter_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter_leaf()
@@ -660,7 +660,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_SingleAsync_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key_leaf()
@@ -674,7 +674,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_inverse_comparison_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key_leaf()
@@ -688,14 +688,14 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_EF_Property_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_leaf()
     {
         await base.ReadItem_with_WithPartitionKey_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key_leaf()
@@ -714,7 +714,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["Id"] = 22)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["id"] = "11f8d1fd-7472-46f5-9e20-16af42b3b8d1")))
 """);
     }
 
@@ -748,7 +748,7 @@ WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["id"] = "PK1
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c"))
 """);
     }
 
@@ -756,40 +756,39 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
     {
         await base.ReadItem_with_non_existent_id_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 999)""");
+        AssertSql("""ReadItem(["PK1"], b964beda-b4e1-4f5c-a729-0a35dae696fe)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking_leaf()
     {
         await base.ReadItem_with_AsNoTracking_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution_leaf()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_discriminator_mapping()
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping()
     {
         await base.ReadItem_with_single_explicit_incorrect_discriminator_mapping();
 
-        // No ReadItem because discriminator value is incorrect
         AssertSql(
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
 """);
     }
 
@@ -797,14 +796,13 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_single_explicit_parameterized_discriminator_mapping();
 
-        // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
 @__discriminator_0='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -813,7 +811,7 @@ OFFSET 0 LIMIT 2
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping_leaf();
 
-        AssertSql("""ReadItem(["PK1"], 11)""");
+        AssertSql("""ReadItem(["PK1"], 188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping_leaf()
@@ -825,7 +823,7 @@ OFFSET 0 LIMIT 2
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = "SinglePartitionKeyEntity")))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = "SinglePartitionKeyEntity")))
 """);
     }
 
@@ -840,7 +838,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND 
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
@@ -238,7 +238,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_hierarchical_partition_key();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], HierarchicalPartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1",1.0,true], HierarchicalPartitionKeyEntity|31887258-bdf9-49b8-89b2-01b6aa741a4a)""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key()
@@ -252,7 +252,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_single_partition_key_constant();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant()
@@ -266,7 +266,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_single_partition_key_parameter();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter()
@@ -280,7 +280,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_SingleAsync();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key()
@@ -294,7 +294,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_inverse_comparison();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key()
@@ -308,14 +308,14 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_EF_Property();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey()
     {
         await base.ReadItem_with_WithPartitionKey();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key()
@@ -334,7 +334,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["Id"] = 2)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["Id"] = "3307a33b-7f28-49ef-9857-48f4e3ebcaed")))
 """);
     }
 
@@ -368,7 +368,7 @@ WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitio
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 1))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34"))
 """);
     }
 
@@ -376,21 +376,21 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
     {
         await base.ReadItem_with_non_existent_id();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|999)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|50b66960-35be-40c5-bc3d-4c9f2799d4d1)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking()
     {
         await base.ReadItem_with_AsNoTracking();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_shared_container()
@@ -622,7 +622,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_hierarchical_partition_key_leaf();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], HierarchicalPartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1",1.0,true], HierarchicalPartitionKeyEntity|316c846c-787f-44b9-aadf-272f1658c5ff)""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key_leaf()
@@ -636,7 +636,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_constant_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant_leaf()
@@ -650,7 +650,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_single_partition_key_parameter_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter_leaf()
@@ -664,7 +664,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_SingleAsync_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key_leaf()
@@ -678,7 +678,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_inverse_comparison_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key_leaf()
@@ -692,14 +692,14 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
     {
         await base.ReadItem_with_EF_Property_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_leaf()
     {
         await base.ReadItem_with_WithPartitionKey_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key_leaf()
@@ -718,7 +718,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["PartitionKey"] =
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["Id"] = 22)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["Id"] = "11f8d1fd-7472-46f5-9e20-16af42b3b8d1")))
 """);
     }
 
@@ -752,7 +752,7 @@ WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKe
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c"))
 """);
     }
 
@@ -760,28 +760,28 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
     {
         await base.ReadItem_with_non_existent_id_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|999)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b964beda-b4e1-4f5c-a729-0a35dae696fe)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking_leaf()
     {
         await base.ReadItem_with_AsNoTracking_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution_leaf()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_discriminator_mapping()
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|1)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping()
@@ -793,7 +793,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND (c["Id"] = 11))
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "DerivedSinglePartitionKeyEntity")))
 """);
     }
 
@@ -808,7 +808,7 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 1) AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -817,7 +817,7 @@ OFFSET 0 LIMIT 2
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping_leaf();
 
-        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|11)""");
+        AssertSql("""ReadItem(["PK1"], SinglePartitionKeyEntity|188d3253-81be-4a87-b58f-a2bd07e6b98c)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping_leaf()
@@ -829,7 +829,7 @@ OFFSET 0 LIMIT 2
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = "SinglePartitionKeyEntity")))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = "SinglePartitionKeyEntity")))
 """);
     }
 
@@ -844,7 +844,7 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND 
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = 11) AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
@@ -234,7 +234,7 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_hierarchical_partition_key();
 
-        AssertSql("""ReadItem(["PK1",1.0,true], 1)""");
+        AssertSql("""ReadItem(["PK1",1.0,true], 31887258-bdf9-49b8-89b2-01b6aa741a4a)""");
     }
 
     public override async Task ReadItem_with_only_hierarchical_partition_key()
@@ -248,7 +248,7 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_single_partition_key_constant();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_constant()
@@ -262,7 +262,7 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_single_partition_key_parameter();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_only_single_partition_key_parameter()
@@ -276,7 +276,7 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_SingleAsync();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_SingleAsync_with_only_partition_key()
@@ -290,7 +290,7 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_inverse_comparison();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_inverse_comparison_with_only_partition_key()
@@ -304,14 +304,14 @@ WHERE (c["PartitionKey"] = "PK1")
     {
         await base.ReadItem_with_EF_Property();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey()
     {
         await base.ReadItem_with_WithPartitionKey();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_WithPartitionKey_with_only_partition_key()
@@ -330,7 +330,7 @@ WHERE (c["PartitionKey"] = "PK1")
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["Id"] = 1) AND (c["Id"] = 2))
+WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["id"] = "3307a33b-7f28-49ef-9857-48f4e3ebcaed"))
 """);
     }
 
@@ -365,7 +365,7 @@ WHERE ((c["id"] = "PK1a") AND (c["id"] = @__partitionKey_0))
             """
 SELECT VALUE c
 FROM root c
-WHERE (c["Id"] = 1)
+WHERE (c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34")
 """);
     }
 
@@ -373,21 +373,21 @@ WHERE (c["Id"] = 1)
     {
         await base.ReadItem_with_non_existent_id();
 
-        AssertSql("""ReadItem(["PK1"], 999)""");
+        AssertSql("""ReadItem(["PK1"], 50b66960-35be-40c5-bc3d-4c9f2799d4d1)""");
     }
 
     public override async Task ReadItem_with_AsNoTracking()
     {
         await base.ReadItem_with_AsNoTracking();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_AsNoTrackingWithIdentityResolution()
     {
         await base.ReadItem_with_AsNoTrackingWithIdentityResolution();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_shared_container()
@@ -415,7 +415,7 @@ WHERE (c["Id"] = 1)
     {
         await base.ReadItem_with_single_explicit_discriminator_mapping();
 
-        AssertSql("""ReadItem(["PK1"], 1)""");
+        AssertSql("""ReadItem(["PK1"], b29bced8-e1e5-420e-82d7-1c7a51703d34)""");
     }
 
     public override async Task ReadItem_with_single_explicit_incorrect_discriminator_mapping()
@@ -427,7 +427,7 @@ WHERE (c["Id"] = 1)
             """
 SELECT VALUE c
 FROM root c
-WHERE ((c["Id"] = 1) AND (c["$type"] = "DerivedSinglePartitionKeyEntity"))
+WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "DerivedSinglePartitionKeyEntity"))
 """);
     }
 
@@ -435,14 +435,13 @@ WHERE ((c["Id"] = 1) AND (c["$type"] = "DerivedSinglePartitionKeyEntity"))
     {
         await base.ReadItem_with_single_explicit_parameterized_discriminator_mapping();
 
-        // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
 @__discriminator_0='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["Id"] = 1) AND (c["$type"] = @__discriminator_0))
+WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
@@ -161,7 +161,11 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async: true,
             ss => ss.Set<HierarchicalPartitionKeyEntity>()
-                .Where(e => e.Id == 1 && e.PartitionKey1 == "PK1" && e.PartitionKey2 == partitionKey2 && e.PartitionKey3));
+                .Where(
+                    e => e.Id == Guid.Parse("31887258-BDF9-49B8-89B2-01B6AA741A4A")
+                        && e.PartitionKey1 == "PK1"
+                        && e.PartitionKey2 == partitionKey2
+                        && e.PartitionKey3));
     }
 
     [ConditionalFact]
@@ -179,7 +183,8 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
     public virtual Task ReadItem_with_single_partition_key_constant()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1 && e.PartitionKey == "PK1"));
+            ss => ss.Set<SinglePartitionKeyEntity>()
+                .Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_only_single_partition_key_constant()
@@ -194,7 +199,8 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
 
         return AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1 && e.PartitionKey == partitionKey));
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -214,7 +220,8 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
 
         return AssertSingle(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1 && e.PartitionKey == partitionKey));
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -231,7 +238,8 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
     public virtual Task ReadItem_with_inverse_comparison()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => 1 == e.Id && "PK1" == e.PartitionKey));
+            ss => ss.Set<SinglePartitionKeyEntity>()
+                .Where(e => Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") == e.Id && "PK1" == e.PartitionKey));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_inverse_comparison_with_only_partition_key()
@@ -244,15 +252,17 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async: true,
             ss => ss.Set<SinglePartitionKeyEntity>().Where(
-                e => EF.Property<int>(e, nameof(SinglePartitionKeyEntity.Id)) == 1
+                e => EF.Property<Guid>(e, nameof(SinglePartitionKeyEntity.Id)) == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")
                     && EF.Property<string>(e, nameof(SinglePartitionKeyEntity.PartitionKey)) == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_WithPartitionKey()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().WithPartitionKey("PK1").Where(e => e.Id == 1),
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.PartitionKey == "PK1").Where(e => e.Id == 1));
+            ss => ss.Set<SinglePartitionKeyEntity>().WithPartitionKey("PK1")
+                .Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")),
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.PartitionKey == "PK1")
+                .Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_WithPartitionKey_with_only_partition_key()
@@ -268,7 +278,10 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
 
         return AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1 && e.Id == 2 && e.PartitionKey == partitionKey),
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")
+                    && e.Id == Guid.Parse("3307A33B-7F28-49EF-9857-48F4E3EBCAED")
+                    && e.PartitionKey == partitionKey),
             assertEmpty: true);
     }
 
@@ -294,26 +307,26 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
     public virtual Task ReadItem_is_not_used_without_partition_key()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1));
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_non_existent_id()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 999 && e.PartitionKey == "PK1"),
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == Guid.Parse("50B66960-35BE-40C5-BC3D-4C9F2799D4D1") && e.PartitionKey == "PK1"),
             assertEmpty: true);
 
     [ConditionalFact]
     public virtual Task ReadItem_with_AsNoTracking()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().AsNoTracking().Where(e => e.Id == 1 && e.PartitionKey == "PK1"));
+            ss => ss.Set<SinglePartitionKeyEntity>().AsNoTracking().Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_AsNoTrackingWithIdentityResolution()
         => AssertQuery(
             async: true,
-            ss => ss.Set<SinglePartitionKeyEntity>().AsNoTrackingWithIdentityResolution().Where(e => e.Id == 1 && e.PartitionKey == "PK1"));
+            ss => ss.Set<SinglePartitionKeyEntity>().AsNoTrackingWithIdentityResolution().Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == "PK1"));
 
     [ConditionalFact]
     public virtual Task ReadItem_with_shared_container()
@@ -342,11 +355,11 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
             async: true,
             ss => ss.Set<SinglePartitionKeyEntity>()
                 .Where(
-                    e => e.Id == 1
+                    e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")
                         && EF.Property<string>(e, "$type") == nameof(SinglePartitionKeyEntity)
                         && e.PartitionKey == partitionKey),
             ss => ss.Set<SinglePartitionKeyEntity>()
-                .Where(e => e.Id == 1 && e.PartitionKey == partitionKey));
+                .Where(e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == partitionKey));
     }
 
     [ConditionalFact]
@@ -358,7 +371,7 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
             async: true,
             ss => ss.Set<SinglePartitionKeyEntity>()
                 .Where(
-                    e => e.Id == 1
+                    e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")
                         && EF.Property<string>(e, "$type") == nameof(DerivedSinglePartitionKeyEntity)
                         && e.PartitionKey == partitionKey),
             ss => ss.Set<SinglePartitionKeyEntity>().Where(e => false),
@@ -374,8 +387,12 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
         return AssertSingle(
             async: true,
             ss => ss.Set<SinglePartitionKeyEntity>()
-                .Where(e => e.Id == 1 && EF.Property<string>(e, "$type") == discriminator && e.PartitionKey == partitionKey),
-            ss => ss.Set<SinglePartitionKeyEntity>().Where(e => e.Id == 1 && e.PartitionKey == partitionKey));
+                .Where(
+                    e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34")
+                        && EF.Property<string>(e, "$type") == discriminator
+                        && e.PartitionKey == partitionKey),
+            ss => ss.Set<SinglePartitionKeyEntity>().Where(
+                e => e.Id == Guid.Parse("B29BCED8-E1E5-420E-82D7-1C7A51703D34") && e.PartitionKey == partitionKey));
     }
 
     protected void AssertSql(params string[] expected)


### PR DESCRIPTION
Fixes #34554

I also needed to fix #34511 to make this work. This was happening because we were removing the by-convention property added by property discovery. We only need to remove it when it's the computed property as well, which is handled by the other case.


