### PR TITLE
[release/6.0] Update dependencies

### DIFF
--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.29.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -21,6 +21,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.36.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Due to a recent change NuGet restore now shows CVE warnings for transitive packages even if the actual version that will be used will be the current one provided by SDK. This PR updates transitive dependencies to minimize the number of warnings

### Customer impact

Warnings on restore when EF packages are referenced.

### How found

Partner ask (templates)

### Regression

No

### Testing

Tested manually.

### Risk

Low.