### PR TITLE
Avoid using `^` and `~` when invalid because of value converters

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConverter.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConverter.cs
@@ -206,9 +206,11 @@ public class SearchConditionConverter(ISqlExpressionFactory sqlExpressionFactory
 
         if (binary.OperatorType is ExpressionType.NotEqual or ExpressionType.Equal)
         {
+            var leftType = newLeft.TypeMapping?.Converter?.ProviderClrType ?? newLeft.Type;
+            var rightType = newRight.TypeMapping?.Converter?.ProviderClrType ?? newRight.Type;
             if (!inSearchConditionContext
-                && (newLeft.Type == typeof(bool) || newLeft.Type.IsEnum || newLeft.Type.IsInteger())
-                && (newRight.Type == typeof(bool) || newRight.Type.IsEnum || newRight.Type.IsInteger()))
+                && (leftType == typeof(bool) || leftType.IsInteger())
+                && (rightType == typeof(bool) || rightType.IsInteger()))
             {
                 // "lhs != rhs" is the same as "CAST(lhs ^ rhs AS BIT)", except that
                 // the first is a boolean, the second is a BIT
@@ -262,7 +264,8 @@ public class SearchConditionConverter(ISqlExpressionFactory sqlExpressionFactory
 
         switch (sqlUnaryExpression.OperatorType)
         {
-            case ExpressionType.Not when sqlUnaryExpression.Type == typeof(bool):
+            case ExpressionType.Not
+                when (sqlUnaryExpression.TypeMapping?.Converter?.ProviderClrType ?? sqlUnaryExpression.Type) == typeof(bool):
             {
                 // when possible, avoid converting to/from predicate form
                 if (!inSearchConditionContext && sqlUnaryExpression.Operand is not (ExistsExpression or InExpression or LikeExpression))

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -8047,6 +8047,13 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Faction>().Where(f => f.ServerAddress == IPAddress.Loopback));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_equality_with_value_converted_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Mission>().Select(m => m.Difficulty == MissionDifficulty.Unknown));
+
     private static readonly IEnumerable<AmmunitionType?> _weaponTypes = new AmmunitionType?[] { AmmunitionType.Cartridge };
 
     [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -9380,6 +9380,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task Contains_on_readonly_enumerable(bool async)
     {
         await base.Contains_on_readonly_enumerable(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -12341,6 +12341,20 @@ WHERE [l].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(bool async)
     {
         await base.FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -10507,6 +10507,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(bool async)
     {
         await base.FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -6999,6 +6999,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
+""");
+    }
+
     public override async Task Navigation_access_on_derived_materialized_entity_using_cast(bool async)
     {
         await base.Navigation_access_on_derived_materialized_entity_using_cast(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -3076,6 +3076,17 @@ WHERE "f"."ServerAddress" = CAST('127.0.0.1' AS TEXT)
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT "m"."Difficulty" = 'Unknown'
+FROM "Missions" AS "m"
+""");
+    }
+
     public override async Task GetValueOrDefault_in_filter_non_nullable_column(bool async)
     {
         await base.GetValueOrDefault_in_filter_non_nullable_column(async);


### PR DESCRIPTION
The transformation of equality/in-equality in a (negated) XOR is only possible
when the expressions are BIT or integer types on the SQL side (i.e. taking value
conversion into account).

Similarly, the Boolean negation `NOT` can be implemented as `~` only if the
underlying expression is a BIT.

Fixes #35093.