### PR TITLE
Add initial implementation for Azure Data Explorer (Kusto) support in…

### DIFF
--- a/src/EFCore.Kusto/EFCore.Kusto.csproj
+++ b/src/EFCore.Kusto/EFCore.Kusto.csproj
@@ -1,0 +1,71 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Azure Data Explorer (Kusto) provider for Entity Framework Core.</Description>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <MinClientVersion>3.6</MinClientVersion>
+    <AssemblyName>Microsoft.EntityFrameworkCore.Kusto</AssemblyName>
+    <RootNamespace>Microsoft.EntityFrameworkCore.Kusto</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>$(PackageTags);Kusto;KQL;AzureDataExplorer</PackageTags>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System.Diagnostics" />
+    <Using Include="System.Linq.Expressions" />
+    <Using Include="System.Reflection" />
+    <Using Include="Microsoft.Azure.Kusto.Data" />
+    <Using Include="Microsoft.EntityFrameworkCore" />
+    <Using Include="Microsoft.EntityFrameworkCore.ChangeTracking" />
+    <Using Include="Microsoft.EntityFrameworkCore.Diagnostics" />
+    <Using Include="Microsoft.EntityFrameworkCore.Design" />
+    <Using Include="Microsoft.EntityFrameworkCore.Infrastructure" />
+    <Using Include="Microsoft.EntityFrameworkCore.Metadata" />
+    <Using Include="Microsoft.EntityFrameworkCore.Metadata.Builders" />
+    <Using Include="Microsoft.EntityFrameworkCore.Metadata.Conventions" />
+    <Using Include="Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure" />
+    <Using Include="Microsoft.EntityFrameworkCore.Query" />
+    <Using Include="Microsoft.EntityFrameworkCore.Storage" />
+    <Using Include="Microsoft.EntityFrameworkCore.Storage.ValueConversion" />
+    <Using Include="Microsoft.EntityFrameworkCore.Update" />
+    <Using Include="Microsoft.EntityFrameworkCore.ValueGeneration" />
+    <Using Include="Microsoft.EntityFrameworkCore.Utilities" />
+    <Using Include="Microsoft.Extensions.Logging" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EFCore\EFCore.csproj" />
+    <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj" ReferenceOutputAssembly="False" OutputItemType="Analyzer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Kusto.Data" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\KustoStrings.Designer.cs">
+      <DependentUpon>KustoStrings.Designer.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\KustoStrings.Designer.tt">
+      <CustomToolNamespace>Microsoft.EntityFrameworkCore.Kusto.Internal</CustomToolNamespace>
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>KustoStrings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+</Project>

--- a/src/EFCore.Kusto/Extensions/KustoDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Kusto/Extensions/KustoDatabaseFacadeExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Kusto.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Kusto.Storage.Internal;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class KustoDatabaseFacadeExtensions
+    {
+        public static KustoClient GetKustoClient(this DatabaseFacade databaseFacade)
+            => GetService<ISingletonKustoClientWrapper>(databaseFacade).Client;
+
+        private static TService GetService<TService>(IInfrastructure<IServiceProvider> databaseFacade)
+            where TService : class
+        {
+            var service = databaseFacade.GetService<TService>();
+            if (service == null)
+            {
+                throw new InvalidOperationException(KustoStrings.KustoNotInUse);
+            }
+
+            return service;
+        }
+
+        public static string GetKustoDatabaseId(this DatabaseFacade databaseFacade)
+        {
+            var kustoOptions = databaseFacade.GetService<IDbContextOptions>().FindExtension<KustoOptionsExtension>();
+            if (kustoOptions == null)
+            {
+                throw new InvalidOperationException(KustoStrings.KustoNotInUse);
+            }
+
+            return kustoOptions.DatabaseName;
+        }
+
+        public static bool IsKusto(this DatabaseFacade database)
+            => database.ProviderName == typeof(KustoOptionsExtension).Assembly.GetName().Name;
+    }
+}

