### PR TITLE
[release/9.0] Remove referencing indexes when reconfiguring a property as a navigation

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
@@ -774,7 +774,7 @@ public abstract class InternalTypeBaseBuilder : AnnotatableBuilder<TypeBase, Int
         {
             if (conflictingProperty.GetConfigurationSource() != ConfigurationSource.Explicit)
             {
-                conflictingProperty.DeclaringType.RemoveProperty(conflictingProperty);
+                conflictingProperty.DeclaringType.Builder.RemoveProperty(conflictingProperty, configurationSource);
             }
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -1251,28 +1251,20 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
         {
             var modelBuilder = CreateModelBuilder();
 
-            modelBuilder.Entity<OneToOneOwnerWithField>(
-                e =>
-                {
-                    e.Property(p => p.Id);
-                    e.Property(p => p.AlternateKey);
-                    e.Property(p => p.Description);
-                    e.HasKey(p => p.Id);
-                });
+            modelBuilder.Entity<OwnerOfOwnees>();
 
             var model = modelBuilder.FinalizeModel();
 
-            var owner = model.FindEntityType(typeof(OneToOneOwnerWithField))!;
-            Assert.Equal(typeof(OneToOneOwnerWithField).FullName, owner.Name);
-            var ownership = owner.FindNavigation(nameof(OneToOneOwnerWithField.OwnedDependent))!.ForeignKey;
+            var owner = model.FindEntityType(typeof(OwnerOfOwnees))!;
+            var ownership = owner.FindNavigation(nameof(OwnerOfOwnees.Ownee1))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(OneToOneOwnerWithField.OwnedDependent), ownership.PrincipalToDependent!.Name);
-            Assert.Equal(nameof(OneToOneOwnedWithField.OneToOneOwner), ownership.DependentToPrincipal!.Name);
-            Assert.Equal(nameof(OneToOneOwnerWithField.Id), ownership.PrincipalKey.Properties.Single().Name);
+            Assert.Equal(nameof(OwnerOfOwnees.Ownee1), ownership.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(Ownee1.Owner), ownership.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(OwnerOfOwnees.Id), ownership.PrincipalKey.Properties.Single().Name);
             var owned = ownership.DeclaringEntityType;
             Assert.Single(owned.GetForeignKeys());
-            Assert.NotNull(model.FindEntityType(typeof(OneToOneOwnedWithField)));
-            Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(OneToOneOwnedWithField)));
+            Assert.NotNull(model.FindEntityType(typeof(Ownee1)));
+            Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(Ownee1)));
         }
 
         protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder>? configure = null)

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
@@ -599,6 +599,12 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Owned<Ownee1>();
             modelBuilder.Owned<Ownee2>();
             modelBuilder.Owned<Ownee3>();
+
+            var model = modelBuilder.FinalizeModel();
+
+            var owner = model.FindEntityType(typeof(OwnerOfOwnees))!;
+            var ownership = owner.FindNavigation(nameof(OwnerOfOwnees.Ownee1))!.ForeignKey;
+            Assert.True(ownership.IsOwnership);
         }
 
         [Flags]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
@@ -1112,16 +1112,23 @@ public abstract partial class ModelBuilderTest
 
     protected class Ownee1
     {
+        public string Data { get; private set; } = "";
+
+        public OwnerOfOwnees Owner { get; private set; } = null!;
         public Ownee3? NewOwnee3 { get; private set; }
     }
 
     protected class Ownee2
     {
+        public Guid Data { get; private set; }
+
         public Ownee3? Ownee3 { get; private set; }
     }
 
     protected class Ownee3
     {
+        public DateTime Data { get; private set; }
+
         public string? Name { get; private set; }
     }
 
@@ -1189,6 +1196,7 @@ public abstract partial class ModelBuilderTest
         public OneToManyOwnerWithField? OneToManyOwner { get; set; }
     }
 
+    [Index(nameof(OwnedDependent))]
     protected class OneToOneOwnerWithField
     {
         public int Id;


### PR DESCRIPTION
Fixes #29997

### Description

When a property is reconfigured as a navigation the referencing objects such as indexes, keys and foreign keys are not removed beforehand leading to an exception.

### Customer impact

For models where a navigation is referenced by data annotations an exception is thrown during model building. A workaround is to ignore the property before configuring it as a navigation.

### How found

Multiple customer reports.

### Regression

Yes. From 6.0.x

### Testing

Test added.

### Risk

Low.