### PR TITLE
In VisitUpdate, match table by alias rather than the exact same instance

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1496,7 +1496,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
                     var table = selectExpression.Tables[i];
                     var joinExpression = table as JoinExpressionBase;
 
-                    if (ReferenceEquals(updateExpression.Table, joinExpression?.Table ?? table))
+                    if (updateExpression.Table.Alias == (joinExpression?.Table.Alias ?? table.Alias))
                     {
                         LiftPredicate(table);
                         continue;

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -63,15 +63,14 @@ DELETE FROM "Owner" AS "o"
 
     public override async Task Replace_ColumnExpression_in_column_setter(bool async)
     {
-        // #33947
-        await Assert.ThrowsAsync<SqliteException>(() => base.Replace_ColumnExpression_in_column_setter(async));
+        await base.Replace_ColumnExpression_in_column_setter(async);
 
         AssertSql(
             """
 UPDATE "OwnedCollection" AS "o0"
 SET "Value" = 'SomeValue'
 FROM "Owner" AS "o"
-INNER JOIN "OwnedCollection" AS "o0" ON "o"."Id" = "o0"."OwnerId"
+WHERE "o"."Id" = "o0"."OwnerId"
 """);
     }
 


### PR DESCRIPTION
- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Tests for the changes have been added (for bug fixes / features) - Fixes a test so no further tests needed
- [x] Code follows the same patterns and style as existing code in this repo

`VisitUpdate` was using `ReferenceEquals` to match tables, which would only match if it was the same instance. It actually should be matching if the tables are the same even if the instance is different.

The only affected test is `Replace_ColumnExpression_in_column_setter`. 
The sqlite test now works and the same change solves the problem for efcore.pg. SQL Server is unaffected as it has its own override which doesn't do this check

Fixes #33947 
