### PR TITLE
[release/9.0-staging TEST ONLY] adjusting some migration tests so that baselines dont depend on the product version

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -755,7 +755,7 @@ FROM [__EFMigrationsHistory]
 ORDER BY [MigrationId];
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000000_Empty', N'9.0.0');
+VALUES (N'00000000000000_Empty', N'7.0.0-test');
 
 --Before
 
@@ -798,18 +798,18 @@ BEGIN
 END
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000001_Migration1', N'9.0.0');
+VALUES (N'00000000000001_Migration1', N'7.0.0-test');
 
 --After
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'9.0.0');
+VALUES (N'00000000000002_Migration2', N'7.0.0-test');
 
 DECLARE @result int;
 EXEC @result = sp_releaseapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session';
 SELECT @result
 """,
-                Fixture.TestSqlLoggerFactory.Sql,
+                Fixture.TestSqlLoggerFactory.Sql.Replace(ProductInfo.GetVersion(), "7.0.0-test"),
                 ignoreLineEndingDifferences: true);
         }
 
@@ -867,7 +867,7 @@ FROM [__EFMigrationsHistory]
 ORDER BY [MigrationId];
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000000_Empty', N'9.0.0');
+VALUES (N'00000000000000_Empty', N'7.0.0-test');
 
 --Before
 
@@ -910,18 +910,18 @@ BEGIN
 END
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000001_Migration1', N'9.0.0');
+VALUES (N'00000000000001_Migration1', N'7.0.0-test');
 
 --After
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'9.0.0');
+VALUES (N'00000000000002_Migration2', N'7.0.0-test');
 
 DECLARE @result int;
 EXEC @result = sp_releaseapplock @Resource = '__EFMigrationsLock', @LockOwner = 'Session';
 SELECT @result
 """,
-                Fixture.TestSqlLoggerFactory.Sql,
+                Fixture.TestSqlLoggerFactory.Sql.Replace(ProductInfo.GetVersion(), "7.0.0-test"),
                 ignoreLineEndingDifferences: true);
         }
 


### PR DESCRIPTION
So that we don't need to update baselines every time we release a new version