### PR TITLE
[release/9.0] Don't execute empty batches

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1426,8 +1426,11 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
         void AppendBatch(string batch)
         {
-            builder.Append(batch);
-            EndStatement(builder, operation.SuppressTransaction);
+            if (!string.IsNullOrWhiteSpace(batch))
+            {
+                builder.Append(batch);
+                EndStatement(builder, operation.SuppressTransaction);
+            }
         }
     }
 
@@ -2524,7 +2527,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 {
                     // for create table we always generate new temporal information from the operation itself
                     // just in case there was a table with that name before that got deleted/renamed
-                    // this shouldn't happen as we re-use existin tables rather than drop/recreate
+                    // this shouldn't happen as we re-use existing tables rather than drop/recreate
                     // but we are being extra defensive here
                     // and also, temporal state (disabled versioning etc.) should always reset when creating a table
                     temporalInformation = BuildTemporalInformationFromMigrationOperation(schema, createTableOperation);

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -152,9 +152,6 @@ SELECT GetDate();
 SELECT GetDate()
 GO
 
-
-GO
-
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000004_Migration4', N'7.0.0-test');
 GO
@@ -297,9 +294,6 @@ GO
 SELECT GetDate();
 --GO
 SELECT GetDate()
-GO
-
-
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])


### PR DESCRIPTION
Fixes #33337

### Description

In EF Core 8.0.3 we fixed an issue where empty lines were incorrectly removed from literals in migration scripts. However, this caused some operations to contain only empty lines.

### Customer impact

Exception thrown when applying a migration in the above scenario, as it's considered an error to execute an empty operation.

### How found

Multiple customer reports since 8.0.3

### Regression

Yes, from 8.0.2. Introduced in https://github.com/dotnet/efcore/pull/32788

### Testing

Tests added

### Risk

Low.