### PR TITLE
[release/9.0] Fix to #34760 - NullReferenceException for a custom ValueConverter in EF Core 9 RC 1.

### DIFF
--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -256,11 +256,17 @@ public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantPro
             ? memberExpression
             : base.VisitMember(memberExpression);
 
-    protected override Expression VisitConstant(ConstantExpression node)
-    {
-        _unsupportedConstantChecker.Check(node);
-        return node;
-    }
+    // issue #34760 - disabling the liftable constant verification because we sometimes are forced to
+    // use them (when type mapping has custom converter but we can't reliably get the correct type mapping
+    // when building the shaper) - if that converter uses a closure, we will embed it in the shaper
+    // we don't have a reasonalbe alternative currently
+    // Once #33517 is done, we should re-enable this check
+    //protected override Expression VisitConstant(ConstantExpression node)
+    //{
+    //    _unsupportedConstantChecker.Check(node);
+
+    //    return node;
+    //}
 #endif
 
     private sealed class UnsupportedConstantChecker(LiftableConstantProcessor liftableConstantProcessor) : ExpressionVisitor

--- a/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
@@ -692,4 +692,123 @@ public abstract class AdHocAdvancedMappingsQueryTestBase : NonSharedModelTestBas
     }
 
     #endregion
+
+    #region 34760
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Projecting_property_with_converter_with_closure(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context34760>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateContext();
+
+        var query = context.Books.Select(x => x.PublishDate);
+
+        var result = await query.ToListAsync();
+        Assert.Equal(2, result.Count);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Projecting_expression_with_converter_with_closure(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context34760>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateContext();
+
+        var query = context.Books
+            .GroupBy(t => t.Id)
+            .Select(g => new
+            {
+                Day = g.Min(t => t.PublishDate)
+            });
+
+        var result = await query.ToListAsync();
+        Assert.Equal(2, result.Count);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Projecting_property_with_converter_without_closure(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context34760>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateContext();
+
+        var query = context.Books
+            .GroupBy(t => t.Id)
+            .Select(g => new
+            {
+                Day = g.Min(t => t.AudiobookDate)
+            });
+
+        var result = await query.ToListAsync();
+        Assert.Equal(2, result.Count);
+    }
+
+    protected class Context34760(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Book> Books { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Book>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<Book>().Property(e => e.PublishDate).HasConversion(new MyDateTimeValueConverterWithClosure(new MyDatetimeConverter()));
+            modelBuilder.Entity<Book>().Property(e => e.AudiobookDate).HasConversion(new MyDateTimeValueConverterWithoutClosure());
+        }
+
+        public Task SeedAsync()
+        {
+            AddRange(
+                new Book {
+                    Id = 1,
+                    Name = "The Blade Itself",
+                    PublishDate = new DateTime(2006, 5, 4, 11, 59, 59),
+                    AudiobookDate = new DateTime(2015, 9, 8, 23, 59, 59)
+                },
+                new Book {
+                    Id = 2,
+                    Name = "Red Rising",
+                    PublishDate = new DateTime(2014, 1, 27, 23, 59, 59),
+                    AudiobookDate = new DateTime(2014, 1, 27, 23, 59, 59),
+                });
+
+            return SaveChangesAsync();
+        }
+
+        public class Book
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public virtual DateTime PublishDate { get; set; }
+            public virtual DateTime AudiobookDate { get; set; }
+        }
+
+        public class MyDateTimeValueConverterWithClosure : ValueConverter<DateTime, DateTime>
+        {
+            public MyDateTimeValueConverterWithClosure(MyDatetimeConverter myDatetimeConverter)
+                : base(
+                    x => myDatetimeConverter.Normalize(x),
+                    x => myDatetimeConverter.Normalize(x))
+            {
+            }
+        }
+
+        public class MyDateTimeValueConverterWithoutClosure : ValueConverter<DateTime, DateTime>
+        {
+            public MyDateTimeValueConverterWithoutClosure()
+                : base(
+                    x => new MyDatetimeConverter().Normalize(x),
+                    x => new MyDatetimeConverter().Normalize(x))
+            {
+            }
+        }
+
+        public class MyDatetimeConverter
+        {
+            public virtual DateTime Normalize(DateTime dateTime)
+                => dateTime.Date;
+        }
+    }
+
+    #endregion
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
@@ -307,4 +307,39 @@ LEFT JOIN [As] AS [a] ON [s].[AId] = [a].[Id]
 ORDER BY [s].[Id]
 """);
     }
+
+    public override async Task Projecting_property_with_converter_with_closure(bool async)
+    {
+        await base.Projecting_property_with_converter_with_closure(async);
+
+        AssertSql(
+"""
+SELECT [b].[PublishDate]
+FROM [Books] AS [b]
+""");
+    }
+
+    public override async Task Projecting_expression_with_converter_with_closure(bool async)
+    {
+        await base.Projecting_expression_with_converter_with_closure(async);
+
+        AssertSql(
+"""
+SELECT MIN([b].[PublishDate]) AS [Day]
+FROM [Books] AS [b]
+GROUP BY [b].[Id]
+""");
+    }
+
+    public override async Task Projecting_property_with_converter_without_closure(bool async)
+    {
+        await base.Projecting_property_with_converter_without_closure(async);
+
+        AssertSql(
+"""
+SELECT MIN([b].[AudiobookDate]) AS [Day]
+FROM [Books] AS [b]
+GROUP BY [b].[Id]
+""");
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
@@ -72,6 +72,35 @@ FROM [NonPublicEntities] AS [n]
 """);
     }
 
