### PR TITLE
Use matching type mapping when translating `BoolSwitch`

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
@@ -137,8 +137,8 @@ public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<Nul
                 args => new CaseExpression(
                     operand: args[0],
                     [
-                        new CaseWhenClause(new SqlConstantExpression(true, typeMapping: BoolTypeMapping.Default), args[1]),
-                        new CaseWhenClause(new SqlConstantExpression(false, typeMapping: BoolTypeMapping.Default), args[2])
+                        new CaseWhenClause(new SqlConstantExpression(true, typeMapping: args[0].TypeMapping), args[1]),
+                        new CaseWhenClause(new SqlConstantExpression(false, typeMapping: args[0].TypeMapping), args[2])
                     ])));
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -3939,8 +3939,8 @@ SELECT CASE CASE
     WHEN [e].[StringA] = N'Foo' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
-    WHEN 1 THEN 3
-    WHEN 0 THEN 2
+    WHEN CAST(1 AS bit) THEN 3
+    WHEN CAST(0 AS bit) THEN 2
 END
 FROM [Entities1] AS [e]
 ORDER BY [e].[Id]
@@ -3959,8 +3959,8 @@ WHERE CASE CASE
     WHEN [e].[StringA] = N'Foo' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
-    WHEN 1 THEN 3
-    WHEN 0 THEN 2
+    WHEN CAST(1 AS bit) THEN 3
+    WHEN CAST(0 AS bit) THEN 2
 END = 2
 """);
     }


### PR DESCRIPTION
Fixes #34900.