### PR TITLE
Fix to #34960 - System.Text.Json.JsonReaderException: '0x00' is invalid after a single JSON value. Expected end of data

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -979,18 +979,17 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             var manager = new Utf8JsonReaderManager(jsonReaderData, queryContext.QueryLogger);
             var tokenType = manager.CurrentReader.TokenType;
 
-            if (tokenType == JsonTokenType.Null)
+            switch (tokenType)
             {
-                return nullable
-                    ? null
-                    : throw new InvalidOperationException(
-                        RelationalStrings.JsonRequiredEntityWithNullJson(typeof(TEntity).Name));
-            }
+                case JsonTokenType.Null:
+                    return nullable
+                        ? null
+                        : throw new InvalidOperationException(
+                            RelationalStrings.JsonRequiredEntityWithNullJson(typeof(TEntity).Name));
 
-            if (tokenType != JsonTokenType.StartObject)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                case not JsonTokenType.StartObject:
+                    throw new InvalidOperationException(
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
             manager.CaptureState();
@@ -1022,15 +1021,16 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             var manager = new Utf8JsonReaderManager(jsonReaderData, queryContext.QueryLogger);
             var tokenType = manager.CurrentReader.TokenType;
 
-            if (tokenType == JsonTokenType.Null)
+            switch (tokenType)
             {
-                return default;
-            }
+                case JsonTokenType.Null:
+                    return default;
 
-            if (tokenType != JsonTokenType.StartArray)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                case not JsonTokenType.StartArray:
+                    throw new InvalidOperationException(CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+
+                default:
+                    break;
             }
 
             var collectionAccessor = navigation.GetCollectionAccessor();
@@ -1096,6 +1096,19 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 return;
             }
 
+            var manager = new Utf8JsonReaderManager(jsonReaderData, queryContext.QueryLogger);
+            var tokenType = manager.CurrentReader.TokenType;
+
+            switch (tokenType)
+            {
+                case JsonTokenType.Null:
+                    return;
+
+                case not JsonTokenType.StartObject:
+                    throw new InvalidOperationException(
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+            }
+
             var included = innerShaper(queryContext, keyPropertyValues, jsonReaderData);
 
             if (!trackingQuery)
@@ -1131,10 +1144,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             var manager = new Utf8JsonReaderManager(jsonReaderData, queryContext.QueryLogger);
             var tokenType = manager.CurrentReader.TokenType;
 
-            if (tokenType != JsonTokenType.StartArray)
+            switch (tokenType)
             {
-                throw new InvalidOperationException(
-                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                case JsonTokenType.Null:
+                    return;
+
+                case not JsonTokenType.StartArray:
+                    throw new InvalidOperationException(
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
             getOrCreateCollectionObject(entity);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
@@ -97,6 +97,41 @@ INSERT INTO [Reviews] ([Rounds], [Id])
 VALUES(N'[{"RoundNumber":11,"SubRounds":[{"SubRoundNumber":111},{"SubRoundNumber":112}]}]', 1)
 """);
 
+    protected override async Task Seed34960(Context34960 ctx)
+    {
+        await base.Seed34960(ctx);
+
+        // JSON nulls
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Collection], [Reference], [Id])
+VALUES(
+N'null',
+N'null',
+4)
+""");
+
+        // JSON object where collection should be
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Junk] ([Collection], [Reference], [Id])
+VALUES(
+N'{ "DoB":"2000-01-01T00:00:00","Text":"junk" }',
+NULL,
+1)
+""");
+
+        // JSON array where entity should be
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Junk] ([Collection], [Reference], [Id])
+VALUES(
+NULL,
+N'[{ "DoB":"2000-01-01T00:00:00","Text":"junk" }]',
+2)
+""");
+    }
+
     protected override Task SeedArrayOfPrimitives(DbContext ctx)
     {
         var entity1 = new MyEntityArrayOfPrimitives

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
@@ -87,6 +87,41 @@ INSERT INTO "Reviews" ("Rounds", "Id")
 VALUES('[{"RoundNumber":11,"SubRounds":[{"SubRoundNumber":111},{"SubRoundNumber":112}]}]', 1)
 """);
 
+    protected override async Task Seed34960(Context34960 ctx)
+    {
+        await base.Seed34960(ctx);
+
+        // JSON nulls
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO "Entities" ("Collection", "Reference", "Id")
+VALUES(
+'null',
+'null',
+4)
+""");
+
+        // JSON object where collection should be
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO "Junk" ("Collection", "Reference", "Id")
+VALUES(
+'{ "DoB":"2000-01-01T00:00:00","Text":"junk" }',
+NULL,
+1)
+""");
+
+        // JSON array where entity should be
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO "Junk" ("Collection", "Reference", "Id")
+VALUES(
+NULL,
+'[{ "DoB":"2000-01-01T00:00:00","Text":"junk" }]',
+2)
+""");
+    }
+
     protected override Task SeedArrayOfPrimitives(DbContext ctx)
     {
         var entity1 = new MyEntityArrayOfPrimitives


### PR DESCRIPTION
When entity or collection of entities is mapped to JSON null value for that object can be represented either as relational null, or as JSON with null value inside 'null'. Problem was that IncludeJsonEntityReference and IncludeJsonEntityCollection were only checking for null value, and not for the JSON 'null'. (MaterializeJsonEntity and MaterializeJsonEntityCollection had the logic for both)

Fix is to add the missing logic so that upon encountering Null token we just return, rather than run shaper code for the entity. Also added some validation that throws if StartObject is not the first token (again, copying logic from MaterializeJsonEntity method)

Fixes #34960