### PR TITLE
[released/9.0] Add missing awaits in MigrationsInfrastructureTestBase

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -286,21 +286,21 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_no_migration_script()
+    public virtual async Task Can_generate_no_migration_script()
     {
         using var db = Fixture.CreateEmptyContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetAndExecuteSqlAsync(migrator.GenerateScript());
+        await SetAndExecuteSqlAsync(migrator.GenerateScript());
     }
 
     [ConditionalFact]
-    public virtual void Can_generate_migration_from_initial_database_to_initial()
+    public virtual async Task Can_generate_migration_from_initial_database_to_initial()
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
 
-        SetAndExecuteSqlAsync(migrator.GenerateScript(fromMigration: Migration.InitialDatabase, toMigration: Migration.InitialDatabase));
+        await SetAndExecuteSqlAsync(migrator.GenerateScript(fromMigration: Migration.InitialDatabase, toMigration: Migration.InitialDatabase));
     }
 
     [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -35,9 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Fixture.TestSqlLoggerFactory.Log.Single(l => l.Id == RelationalEventId.NonTransactionalMigrationOperationWarning).Message);
         }
 
-        public override void Can_generate_migration_from_initial_database_to_initial()
+        public override async Task Can_generate_migration_from_initial_database_to_initial()
         {
-            base.Can_generate_migration_from_initial_database_to_initial();
+            await base.Can_generate_migration_from_initial_database_to_initial();
 
             Assert.Equal(
                 """
@@ -57,9 +57,9 @@ GO
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_no_migration_script()
+        public override async Task Can_generate_no_migration_script()
         {
-            base.Can_generate_no_migration_script();
+            await base.Can_generate_no_migration_script();
 
             Assert.Equal(
                 """

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -12,9 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     public class MigrationsInfrastructureSqliteTest(MigrationsInfrastructureSqliteTest.MigrationsInfrastructureSqliteFixture fixture)
         : MigrationsInfrastructureTestBase<MigrationsInfrastructureSqliteTest.MigrationsInfrastructureSqliteFixture>(fixture)
     {
-        public override void Can_generate_migration_from_initial_database_to_initial()
+        public override async Task Can_generate_migration_from_initial_database_to_initial()
         {
-            base.Can_generate_migration_from_initial_database_to_initial();
+            await base.Can_generate_migration_from_initial_database_to_initial();
 
             Assert.Equal(
                 """
@@ -29,9 +29,9 @@ CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Can_generate_no_migration_script()
+        public override async Task Can_generate_no_migration_script()
         {
-            base.Can_generate_no_migration_script();
+            await base.Can_generate_no_migration_script();
 
             Assert.Equal(
                 """


### PR DESCRIPTION
This is a test-only fix which removes a source of flakiness/instability (missing awaits).

Backports #35106

(cherry picked from commit a3c56773adea670d1672e5ec9c05f608744b861d)
