### PR TITLE
Add all precompiled query tests to the same collection.

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -7,6 +7,7 @@ using static Microsoft.EntityFrameworkCore.TestUtilities.PrecompiledQueryTestHel
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
+[Collection("PrecompiledQuery")]
 public abstract class AdHocPrecompiledQueryRelationalTestBase(ITestOutputHelper testOutputHelper) : NonSharedModelTestBase
 {
     [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     General tests for precompiled queries.
 ///     See also <see cref="PrecompiledSqlPregenerationQueryRelationalTestBase" /> for tests specifically related to SQL pregeneration.
 /// </summary>
+[Collection("PrecompiledQuery")]
 public class PrecompiledQueryRelationalTestBase
 {
     public PrecompiledQueryRelationalTestBase(PrecompiledQueryRelationalFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see cref="PrecompiledQueryRelationalTestBase" /> for general precompiled query tests not related to
 ///     SQL pregeneration.
 /// </summary>
+[Collection("PrecompiledQuery")]
 public class PrecompiledSqlPregenerationQueryRelationalTestBase
 {
     public PrecompiledSqlPregenerationQueryRelationalTestBase(


### PR DESCRIPTION
This avoids running them in parallel as assembly loading is not thread safe.