### PR TITLE
[release/9.0] Take into account store-generated values when ordering update commands

### DIFF
--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
@@ -17,5 +17,9 @@ public class Product : ProductBase
     [ConcurrencyCheck]
     public decimal Price { get; set; }
 
+    public bool IsPrimary { get; set; }
+
+    public bool? IsPrimaryNormalized { get => IsPrimary ? true : null; set { } }
+
     public ICollection<ProductCategory> ProductCategories { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
@@ -29,7 +29,8 @@ public class UpdatesContext(DbContextOptions options) : PoolableDbContext(option
                 Id = productId1,
                 Name = "Apple Cider",
                 Price = 1.49M,
-                DependentId = 778
+                DependentId = 778,
+                IsPrimary = true
             });
         context.Add(
             new Product
@@ -37,7 +38,8 @@ public class UpdatesContext(DbContextOptions options) : PoolableDbContext(option
                 Id = productId2,
                 Name = "Apple Cobler",
                 Price = 2.49M,
-                DependentId = 778
+                DependentId = 778,
+                IsPrimary = false
             });
 
         return context.SaveChangesAsync();

--- a/test/EFCore.Specification.Tests/Update/UpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/Update/UpdatesTestBase.cs
@@ -935,6 +935,10 @@ public abstract class UpdatesTestBase<TFixture>(TFixture fixture) : IClassFixtur
                 .HasForeignKey(e => e.DependentId)
                 .HasPrincipalKey(e => e.PrincipalId);
 
+            modelBuilder.Entity<Product>()
+                .HasIndex(e => new { e.Name, e.IsPrimaryNormalized })
+                .IsUnique();
+
             modelBuilder.Entity<Person>(
                 pb =>
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
@@ -51,7 +51,7 @@ FROM (
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """,
@@ -81,7 +81,7 @@ FROM (
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPTTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPTTest.cs
@@ -48,7 +48,7 @@ LEFT JOIN [SpecialCategory] AS [s] ON [c].[Id] = [s].[Id]
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """,
@@ -75,7 +75,7 @@ LEFT JOIN [SpecialCategory] AS [s] ON [c].[Id] = [s].[Id]
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTest.cs
@@ -44,7 +44,7 @@ FROM [Categories] AS [c]
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """,
@@ -68,7 +68,7 @@ FROM [Categories] AS [c]
             """
 @__category_PrincipalId_0='778' (Nullable = true)
 
-SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[Name], [p].[Price]
+SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
 WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTestBase.cs
@@ -258,6 +258,15 @@ LEFT JOIN [Person] AS [p2] ON [p1].[ParentId] = [p2].[PersonId]
                 .Property(p => p.Id).HasDefaultValueSql("NEWID()");
 
             modelBuilder.Entity<Product>().HasIndex(p => new { p.Name, p.Price }).HasFilter("Name IS NOT NULL");
+
+            modelBuilder.Entity<Product>()
+                .HasIndex(e => new { e.Name, e.IsPrimaryNormalized })
+                .IsUnique()
+                .HasFilter(null);
+
+            modelBuilder.Entity<Product>()
+                .Property(e => e.IsPrimaryNormalized)
+                .HasComputedColumnSql($"IIF(IsPrimary = 1, CONVERT(bit, 1), NULL)", stored: true);
         }
 
         public virtual async Task ResetIdentity()


### PR DESCRIPTION
Fixes #33023

### Description

EF orders update commands in a way that avoids breaking store constraints, like unique indexes.
E.g. if there's a unique index on a `Name` column and there's currently a row with `Jared` and a row with `Sam`.  The user wants to update the first row to `Sam` and the second row to `Artak`. EF needs perform the second update first.

This gets complicated when the index is over a column with a store-computed value since EF cannot predict the value it will have after an update. A workaround is to duplicate the store logic in the C# implementation. This client-side value would never be sent to the store but could be used to determine the update order. However, this workaround was broken because we also needed to avoid dependency cycles in the updates that would prevent establishing an order when a row with the same value is deleted and inserted. The way we handled this was by collapsing the delete and insert into an update and ignoring the store-generated values for ordering purposes.

This change to the ordering logic uses more fine-grained approach for determining whether a store-generated value could affect the ordering that works for both scenarios.

### Customer impact

For models with a unique index over a computed column the update order can no longer be correctly determined and will throw an exception if it doesn't happen to be correct. The workaround is to send updates to the affected table one-by-one, but this would have a negative perf impact.

### How found

Customer reported

### Regression

Yes, from 6.0.x

### Testing

Tests added.

### Risk

Medium. While this code has good test coverage, due to its nature it's hard to predict all the ramifications of this change.