### PR TITLE
[release/9.0] Change some JSON Metadata API to respect null values set explicitly.

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -72,8 +72,12 @@ public static class CosmosEntityTypeExtensions
     /// <param name="entityType">The entity type to get the containing property name for.</param>
     /// <returns>The name of the parent property to which the entity type is mapped.</returns>
     public static string? GetContainingPropertyName(this IReadOnlyEntityType entityType)
-        => entityType[CosmosAnnotationNames.PropertyName] as string
-            ?? GetDefaultContainingPropertyName(entityType);
+    {
+        var propertyName = entityType.FindAnnotation(CosmosAnnotationNames.PropertyName);
+        return propertyName == null
+            ? GetDefaultContainingPropertyName(entityType)
+            : (string?)propertyName.Value;
+    }
 
     private static string? GetDefaultContainingPropertyName(IReadOnlyEntityType entityType)
         => entityType.FindOwnership() is IReadOnlyForeignKey ownership
@@ -198,7 +202,7 @@ public static class CosmosEntityTypeExtensions
     public static IReadOnlyList<string> GetPartitionKeyPropertyNames(this IReadOnlyEntityType entityType)
         => entityType[CosmosAnnotationNames.PartitionKeyNames] as IReadOnlyList<string>
             ?? entityType.BaseType?.GetPartitionKeyPropertyNames()
-            ?? Array.Empty<string>();
+            ?? [];
 
     /// <summary>
     ///     Sets the names of the properties that are used to store the hierarchical partition key.

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -1606,8 +1606,12 @@ public static class RelationalEntityTypeExtensions
     /// <param name="entityType">The entity type to get the container column name for.</param>
     /// <returns>The container column name to which the entity type is mapped.</returns>
     public static string? GetContainerColumnName(this IReadOnlyEntityType entityType)
-        => entityType.FindAnnotation(RelationalAnnotationNames.ContainerColumnName)?.Value as string
-            ?? entityType.FindOwnership()?.PrincipalEntityType.GetContainerColumnName();
+    {
+        var containerColumnName = entityType.FindAnnotation(RelationalAnnotationNames.ContainerColumnName);
+        return containerColumnName == null
+                ? entityType.FindOwnership()?.PrincipalEntityType.GetContainerColumnName()
+                : (string?)containerColumnName.Value;
+    }
 
     /// <summary>
     ///     Sets the column type to use for the container column to which the entity type is mapped.
@@ -1720,8 +1724,14 @@ public static class RelationalEntityTypeExtensions
     ///     <see langword="null" /> is returned for entities that are not mapped to a JSON column.
     /// </returns>
     public static string? GetJsonPropertyName(this IReadOnlyEntityType entityType)
-        => (string?)entityType.FindAnnotation(RelationalAnnotationNames.JsonPropertyName)?.Value
-            ?? (!entityType.IsMappedToJson() ? null : entityType.FindOwnership()!.GetNavigation(pointsToPrincipal: false)!.Name);
+    {
+        var propertyName = entityType.FindAnnotation(RelationalAnnotationNames.JsonPropertyName);
+        return propertyName == null
+                ? (entityType.IsMappedToJson()
+                    ? entityType.FindOwnership()!.GetNavigation(pointsToPrincipal: false)!.Name
+                    : null)
+                : (string?)propertyName.Value;
+    }
 
     /// <summary>
     ///     Sets the value of JSON property name used for the given entity mapped to a JSON column.

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -2833,8 +2833,13 @@ public class RelationalModelValidator : ModelValidator
         IEntityType jsonEntityType)
     {
         var jsonPropertyNames = new List<string>();
-        foreach (var property in jsonEntityType.GetDeclaredProperties().Where(p => !string.IsNullOrEmpty(p.GetJsonPropertyName())))
+        foreach (var property in jsonEntityType.GetDeclaredProperties())
         {
+            if (string.IsNullOrEmpty(property.GetJsonPropertyName()))
+            {
+                continue;
+            }
+
             if (property.TryGetDefaultValue(out var _))
             {
                 throw new InvalidOperationException(
@@ -2857,6 +2862,12 @@ public class RelationalModelValidator : ModelValidator
 
         foreach (var navigation in jsonEntityType.GetDeclaredNavigations())
         {
+            if (!navigation.TargetEntityType.IsMappedToJson()
+                || navigation.IsOnDependent)
+            {
+                continue;
+            }
+
             var jsonPropertyName = navigation.TargetEntityType.GetJsonPropertyName()!;
             if (!jsonPropertyNames.Contains(jsonPropertyName))
             {


### PR DESCRIPTION
Fixes #34434

### Description

This is a follow up to https://github.com/dotnet/efcore/pull/34401#pullrequestreview-2236368614
`GetContainingPropertyName`, `GetContainerColumnName` and `GetJsonPropertyName` didn't respect the `null` value from the annotation and still calculated a default value. This change makes the behavior consistent with other similar API.

### Customer impact

It's currently unlikely for a customer to hit this as they would need to set the annotation value explicitly, but it might be useful in some workarounds if new issues are discovered in this area.

### How found

PR review

### Regression

No

### Testing

Tests added.

### Risk

Low.