### PR TITLE
Handle view mapping in ExecuteDelete/Update translation

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
+using static Microsoft.EntityFrameworkCore.Query.QueryHelpers;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
@@ -517,10 +518,9 @@ public class CosmosSqlTranslatingExpressionVisitor(
     /// </summary>
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
-        if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName)
-            || methodCallExpression.TryGetIndexerArguments(_model, out source, out propertyName))
+        if (IsMemberAccess(methodCallExpression, _model, out var source, out var memberIdentity))
         {
-            return TryBindMember(Visit(source), MemberIdentity.Create(propertyName), out var result, out _)
+            return TryBindMember(Visit(source), memberIdentity, out var result, out _)
                 ? result
                 : QueryCompilationContext.NotTranslatedExpression;
         }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -812,11 +812,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 operation);
 
         /// <summary>
-        ///     ExecuteUpdate was called on entity type '{entityType}', but that entity type is not mapped to a table.
+        ///     ExecuteUpdate or ExecuteDelete was called on entity type '{entityType}', but that entity type is not mapped to a table.
         /// </summary>
-        public static string ExecuteUpdateOnEntityNotMappedToTable(object? entityType)
+        public static string ExecuteUpdateDeleteOnEntityNotMappedToTable(object? entityType)
             => string.Format(
-                GetString("ExecuteUpdateOnEntityNotMappedToTable", nameof(entityType)),
+                GetString("ExecuteUpdateDeleteOnEntityNotMappedToTable", nameof(entityType)),
                 entityType);
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -812,6 +812,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 operation);
 
         /// <summary>
+        ///     ExecuteUpdate was called on entity type '{entityType}', but that entity type is not mapped to a table.
+        /// </summary>
+        public static string ExecuteUpdateOnEntityNotMappedToTable(object? entityType)
+            => string.Format(
+                GetString("ExecuteUpdateOnEntityNotMappedToTable", nameof(entityType)),
+                entityType);
+
+        /// <summary>
         ///     ExecuteUpdate is being used over a LINQ operator which isn't natively supported by the database; this cannot be translated because complex type '{complexType}' is projected out. Rewrite your query to project out the containing entity type instead.
         /// </summary>
         public static string ExecuteUpdateSubqueryNotSupportedOverComplexTypes(object? complexType)
@@ -2130,7 +2138,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -418,8 +418,8 @@
   <data name="ExecuteOperationOnTPT" xml:space="preserve">
     <value>The operation '{operation}' is being applied on entity type '{entityType}', which is using the TPT mapping strategy. 'ExecuteDelete'/'ExecuteUpdate' operations on hierarchies mapped as TPT is not supported.</value>
   </data>
-  <data name="ExecuteUpdateOnEntityNotMappedToTable" xml:space="preserve">
-    <value>ExecuteUpdate was called on entity type '{entityType}', but that entity type is not mapped to a table.</value>
+  <data name="ExecuteUpdateDeleteOnEntityNotMappedToTable" xml:space="preserve">
+    <value>ExecuteUpdate or ExecuteDelete was called on entity type '{entityType}', but that entity type is not mapped to a table.</value>
   </data>
   <data name="ExecuteOperationWithUnsupportedOperatorInSqlGeneration" xml:space="preserve">
     <value>The operation '{operation}' contains a select expression feature that isn't supported in the query SQL generator, but has been declared as supported by provider during translation phase. This is a bug in your EF Core provider, please file an issue.</value>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -417,6 +417,9 @@
   </data>
   <data name="ExecuteOperationOnTPT" xml:space="preserve">
     <value>The operation '{operation}' is being applied on entity type '{entityType}', which is using the TPT mapping strategy. 'ExecuteDelete'/'ExecuteUpdate' operations on hierarchies mapped as TPT is not supported.</value>
+  </data>
+  <data name="ExecuteUpdateOnEntityNotMappedToTable" xml:space="preserve">
+    <value>ExecuteUpdate was called on entity type '{entityType}', but that entity type is not mapped to a table.</value>
   </data>
   <data name="ExecuteOperationWithUnsupportedOperatorInSqlGeneration" xml:space="preserve">
     <value>The operation '{operation}' contains a select expression feature that isn't supported in the query SQL generator, but has been declared as supported by provider during translation phase. This is a bug in your EF Core provider, please file an issue.</value>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
@@ -39,54 +39,86 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             return null;
         }
 
