### PR TITLE
[release/9.0] Avoid infinite recursion on identifying shadow FKs

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -141,7 +141,7 @@ public class ForeignKeyPropertyDiscoveryConvention :
                     && fkProperty.ClrType.IsNullableType() == foreignKey.IsRequired
                     && fkProperty.GetContainingForeignKeys().All(otherFk => otherFk.IsRequired == foreignKey.IsRequired))
                 {
-                    var newType = fkProperty.ClrType.MakeNullable(!foreignKey.IsRequired);
+                    var newType = fkProperty.ClrType.MakeNullable(!foreignKey.IsRequired && !fkProperty.IsKey());
                     if (fkProperty.ClrType != newType)
                     {
                         newProperties.Add(

--- a/test/EFCore.Specification.Tests/ModelBuilding101ManyToManyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101ManyToManyTestBase.cs
@@ -736,6 +736,61 @@ public abstract partial class ModelBuilding101TestBase
     }
 
     [ConditionalFact]
+    public virtual void ManyToManyWithPayloadAndNavsToJoinClassShadowFKsTest()
+        => Model101Test();
+
+    protected class ManyToManyWithPayloadAndNavsToJoinClassShadowFKs
+    {
+        public class Post
+        {
+            public int Id { get; set; }
+            public List<Tag> Tag { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
+        }
+
+        public class Tag
+        {
+            public int Id { get; set; }
+            public List<Post> Post { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
+        }
+
+        public class PostTag
+        {
+        }
+
+        public class Context0 : Context101
+        {
+            public DbSet<Post> Post
+                => Set<Post>();
+
+            public DbSet<Tag> Tag
+                => Set<Tag>();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<Post>()
+                    .HasMany(e => e.Tag)
+                    .WithMany(e => e.Post)
+                    .UsingEntity<PostTag>(
+                        l => l.HasOne<Tag>().WithMany(t => t.PostTags),
+                        r => r.HasOne<Post>().WithMany(p => p.PostTags),
+                        j => { });
+        }
+
+        public class Context1 : Context0
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<Post>()
+                    .HasMany(e => e.Tag)
+                    .WithMany(e => e.Post)
+                    .UsingEntity<PostTag>(
+                        l => l.HasOne<Tag>().WithMany(t => t.PostTags).HasForeignKey("TagId"),
+                        r => r.HasOne<Post>().WithMany(p => p.PostTags).HasForeignKey("PostId"),
+                        j => { });
+        }
+    }
+
+    [ConditionalFact]
     public virtual void ManyToManyWithNoCascadeDeleteTest()
         => Model101Test();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/34875


**Description**
When a user configures a foreign key property without specifying the type or whether it's required EF creates a shadow nullable property by default.

1. If the entity type in question is owned or is the join entity type in a many-to-many relationship, EF will configure the FK properties as the primary key (i.e. an identifying FK). 
2. This will mark the properties as required and trigger a convention to change their types to be non-nullable.
4. This triggers a convention to check again whether the new property types correspond to their nullability, but the condition relies only on the requiredness of the FKs defined on the properties, so it decided that that should be nullable instead.
5. After the properties are made nullable again the key is reapplied on them, leading to step 2

EF throws a custom exception instead of a StackOverflow because the convention implementation unwraps the recursive calls.

**Customer impact**
For affected models, an exception is thrown whenever the context is used. There are several workarounds for the reported scenario, but identifying shadow FKs are pretty common, so this can potentially affect a significant portion of users.

**How found**
Customer reported on 8.0.10

**Regression**
Yes, from 8.0.8. This issue is old, but it was made easier to hit by https://github.com/dotnet/efcore/pull/34388

**Testing**
Test added.

**Risk**
Low.