### PR TITLE
Change analyzer references to use the standard/recommended form

### DIFF
--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -60,4 +60,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\src\Shared\EFDiagnostics.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EFCore\EFCore.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/src/EFCore.InMemory/EFCore.InMemory.csproj
+++ b/src/EFCore.InMemory/EFCore.InMemory.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EFCore\EFCore.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/src/EFCore.Proxies/EFCore.Proxies.csproj
+++ b/src/EFCore.Proxies/EFCore.Proxies.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EFCore\EFCore.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EFCore\EFCore.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -54,7 +54,9 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     IListSource
     where TEntity : class
 {
+#pragma warning disable EF1001
     private ObservableBackedBindingList<TEntity>? _bindingList;
+#pragma warning restore EF1001
     private ObservableCollection<TEntity>? _observable;
     private readonly DbContext _context;
     private readonly IEntityType _entityType;
@@ -472,10 +474,12 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     ///     examples.
     /// </remarks>
     /// <returns>The binding list.</returns>
+#pragma warning disable EF1001
     [RequiresUnreferencedCode(
         "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
     public virtual BindingList<TEntity> ToBindingList()
         => _bindingList ??= new ObservableBackedBindingList<TEntity>(ToObservableCollection());
+#pragma warning restore EF1001
 
     /// <summary>
     ///     This method is called by data binding frameworks when attempting to data bind

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -52,7 +52,7 @@ Microsoft.EntityFrameworkCore.DbSet
 
   <ItemGroup>
     <ProjectReference Include="..\EFCore.Abstractions\EFCore.Abstractions.csproj" />
-    <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore/Properties/TypeForwards.cs
+++ b/src/EFCore/Properties/TypeForwards.cs
@@ -4,8 +4,10 @@
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
+#pragma warning disable EF1001
 [assembly: TypeForwardedTo(typeof(ObservableBackedBindingList<>))]
 [assembly: TypeForwardedTo(typeof(ObservableCollectionExtensions))]
 [assembly: TypeForwardedTo(typeof(ObservableCollectionListSource<>))]
 [assembly: TypeForwardedTo(typeof(SortableBindingList<>))]
 [assembly: TypeForwardedTo(typeof(DeleteBehavior))]
+#pragma warning restore EF1001

--- a/src/Shared/EFDiagnostics.cs
+++ b/src/Shared/EFDiagnostics.cs
@@ -6,7 +6,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// <summary>
 ///     Contains the IDs of diagnostics emitted by EF Core analyzers, [Experimental] and other mechanisms.
 /// </summary>
-public static class EFDiagnostics
+internal static class EFDiagnostics
 {
     public const string InternalUsage = "EF1001";
     public const string InterpolatedStringUsageInRawQueries = "EF1002";

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
@@ -48,4 +48,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\src\Shared\EFDiagnostics.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I've been hitting some build issues related to EFDiagnostics - a static class of constants that lives inside EFCore.Analyzers and used from the our projects. Interestingly, the EFCore projects references EFCore.Analyzers with `PrivateAssets="contentfiles;build"`; the other projects (Relational, Cosmos...) reference it with `ReferenceOutputAssembly="False" OutputItemType="Analyzer"` - which is the proper way to refer to analyzers ([docs](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview)). It seems like only the EFCore dependency on EFCore.Analyzers allows using EFDiagnostics - if I change it to also use `ReferenceOutputAssembly="False" OutputItemType="Analyzer"`, I'm no longer able to use EFDiagnostics.

This PR changes things to work in the standard/recommend way: only `ReferenceOutputAssembly="False" OutputItemType="Analyzer"` is used to reference EFCore.Analyzers, and EFDiagnostics is moved to Shared.
