### PR TITLE
Fix: Value cannot be null parameter name key

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -673,7 +673,13 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
             var processedEntries = new List<IUpdateEntry>();
             foreach (var entry in _entries.Where(e => e.EntityType.IsMappedToJson()))
             {
-                var jsonColumn = GetTableMapping(entry.EntityType)!.Table.FindColumn(entry.EntityType.GetContainerColumnName()!)!;
+                var jsonColumn = GetTableMapping(entry.EntityType)!.Table.FindColumn(entry.EntityType.GetContainerColumnName()!);
+
+                if (jsonColumn == null)
+                {
+                    continue;
+                }
+
                 var jsonPartialUpdateInfo = FindJsonPartialUpdateInfo(entry, processedEntries);
 
                 if (jsonPartialUpdateInfo == null)

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
@@ -203,6 +203,7 @@ public abstract class JsonUpdateFixtureBase : SharedStoreFixtureBase<JsonQueryCo
 
         modelBuilder.Entity<JsonEntityHasComplexChild>().OwnsOne(x => x.EntityReference, b =>
         {
+            b.Property(x => x.Id).ValueGeneratedNever();
             b.ToJson();
             b.OwnsOne(x => x.AEntityReference, bb =>
             {

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
@@ -201,6 +201,15 @@ public abstract class JsonUpdateFixtureBase : SharedStoreFixtureBase<JsonQueryCo
                 b.Property(x => x.Name);
             });
 
+        modelBuilder.Entity<JsonEntityHasComplexChild>().OwnsOne(x => x.EntityReference, b =>
+        {
+            b.ToJson();
+            b.OwnsOne(x => x.AEntityReference, bb =>
+            {
+                bb.ToJson();
+            });
+        });
+
         base.OnModelCreating(modelBuilder, context);
     }
 

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
@@ -201,6 +201,7 @@ public abstract class JsonUpdateFixtureBase : SharedStoreFixtureBase<JsonQueryCo
                 b.Property(x => x.Name);
             });
 
+        modelBuilder.Entity<JsonEntityHasComplexChild>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityHasComplexChild>().OwnsOne(x => x.EntityReference, b =>
         {
             b.Property(x => x.Id).ValueGeneratedNever();

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/AJsonEntityHasComplexChildForReferenceForReference.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/AJsonEntityHasComplexChildForReferenceForReference.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+#nullable disable
+
+public class AJsonEntityHasComplexChildForReferenceForReference
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public int? ParentId { get; set; }
+    public JsonEntityHasComplexChildForReference Parent { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChild.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChild.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+#nullable disable
+
+public class JsonEntityHasComplexChild
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public JsonEntityHasComplexChildForReference EntityReference { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChildForReference.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChildForReference.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+#nullable disable
+
+public class JsonEntityHasComplexChildForReference
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    // A is required for sorting
+    public AJsonEntityHasComplexChildForReferenceForReference AEntityReference { get; set; }
+
+    public int? ParentId { get; set; }
+    public JsonEntityHasComplexChild Parent { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
@@ -16,6 +16,7 @@ public class JsonQueryContext(DbContextOptions options) : DbContext(options)
     public DbSet<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
     public DbSet<JsonEntityAllTypes> JsonEntitiesAllTypes { get; set; }
     public DbSet<JsonEntityConverters> JsonEntitiesConverters { get; set; }
+    public DbSet<JsonEntityHasComplexChild> JsonEntitiesHasComplexChild { get; set; }
 
     public static Task SeedAsync(JsonQueryContext context)
     {


### PR DESCRIPTION
When using ToJson for another entity within a JSON column, no corresponding column is found for that entity, resulting in a [null value](https://github.com/dotnet/efcore/blob/f90a768a7f6fe2dbe80d69331e4efa8e82fa4b97/src/EFCore.Relational/Update/ModificationCommand.cs#L676). Additionally, a null exception is thrown when the [TryGetValue](https://github.com/dotnet/efcore/blob/f90a768a7f6fe2dbe80d69331e4efa8e82fa4b97/src/EFCore.Relational/Update/ModificationCommand.cs#L690) method is used within a dictionary.

Fixes #33831