-        if (entityType.GetViewOrTableMappings().Count() != 1)
+        // Find the table model that maps to the entity type; there must be exactly one (e.g. no entity splitting).
+        ITable targetTable;
+        switch (entityType.GetTableMappings().ToList())
         {
-            AddTranslationErrorDetails(
-                RelationalStrings.ExecuteOperationOnEntitySplitting(
-                    nameof(EntityFrameworkQueryableExtensions.ExecuteDelete), entityType.DisplayName()));
-            return null;
+            case []:
+                throw new NotImplementedException(); // TODO: Throw message to indicate that the entity type is not mapped to any table.
+
+            case [var singleTableMapping]:
+                targetTable = singleTableMapping.Table;
+                break;
+
+            default:
+                AddTranslationErrorDetails(
+                    RelationalStrings.ExecuteOperationOnEntitySplitting(
+                        nameof(EntityFrameworkQueryableExtensions.ExecuteDelete), entityType.DisplayName()));
+                return null;
         }
 
-        // First, check if the provider has a native translation for the delete represented by the select expression.
-        // The default relational implementation handles simple, universally-supported cases (i.e. no operators except for predicate).
-        // Providers may override IsValidSelectExpressionForExecuteDelete to add support for more cases via provider-specific DELETE syntax.
         var selectExpression = (SelectExpression)source.QueryExpression;
