### PR TITLE
Pin runtime version to a non shipping package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,6 +41,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>9305d7f71d73c1d1edeb2a06478c998e40deda8d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="9.0.0-rtm.24516.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>9305d7f71d73c1d1edeb2a06478c998e40deda8d</Sha>
+    </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,8 @@
     <MicrosoftExtensionsLoggingVersion>9.0.0-rtm.24516.5</MicrosoftExtensionsLoggingVersion>
     <MicrosoftNETCoreAppRefVersion>9.0.0-rtm.24516.5</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>9.0.0-rtm.24516.5</MicrosoftNETCoreAppRuntimewinx64Version>
+    <!-- NB: Using BrowserDebugHost to represent the nonshipping version of Microsoft.NETCore.App -->
+    <MicrosoftNETCoreBrowserDebugHostTransportVersion>9.0.0-rtm.24516.5</MicrosoftNETCoreBrowserDebugHostTransportVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rtm.24516.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rtm.24516.5</SystemTextJsonVersion>
     <SystemFormatsAsn1Version>9.0.0-rtm.24516.5</SystemFormatsAsn1Version>

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "dotnet": "9.0.100-rc.2.24474.11",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimewinx64Version)"
+        "$(MicrosoftExtensionsHostFactoryResolverSourcesVersion)"
       ]
     }
   },

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "dotnet": "9.0.100-rc.2.24474.11",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftExtensionsHostFactoryResolverSourcesVersion)"
+        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ]
     }
   },


### PR DESCRIPTION
Without this we're getting build failures on stable branding