### PR TITLE
add MariaDB to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is home to the following [.NET Foundation](https://dotnetfoundat
 
 [![latest version](https://img.shields.io/nuget/v/Microsoft.EntityFrameworkCore)](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore) [![preview version](https://img.shields.io/nuget/vpre/Microsoft.EntityFrameworkCore)](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/absoluteLatest) [![downloads](https://img.shields.io/nuget/dt/Microsoft.EntityFrameworkCore)](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)
 
-EF Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations. EF Core works with SQL Server, Azure SQL Database, SQLite, Azure Cosmos DB, MySQL, PostgreSQL, and other databases through a provider plugin API.
+EF Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations. EF Core works with SQL Server, Azure SQL Database, SQLite, Azure Cosmos DB, MariaDB, MySQL, PostgreSQL, and other databases through a provider plugin API.
 
 ### Installation
 


### PR DESCRIPTION
Suggesting to add MariaDB to README.md as per discussion https://github.com/dotnet/efcore/issues/34867#issuecomment-2403570323 and that the mentioned [Pomelo.EntityFrameworkCore.MySql/](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/) clearly documents MariaDB support. 