### PR TITLE
Set <LangVersion> to preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <PackageTags>Entity Framework Core;entity-framework-core;EF;Data;O/RM;EntityFramework;EntityFrameworkCore;EFCore</PackageTags>
     <Product>Microsoft Entity Framework Core</Product>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>portable</DebugType>
     <PackageProjectUrl>https://docs.microsoft.com/ef/core/</PackageProjectUrl>


### PR DESCRIPTION
See #35100

In #35100, a C# language change caused a break in an EF scenario; if we want to detect this kind of thing early, we need to set our project's `<LangVersion>` to preview. This is similar to how we update our .NET SDK to use preview bits - basically just making sure we work with the latest state of everything.

This does have some potentially negative consequences: we may (inadvertently) introduce C# preview features into the codebase, which may later be reverted or changed.

I'll bring this to design to see what we think.