--- a/src/EFCore.Kusto/Extensions/KustoDbContextOptionsExtensions.cs
+++ b/src/EFCore.Kusto/Extensions/KustoDbContextOptionsExtensions.cs
@@ -1,0 +1,178 @@
+using Azure.Core;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Kusto.Infrastructure.Internal;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class KustoDbContextOptionsExtensions
+    {
+        public static DbContextOptionsBuilder<TContext> UseKusto<TContext>(
+            this DbContextOptionsBuilder<TContext> optionsBuilder,
+            Action<KustoDbContextOptionsBuilder> kustoOptionsAction)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseKusto(
+                (DbContextOptionsBuilder)optionsBuilder,
+                kustoOptionsAction);
+
+        public static DbContextOptionsBuilder UseKusto(
+            this DbContextOptionsBuilder optionsBuilder,
+            Action<KustoDbContextOptionsBuilder> kustoOptionsAction)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(kustoOptionsAction, nameof(kustoOptionsAction));
+
+            ConfigureWarnings(optionsBuilder);
+
+            kustoOptionsAction.Invoke(new KustoDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
+
+        public static DbContextOptionsBuilder<TContext> UseKusto<TContext>(
+            this DbContextOptionsBuilder<TContext> optionsBuilder,
+            string clusterEndpoint,
+            string databaseName,
+            string applicationClientId,
+            string applicationClientSecret,
+            string authority,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseKusto(
+                (DbContextOptionsBuilder)optionsBuilder,
+                clusterEndpoint,
+                databaseName,
+                applicationClientId,
+                applicationClientSecret,
+                authority,
+                kustoOptionsAction);
+
+        public static DbContextOptionsBuilder UseKusto(
+            this DbContextOptionsBuilder optionsBuilder,
+            string clusterEndpoint,
+            string databaseName,
+            string applicationClientId,
+            string applicationClientSecret,
+            string authority,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(clusterEndpoint, nameof(clusterEndpoint));
+            Check.NotNull(databaseName, nameof(databaseName));
+            Check.NotNull(applicationClientId, nameof(applicationClientId));
+            Check.NotNull(applicationClientSecret, nameof(applicationClientSecret));
+            Check.NotNull(authority, nameof(authority));
+
+            var extension = optionsBuilder.Options.FindExtension<KustoOptionsExtension>()
+                ?? new KustoOptionsExtension();
+
+            extension = extension
+                .WithClusterEndpoint(clusterEndpoint)
+                .WithDatabaseName(databaseName)
+                .WithApplicationClientId(applicationClientId)
+                .WithApplicationClientSecret(applicationClientSecret)
+                .WithAuthority(authority);
+
+            ConfigureWarnings(optionsBuilder);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            kustoOptionsAction?.Invoke(new KustoDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
+
+        public static DbContextOptionsBuilder<TContext> UseKusto<TContext>(
+            this DbContextOptionsBuilder<TContext> optionsBuilder,
+            string clusterEndpoint,
+            TokenCredential tokenCredential,
+            string databaseName,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseKusto(
+                (DbContextOptionsBuilder)optionsBuilder,
+                clusterEndpoint,
+                tokenCredential,
+                databaseName,
+                kustoOptionsAction);
+
+        public static DbContextOptionsBuilder UseKusto(
+            this DbContextOptionsBuilder optionsBuilder,
+            string clusterEndpoint,
+            TokenCredential tokenCredential,
+            string databaseName,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(clusterEndpoint, nameof(clusterEndpoint));
+            Check.NotNull(tokenCredential, nameof(tokenCredential));
+            Check.NotNull(databaseName, nameof(databaseName));
+
+            var extension = optionsBuilder.Options.FindExtension<KustoOptionsExtension>()
+                ?? new KustoOptionsExtension();
+
+            extension = extension
+                .WithClusterEndpoint(clusterEndpoint)
+                .WithTokenCredential(tokenCredential)
+                .WithDatabaseName(databaseName);
+
+            ConfigureWarnings(optionsBuilder);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            kustoOptionsAction?.Invoke(new KustoDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
+
+        public static DbContextOptionsBuilder<TContext> UseKusto<TContext>(
+            this DbContextOptionsBuilder<TContext> optionsBuilder,
+            string connectionString,
+            string databaseName,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseKusto(
+                (DbContextOptionsBuilder)optionsBuilder,
+                connectionString,
+                databaseName,
+                kustoOptionsAction);
+
+        public static DbContextOptionsBuilder UseKusto(
+            this DbContextOptionsBuilder optionsBuilder,
+            string connectionString,
+            string databaseName,
+            Action<KustoDbContextOptionsBuilder>? kustoOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(connectionString, nameof(connectionString));
+            Check.NotNull(databaseName, nameof(databaseName));
+
+            var extension = optionsBuilder.Options.FindExtension<KustoOptionsExtension>()
+                ?? new KustoOptionsExtension();
+
+            extension = extension
+                .WithConnectionString(connectionString)
+                .WithDatabaseName(databaseName);
+
+            ConfigureWarnings(optionsBuilder);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            kustoOptionsAction?.Invoke(new KustoDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
+
+        private static void ConfigureWarnings(DbContextOptionsBuilder optionsBuilder)
+        {
+            var coreOptionsExtension
+                = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()
+                ?? new CoreOptionsExtension();
+
+            coreOptionsExtension = coreOptionsExtension.WithWarningsConfiguration(
+                coreOptionsExtension.WarningsConfiguration.TryWithExplicit(
+                    KustoEventId.SyncNotSupported, WarningBehavior.Throw));
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(coreOptionsExtension);
+        }
+    }
+}

--- a/src/EFCore.Kusto/Extensions/KustoDbFunctionsExtensions.cs
+++ b/src/EFCore.Kusto/Extensions/KustoDbFunctionsExtensions.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Kusto.Extensions;
+
+public static class KustoDbFunctionsExtensions
+{
+    public static bool IsDefined(this DbFunctions _, object? expression)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(IsDefined)));
+
+    public static T CoalesceUndefined<T>(
+        this DbFunctions _,
+        T expression1,
+        T expression2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CoalesceUndefined)));
+
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<byte> vector1, ReadOnlyMemory<byte> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<byte> vector1,
+        ReadOnlyMemory<byte> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<byte> vector1,
+        ReadOnlyMemory<byte> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<sbyte> vector1, ReadOnlyMemory<sbyte> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<sbyte> vector1,
+        ReadOnlyMemory<sbyte> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<sbyte> vector1,
+        ReadOnlyMemory<sbyte> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<float> vector1, ReadOnlyMemory<float> vector2)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<float> vector1,
+        ReadOnlyMemory<float> vector2,
+        [NotParameterized] bool useBruteForce)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<float> vector1,
+        ReadOnlyMemory<float> vector2,
+        [NotParameterized] bool useBruteForce,
+        [NotParameterized] DistanceFunction distanceFunction)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+}

--- a/src/EFCore.Kusto/Extensions/KustoEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Kusto/Extensions/KustoEntityTypeBuilderExtensions.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class KustoEntityTypeBuilderExtensions
+    {
+        public static EntityTypeBuilder ToContainer(
+            this EntityTypeBuilder entityTypeBuilder,
+            string? name)
+        {
+            Check.NullButNotEmpty(name, nameof(name));
+
+            entityTypeBuilder.Metadata.SetContainer(name);
+
+            return entityTypeBuilder;
+        }
+
+        public static EntityTypeBuilder<TEntity> ToContainer<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string? name)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)ToContainer((EntityTypeBuilder)entityTypeBuilder, name);
+
+        public static IConventionEntityTypeBuilder? ToContainer(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            string? name,
+            bool fromDataAnnotation = false)
+        {
+            if (!entityTypeBuilder.CanSetContainer(name, fromDataAnnotation))
+            {
+                return null;
+            }
+
+            entityTypeBuilder.Metadata.SetContainer(name, fromDataAnnotation);
+
+            return entityTypeBuilder;
+        }
+
+        public static bool CanSetContainer(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            string? name,
+            bool fromDataAnnotation = false)
+        {
+            Check.NullButNotEmpty(name, nameof(name));
+
+            return entityTypeBuilder.CanSetAnnotation(KustoAnnotationNames.ContainerName, name, fromDataAnnotation);
+        }
+
+        public static EntityTypeBuilder HasPartitionKey(
+            this EntityTypeBuilder entityTypeBuilder,
+            string? name,
+            params string[]? additionalPropertyNames)
+        {
+            Check.NullButNotEmpty(name, nameof(name));
+            Check.HasNoEmptyElements(additionalPropertyNames, nameof(additionalPropertyNames));
+
+            if (name is null)
+            {
+                entityTypeBuilder.Metadata.SetPartitionKeyPropertyNames(null);
+            }
+            else
+            {
+                var propertyNames = new List<string> { name };
+                propertyNames.AddRange(additionalPropertyNames);
+                entityTypeBuilder.Metadata.SetPartitionKeyPropertyNames(propertyNames);
+            }
+
+            return entityTypeBuilder;
+        }
+
+        public static EntityTypeBuilder<TEntity> HasPartitionKey<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string? name,
+            params string[]? additionalPropertyNames)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)HasPartitionKey((EntityTypeBuilder)entityTypeBuilder, name, additionalPropertyNames);
+
+        public static EntityTypeBuilder<TEntity> HasPartitionKey<TEntity, TProperty>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, TProperty>> propertyExpression)
+            where TEntity : class
+        {
+            Check.NotNull(propertyExpression, nameof(propertyExpression));
+
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyNames(
+                propertyExpression.GetMemberAccessList().Select(e => e.GetSimpleMemberName()).ToList());
+
+            return entityTypeBuilder;
+        }
+
+        public static IConventionEntityTypeBuilder? HasPartitionKey(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            string? name,
+            bool fromDataAnnotation = false)
+            => entityTypeBuilder.HasPartitionKey(name == null ? null : [name], fromDataAnnotation);
+
+        public static bool CanSetPartitionKey(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            string? name,
+            bool fromDataAnnotation = false)
+            => entityTypeBuilder.CanSetPartitionKey(name == null ? null : [name], fromDataAnnotation);
+
+        public static IConventionEntityTypeBuilder? HasPartitionKey(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            IReadOnlyList<string>? propertyNames,
+            bool fromDataAnnotation = false)
+        {
+            if (!entityTypeBuilder.CanSetPartitionKey(propertyNames, fromDataAnnotation))
+            {
+                return null;
+            }
+
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyNames(propertyNames, fromDataAnnotation);
+
+            return entityTypeBuilder;
+        }
+
+        public static bool CanSetPartitionKey(
+            this IConventionEntityTypeBuilder entityTypeBuilder,
+            IReadOnlyList<string>? names,
+            bool fromDataAnnotation = false)
+            => entityTypeBuilder.CanSetAnnotation(
+                KustoAnnotationNames.PartitionKeyNames,
+                names is null ? names : Check.HasNoEmptyElements(names, nameof(names)),
+                fromDataAnnotation);
+
+        public static EntityTypeBuilder UseETagConcurrency(this EntityTypeBuilder entityTypeBuilder)
+        {
+            entityTypeBuilder.Property<string>("_etag")
+                .ValueGeneratedOnAddOrUpdate()
+                .IsConcurrencyToken();
+
+            return entityTypeBuilder;
+        }
+
+        public static EntityTypeBuilder<TEntity> UseETagConcurrency<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)UseETagConcurrency((EntityTypeBuilder)entityTypeBuilder);
+    }
+}


### PR DESCRIPTION
… EF Core

* **Project File**
  - Create `EFCore.Kusto.csproj` with necessary references and configurations.

* **DatabaseFacade Extensions**
  - Implement `KustoDatabaseFacadeExtensions` with methods like `GetKustoClient`, `GetKustoDatabaseId`, and `IsKusto`.

* **DbContextOptionsBuilder Extensions**
  - Implement `KustoDbContextOptionsExtensions` with methods like `UseKusto` for various connection configurations.

* **DbFunctions Extensions**
  - Implement `KustoDbFunctionsExtensions` with methods like `IsDefined`, `CoalesceUndefined`, and `VectorDistance`.

* **EntityTypeBuilder Extensions**
  - Implement `KustoEntityTypeBuilderExtensions` with methods like `ToContainer`, `HasPartitionKey`, and `UseETagConcurrency`.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

