### PR TITLE
[release/9.0] Disabling a flaky test

### DIFF
--- a/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
@@ -1381,7 +1381,7 @@ public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
 
     #region 22841
 
-    [ConditionalFact]
+    [ConditionalFact(Skip = "Issue #34727 - flaky test")]
     public virtual async Task SaveChangesAsync_accepts_changes_with_ConfigureAwait_true()
     {
         var contextFactory = await InitializeAsync<Context22841>();


### PR DESCRIPTION
Intermittently fails on Linux for InMemory and Sqlite