### PR TITLE
[release/9.0] Rename IncludeRootDiscriminatorInJsonId to HasRootDiscriminatorInJsonId

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
@@ -531,7 +531,7 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder IncludeRootDiscriminatorInJsonId(
+    public static EntityTypeBuilder HasRootDiscriminatorInJsonId(
         this EntityTypeBuilder entityTypeBuilder,
         bool? includeDiscriminator = true)
     {
@@ -578,11 +578,11 @@ public static class CosmosEntityTypeBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static EntityTypeBuilder<TEntity> IncludeRootDiscriminatorInJsonId<TEntity>(
+    public static EntityTypeBuilder<TEntity> HasRootDiscriminatorInJsonId<TEntity>(
         this EntityTypeBuilder<TEntity> entityTypeBuilder,
         bool? includeDiscriminator = true)
         where TEntity : class
-        => (EntityTypeBuilder<TEntity>)IncludeRootDiscriminatorInJsonId((EntityTypeBuilder)entityTypeBuilder, includeDiscriminator);
+        => (EntityTypeBuilder<TEntity>)HasRootDiscriminatorInJsonId((EntityTypeBuilder)entityTypeBuilder, includeDiscriminator);
 
     /// <summary>
     ///     Includes the discriminator value of the entity type in the JSON "id" value. This was the default behavior before EF Core 9.
@@ -633,12 +633,12 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
-    public static IConventionEntityTypeBuilder? IncludeRootDiscriminatorInJsonId(
+    public static IConventionEntityTypeBuilder? HasRootDiscriminatorInJsonId(
         this IConventionEntityTypeBuilder entityTypeBuilder,
         bool? includeDiscriminator,
         bool fromDataAnnotation = false)
     {
-        if (!entityTypeBuilder.CanSetIncludeRootDiscriminatorInJsonId(includeDiscriminator, fromDataAnnotation))
+        if (!entityTypeBuilder.CanSetRootDiscriminatorInJsonId(includeDiscriminator, fromDataAnnotation))
         {
             return null;
         }
@@ -699,7 +699,7 @@ public static class CosmosEntityTypeBuilderExtensions
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the configuration can be applied.</returns>
-    public static bool CanSetIncludeRootDiscriminatorInJsonId(
+    public static bool CanSetRootDiscriminatorInJsonId(
         this IConventionEntityTypeBuilder entityTypeBuilder,
         bool? includeDiscriminator,
         bool fromDataAnnotation = false)

--- a/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
@@ -165,7 +165,7 @@ public static class CosmosModelBuilderExtensions
     ///     <see langword="null" /> to revert to the default setting.
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static ModelBuilder IncludeRootDiscriminatorInJsonId(
+    public static ModelBuilder HasRootDiscriminatorInJsonId(
         this ModelBuilder modelBuilder,
         bool? includeDiscriminator = true)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/FindCosmosTest.cs
@@ -461,11 +461,11 @@ public abstract class FindCosmosTest : FindTestBase<FindCosmosTest.FindCosmosFix
 
             modelBuilder.Entity<IntKey>()
                 .ToContainer("Ints")
-                .IncludeRootDiscriminatorInJsonId();
+                .HasRootDiscriminatorInJsonId();
 
             modelBuilder.Entity<NullableIntKey>()
                 .ToContainer("Ints")
-                .IncludeRootDiscriminatorInJsonId();
+                .HasRootDiscriminatorInJsonId();
 
             modelBuilder.Entity<StringKey>()
                 .ToContainer("Strings");
@@ -475,7 +475,7 @@ public abstract class FindCosmosTest : FindTestBase<FindCosmosTest.FindCosmosFix
 
             modelBuilder.Entity<BaseType>()
                 .ToContainer("Base")
-                .IncludeRootDiscriminatorInJsonId();
+                .HasRootDiscriminatorInJsonId();
 
             modelBuilder.Entity<ShadowKey>().ToContainer("ShadowKeys");
         }

--- a/test/EFCore.Cosmos.FunctionalTests/KeysWithConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/KeysWithConvertersCosmosTest.cs
@@ -20,7 +20,7 @@ public class KeysWithConvertersCosmosTest(KeysWithConvertersCosmosTest.KeysWithC
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeRootDiscriminatorInJsonId();
+            modelBuilder.HasRootDiscriminatorInJsonId();
         }
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
@@ -42,32 +42,32 @@ public class NorthwindQueryCosmosFixture<TModelCustomizer> : NorthwindQueryFixtu
         modelBuilder.Entity<Employee>().ToContainer("Employees");
 
         modelBuilder.Entity<Order>()
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .ToContainer("ProductsAndOrders");
 
         modelBuilder.Entity<OrderDetail>()
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .ToContainer("ProductsAndOrders");
 
         modelBuilder.Entity<Product>()
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .ToContainer("ProductsAndOrders");
 
         modelBuilder.Entity<OrderQuery>()
             .ToContainer("ProductsAndOrders")
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .HasDiscriminator<string>("$type").HasValue("Order");
 
         modelBuilder
             .Entity<ProductQuery>()
             .ToContainer("ProductsAndOrders")
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .HasDiscriminator<string>("$type").HasValue("Product");
 
         modelBuilder
             .Entity<ProductView>()
             .ToContainer("ProductsAndOrders")
-            .IncludeRootDiscriminatorInJsonId()
+            .HasRootDiscriminatorInJsonId()
             .HasDiscriminator<string>("$type").HasValue("ProductView");
 
         modelBuilder

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
@@ -858,7 +858,7 @@ OFFSET 0 LIMIT 2
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.IncludeRootDiscriminatorInJsonId();
+            modelBuilder.HasRootDiscriminatorInJsonId();
         }
     }
 }


### PR DESCRIPTION
### Description

9.0 introduced two new APIs for Cosmos: IncludeDiscriminatorInJsonId and IncludeRootDiscriminatorInJsonId. We later decided to change the name, but #34403 only renamed IncludeDiscriminatorInJsonId to HasDiscriminatorInJsonId, and left IncludeRootDiscriminatorInJsonId as-is. This PR fixes that.

### Customer impact

None - this is a new, unreleased API in 9.0.

### How found

Discovered while writing documentation.

### Regression

No.

### Testing

Non required.

### Risk

None, method name change only.