### PR TITLE
[release/8.0] Don't execute empty batches 

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1453,8 +1453,11 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
         void AppendBatch(string batch)
         {
-            builder.Append(batch);
-            EndStatement(builder, operation.SuppressTransaction);
+            if (!string.IsNullOrWhiteSpace(batch))
+            {
+                builder.Append(batch);
+                EndStatement(builder, operation.SuppressTransaction);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #33337
Port of #34870

### Description

In EF Core 8.0.3 we fixed an issue where empty lines were incorrectly removed from literals in migration scripts. However, this caused some operations to contain only empty lines.

### Customer impact

Exception thrown when applying a migration in the above scenario, as it's considered an error to execute an empty operation.

### How found

Multiple customer reports since 8.0.3

### Regression

Yes, from 8.0.2. Introduced in https://github.com/dotnet/efcore/pull/32788

### Testing

Tests added

### Risk

Low.