### PR TITLE
[release/9.0] Tools: Fallback to service provider when no context types found

### DIFF
--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -447,7 +447,7 @@ public class DbContextOperations
     public virtual IEnumerable<DbContext> CreateAllContexts()
     {
         EF.IsDesignTime = true;
-        var types = FindContextTypes();
+        var types = FindContextTypes(useServiceProvider: false);
         foreach (var contextPair in types)
         {
             yield return CreateContext(null, contextPair);
@@ -499,7 +499,7 @@ public class DbContextOperations
     public virtual Type GetContextType(string? name)
         => FindContextType(name).Key;
 
-    private IDictionary<Type, Func<DbContext>> FindContextTypes(string? name = null)
+    private IDictionary<Type, Func<DbContext>> FindContextTypes(string? name = null, bool useServiceProvider = true)
     {
         _reporter.WriteVerbose(DesignStrings.FindingContexts);
 
@@ -576,7 +576,7 @@ public class DbContextOperations
             }
 
             if (contexts.Values.All(f => f != null)
-                && (string.IsNullOrEmpty(name) || contexts.Count == 1))
+                && (!useServiceProvider || contexts.Count == 1))
             {
                 return contexts!;
             }

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
@@ -348,12 +348,11 @@ public class CustomTypesIdentityContext(DbContextOptions options)
                     .WithMany(e => e.Users)
                     .UsingEntity<CustomUserRoleString>(
                         j => j.HasOne(e => e.Role).WithMany(e => e.UserRoles).HasForeignKey(e => e.RoleId),
-                        j => j.HasOne(e => e.User).WithMany(e => e.UserRoles).HasForeignKey(e => e.RoleId));
+                        j => j.HasOne(e => e.User).WithMany(e => e.UserRoles).HasForeignKey(e => e.UserId));
 
                 b.HasMany(e => e.Claims).WithOne(e => e.User).HasForeignKey(uc => uc.UserId).IsRequired();
                 b.HasMany(e => e.Logins).WithOne(e => e.User).HasForeignKey(ul => ul.UserId).IsRequired();
                 b.HasMany(e => e.Tokens).WithOne(e => e.User).HasForeignKey(ut => ut.UserId).IsRequired();
-                b.HasMany(e => e.UserRoles).WithOne(e => e.User).HasForeignKey(ur => ur.UserId).IsRequired();
                 b.ToTable("MyUsers");
                 b.Property(u => u.UserName).HasMaxLength(128);
                 b.Property(u => u.NormalizedUserName).HasMaxLength(128);


### PR DESCRIPTION
Fixes #34758

**Description**
In 9 we introduced a circuit-breaker for discovering context types: if all the discovered context types have a corresponding `IDesignTimeDbContextFactory` implementation, then EF won't use the service provider to get the configuration. However, due to incorrect logic this path was also used when no context types were discovered and the user didn't specify the context type name.

**Customer impact**
Running `dotnet ef migrations add` on a typical application that uses migrations project fails. This is a common scenario.
A workaround is to specify the context type with `--context`

**How found**
Reported on 9 RC1 by partner team (Aspire).

**Regression**
Yes, introduced in 5f0887dc5d7af6d728d71875c071e5468e094acc

**Testing**
Tests added.

**Risk**
Low.