### PR TITLE
Allow using foreign keys in Dataverse reverse engineering

### DIFF
--- a/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
+++ b/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
@@ -161,6 +161,14 @@ public class SqlServerLoggingDefinitions : RelationalLoggingDefinitions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public EventDefinitionBase? LogDataverseForeignKeyInvalid;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public EventDefinitionBase? LogDuplicateForeignKeyConstraintIgnored;
 
     /// <summary>

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -69,6 +69,7 @@ public static class SqlServerEventId
         ColumnWithoutTypeWarning,
         ForeignKeyReferencesUnknownPrincipalTableWarning,
         MissingViewDefinitionRightsWarning,
+        DataverseForeignKeyInvalidWarning,
     }
 
     private static readonly string ValidationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
@@ -285,6 +286,14 @@ public static class SqlServerEventId
     ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
     /// </remarks>
     public static readonly EventId ReflexiveConstraintIgnored = MakeScaffoldingId(Id.ReflexiveConstraintIgnored);
+
+    /// <summary>
+    ///     An invalid foreign key constraint was skipped.
+    /// </summary>
+    /// <remarks>
+    ///     This event is in the <see cref="DbLoggerCategory.Scaffolding"/> category.
+    /// </remarks>
+    public static readonly EventId DataverseForeignKeyInvalidWarning = MakeScaffoldingId(Id.DataverseForeignKeyInvalidWarning);
 
     /// <summary>
     ///     A duplicate foreign key constraint was skipped.

--- a/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
@@ -583,6 +583,27 @@ public static class SqlServerLoggerExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public static void DataverseForeignKeyInvalidWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string foreignKeyName,
+        string tableName)
+    {
+        var definition = SqlServerResources.LogDataverseForeignKeyInvalidWarning(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, foreignKeyName, tableName);
+        }
+
+        // No DiagnosticsSource events because these are purely design-time messages
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public static void DuplicateForeignKeyConstraintIgnored(
         this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
         string foreignKeyName,

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -1019,6 +1019,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
+        ///     Skipping foreign key '{foreignKeyName}' on table '{tableName}' since it is not supported by the Dataverse TDS Endpoint
+        /// </summary>
+        public static EventDefinition<string, string> LogDataverseForeignKeyInvalidWarning(IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDataverseForeignKeyInvalid;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDataverseForeignKeyInvalid,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        SqlServerEventId.DataverseForeignKeyInvalidWarning,
+                        LogLevel.Debug,
+                        "SqlServerEventId.LogDataverseForeignKeyInvalidWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            SqlServerEventId.DataverseForeignKeyInvalidWarning,
+                            _resourceManager.GetString("LogDataverseForeignKeyInvalidWarning")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     Savepoints are disabled because Multiple Active Result Sets (MARS) is enabled. If 'SaveChanges' fails, then the transaction cannot be automatically rolled back to a known clean state. Instead, the transaction should be rolled back by the application before retrying 'SaveChanges'. See https://go.microsoft.com/fwlink/?linkid=2149338 for more information and examples. To identify the code which triggers this warning, call 'ConfigureWarnings(w =&gt; w.Throw(SqlServerEventId.SavepointsDisabledBecauseOfMARS))'.
         /// </summary>
         public static EventDefinition LogSavepointsDisabledBecauseOfMARS(IDiagnosticsLogger logger)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -296,6 +296,10 @@
     <value>Skipping foreign key '{foreignKeyName}' on table '{tableName}' since all of its columns reference themselves.</value>
     <comment>Debug SqlServerEventId.ReflexiveConstraintIgnored string string</comment>
   </data>
+  <data name="LogDataverseForeignKeyInvalidWarning" xml:space="preserve">
+    <value>Skipping foreign key '{foreignKeyName}' on table '{tableName}' since it is not supported by the Dataverse TDS Endpoint</value>
+    <comment>Debug SqlServerEventId.DataverseForeignKeyInvalidWarning string string</comment>
+  </data>
   <data name="LogSavepointsDisabledBecauseOfMARS" xml:space="preserve">
     <value>Savepoints are disabled because Multiple Active Result Sets (MARS) is enabled. If 'SaveChanges' fails, then the transaction cannot be automatically rolled back to a known clean state. Instead, the transaction should be rolled back by the application before retrying 'SaveChanges'. See https://go.microsoft.com/fwlink/?linkid=2149338 for more information and examples. To identify the code which triggers this warning, call 'ConfigureWarnings(w =&gt; w.Throw(SqlServerEventId.SavepointsDisabledBecauseOfMARS))'.</value>
     <comment>Warning SqlServerEventId.SavepointsDisabledBecauseOfMARS</comment>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -682,10 +682,7 @@ AND [v].[is_date_correlation_view] = 0
         // This is done separately due to MARS property may be turned off
         GetColumns(connection, tables, tableFilterSql, viewFilter, typeAliases, databaseCollation);
 
-        if (SupportsIndexes())
-        {
-            GetIndexes(connection, tables, tableFilterSql);
-        }
+        GetIndexes(connection, tables, tableFilterSql);
 
         GetForeignKeys(connection, tables, tableFilterSql);
 
@@ -1028,7 +1025,7 @@ SELECT
     [i].[has_filter],
     [i].[filter_definition],
     [i].[fill_factor],
-    COL_NAME([ic].[object_id], [ic].[column_id]) AS [column_name],
+    [c].[name] AS [column_name],
     [ic].[is_descending_key],
     [ic].[is_included_column]
 FROM [sys].[indexes] AS [i]
@@ -1089,7 +1086,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal];";
 
             if (primaryKeyGroups.Length == 1)
             {
-                if (TryGetPrimaryKey(primaryKeyGroups[0], out var primaryKey))
+                if (TryGetPrimaryKey(primaryKeyGroups[0], out var primaryKey) && IsValidPrimaryKey(primaryKey))
                 {
                     _logger.PrimaryKeyFound(primaryKey.Name!, DisplayName(tableSchema, tableName));
                     table.PrimaryKey = primaryKey;
@@ -1135,6 +1132,14 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal];";
                     _logger.IndexFound(indexGroup.Key.Name!, DisplayName(tableSchema, tableName), indexGroup.Key.IsUnique);
                     table.Indexes.Add(index);
                 }
+            }
+
+            bool IsValidPrimaryKey(DatabasePrimaryKey primaryKey)
+            {
+                if (_engineEdition != EngineEdition.DynamicsTdsEndpoint)
+                    return true;
+
+                return primaryKey.Columns.Count == 1 && primaryKey.Columns[0].StoreType == "uniqueidentifier";
             }
 
             bool TryGetPrimaryKey(
@@ -1377,6 +1382,14 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id];
                     foreignKey.PrincipalColumns.Add(principalColumn);
                 }
 
