### PR TITLE
Fix to #35024 - Query could not be translated when using a static ICollection/IList field

### DIFF
--- a/src/EFCore/Query/QueryRootProcessor.cs
+++ b/src/EFCore/Query/QueryRootProcessor.cs
@@ -85,7 +85,7 @@ public class QueryRootProcessor : ExpressionVisitor
 
     private Expression VisitQueryRootCandidate(Expression expression, Type elementClrType)
     {
-        switch (expression)
+        switch (RemoveConvert(expression))
         {
             // An array containing only constants is represented as a ConstantExpression with the array as the value.
             // Convert that into a NewArrayExpression for use with InlineQueryRootExpression
@@ -122,6 +122,11 @@ public class QueryRootProcessor : ExpressionVisitor
             default:
                 return Visit(expression);
         }
+
+        static Expression RemoveConvert(Expression e)
+            => e is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+                ? RemoveConvert(unary.Operand)
+                : e;
     }
 
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -2068,6 +2068,20 @@ SELECT VALUE EXISTS (
         AssertSql();
     }
 
+    public override Task Contains_with_static_IList(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Contains_with_static_IList(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+WHERE c["id"] IN ("ALFKI", "ANATR")
+""");
+            });
+
     public override async Task OfType_Select(bool async)
     {
         // Contains over subquery. Issue #17246.

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1361,6 +1361,15 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })));
     }
 
+    private static readonly IList<string> StaticIds = new List<string> { "ALFKI", "ANATR" };
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_static_IList(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => StaticIds.Contains(c.CustomerID)));
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task OfType_Select(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -2303,6 +2303,18 @@ END
         AssertSql();
     }
 
+    public override async Task Contains_with_static_IList(bool async)
+    {
+        await base.Contains_with_static_IList(async);
+
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ALFKI', N'ANATR')
+""");
+    }
+
     public override async Task OfType_Select(bool async)
     {
         await base.OfType_Select(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -123,6 +123,18 @@ FROM (
     public override async Task Contains_with_local_tuple_array_closure(bool async)
         => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
 
+    public override async Task Contains_with_static_IList(bool async)
+    {
+        await base.Contains_with_static_IList(async);
+
+        AssertSql(
+            """
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+FROM "Customers" AS "c"
+WHERE "c"."CustomerID" IN ('ALFKI', 'ANATR')
+""");
+    }
+
     public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
     {
         await base.Contains_inside_aggregate_function_with_GroupBy(async);


### PR DESCRIPTION
Problem was that when converting primitive collection to inline query root we were not matching the expression if it was constant wrapped in convert. Fix is to remove convert for the purpose of pattern match for the transformation.

Fixes #35024