### PR TITLE
[release/9.0] Don't remove non-existent foreign keys.

### DIFF
--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -990,7 +990,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
 
         removed = foreignKey.PrincipalKey.ReferencingForeignKeys!.Remove(foreignKey);
         Check.DebugAssert(removed, "removed is false");
-        removed = foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys!.Remove(foreignKey);
+        removed = foreignKey.PrincipalEntityType._declaredReferencingForeignKeys!.Remove(foreignKey);
         Check.DebugAssert(removed, "removed is false");
     }
 
@@ -1029,13 +1029,13 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         }
 
         var principalEntityType = foreignKey.PrincipalEntityType;
-        if (principalEntityType.DeclaredReferencingForeignKeys == null)
+        if (principalEntityType._declaredReferencingForeignKeys == null)
         {
-            principalEntityType.DeclaredReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance) { foreignKey };
+            principalEntityType._declaredReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance) { foreignKey };
         }
         else
         {
-            added = principalEntityType.DeclaredReferencingForeignKeys.Add(foreignKey);
+            added = principalEntityType._declaredReferencingForeignKeys.Add(foreignKey);
             Check.DebugAssert(added, "added is false");
         }
     }
@@ -1371,7 +1371,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     public virtual IEnumerable<ForeignKey> GetReferencingForeignKeys()
         => BaseType != null
-            ? (DeclaredReferencingForeignKeys?.Count ?? 0) == 0
+            ? (_declaredReferencingForeignKeys?.Count ?? 0) == 0
                 ? BaseType.GetReferencingForeignKeys()
                 : BaseType.GetReferencingForeignKeys().Concat(GetDeclaredReferencingForeignKeys())
             : GetDeclaredReferencingForeignKeys();
@@ -1383,9 +1383,9 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IEnumerable<ForeignKey> GetDeclaredReferencingForeignKeys()
-        => DeclaredReferencingForeignKeys ?? Enumerable.Empty<ForeignKey>();
+        => _declaredReferencingForeignKeys ?? Enumerable.Empty<ForeignKey>();
 
-    private SortedSet<ForeignKey>? DeclaredReferencingForeignKeys { get; set; }
+    private SortedSet<ForeignKey>? _declaredReferencingForeignKeys;
 
     #endregion
 
@@ -1673,14 +1673,14 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
 
         _skipNavigations.Add(name, skipNavigation);
 
-        if (targetEntityType.DeclaredReferencingSkipNavigations == null)
+        if (targetEntityType._declaredReferencingSkipNavigations == null)
         {
-            targetEntityType.DeclaredReferencingSkipNavigations =
+            targetEntityType._declaredReferencingSkipNavigations =
                 new SortedSet<SkipNavigation>(SkipNavigationComparer.Instance) { skipNavigation };
         }
         else
         {
-            var added = targetEntityType.DeclaredReferencingSkipNavigations.Add(skipNavigation);
+            var added = targetEntityType._declaredReferencingSkipNavigations.Add(skipNavigation);
             Check.DebugAssert(added, "added is false");
         }
 
@@ -1826,7 +1826,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             || foreignKey.ReferencingSkipNavigations!.Remove(navigation);
         Check.DebugAssert(removed, "removed is false");
 
-        removed = navigation.TargetEntityType.DeclaredReferencingSkipNavigations!.Remove(navigation);
+        removed = navigation.TargetEntityType._declaredReferencingSkipNavigations!.Remove(navigation);
         Check.DebugAssert(removed, "removed is false");
 
         navigation.SetRemovedFromModel();
@@ -1855,7 +1855,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     public virtual IEnumerable<SkipNavigation> GetReferencingSkipNavigations()
         => BaseType != null
-            ? (DeclaredReferencingSkipNavigations?.Count ?? 0) == 0
+            ? (_declaredReferencingSkipNavigations?.Count ?? 0) == 0
                 ? BaseType.GetReferencingSkipNavigations()
                 : BaseType.GetReferencingSkipNavigations().Concat(GetDeclaredReferencingSkipNavigations())
             : GetDeclaredReferencingSkipNavigations();
@@ -1867,7 +1867,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IEnumerable<SkipNavigation> GetDeclaredReferencingSkipNavigations()
-        => DeclaredReferencingSkipNavigations ?? Enumerable.Empty<SkipNavigation>();
+        => _declaredReferencingSkipNavigations ?? Enumerable.Empty<SkipNavigation>();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1880,7 +1880,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             ? Enumerable.Empty<SkipNavigation>()
             : GetDerivedTypes<EntityType>().SelectMany(et => et.GetDeclaredReferencingSkipNavigations());
 
-    private SortedSet<SkipNavigation>? DeclaredReferencingSkipNavigations { get; set; }
+    private SortedSet<SkipNavigation>? _declaredReferencingSkipNavigations;
 
     #endregion
 

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -687,6 +687,11 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
         {
             foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
             {
+                if (!foreignKey.IsInModel)
+                {
+                    continue;
+                }
+
                 if (foreignKey.IsOwnership
                     && configurationSource.Overrides(foreignKey.DeclaringEntityType.GetConfigurationSource()))
                 {

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -855,6 +855,47 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
                 owned.DisplayName());
         }
 
+        [ConditionalFact] // Issue #34329
+        public virtual void Navigation_cycle_can_be_broken()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<EntityType1>().Ignore(x => x.E2);
+
+            var model = modelBuilder.FinalizeModel();
+
+            var principal = model.FindEntityType(typeof(EntityType1))!;
+            Assert.Null(principal.FindNavigation(nameof(EntityType1.E2)));
+            Assert.Null(model.FindEntityType(typeof(EntityType2)));
+        }
+
+        protected class EntityType1
+        {
+            public int Id { get; set; }
+            public EntityType2? E2 { get; set; }
+        }
+
+
+        protected class EntityType2
+        {
+            public int Id { get; set; }
+            public EntityType3? E3 { get; set; }
+
+            public EntityType4? E4 { get; set; }
+        }
+
+        protected class EntityType3
+        {
+            public int Id { get; set; }
+            public EntityType2? U2 { get; set; }
+        }
+
+        protected class EntityType4
+        {
+            public int Id { get; set; }
+            public EntityType3? E3 { get; set; }
+        }
+
         protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder>? configure = null)
             => new GenericTestModelBuilder(Fixture, configure);
     }


### PR DESCRIPTION
Fixes #34329

### Description

When a navigation to an owned entity type is ignored the entity type is removed and this cascades through the referencing owned entity types. And if one of them had a back navigation to the top owned entity type then we'll try to remove it again causing an exception.

### Customer impact

An exception is thrown when ignoring a navigation to an owned entity type for the affected models. There's a workaround, but this issue is hard to diagnose for the users.

### How found

Reported by a user on 8.0.7

### Regression

No

### Testing

Tests added.

### Risk

Low.