### PR TITLE
[release/9.0] Nanoseconds and microseconds processing fix on Cosmos

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMemberTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosDateTimeMemberTranslator.cs
@@ -41,8 +41,8 @@ public class CosmosDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionF
             nameof(DateTime.Minute) => DatePart("mi"),
             nameof(DateTime.Second) => DatePart("ss"),
             nameof(DateTime.Millisecond) => DatePart("ms"),
-            nameof(DateTime.Microsecond) => DatePart("mcs"),
-            nameof(DateTime.Nanosecond) => DatePart("ns"),
+            nameof(DateTime.Microsecond) => sqlExpressionFactory.Modulo(DatePart("mcs"), sqlExpressionFactory.Constant(1000)),
+            nameof(DateTime.Nanosecond) => sqlExpressionFactory.Modulo(DatePart("ns"), sqlExpressionFactory.Constant(1000)),
 
             nameof(DateTime.UtcNow)
                 => sqlExpressionFactory.Function(


### PR DESCRIPTION
Backport of #34861. For Cosmos only because Cosmos already had the support.

### Description
In Cosmos provider for EF Core 9 we improperly translated `Nanosecond` and `Microsecond` properties leading into mismatch between expected .NET behavior and what was actually done in database. This is a new functionality in 9.0.

### Customer impact
Incorrect data returned from query. Possible data corruption bug.

### How found
Found while implementing same support for SQL Server.

### Regression
No.

### Testing
Tests added (in `main` covering bigger area).

### Risk
Low.