### PR TITLE
Add SqlServer translation for DateOnly.ToDateTime(timeOnly)

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateOnlyMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateOnlyMethodTranslator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection.Metadata;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 // ReSharper disable once CheckNamespace
@@ -20,6 +21,9 @@ public class SqlServerDateOnlyMethodTranslator : IMethodCallTranslator
         { typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.AddMonths), [typeof(int)])!, "month" },
         { typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.AddDays), [typeof(int)])!, "day" }
     };
+
+    private static readonly MethodInfo ToDateTimeMethodInfo
+        = typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.ToDateTime), [typeof(TimeOnly)])!;
 
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
@@ -44,18 +48,50 @@ public class SqlServerDateOnlyMethodTranslator : IMethodCallTranslator
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
-        if (_methodInfoDatePartMapping.TryGetValue(method, out var datePart)
-            && instance != null)
+        if (instance != null)
         {
-            instance = _sqlExpressionFactory.ApplyDefaultTypeMapping(instance);
+            if (method == ToDateTimeMethodInfo)
+            {
+                var timeOnly = arguments[0];
 
-            return _sqlExpressionFactory.Function(
-                "DATEADD",
-                new[] { _sqlExpressionFactory.Fragment(datePart), _sqlExpressionFactory.Convert(arguments[0], typeof(int)), instance },
-                nullable: true,
-                argumentsPropagateNullability: new[] { false, true, true },
-                instance.Type,
-                instance.TypeMapping);
+                // We need to refrain from doing the translation when either the DateOnly or the TimeOnly
+                // are a complex SQL expression (anything other than a column/constant/parameter), to avoid evaluating them multiple
+                // potentially expensive arbitrary expressions multiple times.
+                if (instance is not ColumnExpression and not SqlParameterExpression and not SqlConstantExpression
+                    || timeOnly is not ColumnExpression and not SqlParameterExpression and not SqlConstantExpression)
+                {
+                    return null;
+                }
+
+                return _sqlExpressionFactory.Function(
+                    "DATETIME2FROMPARTS",
+                    [
+                        MapDatePartExpression("year", instance),
+                        MapDatePartExpression("month", instance),
+                        MapDatePartExpression("day", instance),
+                        MapDatePartExpression("hour", timeOnly),
+                        MapDatePartExpression("minute", timeOnly),
+                        MapDatePartExpression("second", timeOnly),
+                        MapDatePartExpression("fraction", timeOnly),
+                        _sqlExpressionFactory.Constant(7, typeof(int)),
+                    ],
+                    nullable: true,
+                    argumentsPropagateNullability: [true, true, true, true, true, true, true, false],
+                    typeof(DateTime));
+            }
+
+            if (_methodInfoDatePartMapping.TryGetValue(method, out var datePart))
+            {
+                instance = _sqlExpressionFactory.ApplyDefaultTypeMapping(instance);
+
+                return _sqlExpressionFactory.Function(
+                    "DATEADD",
+                    [_sqlExpressionFactory.Fragment(datePart), _sqlExpressionFactory.Convert(arguments[0], typeof(int)), instance],
+                    nullable: true,
+                    argumentsPropagateNullability: [false, true, true],
+                    instance.Type,
+                    instance.TypeMapping);
+            }
         }
 
         if (method.DeclaringType == typeof(DateOnly)
@@ -66,5 +102,47 @@ public class SqlServerDateOnlyMethodTranslator : IMethodCallTranslator
         }
 
         return null;
+    }
+
+    private SqlExpression MapDatePartExpression(string datepart, SqlExpression argument)
+    {
+        if (argument is SqlConstantExpression constantArgument)
+        {
+            var constant = datepart switch
+            {
+                "year" => ((DateOnly)constantArgument.Value!).Year,
+                "month" => ((DateOnly)constantArgument.Value!).Month,
+                "day" => ((DateOnly)constantArgument.Value!).Day,
+                "hour" => ((TimeOnly)constantArgument.Value!).Hour,
+                "minute" => ((TimeOnly)constantArgument.Value!).Minute,
+                "second" => ((TimeOnly)constantArgument.Value!).Second,
+                "fraction" => ((TimeOnly)constantArgument.Value!).Ticks % 10_000_000,
+
+                _ => throw new UnreachableException()
+            };
+
+            return _sqlExpressionFactory.Constant(constant, typeof(int));
+        }
+
+        if (datepart == "fraction")
+        {
+            return _sqlExpressionFactory.Divide(
+                _sqlExpressionFactory.Function(
+                    "DATEPART",
+                    [_sqlExpressionFactory.Fragment("nanosecond"), argument],
+                    nullable: true,
+                    argumentsPropagateNullability: [true, true],
+                    typeof(int)
+                ),
+                _sqlExpressionFactory.Constant(100, typeof(int))
+            );
+        }
+
+        return _sqlExpressionFactory.Function(
+            "DATEPART",
+            [_sqlExpressionFactory.Fragment(datepart), argument],
+            nullable: true,
+            argumentsPropagateNullability: [true, true],
+            typeof(int));
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/TemporalTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/TemporalTranslationsCosmosTest.cs
@@ -228,6 +228,21 @@ WHERE (DateTimePart("ms", c["DateTime"]) = 123)
     public override Task DateOnly_FromDateTime_compared_to_constant_and_parameter(bool async)
         => AssertTranslationFailed(() => base.DateOnly_FromDateTime(async));
 
+    public override Task DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(bool async)
+        => AssertTranslationFailed(() => base.DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(async));
+
+    public override Task DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(bool async)
+        => AssertTranslationFailed(() => base.DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(async));
+
+    public override Task DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(bool async)
+        => AssertTranslationFailed(() => base.DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(async));
+
+    public override Task DateOnly_ToDateTime_with_complex_DateTime(bool async)
+        => AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_DateTime(async));
+
+    public override Task DateOnly_ToDateTime_with_complex_TimeOnly(bool async)
+        => AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_TimeOnly(async));
+
     #endregion DateOnly
 
     #region TimeOnly

