### PR TITLE
[release/9.0] Don't break transactions across batches

### DIFF
--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -233,7 +233,7 @@ public abstract class HistoryRepository : IHistoryRepository
     ///     Gets an exclusive lock on the database.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// 
+    ///
     /// <returns>An object that can be disposed to release the lock.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public abstract Task<IMigrationsDatabaseLock> AcquireDatabaseLockAsync(CancellationToken cancellationToken = default);

--- a/src/EFCore.Relational/Migrations/Internal/MigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationCommandExecutor.cs
@@ -156,7 +156,7 @@ public class MigrationCommandExecutor(IExecutionStrategy executionStrategy) : IM
         CancellationToken cancellationToken = default)
         => ExecuteNonQueryAsync(
             migrationCommands.ToList(), connection, new MigrationExecutionState(), commitTransaction: true, System.Data.IsolationLevel.Unspecified, cancellationToken);
-    
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1426,8 +1426,11 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
         void AppendBatch(string batch)
         {
-            builder.Append(batch);
-            EndStatement(builder, operation.SuppressTransaction);
+            if (!string.IsNullOrWhiteSpace(batch))
+            {
+                builder.Append(batch);
+                EndStatement(builder, operation.SuppressTransaction);
+            }
         }
     }
 
@@ -2524,7 +2527,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 {
                     // for create table we always generate new temporal information from the operation itself
                     // just in case there was a table with that name before that got deleted/renamed
-                    // this shouldn't happen as we re-use existin tables rather than drop/recreate
+                    // this shouldn't happen as we re-use existing tables rather than drop/recreate
                     // but we are being extra defensive here
                     // and also, temporal state (disabled versioning etc.) should always reset when creating a table
                     temporalInformation = BuildTemporalInformationFromMigrationOperation(schema, createTableOperation);

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -291,7 +291,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         using var db = Fixture.CreateEmptyContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript());
+        SetAndExecuteSqlAsync(migrator.GenerateScript());
     }
 
     [ConditionalFact]
@@ -300,113 +300,126 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript(fromMigration: Migration.InitialDatabase, toMigration: Migration.InitialDatabase));
+        SetAndExecuteSqlAsync(migrator.GenerateScript(fromMigration: Migration.InitialDatabase, toMigration: Migration.InitialDatabase));
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_up_scripts()
+    public virtual async Task Can_generate_up_and_down_scripts()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript());
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript());
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration7",
+            toMigration: Migration.InitialDatabase),
+            append: true);
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_up_scripts_noTransactions()
+    public virtual async Task Can_generate_up_and_down_scripts_noTransactions()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript(options: MigrationsSqlGenerationOptions.NoTransactions));
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(options: MigrationsSqlGenerationOptions.NoTransactions));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration7",
+            toMigration: Migration.InitialDatabase,
+            MigrationsSqlGenerationOptions.NoTransactions),
+            append: true);
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_one_up_script()
+    public virtual async Task Can_generate_one_up_and_down_script()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript(fromMigration: "00000000000001_Migration1", toMigration: "00000000000002_Migration2"));
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        await ExecuteSqlAsync(migrator.GenerateScript(
+            toMigration: "00000000000001_Migration1"));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "00000000000001_Migration1",
+            toMigration: "00000000000002_Migration2"));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "00000000000002_Migration2",
+            toMigration: "00000000000001_Migration1"),
+            append: true);
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_up_script_using_names()
+    public virtual async Task Can_generate_up_and_down_script_using_names()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript(fromMigration: "Migration1", toMigration: "Migration2"));
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        await ExecuteSqlAsync(migrator.GenerateScript(
+            toMigration: "Migration1"));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration1",
+            toMigration: "Migration2"));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration2",
+            toMigration: "Migration1"),
+            append: true);
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_idempotent_up_scripts()
+    public virtual async Task Can_generate_idempotent_up_and_down_scripts()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(migrator.GenerateScript(options: MigrationsSqlGenerationOptions.Idempotent));
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            toMigration: "Migration2",
+            options: MigrationsSqlGenerationOptions.Idempotent));
+
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration2",
+            toMigration: Migration.InitialDatabase,
+            MigrationsSqlGenerationOptions.Idempotent),
+            append: true);
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_idempotent_up_scripts_noTransactions()
+    public virtual async Task Can_generate_idempotent_up_and_down_scripts_noTransactions()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetSql(
-            migrator.GenerateScript(
-                options: MigrationsSqlGenerationOptions.Idempotent
-                | MigrationsSqlGenerationOptions.NoTransactions));
-    }
+        await db.Database.EnsureDeletedAsync();
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
-    [ConditionalFact]
-    public virtual void Can_generate_down_scripts()
-    {
-        using var db = Fixture.CreateContext();
-        var migrator = db.GetService<IMigrator>();
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            toMigration: "Migration2",
+            options: MigrationsSqlGenerationOptions.Idempotent | MigrationsSqlGenerationOptions.NoTransactions));
 