+    public override async Task Projecting_property_requiring_converter_with_closure_is_not_supported()
+    {
+        await base.Projecting_property_requiring_converter_with_closure_is_not_supported();
+
+        AssertSql();
+    }
+
+    public override async Task Projecting_expression_requiring_converter_without_closure_works()
+    {
+        await base.Projecting_expression_requiring_converter_without_closure_works();
+
+        AssertSql(
+"""
+SELECT [b].[AudiobookDate]
+FROM [Books] AS [b]
+""");
+    }
+
+    public override async Task Projecting_entity_with_property_requiring_converter_with_closure_works()
+    {
+        await base.Projecting_entity_with_property_requiring_converter_with_closure_works();
+
+        AssertSql(
+"""
+SELECT [b].[Id], [b].[AudiobookDate], [b].[Name], [b].[PublishDate]
+FROM [Books] AS [b]
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
**Description**

For AOT/precompiled queries we now do special processing (lifting) of all non-literal constants. We essentially provide a way to resolve the constant from well established entry points, e.g. model. Problem happens for cases where we are projecting a property with a custom converter but do it in such a way that we lose the IProperty information (e.g. by projecting individual property, rather than as part of an entity) Without IProperty information we can't reliably extract the proper type mapping for that property and as a result we don't know what custom converter to use. What we used to do is "guess" the type mapping based on CLR type of the property. This is pretty much always wrong, and it also broke non-precompiled scenarios. Fix is to just use ConvertFromProviderExpression expression irrespective of whether it contains closures or not. We only do that if we don't have the IProperty information. This also requires disabling non-literal constant validation we do in the post processing, as now some queries may contain "unliftable" constants. We should re-enable the validation once the issue is properly addressed (#33517)

Fixes #34760

**Customer impact**
Projecting a property with custom converter could sometimes fail with (NRE). Workaround was to modify the converter so that it doesn't use a closure variable, which is tedious, not intuitive and has perf impact.

**How found**
Customer reported on EF 9 RC1

**Regression**
Yes, from EF 8

**Testing**
Test added, both regular and precompiled query cases.

**Risk**
Low. Very targeted change. We revert to EF8 behavior for the affected scenarios. Precompiled query will not work, but it is an experimental feature in EF9 and this scenario was already broken before the fix.