--- a/test/EFCore.Specification.Tests/Query/Translations/TemporalTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/TemporalTranslationsTestBase.cs
@@ -218,6 +218,47 @@ public abstract class TemporalTranslationsTestBase<TFixture>(TFixture fixture) :
                 .Where(x => new[] { dateOnly, new DateOnly(1998, 5, 4) }.Contains(DateOnly.FromDateTime(x.DateTime))));
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>()
+                .Where(o => o.DateOnly.ToDateTime(new TimeOnly(21, 5, 19, 940, 500)) == new DateTime(2020, 1, 1, 21, 5, 19, 940, 500)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>()
+                .Where(o => o.DateOnly.ToDateTime(o.TimeOnly) == new DateTime(2020, 1, 1, 15, 30, 10)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>()
+                .Where(o => new DateOnly(1990, 11, 10).ToDateTime(o.TimeOnly) == new DateTime(1990, 11, 10, 15, 30, 10)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DateOnly_ToDateTime_with_complex_DateTime(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>()
+                .Where(o => o.DateOnly.AddYears(1).ToDateTime(o.TimeOnly) == new DateTime(2021, 1, 1, 15, 30, 10)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DateOnly_ToDateTime_with_complex_TimeOnly(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>()
+                .Where(o => o.DateOnly.ToDateTime(o.TimeOnly.AddHours(1)) == new DateTime(2020, 1, 1, 16, 30, 10))
+                .AsTracking());
+
     #endregion DateOnly
 
     #region TimeOnly

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/TemporalTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/TemporalTranslationsSqlServerTest.cs
@@ -324,6 +324,56 @@ WHERE CAST([b].[DateTime] AS date) IN (@dateOnly, '1998-05-04')
 """);
     }
 
+    public override async Task DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(bool async)
+    {
+        await base.DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATETIME2FROMPARTS(DATEPART(year, [b].[DateOnly]), DATEPART(month, [b].[DateOnly]), DATEPART(day, [b].[DateOnly]), 21, 5, 19, 9405000, 7) = '2020-01-01T21:05:19.9405000'
+""");
+    }
+
+    public override async Task DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(bool async)
+    {
+        await base.DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATETIME2FROMPARTS(DATEPART(year, [b].[DateOnly]), DATEPART(month, [b].[DateOnly]), DATEPART(day, [b].[DateOnly]), DATEPART(hour, [b].[TimeOnly]), DATEPART(minute, [b].[TimeOnly]), DATEPART(second, [b].[TimeOnly]), DATEPART(nanosecond, [b].[TimeOnly]) / 100, 7) = '2020-01-01T15:30:10.0000000'
+""");
+    }
+
+    public override async Task DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(bool async)
+    {
+        await base.DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATETIME2FROMPARTS(1990, 11, 10, DATEPART(hour, [b].[TimeOnly]), DATEPART(minute, [b].[TimeOnly]), DATEPART(second, [b].[TimeOnly]), DATEPART(nanosecond, [b].[TimeOnly]) / 100, 7) = '1990-11-10T15:30:10.0000000'
+""");
+    }
+
+    public override async Task DateOnly_ToDateTime_with_complex_DateTime(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_DateTime(async));
+
+        AssertSql();
+    }
+
+    public override async Task DateOnly_ToDateTime_with_complex_TimeOnly(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_TimeOnly(async));
+
+        AssertSql();
+    }
+
     #endregion DateOnly
 
     #region TimeOnly

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/TemporalTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/TemporalTranslationsSqliteTest.cs
@@ -363,6 +363,41 @@ WHERE date("b"."DateOnly", CAST(3 AS TEXT) || ' years', CAST(3 AS TEXT) || ' mon
 """);
     }
 
+    public override async Task DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_property_DateOnly_with_constant_TimeOnly(async));
+
+        AssertSql();
+    }
+
+    public override async Task DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_property_DateOnly_with_property_TimeOnly(async));
+
+        AssertSql();
+    }
+
+    public override async Task DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_constant_DateTime_with_property_TimeOnly(async));
+
+        AssertSql();
+    }
+
+    public override async Task DateOnly_ToDateTime_with_complex_DateTime(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_DateTime(async));
+
+        AssertSql();
+    }
+
+    public override async Task DateOnly_ToDateTime_with_complex_TimeOnly(bool async)
+    {
+        await AssertTranslationFailed(() => base.DateOnly_ToDateTime_with_complex_TimeOnly(async));
+
+        AssertSql();
+    }
+
     #endregion DateOnly
 
     #region TimeOnly


### PR DESCRIPTION
Fixes #35076

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

---

I created the PR as draft
- The translation is done as expected
- [x] TODO: I have an issue in comparison between datetime and string, I need to cast const value as datetime `please guide where to look`
- [x] TODO: add support for `DateOnly` as constant with `TimeOnly` Property


