### PR TITLE
[release/9.0] Fix conditional test evaluation in funcletizer

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -307,6 +307,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fallbacks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=funcletization/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=funcletize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Funcletizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Includable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -509,7 +509,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         var test = Visit(conditional.Test, out var testState);
 
         // If the test evaluates, simplify the conditional away by bubbling up the leg that remains
-        if (testState.IsEvaluatable && Evaluate(conditional.Test) is bool testBoolValue)
+        if (testState.IsEvaluatable && Evaluate(test) is bool testBoolValue)
         {
             return testBoolValue
                 ? Visit(conditional.IfTrue, out _state)
@@ -905,7 +905,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         var method = methodCall.Method;
 
         // Handle some special, well-known functions
-        // If this is a call to EF.Constant(), or EF.Parameter(), then examine the operand; it it's isn't evaluatable (i.e. contains a
+        // If this is a call to EF.Constant(), or EF.Parameter(), then examine the operand; if it isn't evaluatable (i.e. contains a
         // reference to a database table), throw immediately. Otherwise, evaluate the operand (either as a constant or as a parameter) and
         // return that.
         if (method.DeclaringType == typeof(EF))

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4547,11 +4547,25 @@ ORDER BY c["id"]
             async, async a =>
             {
                 await base.MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(a);
+
                 AssertSql(
                     """
 SELECT VALUE c["id"]
 FROM root c
 WHERE STARTSWITH(c["id"], "A")
+""");
+            });
+
+    public override Task Funcletize_conditional_with_evaluatable_test(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Funcletize_conditional_with_evaluatable_test(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
 """);
             });
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5152,6 +5152,16 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Funcletize_conditional_with_evaluatable_test(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => (AlwaysFalse() && c.CustomerID == "ALFKI" ? "yes" : "no") == "no"));
+
+    private static bool AlwaysFalse()
+        => false;
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Null_parameter_name_works(bool async)
     {
         using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5657,6 +5657,17 @@ WHERE [c].[CustomerID] LIKE N'A%'
 """);
     }
 
+    public override async Task Funcletize_conditional_with_evaluatable_test(bool async)
+    {
+        await base.Funcletize_conditional_with_evaluatable_test(async);
+
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+""");
+    }
+
     public override async Task Projecting_collection_split(bool async)
     {
         await base.Projecting_collection_split(async);


### PR DESCRIPTION
Fixes #34883

## Description

EF's funcletizer (first and very important step in the query pipeline) was rewritten in EF 9, both to allow query precompilation (NativeAOT) and for better performance (see #33106). The new implementation contains a bug in the conditional expression handling when the test component of the conditional expression is client-evaluatable.

## Customer impact

Queries that contain the conditional operator with a client-evaluatable test (e.g. `foo() ? x : y` sometimes fail to execute.

## How found

Customer reported on 9.0.0-rc1

## Regression

Yes, from 8.

## Testing

Test added.

## Risk

Low