### PR TITLE
Use the proper type mapping for the result of AVG

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -459,7 +459,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         }
 
         var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
-        projection = _sqlExpressionFactory.Function("AVG", new[] { projection }, resultType, _typeMappingSource.FindMapping(resultType) ?? projection.TypeMapping);
+        projection = _sqlExpressionFactory.Function("AVG", new[] { projection }, resultType, _typeMappingSource.FindMapping(resultType));
 
         return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -459,7 +459,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         }
 
         var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
-        projection = _sqlExpressionFactory.Function("AVG", new[] { projection }, projection.Type, projection.TypeMapping);
+        projection = _sqlExpressionFactory.Function("AVG", new[] { projection }, resultType, _typeMappingSource.FindMapping(resultType) ?? projection.TypeMapping);
 
         return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -699,22 +699,19 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
         AssertSql();
     }
 
-    public override async Task Average_with_no_arg(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_no_arg(async));
+    public override Task Average_with_no_arg(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_with_no_arg(a);
 
-            AssertSql(
-                """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["$type"] = "Order")
 """);
-        }
-    }
+            });
 
     public override Task Average_with_binary_expression(bool async)
         => Fixture.NoSyncTest(
@@ -730,22 +727,19 @@ WHERE (c["$type"] = "Order")
 """);
             });
 
-    public override async Task Average_with_arg(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_arg(async));
+    public override Task Average_with_arg(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_with_arg(a);
 
-            AssertSql(
-                """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["$type"] = "Order")
 """);
-        }
-    }
+            });
 
     public override Task Average_with_arg_expression(bool async)
         => Fixture.NoSyncTest(


### PR DESCRIPTION
The translation of `Average` in Cosmos uses the same type mapping of its input for its return.

While this is fine if its input is a float, double, decimal, if you have an int or long as input it sets the return type as the same, thus causing a truncation when the results are read.

This fixes it by using the `resultType` passed in (the result type of the C# Average method - either float or double)

Fixes #26378 

