### PR TITLE
[release/9.0] Bump Microsoft.Azure.Cosmos from 3.42.0 to 3.43.0

### DIFF
--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/34635