### PR TITLE
Keep parameter values out IMemoryCache in RelationalCommandCache

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -119,7 +119,7 @@ public class RelationalCommandCache : IPrintableExpression
             {
                 _parameterInfos[key] = new ParameterInfo
                 {
-                    IsNull = value == null,
+                    IsNull = value is null,
                     ObjectArrayLength = value is object[] arr ? arr.Length : null
                 };
             }


### PR DESCRIPTION
Only store necessary info for parameter values RelationalCommandCacheKey to prevent memory leaks.

This a relatively serious memory leak defect and needs to be ported back to the `release/8.0` branch as well.

Fixes #34028

- [X] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [X] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [X] The code builds and tests pass locally (also verified by our automated build checks)
- [X] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code follows the same patterns and style as existing code in this repo

