### PR TITLE
[release/9.0] Keep parameter values out IMemoryCache in RelationalCommandCache

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Caching.Memory;
@@ -106,11 +105,25 @@ public class RelationalCommandCache : IPrintableExpression
         }
     }
 
-    private readonly struct CommandCacheKey(Expression queryExpression, IReadOnlyDictionary<string, object?> parameterValues)
-        : IEquatable<CommandCacheKey>
+    private readonly struct CommandCacheKey : IEquatable<CommandCacheKey>
     {
-        private readonly Expression _queryExpression = queryExpression;
-        private readonly IReadOnlyDictionary<string, object?> _parameterValues = parameterValues;
+        private readonly Expression _queryExpression;
+        private readonly Dictionary<string, ParameterInfo> _parameterInfos;
+
+        internal CommandCacheKey(Expression queryExpression, IReadOnlyDictionary<string, object?> parameterValues)
+        {
+            _queryExpression = queryExpression;
+            _parameterInfos = new Dictionary<string, ParameterInfo>();
+
+            foreach (var (key, value) in parameterValues)
+            {
+                _parameterInfos[key] = new ParameterInfo
+                {
+                    IsNull = value is null,
+                    ObjectArrayLength = value is object[] arr ? arr.Length : null
+                };
+            }
+        }
 
         public override bool Equals(object? obj)
             => obj is CommandCacheKey commandCacheKey
@@ -124,26 +137,17 @@ public class RelationalCommandCache : IPrintableExpression
                 return false;
             }
 
-            if (_parameterValues.Count > 0)
+            Check.DebugAssert(
+                _parameterInfos.Count == commandCacheKey._parameterInfos.Count,
+                "Parameter Count mismatch between identical queries");
+
+            if (_parameterInfos.Count > 0)
             {
-                foreach (var (key, value) in _parameterValues)
+                foreach (var (key, info) in _parameterInfos)
                 {
-                    if (!commandCacheKey._parameterValues.TryGetValue(key, out var otherValue))
+                    if (!commandCacheKey._parameterInfos.TryGetValue(key, out var otherInfo) || info != otherInfo)
                     {
                         return false;
-                    }
-
-                    // ReSharper disable once ArrangeRedundantParentheses
-                    if ((value == null) != (otherValue == null))
-                    {
-                        return false;
-                    }
-
-                    if (value is IEnumerable
-                        && value.GetType() == typeof(object[]))
-                    {
-                        // FromSql parameters must have the same number of elements
-                        return ((object[])value).Length == (otherValue as object[])?.Length;
                     }
                 }
             }
@@ -154,4 +158,8 @@ public class RelationalCommandCache : IPrintableExpression
         public override int GetHashCode()
             => RuntimeHelpers.GetHashCode(_queryExpression);
     }
+
+    // Note that we keep only the null-ness of parameters (and array length for FromSql object arrays),
+    // and avoid referencing the actual parameter data (see #34028).
+    private readonly record struct ParameterInfo(bool IsNull, int? ObjectArrayLength);
 }


### PR DESCRIPTION
Store only nullness and array lengths in struct form to prevent parameters memory leaks

Fixes #34028
Backports #34028

**Description**
EF's query pipeline contains a SQL cache, whose key contains the nullness of parameters; this is needed since different nullness requires different SQL (e.g. `WHERE b.Name = @p` (where p is non-null), vs. `WHERE b.Name IS NULL` (where p is null)). The cache key implementation currently references the parameter value, rather than just recording whether it was null or not. This causes user data to be referenced from internal caching, keeping potentially large amounts of data referenced and preventing the GC from reclaiming them.

**Customer impact**
In some cases, large amounts of user data will be kept in memory and will never get garbage-collected.

**How found**
Customer reported on 8.0

**Regression**
No

**Testing**
Testing that a reference is kept to an object isn't feasible in a reliable way.

**Risk**
Low.