### PR TITLE
Optimize MIN/MAX over DISTINCT

### DIFF
--- a/src/EFCore.Relational/Query/EnumerableExpression.cs
+++ b/src/EFCore.Relational/Query/EnumerableExpression.cs
@@ -68,11 +68,12 @@ public class EnumerableExpression : Expression, IPrintableExpression
         => new(expression, IsDistinct, Predicate, Orderings);
 
     /// <summary>
-    ///     Applies DISTINCT operator to the selector of the <see cref="EnumerableExpression" />.
+    ///     Sets whether the DISTINCT operator should be applied to the selector
+    ///     of the <see cref="EnumerableExpression" />.
     /// </summary>
     /// <returns>The new expression with specified component updated.</returns>
-    public virtual EnumerableExpression ApplyDistinct()
-        => new(Selector, distinct: true, Predicate, Orderings);
+    public virtual EnumerableExpression SetDistinct(bool value)
+        => new(Selector, distinct: value, Predicate, Orderings);
 
     /// <summary>
     ///     Applies filter predicate to the <see cref="EnumerableExpression" />.

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -954,6 +954,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateMax(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
     {
+        var selectExpression = (SelectExpression)source.QueryExpression;
+        selectExpression.IsDistinct = false;
+
         // For Max() over an inline array, translate to GREATEST() if possible; otherwise use the default translation of aggregate SQL
         // MAX().
         // Note that some providers propagate NULL arguments (SQLite, MySQL), while others only return NULL if all arguments evaluate to
@@ -974,6 +977,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateMin(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
     {
+        var selectExpression = (SelectExpression)source.QueryExpression;
+        selectExpression.IsDistinct = false;
+
         // See comments above in TranslateMax()
         if (TryExtractBareInlineCollectionValues(source, out var values)
             && _sqlTranslator.GenerateLeast(values, resultType.UnwrapNullableType()) is SqlFunctionExpression leastExpression

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1362,12 +1362,15 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             {
                 switch (genericMethod.Name)
                 {
-                    case nameof(Queryable.Average)
-                        when QueryableMethods.IsAverageWithoutSelector(genericMethod):
                     case nameof(Queryable.Max)
                         when genericMethod == QueryableMethods.MaxWithoutSelector:
                     case nameof(Queryable.Min)
                         when genericMethod == QueryableMethods.MinWithoutSelector:
+                        enumerableExpression = enumerableExpression.SetDistinct(false);
+                        break;
+
+                    case nameof(Queryable.Average)
+                        when QueryableMethods.IsAverageWithoutSelector(genericMethod):
                     case nameof(Queryable.Sum)
                         when QueryableMethods.IsSumWithoutSelector(genericMethod):
                     case nameof(Queryable.Count)
@@ -1376,12 +1379,16 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                         when genericMethod == QueryableMethods.LongCountWithoutPredicate:
                         break;
 
-                    case nameof(Queryable.Average)
-                        when QueryableMethods.IsAverageWithSelector(genericMethod):
                     case nameof(Queryable.Max)
                         when genericMethod == QueryableMethods.MaxWithSelector:
                     case nameof(Queryable.Min)
                         when genericMethod == QueryableMethods.MinWithSelector:
+                        enumerableExpression = enumerableExpression.SetDistinct(false);
+                        enumerableExpression = ProcessSelector(enumerableExpression, arguments[1].UnwrapLambdaFromQuote());
+                        break;
+
+                    case nameof(Queryable.Average)
+                        when QueryableMethods.IsAverageWithSelector(genericMethod):
                     case nameof(Queryable.Sum)
                         when QueryableMethods.IsSumWithSelector(genericMethod):
                         enumerableExpression = ProcessSelector(enumerableExpression, arguments[1].UnwrapLambdaFromQuote());
@@ -1478,7 +1485,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
                         if (!enumerableSource.IsDistinct)
                         {
-                            enumerableExpression = enumerableSource.ApplyDistinct();
+                            enumerableExpression = enumerableSource.SetDistinct(true);
                             return true;
                         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2475,7 +2475,7 @@ FROM (
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], AVG(DISTINCT (CAST([o].[OrderID] AS float))) AS [Average], COUNT(DISTINCT ([o].[EmployeeID])) AS [Count], COUNT_BIG(DISTINCT ([o].[EmployeeID])) AS [LongCount], MAX(DISTINCT ([o].[OrderDate])) AS [Max], MIN(DISTINCT ([o].[OrderDate])) AS [Min], COALESCE(SUM(DISTINCT ([o].[OrderID])), 0) AS [Sum]
+SELECT [o].[CustomerID] AS [Key], AVG(DISTINCT (CAST([o].[OrderID] AS float))) AS [Average], COUNT(DISTINCT ([o].[EmployeeID])) AS [Count], COUNT_BIG(DISTINCT ([o].[EmployeeID])) AS [LongCount], MAX([o].[OrderDate]) AS [Max], MIN([o].[OrderDate]) AS [Min], COALESCE(SUM(DISTINCT ([o].[OrderID])), 0) AS [Sum]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2487,7 +2487,7 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], MAX(DISTINCT ([o].[OrderDate])) AS [Max]
+SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderDate]) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2499,9 +2499,9 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], MAX(DISTINCT (CASE
+SELECT [o].[CustomerID] AS [Key], MAX(CASE
     WHEN [o].[OrderDate] IS NOT NULL THEN [o].[OrderDate]
-END)) AS [Max]
+END) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -4744,11 +4744,8 @@ FROM (
 
         AssertSql(
             """
-SELECT MAX([o0].[OrderID])
-FROM (
-    SELECT DISTINCT [o].[OrderID]
-    FROM [Orders] AS [o]
-) AS [o0]
+SELECT MAX([o].[OrderID])
+FROM [Orders] AS [o]
 """);
     }
 
@@ -4758,11 +4755,8 @@ FROM (
 
         AssertSql(
             """
-SELECT MIN([o0].[OrderID])
-FROM (
-    SELECT DISTINCT [o].[OrderID]
-    FROM [Orders] AS [o]
-) AS [o0]
+SELECT MIN([o].[OrderID])
+FROM [Orders] AS [o]
 """);
     }
 


### PR DESCRIPTION
When a value is computed as MAX or MIN of a subquery, DISTINCT has no effect and can be removed.

Fixes #34483.