### PR TITLE
[release/9.0] Use the specified migrations assembly in validation

### DIFF
--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -287,13 +287,19 @@ public class MigrationsOperations
         var assemblyName = _assembly.GetName();
         var options = services.GetRequiredService<IDbContextOptions>();
         var contextType = services.GetRequiredService<ICurrentDbContext>().Context.GetType();
-        var migrationsAssemblyName = RelationalOptionsExtension.Extract(options).MigrationsAssembly
-            ?? contextType.Assembly.GetName().Name;
-        if (assemblyName.Name != migrationsAssemblyName
-            && assemblyName.FullName != migrationsAssemblyName)
+        var optionsExtension = RelationalOptionsExtension.Extract(options);
+        if (optionsExtension.MigrationsAssemblyObject == null
+            || optionsExtension.MigrationsAssemblyObject != _assembly)
         {
-            throw new OperationException(
-                DesignStrings.MigrationsAssemblyMismatch(assemblyName.Name, migrationsAssemblyName));
+            var migrationsAssemblyName = optionsExtension.MigrationsAssembly
+                ?? optionsExtension.MigrationsAssemblyObject?.GetName().Name
+                ?? contextType.Assembly.GetName().Name;
+            if (assemblyName.Name != migrationsAssemblyName
+                && assemblyName.FullName != migrationsAssemblyName)
+            {
+                throw new OperationException(
+                    DesignStrings.MigrationsAssemblyMismatch(assemblyName.Name, migrationsAssemblyName));
+            }
         }
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
@@ -31,8 +31,9 @@ public class MigrationsAssembly : IMigrationsAssembly
     {
         _contextType = currentContext.Context.GetType();
 
-        var assemblyName = RelationalOptionsExtension.Extract(options).MigrationsAssembly;
-        var assemblyObject = RelationalOptionsExtension.Extract(options).MigrationsAssemblyObject;
+        var optionsExtension = RelationalOptionsExtension.Extract(options);
+        var assemblyName = optionsExtension.MigrationsAssembly;
+        var assemblyObject = optionsExtension.MigrationsAssemblyObject;
 
         Assembly = assemblyName == null
             ? assemblyObject ?? _contextType.Assembly

--- a/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
@@ -22,5 +22,34 @@ public class MigrationsOperationsTest
             args: null);
     }
 
+    [ConditionalFact]
+    public void Can_use_migrations_assembly()
+    {
+        // Even though newer versions of the tools will pass an empty array
+        // older versions of the tools can pass null args.
+        var assembly = MockAssembly.Create(typeof(AssemblyTestContext));
+        var migrationsAssembly = MockAssembly.Create();
+        AssemblyTestContext.MigrationsAssembly = migrationsAssembly;
+        var testOperations = new TestMigrationsOperations(
+            new TestOperationReporter(),
+            assembly,
+            assembly,
+            "projectDir",
+            "RootNamespace",
+            "C#",
+            nullable: false,
+            args: null);
+
+        testOperations.AddMigration("Test", null, null, null, dryRun: true);
+    }
+
     private class TestContext : DbContext;
+
+    private class AssemblyTestContext : DbContext
+    {
+        public static Assembly MigrationsAssembly { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlServer(o => o.MigrationsAssembly(MigrationsAssembly));
+    }
 }


### PR DESCRIPTION
Fixes #34772

**Description**
In 9 we accepted a community PR that [adds a way to specify an `Assembly` for migrations](https://github.com/dotnet/efcore/pull/32473). However, the validation logic for this option wasn't updated

**Customer impact**
Running `dotnet ef migrations add` fails if the above option is specified. The workaround is to specify the assembly name instead, but this isn't possible for test scenarios where the assembly is generated dynamically.

**How found**
Reported on 9 RC1 by partner team (Aspire).

**Regression**
No, new feature

**Testing**
Test added.

**Risk**
Low.