### PR TITLE
[release/9.0] Generate correct calls for complex and primitive properties in the model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -443,7 +443,8 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
         var clrType = (FindValueConverter(property)?.ProviderClrType ?? property.ClrType)
             .MakeNullable(property.IsNullable);
 
-        var propertyBuilderName = $"{entityTypeBuilderName}.Property<{Code.Reference(clrType)}>({Code.Literal(property.Name)})";
+        var propertyCall = property.IsPrimitiveCollection ? "PrimitiveCollection" : "Property";
+        var propertyBuilderName = $"{entityTypeBuilderName}.{propertyCall}<{Code.Reference(clrType)}>({Code.Literal(property.Name)})";
 
         stringBuilder
             .AppendLine()

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -55,17 +55,41 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         = typeof(SqlServerPropertyBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerPropertyBuilderExtensions.IsSparse), [typeof(PropertyBuilder), typeof(bool)])!;
 
+    private static readonly MethodInfo PrimitiveCollectionIsSparseMethodInfo
+        = typeof(SqlServerPrimitiveCollectionBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerPrimitiveCollectionBuilderExtensions.IsSparse), [typeof(PrimitiveCollectionBuilder), typeof(bool)])!;
+
+    private static readonly MethodInfo ComplexTypePropertyIsSparseMethodInfo
+        = typeof(SqlServerComplexTypePropertyBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerComplexTypePropertyBuilderExtensions.IsSparse), [typeof(ComplexTypePropertyBuilder), typeof(bool)])!;
+
+    private static readonly MethodInfo ComplexTypePrimitiveCollectionIsSparseMethodInfo
+        = typeof(SqlServerComplexTypePrimitiveCollectionBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerComplexTypePrimitiveCollectionBuilderExtensions.IsSparse), [typeof(ComplexTypePrimitiveCollectionBuilder), typeof(bool)])!;
+
     private static readonly MethodInfo PropertyUseIdentityColumnsMethodInfo
         = typeof(SqlServerPropertyBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerPropertyBuilderExtensions.UseIdentityColumn), [typeof(PropertyBuilder), typeof(long), typeof(int)])!;
+
+    private static readonly MethodInfo ComplexTypePropertyUseIdentityColumnsMethodInfo
+        = typeof(SqlServerComplexTypePropertyBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerComplexTypePropertyBuilderExtensions.UseIdentityColumn), [typeof(ComplexTypePropertyBuilder), typeof(long), typeof(int)])!;
 
     private static readonly MethodInfo PropertyUseHiLoMethodInfo
         = typeof(SqlServerPropertyBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerPropertyBuilderExtensions.UseHiLo), [typeof(PropertyBuilder), typeof(string), typeof(string)])!;
 
+    private static readonly MethodInfo ComplexTypePropertyUseHiLoMethodInfo
+        = typeof(SqlServerComplexTypePropertyBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerComplexTypePropertyBuilderExtensions.UseHiLo), [typeof(ComplexTypePropertyBuilder), typeof(string), typeof(string)])!;
+
     private static readonly MethodInfo PropertyUseSequenceMethodInfo
         = typeof(SqlServerPropertyBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerPropertyBuilderExtensions.UseSequence), [typeof(PropertyBuilder), typeof(string), typeof(string)])!;