-        SetSql(
-            migrator.GenerateScript(
-                fromMigration: "Migration2",
-                toMigration: Migration.InitialDatabase));
-    }
-
-    [ConditionalFact]
-    public virtual void Can_generate_one_down_script()
-    {
-        using var db = Fixture.CreateContext();
-        var migrator = db.GetService<IMigrator>();
-
-        SetSql(
-            migrator.GenerateScript(
-                fromMigration: "00000000000002_Migration2",
-                toMigration: "00000000000001_Migration1"));
-    }
-
-    [ConditionalFact]
-    public virtual void Can_generate_down_script_using_names()
-    {
-        using var db = Fixture.CreateContext();
-        var migrator = db.GetService<IMigrator>();
-
-        SetSql(
-            migrator.GenerateScript(
-                fromMigration: "Migration2",
-                toMigration: "Migration1"));
-    }
-
-    [ConditionalFact]
-    public virtual void Can_generate_idempotent_down_scripts()
-    {
-        using var db = Fixture.CreateContext();
-        var migrator = db.GetService<IMigrator>();
-
-        SetSql(
-            migrator.GenerateScript(
-                fromMigration: "Migration2",
-                toMigration: Migration.InitialDatabase,
-                MigrationsSqlGenerationOptions.Idempotent));
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(
+            fromMigration: "Migration2",
+            toMigration: Migration.InitialDatabase,
+            MigrationsSqlGenerationOptions.Idempotent | MigrationsSqlGenerationOptions.NoTransactions),
+            append: true);
     }
 
     [ConditionalFact]
@@ -446,8 +459,14 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         Assert.Equal(0, operations.Count);
     }
 
-    private void SetSql(string value)
-        => Sql = value.Replace(ProductInfo.GetVersion(), "7.0.0-test");
+    private Task SetAndExecuteSqlAsync(string value, bool append = false)
+    {
+        var sql = value.Replace(ProductInfo.GetVersion(), "7.0.0-test");
+        Sql = append ? Sql + sql : sql;
+        return ExecuteSqlAsync(sql);
+    }
+
+    protected abstract Task ExecuteSqlAsync(string value);
 }
 
 public abstract class MigrationsInfrastructureFixtureBase
@@ -599,27 +618,34 @@ public abstract class MigrationsInfrastructureFixtureBase
             {
                 migrationBuilder.Sql(
                     """
-                CREATE PROCEDURE [dbo].[GotoReproduction]
-                AS
-                BEGIN
-                    DECLARE @Counter int;
-                    SET @Counter = 1;
-                    WHILE @Counter < 10
+                    CREATE PROCEDURE [dbo].[GotoReproduction]
+                    AS
                     BEGIN
-                        SELECT @Counter
-                        SET @Counter = @Counter + 1
-                        IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
-                        IF @Counter = 5 GOTO Branch_Two --This will never execute.
-                    END
-                    Branch_One:
-                        SELECT 'Jumping To Branch One.'
-                        GOTO Branch_Three; --This will prevent Branch_Two from executing.
-                    Branch_Two:
-                        SELECT 'Jumping To Branch Two.'
-                    Branch_Three:
-                        SELECT 'Jumping To Branch Three.'
-                END;
-            """);
+                        DECLARE @Counter int;
+                        SET @Counter = 1;
+                        WHILE @Counter < 10
+                        BEGIN
+                            SELECT @Counter
+                            SET @Counter = @Counter + 1
+                            IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+                            IF @Counter = 5 GOTO Branch_Two --This will never execute.
+                        END
+                        Branch_One:
+                            SELECT 'Jumping To Branch One.'
+                            GOTO Branch_Three; --This will prevent Branch_Two from executing.'
+                        Branch_Two:
+                            SELECT 'Jumping To Branch Two.'
+                        Branch_Three:
+                            SELECT 'Jumping To Branch Three.'
+                    END;
+
+                    GO
+                    SELECT GetDate();
+                    --GO
+                    SELECT GetDate()
+                    GO
+
+                    """, suppressTransaction: true);
             }
         }
 
@@ -639,7 +665,12 @@ public abstract class MigrationsInfrastructureFixtureBase
             """;
 
         protected override void Up(MigrationBuilder migrationBuilder)
-            => migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, '{TestValue}')");
+        {
+            if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, '{TestValue}')");
+            }
+        }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
@@ -658,7 +689,12 @@ public abstract class MigrationsInfrastructureFixtureBase
             """;
 
         protected override void Up(MigrationBuilder migrationBuilder)
-            => migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, '{TestValue}')");
+        {
+            if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, '{TestValue}')");
+            }
+        }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
@@ -670,17 +706,24 @@ public abstract class MigrationsInfrastructureFixtureBase
     private class Migration7 : Migration
     {
         public const string TestValue = """
