### PR TITLE
[TINY] Do not return null namespace for Types

### DIFF
--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -631,7 +631,10 @@ internal static class SharedTypeExtensions
         }
         else
         {
-            yield return type.Namespace!;
+            if (type.Namespace is not null)
+            {
+                yield return type.Namespace;
+            }
         }
 
         if (type.IsGenericType)


### PR DESCRIPTION
Fixes #34993