+
+    private static readonly MethodInfo ComplexTypePropertyUseSequenceMethodInfo
+        = typeof(SqlServerComplexTypePropertyBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerComplexTypePropertyBuilderExtensions.UseSequence), [typeof(ComplexTypePropertyBuilder), typeof(string), typeof(string)])!;
 
     private static readonly MethodInfo IndexIsClusteredMethodInfo
         = typeof(SqlServerIndexBuilderExtensions).GetRuntimeMethod(
@@ -144,7 +168,7 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
     {
         var fragments = new List<MethodCallCodeFragment>(base.GenerateFluentApiCalls(model, annotations));
 
-        if (GenerateValueGenerationStrategy(annotations, model, onModel: true) is MethodCallCodeFragment valueGenerationStrategy)
+        if (GenerateValueGenerationStrategy(annotations, model, onModel: true, complexType: false) is MethodCallCodeFragment valueGenerationStrategy)
         {
             fragments.Add(valueGenerationStrategy);
         }
@@ -179,7 +203,9 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
     {
         var fragments = new List<MethodCallCodeFragment>(base.GenerateFluentApiCalls(property, annotations));
 
-        if (GenerateValueGenerationStrategy(annotations, property.DeclaringType.Model, onModel: false) is MethodCallCodeFragment
+        var isPrimitiveCollection = property.IsPrimitiveCollection;
+
+        if (GenerateValueGenerationStrategy(annotations, property.DeclaringType.Model, onModel: false, complexType: property.DeclaringType is IComplexType) is MethodCallCodeFragment
             valueGenerationStrategy)
         {
             fragments.Add(valueGenerationStrategy);
@@ -187,10 +213,17 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
 
         if (GetAndRemove<bool?>(annotations, SqlServerAnnotationNames.Sparse) is bool isSparse)
         {
+            var methodInfo = isPrimitiveCollection
+                ? property.DeclaringType is IComplexType
+                    ? ComplexTypePrimitiveCollectionIsSparseMethodInfo
+                    : PrimitiveCollectionIsSparseMethodInfo
+                : property.DeclaringType is IComplexType
+                    ? ComplexTypePropertyIsSparseMethodInfo
+                    : PropertyIsSparseMethodInfo;
             fragments.Add(
                 isSparse
-                    ? new MethodCallCodeFragment(PropertyIsSparseMethodInfo)
-                    : new MethodCallCodeFragment(PropertyIsSparseMethodInfo, false));
+                    ? new MethodCallCodeFragment(methodInfo)
+                    : new MethodCallCodeFragment(methodInfo, false));
         }
 
         return fragments;
@@ -367,7 +400,8 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
     private static MethodCallCodeFragment? GenerateValueGenerationStrategy(
         IDictionary<string, IAnnotation> annotations,
         IModel model,
-        bool onModel)
+        bool onModel,
+        bool complexType)
     {
         SqlServerValueGenerationStrategy strategy;
         if (annotations.TryGetValue(SqlServerAnnotationNames.ValueGenerationStrategy, out var strategyAnnotation)
@@ -405,7 +439,11 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                     ?? model.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement)?.Value as int?
                     ?? 1;
                 return new MethodCallCodeFragment(
-                    onModel ? ModelUseIdentityColumnsMethodInfo : PropertyUseIdentityColumnsMethodInfo,
+                    onModel
+                        ? ModelUseIdentityColumnsMethodInfo
+                        : complexType
+                            ? ComplexTypePropertyUseIdentityColumnsMethodInfo
+                            : PropertyUseIdentityColumnsMethodInfo,
                     (seed, increment) switch
                     {
                         (1L, 1) => [],
@@ -418,7 +456,11 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                 var name = GetAndRemove<string>(annotations, SqlServerAnnotationNames.HiLoSequenceName);
                 var schema = GetAndRemove<string>(annotations, SqlServerAnnotationNames.HiLoSequenceSchema);
                 return new MethodCallCodeFragment(
-                    onModel ? ModelUseHiLoMethodInfo : PropertyUseHiLoMethodInfo,
+                    onModel
+                        ? ModelUseHiLoMethodInfo
+                        : complexType
+                            ? ComplexTypePropertyUseHiLoMethodInfo
+                            : PropertyUseHiLoMethodInfo,
                     (name, schema) switch
                     {
                         (null, null) => [],
@@ -435,7 +477,11 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
 
                 var schema = GetAndRemove<string>(annotations, SqlServerAnnotationNames.SequenceSchema);
                 return new MethodCallCodeFragment(
-                    onModel ? ModelUseKeySequencesMethodInfo : PropertyUseSequenceMethodInfo,
+                    onModel
+                        ? ModelUseKeySequencesMethodInfo
+                        : complexType
+                            ? ComplexTypePropertyUseSequenceMethodInfo
+                            : PropertyUseSequenceMethodInfo,
                     (name: nameOrSuffix, schema) switch
                     {
                         (null, null) => [],


### PR DESCRIPTION
Fixes #34578

### Description

The model snapshot generated for migrations contains incorrect calls for primitive collections and extension methods on complex type properties.

### Customer impact

Generated snapshot fails to compile and needs to be fixed manually each time it's generated.

### How found

Reported by a user on 8.0.8

### Regression

No, new feature in 8.0

### Testing

Tests added.

### Risk

Low. Only affects design-time