### PR TITLE
Don't remove the annotation in NonNullableConventionBase

### DIFF
--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
 /// </remarks>
-public abstract class NonNullableConventionBase : IModelFinalizingConvention
+public abstract class NonNullableConventionBase
 {
     /// <summary>
     ///     Creates a new instance of <see cref="NonNullableConventionBase" />.
@@ -63,10 +63,4 @@ public abstract class NonNullableConventionBase : IModelFinalizingConvention
 
         return nullabilityInfo is not null;
     }
-
-    /// <inheritdoc />
-    public virtual void ProcessModelFinalizing(
-        IConventionModelBuilder modelBuilder,
-        IConventionContext<IConventionModelBuilder> context)
-        => modelBuilder.Metadata.RemoveAnnotation(CoreAnnotationNames.NonNullableConventionState);
 }


### PR DESCRIPTION
The convention is getting invoked after `ModelFinalizing` in some cases, so it will recreate the annotation, wasting CPU cycles