### PR TITLE
[release/9.0] Fix Cosmos enum partition keys

### DIFF
--- a/src/EFCore.Cosmos/Extensions/Internal/PartitionKeyBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/Internal/PartitionKeyBuilderExtensions.cs
@@ -22,6 +22,16 @@ public static class PartitionKeyBuilderExtensions
     /// </summary>
     public static PartitionKeyBuilder Add(this PartitionKeyBuilder builder, object? value, IProperty? property)
     {
+        if (value is not null && value.GetType() is var clrType && clrType.IsInteger() && property is not null)
+        {
+            var unwrappedType = property.ClrType.UnwrapNullableType();
+            value = unwrappedType.IsEnum
+                ? Enum.ToObject(unwrappedType, value)
+                : unwrappedType == typeof(char)
+                    ? Convert.ChangeType(value, unwrappedType)
+                    : value;
+        }
+
         var converter = property?.GetTypeMapping().Converter;
         if (converter != null)
         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#nullable disable
+
+public class AdHocMiscellaneousQueryCosmosTest : NonSharedModelTestBase
+{
+    #region 34911
+
+    [ConditionalFact]
+    public virtual async Task Enum_partition_key()
+    {
+        var contextFactory = await InitializeAsync<Context34911>(
+            onModelCreating: b => b.Entity<Context34911.Member>().HasPartitionKey(d => d.MemberType),
+            seed: async context =>
+            {
+                context.Members.Add(new Context34911.Member { MemberType = Context34911.MemberType.Admin, Name = "Some Admin" });
+                await context.SaveChangesAsync();
+            });
+
+        await using (var context = contextFactory.CreateContext())
+        {
+            var admin = await context.Members.Where(p => p.MemberType == Context34911.MemberType.Admin).SingleAsync();
+            Assert.Equal("Some Admin", admin.Name);
+        }
+    }
+
+    protected class Context34911(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Member> Members { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Member>().HasData(new Member { Id = 1, Name = "Product 1" });
+
+        public class Member
+        {
+            public int Id { get; set; }
+            public MemberType MemberType { get; set; }
+            public string Name { get; set; }
+        }
+
+        public enum MemberType
+        {
+            User,
+            Admin
+        }
+    }
+
+    #endregion 34911
+
+    protected override string StoreName
+        => "AdHocMiscellaneousQueryTests";
+
+    protected override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => builder.ConfigureWarnings(b => b.Ignore(CosmosEventId.NoPartitionKeyDefined));
+
+    protected override ITestStoreFactory TestStoreFactory
+        => CosmosTestStoreFactory.Instance;
+}


### PR DESCRIPTION
Fixes #34911

**Description**
Among the many changes done to the Cosmos provider in 9.0, the logic for handling partition keys was rewritten; the new logic fails to handle enum constants properly - these require special handling because of how the C# compiler produces expression trees around enums.

**Customer impact**
When an enum property is used as a partition key, queries filtering on that property fail to execute (this is expected to be a relatively common scenario).

**How found**
Customer reported on 9.0.0-rc.2

**Regression**
Yes

**Testing**
Added.

**Risk**
Very low.