### PR TITLE
Handle GO within a sql statement better

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -83,7 +83,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
             x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
             x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
-            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
+            x => Assert.Equal("00000000000007_Migration7", x.MigrationId),
+            x => Assert.Equal("00000000000008_Migration8", x.MigrationId));
 
         Assert.Equal(1, Fixture.SeedCallCount);
         Assert.Equal(0, Fixture.SeedAsyncCallCount);
@@ -110,7 +111,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000004_Migration4", x.MigrationId),
             x => Assert.Equal("00000000000005_Migration5", x.MigrationId),
             x => Assert.Equal("00000000000006_Migration6", x.MigrationId),
-            x => Assert.Equal("00000000000007_Migration7", x.MigrationId));
+            x => Assert.Equal("00000000000007_Migration7", x.MigrationId),
+            x => Assert.Equal("00000000000008_Migration8", x.MigrationId));
 
         Assert.Equal(0, Fixture.SeedCallCount);
         Assert.Equal(1, Fixture.SeedAsyncCallCount);
@@ -681,6 +683,32 @@ public abstract class MigrationsInfrastructureFixtureBase
 
         protected override void Up(MigrationBuilder migrationBuilder)
             => migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '{TestValue}')");
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("00000000000008_Migration8")]
+    private class Migration8 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql(@"
+
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+
+");
+            }
+        }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -17,12 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         MigrationsInfrastructureSqlServerTest.MigrationsInfrastructureSqlServerFixture fixture)
         : MigrationsInfrastructureTestBase<MigrationsInfrastructureSqlServerTest.MigrationsInfrastructureSqlServerFixture>(fixture)
     {
-        public override void Can_apply_all_migrations() // Issue #32826
-            => Assert.Throws<SqlException>(base.Can_apply_all_migrations);
-
-        public override Task Can_apply_all_migrations_async() // Issue #32826
-            => Assert.ThrowsAsync<SqlException>(base.Can_apply_all_migrations_async);
-
         public override void Can_apply_range_of_migrations()
         {
             base.Can_apply_range_of_migrations();
@@ -183,13 +177,28 @@ Value With
 
 GO
 
-
 Empty Lines
 GO')
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+GO
+
+
+
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+
+
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000008_Migration8', N'7.0.0-test');
 GO
 
 COMMIT;
@@ -296,13 +305,28 @@ Value With
 
 GO
 
-
 Empty Lines
 GO')
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+GO
+
+
+
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+SELECT GetDate()
+GO
+
+
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000008_Migration8', N'7.0.0-test');
 GO
 
 
@@ -546,14 +570,7 @@ BEGIN
     INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
     Value With
 
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
+    GO
 
     Empty Lines
     GO')
@@ -567,6 +584,34 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+
+
+    SELECT GetDate()
+    GO
+    SELECT GetDate()
+    GO
+    SELECT GetDate()
+    GO
+
+
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000008_Migration8', N'7.0.0-test');
 END;
 GO
 
@@ -755,14 +800,7 @@ BEGIN
     INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
     Value With
 
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
+    GO
 
     Empty Lines
     GO')
@@ -776,6 +814,34 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+
+
+    SELECT GetDate()
+    GO
+    SELECT GetDate()
+    GO
+    SELECT GetDate()
+    GO
+
+
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000008_Migration8', N'7.0.0-test');
 END;
 GO
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -189,12 +189,11 @@ GO
 
 SELECT GetDate()
 GO
-SELECT GetDate()
-GO
+
 SELECT GetDate()
 GO
 
-
+SELECT GetDate()
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -317,12 +316,11 @@ GO
 
 SELECT GetDate()
 GO
-SELECT GetDate()
-GO
+
 SELECT GetDate()
 GO
 
-
+SELECT GetDate()
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -595,13 +593,24 @@ BEGIN
 
 
     SELECT GetDate()
-    GO
-    SELECT GetDate()
-    GO
-    SELECT GetDate()
-    GO
+END;
+GO
 
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    SELECT GetDate()
+END;
+GO
 
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    SELECT GetDate()
 END;
 GO
 
@@ -825,13 +834,24 @@ BEGIN
 
 
     SELECT GetDate()
-    GO
-    SELECT GetDate()
-    GO
-    SELECT GetDate()
-    GO
+END;
+GO
 
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    SELECT GetDate()
+END;
+GO
 
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000008_Migration8'
+)
+BEGIN
+    SELECT GetDate()
 END;
 GO
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -745,6 +745,159 @@ EXEC sp_rename N'[dbo].[People]', N'Person', 'OBJECT';
     }
 
     [ConditionalFact]
+    public virtual void SqlOperation_handles_single_quote_literal()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+    Value With
+    
+    GO
+
+    Empty Lines')
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+Value With
+
+GO
+
+Empty Lines')
+
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void SqlOperation_handles_single_quote_literal_escaped()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+    Value'' With
+    
+    GO
+
+    Empty Lines')
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+Value'' With
+
+GO
+
+Empty Lines')
+
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void SqlOperation_handles_single_quote_literal_with_double_quote()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+    Value" With
+    
+    GO
+
+    Empty Lines')
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+Value" With
+
+GO
+
+Empty Lines')
+
+""");
+    }
+
+
+    [ConditionalFact]
+    public virtual void SqlOperation_handles_double_quote_literal()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+    Value With
+    
+    GO
+
+    Empty Lines")
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+Value With
+
+GO
+
+Empty Lines")
+
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void SqlOperation_handles_double_quote_literal_escaped()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+    Value"" With
+    
+    GO
+
+    Empty Lines")
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+Value"" With
+
+GO
+
+Empty Lines")
+
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void SqlOperation_handles_double_quote_literal_with_single_quote()
+    {
+        Generate(
+            new SqlOperation { Sql = """
+    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+    Value' With
+
+    Empty Lines")
+    GO
+    """ });
+
+        AssertSql(
+            """
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, "GO
+Value' With
+
+Empty Lines")
+
+""");
+    }
+
+    [ConditionalFact]
     public virtual void SqlOperation_ignores_sequential_gos()
     {
         Generate(

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -105,6 +105,9 @@ GO')
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000007_Migration7', '7.0.0-test');
 
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000008_Migration8', '7.0.0-test');
+
 COMMIT;
 
 
@@ -169,6 +172,9 @@ GO')
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000007_Migration7', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000008_Migration8', '7.0.0-test');
 
 
 """,


### PR DESCRIPTION
fixes #32826

It occurred to me that you don't need to inspect/parse the SQL to decide how to handle the `GO`. The way EFCore place the batch terminator (`GO`) appears to always be preceded by a statement that has a statement terminator (`;`). Even if the statement has multiple lines (such as those with a BEGIN and END) it still only ends up with 1 statement terminator.

Hence the theory is the only `GO` in question that we are truly looking for are those on its own line and are preceded by a statement terminated line. 

The current tests now work.

I think this might also fix #33337

From the migration they think is the problem
```
migrationBuilder.Sql(@"

SELECT GetDate()
GO
SELECT GetDate()
GO
SELECT GetDate()
GO

");
```

Given that there are no statement terminators this ends up becoming all one batch. Also given one of the concerns was that a batch was solely an empty string, I added a check to only add if there is something to add. With or without that test, it doesn't change any line spacing of the sql output so at least for the tests/migrations we have it doesn't make any difference