### PR TITLE
Apply fix from #34729 to Cosmos SqlExpressionFactory to keep it in sync

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -156,7 +156,7 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
             case ExpressionType.Coalesce:
             {
                 inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
-                resultType = inferredTypeMapping?.ClrType ?? left.Type;
+                resultType = inferredTypeMapping?.ClrType ?? (left.Type != typeof(object) ? left.Type : right.Type);
                 resultTypeMapping = inferredTypeMapping;
                 break;
             }


### PR DESCRIPTION
From discussion in #34729 

Add that fix to the Cosmos SqlExpressionFactory to keep in sync with the relational version

Note that related tests for Cosmos still fail due to #34963 

@roji Actually not sure if this is entirely needed. From the other issue in relational databases, `left.Type` is an object because it leaves the unary convert (with Type of object) around. Cosmos strips the convert out and just leaves the operand which generally already has a Type and Type mapping.