### PR TITLE
Fix to #34749 - Created query for projection with ownedMany and join is wrong

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -565,6 +565,12 @@ public partial class NavigationExpandingExpressionVisitor
                 {
                     return memberExpression;
                 }
+
+                var complexProperty = entityType?.FindComplexProperty(memberExpression.Member);
+                if (complexProperty != null)
+                {
+                    return memberExpression;
+                }
             }
 
             return base.VisitMember(memberExpression);

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -76,6 +76,50 @@ public abstract class AdHocComplexTypeQueryTestBase : NonSharedModelTestBase
 
     #endregion 33449
 
+    #region 34749
+
+    [ConditionalFact]
+    public virtual async Task Projecting_complex_property_does_not_auto_include_owned_types()
+    {
+        var contextFactory = await InitializeAsync<Context34749>();
+
+        await using var context = contextFactory.CreateContext();
+
+        _ = await context.Set<Context34749.EntityType>().Select(x => x.Complex).ToListAsync();
+    }
+
+    private class Context34749(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<EntityType>(b =>
+            {
+                b.ComplexProperty(x => x.Complex);
+                b.OwnsOne(x => x.OwnedReference);
+            });
+
+        public class EntityType
+        {
+            public int Id { get; set; }
+            public string? Name { get; set; }
+            public OwnedType OwnedReference { get; set; } = null!;
+            public ComplexType Complex { get; set; } = null!;
+        }
+
+        public class ComplexType
+        {
+            public int Number { get; set; }
+            public string? Name { get; set; }
+        }
+
+        public class OwnedType
+        {
+            public string? Foo { get; set; }
+            public int Bar { get; set; }
+        }
+    }
+
+    #endregion
+
     protected override string StoreName
         => "AdHocComplexTypeQueryTest";
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -21,6 +21,17 @@ WHERE [e].[ComplexContainer_Id] = @__entity_equality_container_0_Id AND [e].[Com
 """);
     }
 
+    public override async Task Projecting_complex_property_does_not_auto_include_owned_types()
+    {
+        await base.Projecting_complex_property_does_not_auto_include_owned_types();
+
+        AssertSql(
+"""
+SELECT [e].[Complex_Name], [e].[Complex_Number]
+FROM [EntityType] AS [e]
+""");
+    }
+
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;
 


### PR DESCRIPTION
Problem was that nav expansion didn't short-circuit include expansion when it encountered complex type projection, like it did for scalar properties.

Fixes #34749