+            --Start
             GO
             Value With
 
             GO
 
-            Empty Lines
+            Empty Lines;
             GO
+
             """;
 
         protected override void Up(MigrationBuilder migrationBuilder)
-            => migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '{TestValue}')");
+        {
+            if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql($"INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '{TestValue}')");
+            }
+        }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -108,26 +108,86 @@ public abstract class RelationalDatabaseCleaner
 
     private static void ExecuteScript(IRelationalConnection connection, IRawSqlCommandBuilder sqlBuilder, string customSql)
     {
-        var batches = Regex.Split(
-            Regex.Replace(
-                customSql,
-                @"\\\r?\n",
-                string.Empty,
-                default,
-                TimeSpan.FromMilliseconds(1000.0)),
-            @"^\s*(GO[ \t]+[0-9]+|GO)(?:\s+|$)",
-            RegexOptions.IgnoreCase | RegexOptions.Multiline,
-            TimeSpan.FromMilliseconds(1000.0));
-        for (var i = 0; i < batches.Length; i++)
+        foreach (var batch in SplitBatches(customSql))
         {
-            if (batches[i].StartsWith("GO", StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrWhiteSpace(batches[i]))
-            {
-                continue;
-            }
-
-            sqlBuilder.Build(batches[i])
+            sqlBuilder.Build(batch)
                 .ExecuteNonQuery(new RelationalCommandParameterObject(connection, null, null, null, null));
+        }
+    }
+
+    public static IReadOnlyList<string> SplitBatches(string sql)
+    {
+        var batches = new List<string>();
+        var preBatched = sql
+            .Replace("\\\n", "")
+            .Replace("\\\r\n", "")
+            .Split(["\r\n", "\n"], StringSplitOptions.None);
+
+        var quoted = false;
+        var batchBuilder = new StringBuilder();
+        foreach (var line in preBatched)
+        {
+            var trimmed = line.TrimStart();
+            if (!quoted
+                && trimmed.StartsWith("GO", StringComparison.OrdinalIgnoreCase)
+                && (trimmed.Length == 2
+                    || char.IsWhiteSpace(trimmed[2])))
+            {
+                var batch = batchBuilder.ToString();
+                batchBuilder.Clear();
+
+                var count = trimmed.Length >= 4
+                    && int.TryParse(trimmed.AsSpan(3), out var specifiedCount)
+                        ? specifiedCount
+                        : 1;
+
+                for (var j = 0; j < count; j++)
+                {
+                    AppendBatch(batch);
+                }
+            }
+            else
+            {
+                var commentStart = false;
+                foreach (var c in trimmed)
+                {
+                    switch (c)
+                    {
+                        case '\'':
+                            quoted = !quoted;
+                            commentStart = false;
+                            break;
+                        case '-':
+                            if (!quoted)
+                            {
+                                if (commentStart)
+                                {
+                                    goto LineEnd;
+                                }
+                                commentStart = true;
+                            }
+                            break;
+                        default:
+                            commentStart = false;
+                            break;
+                    }
+                }
+
+                LineEnd:
+                batchBuilder.AppendLine(line);
+            }
+        }
+
+        AppendBatch(batchBuilder.ToString());
+
+        return batches;
+
+        void AppendBatch(string batch)
+        {
+            if (!string.IsNullOrWhiteSpace(batch))
+            {
+                batches.Add(batch);
+            }
         }
     }
 

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+#nullable disable
+
 namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration;
 
 public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator(context)
@@ -98,6 +100,8 @@ public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator
 
         return injector.Visit(expression);
     }
+
+#nullable restore
 
     private class ExpressionFinder(InjectWhereExpressionMutator mutator) : ExpressionVisitor
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -152,9 +152,6 @@ SELECT GetDate();
 SELECT GetDate()
 GO
 
-
-GO
-
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000004_Migration4', N'7.0.0-test');
 GO
@@ -297,9 +294,6 @@ GO
 SELECT GetDate();
 --GO
 SELECT GetDate()
-GO
-
-
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -79,9 +79,9 @@ GO
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_up_scripts()
+        public override async Task Can_generate_up_and_down_scripts()
         {
-            base.Can_generate_up_scripts();
+            await base.Can_generate_up_and_down_scripts();
 
             Assert.Equal(
                 """
