### PR TITLE
[release/9.0] Don't throw on non-transactional migration operation warning.

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -463,8 +463,7 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
                 .TryWithExplicit(RelationalEventId.IndexPropertiesMappedToNonOverlappingTables, WarningBehavior.Throw)
                 .TryWithExplicit(RelationalEventId.ForeignKeyPropertiesMappedToUnrelatedTables, WarningBehavior.Throw)
                 .TryWithExplicit(RelationalEventId.StoredProcedureConcurrencyTokenNotMapped, WarningBehavior.Throw)
-                .TryWithExplicit(RelationalEventId.PendingModelChangesWarning, WarningBehavior.Throw)
-                .TryWithExplicit(RelationalEventId.NonTransactionalMigrationOperationWarning, WarningBehavior.Throw));
+                .TryWithExplicit(RelationalEventId.PendingModelChangesWarning, WarningBehavior.Throw));
 
     /// <summary>
     ///     Information/metadata for a <see cref="RelationalOptionsExtension" />.


### PR DESCRIPTION
Fixes #34829

### Description

In EF Core 9 we introduced a warning exception when a migration is applied, it contains more than one operation and one of them can't be executed in a transaction. However, we found that there are some non-transactional operations on SQL Server that cannot be separated into several migrations. So we decided to downgrade this to a logged warning.

### Customer impact

Exception thrown when applying a migration in the above scenario.

### How found

App writing.

### Regression

No, new feature

### Testing

Tested manually.

### Risk

Low.