### PR TITLE
Allow SqlFragmentExpression to have a type/type mapping

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -435,6 +435,8 @@ public interface ISqlExpressionFactory
     ///     Creates a new <see cref="SqlExpression" /> which represents a SQL token.
     /// </summary>
     /// <param name="sql">A string token to print in SQL tree.</param>
+    /// <param name="type">The <see cref="Type" /> of the expression. Defaults to <see langword="void" />. </param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
     /// <returns>An expression representing a SQL token.</returns>
-    SqlExpression Fragment(string sql);
+    SqlExpression Fragment(string sql, Type? type = null, RelationalTypeMapping? typeMapping = null);
 }

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -956,8 +956,8 @@ public class SqlExpressionFactory : ISqlExpressionFactory
         => ApplyDefaultTypeMapping(new LikeExpression(match, pattern, escapeChar, null));
 
     /// <inheritdoc />
-    public virtual SqlExpression Fragment(string sql)
-        => new SqlFragmentExpression(sql);
+    public virtual SqlExpression Fragment(string sql, Type? type = null, RelationalTypeMapping? typeMapping = null)
+        => new SqlFragmentExpression(sql, type, typeMapping);
 
     /// <inheritdoc />
     public virtual SqlExpression Constant(object value, RelationalTypeMapping? typeMapping = null)

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2915,7 +2915,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                                 ? innerSelect.Orderings
                                 : innerSelect._identifier.Count > 0
                                     ? innerSelect._identifier.Select(e => new OrderingExpression(e.Column, true))
-                                    : new[] { new OrderingExpression(new SqlFragmentExpression("(SELECT 1)"), true) };
+                                    : new[] { new OrderingExpression(new SqlFragmentExpression("(SELECT 1)", typeof(int)), true) };
 
                             var rowNumberExpression = new RowNumberExpression(
                                 partitions, orderings.ToList(), (limit ?? offset)!.TypeMapping);

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
@@ -20,8 +20,10 @@ public class SqlFragmentExpression : SqlExpression
     ///     Creates a new instance of the <see cref="SqlFragmentExpression" /> class.
     /// </summary>
     /// <param name="sql">A string token to print in SQL tree.</param>
-    public SqlFragmentExpression(string sql)
-        : base(typeof(string), null)
+    /// <param name="type">The <see cref="Type" /> of the expression. Defaults to <see langword="object" />. </param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
+    public SqlFragmentExpression(string sql, Type? type = null, RelationalTypeMapping? typeMapping = null)
+        : base(type ?? typeof(object), typeMapping)
         => Sql = sql;
 
     /// <summary>
@@ -36,8 +38,11 @@ public class SqlFragmentExpression : SqlExpression
     /// <inheritdoc />
     public override Expression Quote()
         => New(
-            _quotingConstructor ??= typeof(SqlFragmentExpression).GetConstructor([typeof(string)])!,
-            Constant(Sql)); // TODO: The new type mapping once that's merged
+            _quotingConstructor ??=
+                typeof(SqlFragmentExpression).GetConstructor([typeof(string), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Constant(Sql),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)


### PR DESCRIPTION
We use SqlFragmentExpression to represent arbitrary SQL fragments which don't have a better representation. Right now, the type is hard-coded to `string` (arbitrary) and the node cannot have a type mapping. However, it's sometimes necessary to use such fragments to represent specific types, so this PR allows constructing fragments with a Type and TypeMapping, like any other SqlExpression.

This also changes the default type from string to object.