@@ -96,6 +96,150 @@ END;
 GO
 
 BEGIN TRANSACTION;
+CREATE TABLE [Table1] (
+    [Id] int NOT NULL,
+    [Foo] int NOT NULL,
+    [Description] nvarchar(max) NOT NULL,
+    CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
+);
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+
+EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+
+COMMIT;
+GO
+
+CREATE DATABASE TransactionSuppressed;
+GO
+
+DROP DATABASE TransactionSuppressed;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+GO
+
+CREATE PROCEDURE [dbo].[GotoReproduction]
+AS
+BEGIN
+    DECLARE @Counter int;
+    SET @Counter = 1;
+    WHILE @Counter < 10
+    BEGIN
+        SELECT @Counter
+        SET @Counter = @Counter + 1
+        IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+        IF @Counter = 5 GOTO Branch_Two --This will never execute.
+    END
+    Branch_One:
+        SELECT 'Jumping To Branch One.'
+        GOTO Branch_Three; --This will prevent Branch_Two from executing.'
+    Branch_Two:
+        SELECT 'Jumping To Branch Two.'
+    Branch_Three:
+        SELECT 'Jumping To Branch Three.'
+END;
+
+GO
+
+SELECT GetDate();
+--GO
+SELECT GetDate()
+GO
+
+
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+GO
+
+BEGIN TRANSACTION;
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
+
+Empty Lines')
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000005_Migration5', N'7.0.0-test');
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
+Value With
+
+Empty Lines')
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000006_Migration6', N'7.0.0-test');
+
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '--Start
+
+Value With
+
+
+
+Empty Lines;
+
+')
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000007_Migration7', N'7.0.0-test');
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000007_Migration7';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000006_Migration6';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000005_Migration5';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000004_Migration4';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000003_Migration3';
+
+EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000002_Migration2';
+
+DROP TABLE [Table1];
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000001_Migration1';
+
+COMMIT;
+GO
+
+
+""",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override async Task Can_generate_up_and_down_scripts_noTransactions()
+        {
+            await base.Can_generate_up_and_down_scripts_noTransactions();
+
+            Assert.Equal(
+                """
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
 GO
 
 CREATE TABLE [Table1] (
@@ -117,42 +261,45 @@ INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000002_Migration2', N'7.0.0-test');
 GO
 
-COMMIT;
-GO
-
 CREATE DATABASE TransactionSuppressed;
 GO
 
 DROP DATABASE TransactionSuppressed;
 GO
 
-BEGIN TRANSACTION;
-GO
-
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000003_Migration3', N'7.0.0-test');
 GO
 
-    CREATE PROCEDURE [dbo].[GotoReproduction]
-    AS
+CREATE PROCEDURE [dbo].[GotoReproduction]
+AS
+BEGIN
+    DECLARE @Counter int;
+    SET @Counter = 1;
+    WHILE @Counter < 10
     BEGIN
-        DECLARE @Counter int;
-        SET @Counter = 1;
-        WHILE @Counter < 10
-        BEGIN
-            SELECT @Counter
-            SET @Counter = @Counter + 1
-            IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
-            IF @Counter = 5 GOTO Branch_Two --This will never execute.
-        END
-        Branch_One:
-            SELECT 'Jumping To Branch One.'
-            GOTO Branch_Three; --This will prevent Branch_Two from executing.
-        Branch_Two:
-            SELECT 'Jumping To Branch Two.'
-        Branch_Three:
-            SELECT 'Jumping To Branch Three.'
-    END;
+        SELECT @Counter
+        SET @Counter = @Counter + 1
+        IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+        IF @Counter = 5 GOTO Branch_Two --This will never execute.
+    END
+    Branch_One:
+        SELECT 'Jumping To Branch One.'
+        GOTO Branch_Three; --This will prevent Branch_Two from executing.'
+    Branch_Two:
+        SELECT 'Jumping To Branch Two.'
+    Branch_Three:
+        SELECT 'Jumping To Branch Three.'
+END;
+
+GO
+
+SELECT GetDate();
+--GO
+SELECT GetDate()
+GO
+
+
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -178,620 +325,42 @@ INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000006_Migration6', N'7.0.0-test');
 GO
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
+INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '--Start
+GO
+
 Value With
 
 GO
 
 
-Empty Lines
-GO')
+Empty Lines;
+GO
+
+')
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000007_Migration7', N'7.0.0-test');
 GO
 
-COMMIT;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000007_Migration7';
 GO
 
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_up_scripts_noTransactions()
-        {
-            base.Can_generate_up_scripts_noTransactions();
-
-            Assert.Equal(
-                """
-IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
-BEGIN
-    CREATE TABLE [__EFMigrationsHistory] (
-        [MigrationId] nvarchar(150) NOT NULL,
-        [ProductVersion] nvarchar(32) NOT NULL,
-        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-    );
-END;
-GO
-
-CREATE TABLE [Table1] (
-    [Id] int NOT NULL,
-    [Foo] int NOT NULL,
-    [Description] nvarchar(max) NOT NULL,
-    CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-);
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000001_Migration1', N'7.0.0-test');
-GO
-
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
-GO
-
-CREATE DATABASE TransactionSuppressed;
-GO
-
-DROP DATABASE TransactionSuppressed;
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000003_Migration3', N'7.0.0-test');
-GO
-
-    CREATE PROCEDURE [dbo].[GotoReproduction]
-    AS
-    BEGIN
-        DECLARE @Counter int;
-        SET @Counter = 1;
-        WHILE @Counter < 10
-        BEGIN
-            SELECT @Counter
-            SET @Counter = @Counter + 1
-            IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
-            IF @Counter = 5 GOTO Branch_Two --This will never execute.
-        END
-        Branch_One:
-            SELECT 'Jumping To Branch One.'
-            GOTO Branch_Three; --This will prevent Branch_Two from executing.
-        Branch_Two:
-            SELECT 'Jumping To Branch Two.'
-        Branch_Three:
-            SELECT 'Jumping To Branch Three.'
-    END;
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000004_Migration4', N'7.0.0-test');
-GO
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
-
-Empty Lines')
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000005_Migration5', N'7.0.0-test');
-GO
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
-Value With
-
-Empty Lines')
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000006_Migration6', N'7.0.0-test');
-GO
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
-Value With
-
-GO
-
-
-Empty Lines
-GO')
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000007_Migration7', N'7.0.0-test');
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_one_up_script()
-        {
-            base.Can_generate_one_up_script();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
-GO
-
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
-GO
-
-COMMIT;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_up_script_using_names()
-        {
-            base.Can_generate_up_script_using_names();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
-GO
-
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
-GO
-
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
-GO
-
-COMMIT;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_idempotent_up_scripts()
-        {
-            base.Can_generate_idempotent_up_scripts();
-
-            Assert.Equal(
-                """
-IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
-BEGIN
-    CREATE TABLE [__EFMigrationsHistory] (
-        [MigrationId] nvarchar(150) NOT NULL,
-        [ProductVersion] nvarchar(32) NOT NULL,
-        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-    );
-END;
-GO
-
-BEGIN TRANSACTION;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000001_Migration1'
-)
-BEGIN
-    CREATE TABLE [Table1] (
-        [Id] int NOT NULL,
-        [Foo] int NOT NULL,
-        [Description] nvarchar(max) NOT NULL,
-        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-    );
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000001_Migration1'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000002_Migration2'
-)
-BEGIN
-    EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000002_Migration2'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
-END;
-GO
-
-COMMIT;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    CREATE DATABASE TransactionSuppressed;
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    DROP DATABASE TransactionSuppressed;
-END;
-GO
-
-BEGIN TRANSACTION;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000003_Migration3', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000004_Migration4'
-)
-BEGIN
-        CREATE PROCEDURE [dbo].[GotoReproduction]
-        AS
-        BEGIN
-            DECLARE @Counter int;
-            SET @Counter = 1;
-            WHILE @Counter < 10
-            BEGIN
-                SELECT @Counter
-                SET @Counter = @Counter + 1
-                IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
-                IF @Counter = 5 GOTO Branch_Two --This will never execute.
-            END
-            Branch_One:
-                SELECT 'Jumping To Branch One.'
-                GOTO Branch_Three; --This will prevent Branch_Two from executing.
-            Branch_Two:
-                SELECT 'Jumping To Branch Two.'
-            Branch_Three:
-                SELECT 'Jumping To Branch Three.'
-        END;
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000004_Migration4'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000004_Migration4', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000005_Migration5'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
-
-    Empty Lines')
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000005_Migration5'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000005_Migration5', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000006_Migration6'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
-    Value With
-
-    Empty Lines')
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000006_Migration6'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000006_Migration6', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
-    Value With
-
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-
-    Empty Lines
-    GO')
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000007_Migration7', N'7.0.0-test');
-END;
-GO
-
-COMMIT;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_idempotent_up_scripts_noTransactions()
-        {
-            base.Can_generate_idempotent_up_scripts_noTransactions();
-
-            Assert.Equal(
-                """
-IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
-BEGIN
-    CREATE TABLE [__EFMigrationsHistory] (
-        [MigrationId] nvarchar(150) NOT NULL,
-        [ProductVersion] nvarchar(32) NOT NULL,
-        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
-    );
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000001_Migration1'
-)
-BEGIN
-    CREATE TABLE [Table1] (
-        [Id] int NOT NULL,
-        [Foo] int NOT NULL,
-        [Description] nvarchar(max) NOT NULL,
-        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-    );
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000001_Migration1'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000002_Migration2'
-)
-BEGIN
-    EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000002_Migration2'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    CREATE DATABASE TransactionSuppressed;
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    DROP DATABASE TransactionSuppressed;
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000003_Migration3'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000003_Migration3', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000004_Migration4'
-)
-BEGIN
-        CREATE PROCEDURE [dbo].[GotoReproduction]
-        AS
-        BEGIN
-            DECLARE @Counter int;
-            SET @Counter = 1;
-            WHILE @Counter < 10
-            BEGIN
-                SELECT @Counter
-                SET @Counter = @Counter + 1
-                IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
-                IF @Counter = 5 GOTO Branch_Two --This will never execute.
-            END
-            Branch_One:
-                SELECT 'Jumping To Branch One.'
-                GOTO Branch_Three; --This will prevent Branch_Two from executing.
-            Branch_Two:
-                SELECT 'Jumping To Branch Two.'
-            Branch_Three:
-                SELECT 'Jumping To Branch Three.'
-        END;
-END;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000006_Migration6';
 GO
 
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000004_Migration4'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000004_Migration4', N'7.0.0-test');
-END;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000005_Migration5';
 GO
 
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000005_Migration5'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
-
-    Empty Lines')
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000005_Migration5'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000005_Migration5', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000006_Migration6'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
-    Value With
-
-    Empty Lines')
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000006_Migration6'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000006_Migration6', N'7.0.0-test');
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-    INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
-    Value With
-
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-
-    Empty Lines
-    GO')
-END;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000004_Migration4';
 GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000007_Migration7'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000007_Migration7', N'7.0.0-test');
-END;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_down_scripts()
-        {
-            base.Can_generate_down_scripts();
 
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000003_Migration3';
 GO
 
 EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
@@ -808,6 +377,33 @@ DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000001_Migration1';
 GO
 
+
+""",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override async Task Can_generate_one_up_and_down_script()
+        {
+            await base.Can_generate_one_up_and_down_script();
+
+            Assert.Equal(
+                """
+BEGIN TRANSACTION;
+EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000002_Migration2';
+
 COMMIT;
 GO
 
@@ -817,13 +413,196 @@ GO
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_idempotent_down_scripts()
+        public override async Task Can_generate_up_and_down_script_using_names()
         {
-            base.Can_generate_idempotent_down_scripts();
+            await base.Can_generate_up_and_down_script_using_names();
 
             Assert.Equal(
                 """
 BEGIN TRANSACTION;
+EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
+
+DELETE FROM [__EFMigrationsHistory]
+WHERE [MigrationId] = N'00000000000002_Migration2';
+
+COMMIT;
+GO
+
+
+""",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override async Task Can_generate_idempotent_up_and_down_scripts()
+        {
+            await base.Can_generate_idempotent_up_and_down_scripts();
+
+            Assert.Equal(
+                """
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
+GO
+
+BEGIN TRANSACTION;
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    CREATE TABLE [Table1] (
+        [Id] int NOT NULL,
+        [Foo] int NOT NULL,
+        [Description] nvarchar(max) NOT NULL,
+        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
+    );
+END;
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+END;
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
+END;
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+END;
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
+END;
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2';
+END;
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    DROP TABLE [Table1];
+END;
+
+IF EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1';
+END;
+
+COMMIT;
+GO
+
+
+""",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override async Task Can_generate_idempotent_up_and_down_scripts_noTransactions()
+        {
+            await base.Can_generate_idempotent_up_and_down_scripts_noTransactions();
+
+            Assert.Equal(
+                """
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    CREATE TABLE [Table1] (
+        [Id] int NOT NULL,
+        [Foo] int NOT NULL,
+        [Description] nvarchar(max) NOT NULL,
+        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+END;
 GO
 
 IF EXISTS (
@@ -862,59 +641,6 @@ BEGIN
     DELETE FROM [__EFMigrationsHistory]
     WHERE [MigrationId] = N'00000000000001_Migration1';
 END;
-GO
-
-COMMIT;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_one_down_script()
-        {
-            base.Can_generate_one_down_script();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
-GO
-
-EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
-GO
-
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000002_Migration2';
-GO
-
-COMMIT;
-GO
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_down_script_using_names()
-        {
-            base.Can_generate_down_script_using_names();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
-GO
-
-EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
-GO
-
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000002_Migration2';
-GO
-
-COMMIT;
 GO
 
 
@@ -1821,6 +1547,12 @@ END
         {
             using var context = new ApplicationDbContext();
             DiffSnapshot(new AspNetIdentity30ModelSnapshot(), context);
+        }
+
+        protected override Task ExecuteSqlAsync(string value)
+        {
+            ((SqlServerTestStore)Fixture.TestStore).ExecuteScript(value);
+            return Task.CompletedTask;
         }
 
         public class AspNetIdentity30ModelSnapshot : ModelSnapshot

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -166,9 +166,7 @@ public class SqlServerTestStore : RelationalTestStore
         => Execute(
             Connection, command =>
             {
-                foreach (var batch in
-                         new Regex("^GO", RegexOptions.IgnoreCase | RegexOptions.Multiline, TimeSpan.FromMilliseconds(1000.0))
-                             .Split(script).Where(b => !string.IsNullOrEmpty(b)))
+                foreach (var batch in RelationalDatabaseCleaner.SplitBatches(script))
                 {
                     command.CommandText = batch;
                     command.ExecuteNonQuery();

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -46,9 +46,9 @@ CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_up_scripts()
+        public override async Task Can_generate_up_and_down_scripts()
         {
-            base.Can_generate_up_scripts();
+            await base.Can_generate_up_and_down_scripts();
 
             Assert.Equal(
                 """
@@ -58,7 +58,6 @@ CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
 );
 
 BEGIN TRANSACTION;
-
 CREATE TABLE "Table1" (
     "Id" INTEGER NOT NULL CONSTRAINT "PK_Table1" PRIMARY KEY,
     "Foo" INTEGER NOT NULL,
@@ -79,158 +78,32 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
-
-Empty Lines')
-
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000005_Migration5', '7.0.0-test');
 
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
-Value With
-
-Empty Lines')
-
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000006_Migration6', '7.0.0-test');
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
-Value With
-
-GO
-
-Empty Lines
-GO')
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000007_Migration7', '7.0.0-test');
 
 COMMIT;
 
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_up_scripts_noTransactions()
-        {
-            base.Can_generate_up_scripts_noTransactions();
-
-            Assert.Equal(
-                """
-CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
-    "MigrationId" TEXT NOT NULL CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY,
-    "ProductVersion" TEXT NOT NULL
-);
-
-CREATE TABLE "Table1" (
-    "Id" INTEGER NOT NULL CONSTRAINT "PK_Table1" PRIMARY KEY,
-    "Foo" INTEGER NOT NULL,
-    "Description" TEXT NOT NULL
-);
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000001_Migration1', '7.0.0-test');
-
-ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000002_Migration2', '7.0.0-test');
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000003_Migration3', '7.0.0-test');
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000004_Migration4', '7.0.0-test');
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-1, 3, 'Value With
-
-Empty Lines')
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000005_Migration5', '7.0.0-test');
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
-Value With
-
-Empty Lines')
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000006_Migration6', '7.0.0-test');
-
-INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, 'GO
-Value With
-
-GO
-
-Empty Lines
-GO')
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000007_Migration7', '7.0.0-test');
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_one_up_script()
-        {
-            base.Can_generate_one_up_script();
-
-            Assert.Equal(
-                """
 BEGIN TRANSACTION;
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000007_Migration7';
 
-ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000006_Migration6';
 
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000002_Migration2', '7.0.0-test');
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000005_Migration5';
 
-COMMIT;
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000004_Migration4';
 
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_up_script_using_names()
-        {
-            base.Can_generate_up_script_using_names();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
-
-ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('00000000000002_Migration2', '7.0.0-test');
-
-COMMIT;
-
-
-""",
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        public override void Can_generate_idempotent_up_scripts()
-            => Assert.Throws<NotSupportedException>(() => base.Can_generate_idempotent_up_scripts());
-
-        public override void Can_generate_idempotent_up_scripts_noTransactions()
-            => Assert.Throws<NotSupportedException>(() => base.Can_generate_idempotent_up_scripts_noTransactions());
-
-        public override void Can_generate_down_scripts()
-        {
-            base.Can_generate_down_scripts();
-
-            Assert.Equal(
-                """
-BEGIN TRANSACTION;
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000003_Migration3';
 
 ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
 
@@ -250,14 +123,92 @@ COMMIT;
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_one_down_script()
+        public override async Task Can_generate_up_and_down_scripts_noTransactions()
         {
-            base.Can_generate_one_down_script();
+            await base.Can_generate_up_and_down_scripts_noTransactions();
+
+            Assert.Equal(
+                """
+CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
+    "MigrationId" TEXT NOT NULL CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY,
+    "ProductVersion" TEXT NOT NULL
+);
+
+CREATE TABLE "Table1" (
+    "Id" INTEGER NOT NULL CONSTRAINT "PK_Table1" PRIMARY KEY,
+    "Foo" INTEGER NOT NULL,
+    "Description" TEXT NOT NULL
+);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000001_Migration1', '7.0.0-test');
+
+ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000002_Migration2', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000003_Migration3', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000004_Migration4', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000005_Migration5', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000006_Migration6', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000007_Migration7', '7.0.0-test');
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000007_Migration7';
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000006_Migration6';
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000005_Migration5';
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000004_Migration4';
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000003_Migration3';
+
+ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000002_Migration2';
+
+DROP TABLE "Table1";
+
+DELETE FROM "__EFMigrationsHistory"
+WHERE "MigrationId" = '00000000000001_Migration1';
+
+
+""",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override async Task Can_generate_one_up_and_down_script()
+        {
+            await base.Can_generate_one_up_and_down_script();
 
             Assert.Equal(
                 """
 BEGIN TRANSACTION;
+ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
 
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000002_Migration2', '7.0.0-test');
+
+COMMIT;
+
+BEGIN TRANSACTION;
 ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
 
 DELETE FROM "__EFMigrationsHistory"
@@ -271,14 +222,21 @@ COMMIT;
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_down_script_using_names()
+        public override async Task Can_generate_up_and_down_script_using_names()
         {
-            base.Can_generate_down_script_using_names();
+            await base.Can_generate_up_and_down_script_using_names();
 
             Assert.Equal(
                 """
 BEGIN TRANSACTION;
+ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
 
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000002_Migration2', '7.0.0-test');
+
+COMMIT;
+
+BEGIN TRANSACTION;
 ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
 
 DELETE FROM "__EFMigrationsHistory"
@@ -292,8 +250,11 @@ COMMIT;
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_idempotent_down_scripts()
-            => Assert.Throws<NotSupportedException>(() => base.Can_generate_idempotent_down_scripts());
+        public override Task Can_generate_idempotent_up_and_down_scripts()
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Can_generate_idempotent_up_and_down_scripts());
+
+        public override Task Can_generate_idempotent_up_and_down_scripts_noTransactions()
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Can_generate_idempotent_up_and_down_scripts_noTransactions());
 
         public override void Can_get_active_provider()
         {
@@ -1105,6 +1066,17 @@ COMMIT;
         {
             using var context = new ApplicationDbContext();
             DiffSnapshot(new AspNetIdentity30ModelSnapshot(), context);
+        }
+
+        protected override Task ExecuteSqlAsync(string value)
+        {
+            var testStore = ((SqliteTestStore)Fixture.TestStore);
+            if (testStore.ConnectionState != System.Data.ConnectionState.Open)
+            {
+                testStore.OpenConnection();
+            }
+            testStore.ExecuteNonQuery(value);
+            return Task.CompletedTask;
         }
 
         public class MigrationsInfrastructureSqliteFixture : MigrationsInfrastructureFixtureBase


### PR DESCRIPTION
Fixes #34841

### Description

In EF Core 9 we made the transaction span across several migrations, but when generating SQL scripts instead of applying the migration directly we are still adding `GO` statements between the migration and they commit or rollback the transaction implicitly, potentially leaving the database in a broken state after the following commands are applied.

### Customer impact

In some cases, this leads to a partially applied migration that needs to be fixed manually. The workaround is to delete the incorrect `GO` statements from the script manually, but this is laborious and error-prone.

### How found

Customer reported on 9.0.0-rc1

### Regression

Yes, from 8.0.x

### Testing

Tests added.

### Risk

Low.