### PR TITLE
Fix to #35007 - EF Core fails to translate LINQ query to SQL if JOIN contains multiple columns

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -567,6 +567,55 @@ INNER JOIN (
 """);
     }
 
+    public override async Task GroupJoin_aggregate_anonymous_key_selectors(bool async)
+    {
+        await base.GroupJoin_aggregate_anonymous_key_selectors(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], (
+    SELECT COALESCE(SUM(CAST(LEN([o].[CustomerID]) AS int)), 0)
+    FROM [Orders] AS [o]
+    WHERE [c].[City] IS NOT NULL AND [c].[CustomerID] = [o].[CustomerID] AND [c].[City] = N'London') AS [Sum]
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task GroupJoin_aggregate_anonymous_key_selectors2(bool async)
+    {
+        await base.GroupJoin_aggregate_anonymous_key_selectors2(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], (
+    SELECT COALESCE(SUM(CAST(LEN([o].[CustomerID]) AS int)), 0)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND 1996 = DATEPART(year, [o].[OrderDate])) AS [Sum]
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task GroupJoin_aggregate_anonymous_key_selectors_one_argument(bool async)
+    {
+        await base.GroupJoin_aggregate_anonymous_key_selectors_one_argument(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], (
+    SELECT COALESCE(SUM(CAST(LEN([o].[CustomerID]) AS int)), 0)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) AS [Sum]
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task GroupJoin_aggregate_nested_anonymous_key_selectors(bool async)
+    {
+        await base.GroupJoin_aggregate_nested_anonymous_key_selectors(async);
+
+        AssertSql();
+    }
+
     public override async Task Inner_join_with_tautology_predicate_converts_to_cross_join(bool async)
     {
         await base.Inner_join_with_tautology_predicate_converts_to_cross_join(async);
@@ -990,6 +1039,13 @@ CROSS JOIN (
 ) AS [o0]
 INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
 """);
+    }
+
+    public override async Task Join_with_key_selectors_being_nested_anonymous_objects(bool async)
+    {
+        await base.Join_with_key_selectors_being_nested_anonymous_objects(async);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was in the GroupJoinConvertingExpressionVisitor where we convert GroupJoin key selectors into the correlation predicate for result selector subqueries. We blindly copy them over and in case of composite key selectors which fail to translate later in the pipeline (can't translate equals on anonymous object that is not a constant). Normally when processing regular joins we have logic that breaks up anonymous objects into constituent parts and compare them one by one instead (CreateJoinPredicate). However by the time we get to the translation we are dealing with a subquery with a Where predicate - we don't know at that point that it came from GroupJoin.

Fix is to tweak the logic in GroupJoinConvertingExpressionVisitor to break apart anonymous objects, like we do in CreateJoinPredicate

Fixes #35007