+                if (!invalid && _engineEdition == EngineEdition.DynamicsTdsEndpoint && !IsValidDataverseForeignKey(foreignKey))
+                {
+                    invalid = true;
+                    _logger.DataverseForeignKeyInvalidWarning(
+                        fkName!,
+                        DisplayName(table.Schema, table.Name));
+                }
+
                 if (!invalid)
                 {
                     if (foreignKey.Columns.SequenceEqual(foreignKey.PrincipalColumns))
@@ -1405,6 +1418,26 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id];
                     }
                 }
             }
+        }
+
+        bool IsValidDataverseForeignKey(DatabaseForeignKey foreignKey)
+        {
+            if (foreignKey.Columns.Count != 1)
+                return false;
+
+            if (foreignKey.Columns[0].StoreType != "uniqueidentifier")
+                return false;
+
+            if (foreignKey.PrincipalTable.PrimaryKey == null)
+                return false;
+
+            if (foreignKey.PrincipalTable.PrimaryKey.Columns.Count != 1)
+                return false;
+
+            if (foreignKey.PrincipalTable.PrimaryKey.Columns[0].Name != foreignKey.PrincipalColumns[0].Name)
+                return false;
+            
+            return true;
         }
     }
 
@@ -1455,9 +1488,6 @@ ORDER BY [table_schema], [table_name], [tr].[name];
 
     private bool SupportsSequences()
         => _compatibilityLevel >= 110 && IsFullFeaturedEngineEdition();
-
-    private bool SupportsIndexes()
-        => _engineEdition != EngineEdition.DynamicsTdsEndpoint;
 
     private bool SupportsViews()
         => _engineEdition != EngineEdition.DynamicsTdsEndpoint;


### PR DESCRIPTION
- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

Reverse engineering Dataverse tables ignores primary keys and therefore foreign keys, presumably because Dataverse does not support the `COL_NAME` function being used in the query to retrieve the index details.

This PR mainly changes that query to use the column name from the `sys.columns` catalog view instead, which is supported by Dataverse.

It also introduces checks on the primary and foreign keys to ensure it only uses single `uniqueidentifier` column keys for Dataverse as the metadata can expose various other internal keys of different types which break the code generation, such as a foreign key of a string type referencing a primary key of a uniqueidentifier type. As the developer is not able to make any changes to these internal schemas to correct them, it's necessary to simply ignore them during the code generation instead.