-        if (IsValidSelectExpressionForExecuteDelete(selectExpression, shaper, out var tableExpression))
-        {
-            if (AreOtherNonOwnedEntityTypesInTheTable(entityType.GetRootType(), tableExpression.Table))
-            {
-                AddTranslationErrorDetails(
-                    RelationalStrings.ExecuteDeleteOnTableSplitting(tableExpression.Table.SchemaQualifiedName));
 
-                return null;
+        // Find the table expression in the SelectExpression that corresponds to the projected entity type.
+        var projectionBindingExpression = (ProjectionBindingExpression)shaper.ValueBufferExpression;
+        var projection = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+        var column = projection.BindProperty(shaper.StructuralType.GetProperties().First());
+        var tableExpression = selectExpression.GetTable(column, out var tableIndex);
+
+        // If the projected table expression (the thing to be deleted) isn't a TableExpression (e.g. it's a set operation), we can't
+        // translate to a simple DELETE (which requires a simple target table), and must fall back to rewriting as a subquery.
+        if (tableExpression.UnwrapJoin() is TableExpression unwrappedTableExpression)
+        {
+            // In normal cases, the table expression will be refer to the same table model we found above for the entity type.
+            if (unwrappedTableExpression.Table is ITable)
+            {
+                Check.DebugAssert(
+                    unwrappedTableExpression.Table == targetTable,
+                    "Projected table is a table, but not the same one mapped to the entity type");
+            }
+            else
+            {
+                // If the entity is also mapped to a view, the SelectExpression will refer to the view instead, since translation happens
+                // with the assumption that we're querying, not deleting.
+                // For this case, we must replace the TableExpression in the SelectExpression - referring to the view - with the one that
+                // refers to the mutable table.
+                Check.DebugAssert(
+                    unwrappedTableExpression.Table.EntityTypeMappings.Any(etm => etm.TypeBase == entityType),
+                    "Projected table is not mapped to the entity type projected by the shaper");
+
+                unwrappedTableExpression = new TableExpression(unwrappedTableExpression.Alias, targetTable);
+                tableExpression = tableExpression is JoinExpressionBase join
+                    ? join.Update(unwrappedTableExpression)
+                    : unwrappedTableExpression;
+                var newTables = selectExpression.Tables.ToList();
+                newTables[tableIndex] = tableExpression;
+
+                // Note that we need to keep the select mutable, because if IsValidSelectExpressionForExecuteDelete below returns false,
+                // we need to compose on top of it.
+                selectExpression.SetTables(newTables);
             }
 
-            selectExpression.ReplaceProjection(new List<Expression>());
-            selectExpression.ApplyProjection();
-
-            return new NonQueryExpression(new DeleteExpression(tableExpression, selectExpression));
-
-            static bool AreOtherNonOwnedEntityTypesInTheTable(IEntityType rootType, ITableBase table)
+            // Finally, check if the provider has a native translation for the delete represented by the select expression.
+            // The default relational implementation handles simple, universally-supported cases (i.e. no operators except for predicate).
+            // Providers may override IsValidSelectExpressionForExecuteDelete to add support for more cases via provider-specific DELETE syntax.
+            if (IsValidSelectExpressionForExecuteDelete(selectExpression))
             {
-                foreach (var entityTypeMapping in table.EntityTypeMappings)
+                if (AreOtherNonOwnedEntityTypesInTheTable(entityType.GetRootType(), unwrappedTableExpression.Table))
                 {
-                    var typeBase = entityTypeMapping.TypeBase;
-                    if ((entityTypeMapping.IsSharedTablePrincipal == true
-                            && typeBase != rootType)
-                        || (entityTypeMapping.IsSharedTablePrincipal == false
-                            && typeBase is IEntityType entityType
-                            && entityType.GetRootType() != rootType
-                            && !entityType.IsOwned()))
-                    {
-                        return true;
-                    }
+                    AddTranslationErrorDetails(
+                        RelationalStrings.ExecuteDeleteOnTableSplitting(unwrappedTableExpression.Table.SchemaQualifiedName));
+
+                    return null;
                 }
 
-                return false;
+                selectExpression.ReplaceProjection(new List<Expression>());
+                selectExpression.ApplyProjection();
+
+                return new NonQueryExpression(new DeleteExpression(unwrappedTableExpression, selectExpression));
             }
         }
 
-        // The provider doesn't natively support the delete.
+        // We can't translate to a simple delete (e.g. the provider doesn't support one of the clauses).
         // As a fallback, we place the original query in a Contains subquery, which will get translated via the regular entity equality/
         // containment mechanism (InExpression for non-composite keys, Any for composite keys)
         var pk = entityType.FindPrimaryKey();
@@ -109,6 +141,25 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             Expression.Quote(Expression.Lambda(predicateBody, entityParameter)));
 
         return TranslateExecuteDelete((ShapedQueryExpression)Visit(newSource));
+
+        static bool AreOtherNonOwnedEntityTypesInTheTable(IEntityType rootType, ITableBase table)
+        {
+            foreach (var entityTypeMapping in table.EntityTypeMappings)
+            {
+                var typeBase = entityTypeMapping.TypeBase;
+                if ((entityTypeMapping.IsSharedTablePrincipal == true
+                        && typeBase != rootType)
+                    || (entityTypeMapping.IsSharedTablePrincipal == false
+                        && typeBase is IEntityType entityType
+                        && entityType.GetRootType() != rootType
+                        && !entityType.IsOwned()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     /// <summary>
@@ -126,32 +177,17 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
     ///     </para>
     /// </remarks>
     /// <param name="selectExpression">The select expression to validate.</param>
-    /// <param name="shaper">The structural type shaper expression on which the delete operation is being applied.</param>
-    /// <param name="tableExpression">The table expression from which rows are being deleted.</param>
     /// <returns>
     ///     Returns <see langword="true" /> if the current select expression can be used for delete as-is, <see langword="false" /> otherwise.
     /// </returns>
-    protected virtual bool IsValidSelectExpressionForExecuteDelete(
-        SelectExpression selectExpression,
-        StructuralTypeShaperExpression shaper,
-        [NotNullWhen(true)] out TableExpression? tableExpression)
-    {
-        if (selectExpression is
-            {
-                Tables: [TableExpression expression],
-                Orderings: [],
-                Offset: null,
-                Limit: null,
-                GroupBy: [],
-                Having: null
-            })
+    protected virtual bool IsValidSelectExpressionForExecuteDelete(SelectExpression selectExpression)
+        => selectExpression is
         {
-            tableExpression = expression;
-
-            return true;
-        }
-
-        tableExpression = null;
-        return false;
-    }
+            Tables: [TableExpression],
+            Orderings: [],
+            Offset: null,
+            Limit: null,
+            GroupBy: [],
+            Having: null
+        };
 }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
@@ -44,7 +44,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         switch (entityType.GetTableMappings().ToList())
         {
             case []:
-                throw new NotImplementedException(); // TODO: Throw message to indicate that the entity type is not mapped to any table.
+                throw new InvalidOperationException(
+                    RelationalStrings.ExecuteUpdateDeleteOnEntityNotMappedToTable(entityType.DisplayName()));
 
             case [var singleTableMapping]:
                 targetTable = singleTableMapping.Table;
@@ -103,7 +104,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             // Providers may override IsValidSelectExpressionForExecuteDelete to add support for more cases via provider-specific DELETE syntax.
             if (IsValidSelectExpressionForExecuteDelete(selectExpression))
             {
-                if (AreOtherNonOwnedEntityTypesInTheTable(entityType.GetRootType(), unwrappedTableExpression.Table))
+                if (AreOtherNonOwnedEntityTypesInTheTable(entityType.GetRootType(), targetTable))
                 {
                     AddTranslationErrorDetails(
                         RelationalStrings.ExecuteDeleteOnTableSplitting(unwrappedTableExpression.Table.SchemaQualifiedName));

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using static Microsoft.EntityFrameworkCore.Query.QueryHelpers;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -105,6 +106,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             [NotNullWhen(true)] out List<ColumnValueSetter>? translatedSetters,
             [NotNullWhen(true)] out TableExpressionBase? targetTable)
         {
+            var select = (SelectExpression)source.QueryExpression;
+
             targetTable = null;
             string? targetTableAlias = null;
             var tempTranslatedSetters = new List<ColumnValueSetter>();
@@ -118,10 +121,72 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 (propertySelector, var valueSelector) = setter;
                 var propertySelectorBody = RemapLambdaBody(source, propertySelector).UnwrapTypeConversion(out _);
 
-                switch (_sqlTranslator.TranslateProjection(propertySelectorBody))
+                // The top-most node on the property selector must be a member access; chop it off to get the base expression and member.
+                // We'll bind the member manually below, so as to get the IPropertyBase it represents - that's important for later.
+                if (!IsMemberAccess(propertySelectorBody, QueryCompilationContext.Model, out var baseExpression, out var member))
+                {
+                    AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
+                    return false;
+                }
+
+                if (!_sqlTranslator.TryBindMember(_sqlTranslator.Visit(baseExpression), member, out var translatedBaseExpression, out var propertyBase))
+                {
+                    AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
+                    return false;
+                }
+
+                // Hack: when returning a StructuralTypeShaperExpression, _sqlTranslator returns it wrapped by a
+                // StructuralTypeReferenceExpression, which is supposed to be a private wrapper only with the SQL translator.
+                // Call TranslateProjection to unwrap it (need to look into getting rid StructuralTypeReferenceExpression altogether).
+                translatedBaseExpression = _sqlTranslator.TranslateProjection(translatedBaseExpression);
+
+                switch (translatedBaseExpression)
                 {
                     case ColumnExpression column:
                     {
+                        if (propertyBase is not IProperty property)
+                        {
+                            throw new UnreachableException("Property selector translated to ColumnExpression but no IProperty");
+                        }
+
+                        var tableExpression = select.GetTable(column, out var tableIndex);
+                        if (tableExpression.UnwrapJoin() is TableExpression { Table: not ITable } unwrappedTableExpression)
+                        {
+                            // If the entity is also mapped to a view, the SelectExpression will refer to the view instead, since
+                            // translation happens with the assumption that we're querying, not deleting.
+                            // For this case, we must replace the TableExpression in the SelectExpression - referring to the view - with the
+                            // one that refers to the mutable table.
+
+                            // Get the column on the (mutable) table which corresponds to the property being set
+                            var targetColumnModel = property.DeclaringType.GetTableMappings()
+                                .SelectMany(tm => tm.ColumnMappings)
+                                .SingleOrDefault(cm => cm.Property == property)?.Column;
+
+                            if (targetColumnModel is null)
+                            {
+                                throw new InvalidOperationException(
+                                    RelationalStrings.ExecuteUpdateOnEntityNotMappedToTable(property.DeclaringType.DisplayName()));
+                            }
+
+                            if (targetColumnModel.Name != column.Name)
+                            {
+                                // If we ever allow mapping the same property to different column names on the view and table, we'll need
+                                // to also recursively visit the SelectExpression and replace ColumnExpressions
+                                throw new UnreachableException("Table and view column names should match");
+                            }
+
+                            unwrappedTableExpression = new TableExpression(unwrappedTableExpression.Alias, targetColumnModel.Table);
+                            tableExpression = tableExpression is JoinExpressionBase join
+                                ? join.Update(unwrappedTableExpression)
+                                : unwrappedTableExpression;
+                            var newTables = select.Tables.ToList();
+                            newTables[tableIndex] = tableExpression;
+
+                            // Note that we need to keep the select mutable, because if IsValidSelectExpressionForExecuteDelete below returns false,
+                            // we need to compose on top of it.
+                            select.SetTables(newTables);
+                        }
+
                         if (!IsColumnOnSameTable(column, propertySelector)
                             || TranslateSqlSetterValueSelector(source, valueSelector, column) is not SqlExpression translatedValueSelector)
                         {
@@ -135,10 +200,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     // TODO: This is for column flattening; implement JSON complex type support as well.
                     case StructuralTypeShaperExpression
                     {
-                        StructuralType: IComplexType,
+                        StructuralType: IComplexType complexType,
                         ValueBufferExpression: StructuralTypeProjectionExpression
                     } shaper:
                     {
+                        Check.DebugAssert(
+                            propertyBase is IComplexProperty complexProperty && complexProperty.ComplexType == complexType,
+                            "PropertyBase should be a complex property referring to the correct complex type");
+
                         if (TranslateSetterValueSelector(source, valueSelector, shaper.Type) is not Expression translatedValueSelector
                             || !TryProcessComplexType(shaper, translatedValueSelector))
                         {
@@ -373,26 +442,12 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             // The following mechanism for extracting the entity type from property selectors only supports simple member access,
             // EF.Function, etc. We also unwrap casts to interface/base class (#29618). Note that owned IncludeExpressions have already
             // been pruned from the source before remapping the lambda (#28727).
-
             var firstPropertySelector = setters[0].PropertySelector;
-            var shaper = RemapLambdaBody(source, firstPropertySelector).UnwrapTypeConversion(out _) switch
-            {
-                MemberExpression { Expression : not null } memberExpression
-                    when memberExpression.Expression.UnwrapTypeConversion(out _) is StructuralTypeShaperExpression s
-                    => s,
-
-                MethodCallExpression mce when mce.TryGetEFPropertyArguments(out var source, out _)
-                    && source.UnwrapTypeConversion(out _) is StructuralTypeShaperExpression s
-                    => s,
-
-                MethodCallExpression mce when mce.TryGetIndexerArguments(RelationalDependencies.Model, out var source2, out _)
-                    && source2.UnwrapTypeConversion(out _) is StructuralTypeShaperExpression s
-                    => s,
-
-                _ => null
-            };
-
-            if (shaper is null)
+            if (!IsMemberAccess(
+                    RemapLambdaBody(source, firstPropertySelector).UnwrapTypeConversion(out _),
+                    RelationalDependencies.Model,
+                    out var baseExpression)
+                || baseExpression.UnwrapTypeConversion(out _) is not StructuralTypeShaperExpression shaper)
             {
                 AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(firstPropertySelector));
                 return null;
@@ -474,20 +529,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         static Expression GetEntitySource(IModel model, Expression propertyAccessExpression)
         {
             propertyAccessExpression = propertyAccessExpression.UnwrapTypeConversion(out _);
-            if (propertyAccessExpression is MethodCallExpression mce)
-            {
-                if (mce.TryGetEFPropertyArguments(out var source, out _))
-                {
-                    return source;
-                }
-
-                if (mce.TryGetIndexerArguments(model, out var source2, out _))
-                {
-                    return source2;
-                }
-            }
-
-            return ((MemberExpression)propertyAccessExpression).Expression!;
+            return IsMemberAccess(propertyAccessExpression, model, out var source)
+                ? source
+                : ((MemberExpression)propertyAccessExpression).Expression!;
         }
     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2726,7 +2726,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             if (table.UnwrapJoin().Alias == column.TableAlias)
             {
                 tableIndex = i;
-                return _tables[i];
+                return table;
             }
         }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -238,6 +238,20 @@ public sealed partial class SelectExpression : TableExpressionBase
     public SqlExpression? Offset { get; private set; }
 
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public void SetTables(IReadOnlyList<TableExpressionBase> tables)
+    {
+        Check.DebugAssert(IsMutable, "Attempt to mutate an immutable SelectExpression");
+        _tables.Clear();
+        _tables.AddRange(tables);
+    }
+
+    /// <summary>
     ///     Applies a given set of tags.
     /// </summary>
     /// <param name="tags">A list of tags to apply.</param>
@@ -2698,12 +2712,21 @@ public sealed partial class SelectExpression : TableExpressionBase
     ///     <see cref="SelectExpression" /> based on its alias.
     /// </summary>
     public TableExpressionBase GetTable(ColumnExpression column)
+        => GetTable(column, out _);
+
+    /// <summary>
+    ///     Retrieves the <see cref="TableExpressionBase" /> referenced by the given column, looking it up on this
+    ///     <see cref="SelectExpression" /> based on its alias.
+    /// </summary>
+    public TableExpressionBase GetTable(ColumnExpression column, out int tableIndex)
     {
-        foreach (var table in Tables)
+        for (var i = 0; i < _tables.Count; i++)
         {
+            var table = _tables[i];
             if (table.UnwrapJoin().Alias == column.TableAlias)
             {
-                return table;
+                tableIndex = i;
+                return _tables[i];
             }
         }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -442,39 +442,11 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override bool IsValidSelectExpressionForExecuteDelete(
-        SelectExpression selectExpression,
-        StructuralTypeShaperExpression shaper,
-        [NotNullWhen(true)] out TableExpression? tableExpression)
-    {
-        if (selectExpression.Offset == null
-            && selectExpression.GroupBy.Count == 0
-            && selectExpression.Having == null
-            && selectExpression.Orderings.Count == 0)
-        {
-            TableExpressionBase table;
-            if (selectExpression.Tables.Count == 1)
-            {
-                table = selectExpression.Tables[0];
-            }
-            else
-            {
-                var projectionBindingExpression = (ProjectionBindingExpression)shaper.ValueBufferExpression;
-                var projection = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
-                var column = projection.BindProperty(shaper.StructuralType.GetProperties().First());
-                table = selectExpression.GetTable(column).UnwrapJoin();
-            }
-
-            if (table is TableExpression te)
-            {
-                tableExpression = te;
-                return true;
-            }
-        }
-
-        tableExpression = null;
-        return false;
-    }
+    protected override bool IsValidSelectExpressionForExecuteDelete(SelectExpression selectExpression)
+        => selectExpression.Offset == null
+           && selectExpression.GroupBy.Count == 0
+           && selectExpression.Having == null
+           && selectExpression.Orderings.Count == 0;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/QueryHelpers.cs
+++ b/src/EFCore/Query/QueryHelpers.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Various helpers for query translation.
+/// </summary>
+public static class QueryHelpers
+{
+    /// <summary>
+    ///     Returns whether the given expression represents a member access and if so, returns the decomposed base expression and the member
+    ///     identity.
+    /// </summary>
+    /// <param name="expression">The expression to check.</param>
+    /// <param name="model">The model being used.</param>
+    /// <param name="baseExpression">The given expression, with the top-level member access node removed.</param>
+    /// <returns>
+    ///     <see langword="true" /> if <paramref name="expression"/> represents a member access, <see langword="false" /> otherwise.
+    /// </returns>
+    public static bool IsMemberAccess(
+        Expression expression,
+        IModel model,
+        [NotNullWhen(true)] out Expression? baseExpression)
+        => IsMemberAccess(expression, model, out baseExpression, out _);
+
+    /// <summary>
+    ///     Returns whether the given expression represents a member access and if so, returns the decomposed base expression and the member
+    ///     identity.
+    /// </summary>
+    /// <param name="expression">The expression to check.</param>
+    /// <param name="model">The model being used.</param>
+    /// <param name="baseExpression">The given expression, with the top-level member access node removed.</param>
+    /// <param name="memberIdentity">A <see cref="MemberIdentity" /> representing the member being accessed.</param>
+    /// <returns>
+    ///     <see langword="true" /> if <paramref name="expression"/> represents a member access, <see langword="false" /> otherwise.
+    /// </returns>
+    public static bool IsMemberAccess(
+        Expression expression,
+        IModel model,
+        [NotNullWhen(true)] out Expression? baseExpression,
+        out MemberIdentity memberIdentity)
+    {
+        switch (expression)
+        {
+            case MemberExpression { Expression: not null } member:
+                baseExpression = member.Expression;
+                memberIdentity = MemberIdentity.Create(member.Member);
+                return true;
+            case MethodCallExpression methodCall
+                when methodCall.TryGetEFPropertyArguments(out baseExpression, out var propertyName)
+                || methodCall.TryGetIndexerArguments(model, out baseExpression, out propertyName):
+                memberIdentity = MemberIdentity.Create(propertyName);
+                return true;
+            default:
+                memberIdentity = MemberIdentity.None;
+                baseExpression = null;
+                return false;
+        }
+    }
+}

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Internal;
+using static Microsoft.EntityFrameworkCore.Query.QueryHelpers;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -558,9 +559,8 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
         // The method isn't a LINQ operator on Queryable/QueryableExtensions.
 
         // Identify property access, e.g. primitive collection property (context.Blogs.Where(b => b.Tags.Contains(...)))
-        if ((methodCallExpression.TryGetEFPropertyArguments(out var propertyAccessSource, out var propertyName)
-                || methodCallExpression.TryGetIndexerArguments(QueryCompilationContext.Model, out propertyAccessSource, out propertyName))
-            && TranslateMemberAccess(propertyAccessSource, MemberIdentity.Create(propertyName)) is ShapedQueryExpression translation)
+        if (IsMemberAccess(methodCallExpression, QueryCompilationContext.Model, out var propertyAccessSource, out var propertyName)
+            && TranslateMemberAccess(propertyAccessSource, propertyName) is ShapedQueryExpression translation)
         {
             return translation;
         }

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesRelationalTestBase.cs
@@ -115,7 +115,7 @@ public abstract class NonSharedModelBulkUpdatesRelationalTestBase : NonSharedMod
 
     [ConditionalTheory] // #34677, #34706
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Update_complex_type_type_with_view_mapping(bool async)
+    public virtual async Task Update_complex_type_with_view_mapping(bool async)
     {
         var contextFactory = await InitializeAsync<Context34677>(seed: async context => await context.Seed());
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -192,6 +192,37 @@ WHERE [o].[Id] = 1
 """);
     }
 
+    public override async Task Delete_with_view_mapping(bool async)
+    {
+        await base.Delete_with_view_mapping(async);
+
+        AssertSql(
+            """
+DELETE FROM [b]
+FROM [Blogs] AS [b]
+""");
+    }
+
+    public override async Task Update_with_view_mapping(bool async)
+    {
+        await base.Update_with_view_mapping(async);
+
+        AssertSql(
+            """
+UPDATE [b]
+SET [b].[Data] = N'Updated'
+FROM [Blogs] AS [b]
+""");
+    }
+
+    public override async Task Update_complex_type_type_with_view_mapping(bool async)
+    {
+        await base.Update_complex_type_type_with_view_mapping(async);
+
+        // #34706
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -215,9 +215,9 @@ FROM [Blogs] AS [b]
 """);
     }
 
-    public override async Task Update_complex_type_type_with_view_mapping(bool async)
+    public override async Task Update_complex_type_with_view_mapping(bool async)
     {
-        await base.Update_complex_type_type_with_view_mapping(async);
+        await base.Update_complex_type_with_view_mapping(async);
 
         // #34706
         AssertSql();

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -214,9 +214,9 @@ SET "Data" = 'Updated'
 """);
     }
 
-    public override async Task Update_complex_type_type_with_view_mapping(bool async)
+    public override async Task Update_complex_type_with_view_mapping(bool async)
     {
-        await base.Update_complex_type_type_with_view_mapping(async);
+        await base.Update_complex_type_with_view_mapping(async);
 
         // #34706
         AssertSql();

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -193,6 +193,35 @@ WHERE "o"."Id" = 1
 """);
     }
 
+    public override async Task Delete_with_view_mapping(bool async)
+    {
+        await base.Delete_with_view_mapping(async);
+
+        AssertSql(
+            """
+DELETE FROM "Blogs" AS "b"
+""");
+    }
+
+    public override async Task Update_with_view_mapping(bool async)
+    {
+        await base.Update_with_view_mapping(async);
+
+        AssertSql(
+            """
+UPDATE "Blogs" AS "b"
+SET "Data" = 'Updated'
+""");
+    }
+
+    public override async Task Update_complex_type_type_with_view_mapping(bool async)
+    {
+        await base.Update_complex_type_type_with_view_mapping(async);
+
+        // #34706
+        AssertSql();
+    }
+
     protected override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Log(SqliteEventId.CompositeKeyWithValueGeneration));
 


### PR DESCRIPTION
ExecuteDelete/Update take as input the SelectExpression that was translated so far, just prior to their appearance; that SelectExpression is assumed to be reading the tables, so references views rather than tables.

Note that the query may reference multiples tables. The additional tables (not the one being mutated) do need to be views, as we're reading from them. But during translation, we don't know which table is being updated - the user can start from one root, and project out a navigation to be deleted. So we only know the target table at the end of translation.

So the approach here is to detect the case where the table to be changed is a view, find the table corresponding to that view, and replace it in the SelectExpression.

Note that handling ExecuteUpdate where the property to set is a complex type and there's a vide mapping isn't yet supported; this is blocking on #34706.

Closes #34677