### PR TITLE
Simplify parameter names

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -24,7 +24,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
     QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
     : ExpressionVisitor
 {
-    private const string RuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "entity_equality_";
+    private const string RuntimeParameterPrefix = "entity_equality_";
 
     private static readonly MethodInfo ParameterValueExtractorMethod =
         typeof(CosmosSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ParameterValueExtractor))!;
@@ -1040,9 +1040,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
                     QueryCompilationContext.QueryContextParameter
                 );
 
-                var newParameterName =
-                    $"{RuntimeParameterPrefix}"
-                    + $"{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                var newParameterName = $"{RuntimeParameterPrefix}{sqlParameterExpression.Name}_{property.Name}";
 
                 rewrittenSource = queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                 break;
@@ -1165,9 +1163,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
                         Expression.Constant(property, typeof(IProperty))),
                     QueryCompilationContext.QueryContextParameter);
 
-                var newParameterName =
-                    $"{RuntimeParameterPrefix}"
-                    + $"{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                var newParameterName = $"{RuntimeParameterPrefix}{sqlParameterExpression.Name}_{property.Name}";
 
                 return queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
 /// </summary>
 public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
 {
-    private const string RuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "entity_equality_";
+    private const string RuntimeParameterPrefix = "entity_equality_";
 
     private static readonly List<MethodInfo> SingleResultMethodInfos =
     [
@@ -1298,9 +1298,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
                     QueryCompilationContext.QueryContextParameter
                 );
 
-                var newParameterName =
-                    $"{RuntimeParameterPrefix}"
-                    + $"{parameterName[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                var newParameterName = $"{RuntimeParameterPrefix}{parameterName}_{property.Name}";
 
                 rewrittenSource = _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                 break;
@@ -1442,9 +1440,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
                         Expression.Constant(property, typeof(IProperty))),
                     QueryCompilationContext.QueryContextParameter);
 
-                var newParameterName =
-                    $"{RuntimeParameterPrefix}"
-                    + $"{parameterName[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                var newParameterName = $"{RuntimeParameterPrefix}{parameterName}_{property.Name}";
 
                 return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
 

--- a/src/EFCore.Relational/Query/Internal/RelationalParameterProcessor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalParameterProcessor.cs
@@ -1,26 +1,39 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
+///     This visitor processes the parameters of <see cref="FromSqlExpression" />, expanding them and creating the appropriate
+///     <see cref="IRelationalParameter" /> for them, and ensures parameter names are unique across the SQL tree.
+/// </summary>
+/// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-/// </summary>
-public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
+/// </remarks>
+public class RelationalParameterProcessor : ExpressionVisitor
 {
     private readonly IDictionary<FromSqlExpression, Expression> _visitedFromSqlExpressions
         = new Dictionary<FromSqlExpression, Expression>(ReferenceEqualityComparer.Instance);
 
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
     private readonly IRelationalTypeMappingSource _typeMappingSource;
+    private readonly ISqlGenerationHelper _sqlGenerationHelper;
     private readonly IParameterNameGeneratorFactory _parameterNameGeneratorFactory;
+
+    /// <summary>
+    ///     Contains parameter names seen so far, for uniquification. These parameter names have already gone through
+    ///     <see cref="ISqlGenerationHelper.GenerateParameterName(string)"/> (i.e. they're prefixed), since
+    ///     <see cref="DbParameter.ParameterName" /> can be prefixed or not.
+    /// </summary>
+    private readonly HashSet<string> _prefixedParameterNames = new();
+
+    private readonly Dictionary<string, SqlParameterExpression> _sqlParameters = new();
 
     private IReadOnlyDictionary<string, object?> _parametersValues;
     private ParameterNameGenerator _parameterNameGenerator;
@@ -32,7 +45,7 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public FromSqlParameterExpandingExpressionVisitor(
+    public RelationalParameterProcessor(
         RelationalParameterBasedSqlProcessorDependencies dependencies)
     {
         Dependencies = dependencies;
@@ -40,6 +53,7 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
         _sqlExpressionFactory = dependencies.SqlExpressionFactory;
         _typeMappingSource = dependencies.TypeMappingSource;
         _parameterNameGeneratorFactory = dependencies.ParameterNameGeneratorFactory;
+        _sqlGenerationHelper = dependencies.SqlGenerationHelper;
         _parametersValues = default!;
         _parameterNameGenerator = default!;
     }
@@ -61,6 +75,8 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
         out bool canCache)
     {
         _visitedFromSqlExpressions.Clear();
+        _prefixedParameterNames.Clear();
+        _sqlParameters.Clear();
         _parameterNameGenerator = _parameterNameGeneratorFactory.Create();
         _parametersValues = parameterValues;
         _canCache = true;
@@ -77,19 +93,55 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [return: NotNullIfNotNull(nameof(expression))]
-    public override Expression? Visit(Expression? expression)
+    protected override Expression VisitExtension(Expression expression)
+        => expression switch
+        {
+            FromSqlExpression fromSql
+                => _visitedFromSqlExpressions.TryGetValue(fromSql, out var visitedFromSql)
+                    ? visitedFromSql
+                    : _visitedFromSqlExpressions[fromSql] = VisitFromSql(fromSql),
+
+            SqlParameterExpression parameter => VisitSqlParameter(parameter),
+
+            _ => base.VisitExtension(expression)
+        };
+
+    private SqlParameterExpression VisitSqlParameter(SqlParameterExpression parameter)
     {
-        if (expression is not FromSqlExpression fromSql)
+        var typeMapping = parameter.TypeMapping!;
+
+        // Try to see if a parameter already exists - if so, just integrate the same placeholder into the SQL instead of sending the same
+        // data twice.
+        // Note that if the type mapping differs, we do send the same data twice (e.g. the same string may be sent once as Unicode, once as
+        // non-Unicode).
+        // TODO: Note that we perform Equals comparison on the value converter. We should be able to do reference comparison, but for
+        // that we need to ensure that there's only ever one type mapping instance (i.e. no type mappings are ever instantiated out of the
+        // type mapping source). See #30677.
+        if (_sqlParameters.TryGetValue(parameter.InvariantName, out var existingParameter)
+            && existingParameter is { TypeMapping: RelationalTypeMapping existingTypeMapping }
+            && string.Equals(existingTypeMapping.StoreType, typeMapping.StoreType, StringComparison.OrdinalIgnoreCase)
+            && (existingTypeMapping.Converter is null && typeMapping.Converter is null
+                || existingTypeMapping.Converter is not null && existingTypeMapping.Converter.Equals(typeMapping.Converter)))
         {
-            return base.Visit(expression);
+            return parameter;
         }
 
-        if (_visitedFromSqlExpressions.TryGetValue(fromSql, out var visitedFromSql))
-        {
-            return visitedFromSql;
-        }
+        var uniquifiedName = UniquifyParameterName(parameter.Name);
+        var newParameter = uniquifiedName == parameter.Name
+            ? parameter
+            : new SqlParameterExpression(
+                parameter.InvariantName,
+                uniquifiedName,
+                parameter.Type,
+                parameter.IsNullable,
+                parameter.ShouldBeConstantized,
+                parameter.TypeMapping);
 
+        return _sqlParameters[newParameter.InvariantName] = newParameter;
+    }
+
+    private FromSqlExpression VisitFromSql(FromSqlExpression fromSql)
+    {
         switch (fromSql.Arguments)
         {
             case QueryParameterExpression queryParameter:
@@ -101,22 +153,14 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
                 // ReSharper disable once ForCanBeConvertedToForeach
                 for (var i = 0; i < parameterValues.Length; i++)
                 {
-                    var parameterName = _parameterNameGenerator.GenerateNext();
                     if (parameterValues[i] is DbParameter dbParameter)
                     {
-                        if (string.IsNullOrEmpty(dbParameter.ParameterName))
-                        {
-                            dbParameter.ParameterName = parameterName;
-                        }
-                        else
-                        {
-                            parameterName = dbParameter.ParameterName;
-                        }
-
-                        subParameters.Add(new RawRelationalParameter(parameterName, dbParameter));
+                        ProcessDbParameter(dbParameter);
+                        subParameters.Add(new RawRelationalParameter(dbParameter.ParameterName, dbParameter));
                     }
                     else
                     {
+                        var parameterName = GenerateNewParameterName();
                         subParameters.Add(
                             new TypeMappedRelationalParameter(
                                 parameterName,
@@ -126,18 +170,18 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
                     }
                 }
 
-                return _visitedFromSqlExpressions[fromSql] = fromSql.Update(
-                    Expression.Constant(new CompositeRelationalParameter(queryParameter.Name!, subParameters)));
+                return fromSql.Update(Expression.Constant(new CompositeRelationalParameter(queryParameter.Name, subParameters)));
 
             case ConstantExpression { Value: object?[] existingValues }:
             {
                 var constantValues = new object?[existingValues.Length];
+
                 for (var i = 0; i < existingValues.Length; i++)
                 {
                     constantValues[i] = ProcessConstantValue(existingValues[i]);
                 }
 
-                return _visitedFromSqlExpressions[fromSql] = fromSql.Update(Expression.Constant(constantValues, typeof(object[])));
+                return fromSql.Update(Expression.Constant(constantValues, typeof(object[])));
             }
 
             case NewArrayExpression { Expressions: var expressions }:
@@ -154,29 +198,19 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
                     constantValues[i] = ProcessConstantValue(existingValue);
                 }
 
-                return _visitedFromSqlExpressions[fromSql] = fromSql.Update(Expression.Constant(constantValues, typeof(object[])));
+                return fromSql.Update(Expression.Constant(constantValues, typeof(object[])));
             }
 
             default:
-                Check.DebugFail("FromSql.Arguments must be Constant/QueryParameterExpression");
-                return null;
+                throw new UnreachableException("FromSql.Arguments must be Constant/QueryParameterExpression");
         }
 
         object ProcessConstantValue(object? existingConstantValue)
         {
             if (existingConstantValue is DbParameter dbParameter)
             {
-                var parameterName = _parameterNameGenerator.GenerateNext();
-                if (string.IsNullOrEmpty(dbParameter.ParameterName))
-                {
-                    dbParameter.ParameterName = parameterName;
-                }
-                else
-                {
-                    parameterName = dbParameter.ParameterName;
-                }
-
-                return new RawRelationalParameter(parameterName, dbParameter);
+                ProcessDbParameter(dbParameter);
+                return new RawRelationalParameter(dbParameter.ParameterName, dbParameter);
             }
 
             return _sqlExpressionFactory.Constant(
@@ -184,5 +218,40 @@ public class FromSqlParameterExpandingExpressionVisitor : ExpressionVisitor
                 existingConstantValue?.GetType() ?? typeof(object),
                 _typeMappingSource.GetMappingForValue(existingConstantValue));
         }
+
+        void ProcessDbParameter(DbParameter dbParameter)
+        {
+            dbParameter.ParameterName = string.IsNullOrEmpty(dbParameter.ParameterName)
+                ? GenerateNewParameterName()
+                : UniquifyParameterName(dbParameter.ParameterName);
+        }
+    }
+
+    private string GenerateNewParameterName()
+    {
+        string name, prefixedName;
+        do
+        {
+            name = _parameterNameGenerator.GenerateNext();
+            prefixedName = _sqlGenerationHelper.GenerateParameterName(name);
+        }
+        while (_prefixedParameterNames.Contains(prefixedName));
+
+        _prefixedParameterNames.Add(prefixedName);
+        return name;
+    }
+
+    private string UniquifyParameterName(string originalName)
+    {
+        var parameterName = originalName;
+        var prefixedName = _sqlGenerationHelper.GenerateParameterName(originalName);
+        for (var j = 0; _prefixedParameterNames.Contains(prefixedName); j++)
+        {
+            parameterName = originalName + j;
+            prefixedName = _sqlGenerationHelper.GenerateParameterName(parameterName);
+        }
+
+        _prefixedParameterNames.Add(prefixedName);
+        return parameterName;
     }
 }

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -19,8 +19,8 @@ public class QuerySqlGenerator : SqlExpressionVisitor
 {
     private readonly IRelationalCommandBuilderFactory _relationalCommandBuilderFactory;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
+    private readonly HashSet<string> _parameterNames = new();
     private IRelationalCommandBuilder _relationalCommandBuilder;
-    private Dictionary<string, int>? _repeatedParameterCounts;
 
     /// <summary>
     ///     Creates a new instance of the <see cref="QuerySqlGenerator" /> class.
@@ -466,15 +466,15 @@ public class QuerySqlGenerator : SqlExpressionVisitor
                 substitutions = new string[constantValues.Length];
                 for (var i = 0; i < constantValues.Length; i++)
                 {
-                    var value = constantValues[i];
-                    if (value is RawRelationalParameter rawRelationalParameter)
+                    switch (constantValues[i])
                     {
-                        substitutions[i] = _sqlGenerationHelper.GenerateParameterNamePlaceholder(rawRelationalParameter.InvariantName);
-                        _relationalCommandBuilder.AddParameter(rawRelationalParameter);
-                    }
-                    else if (value is SqlConstantExpression sqlConstantExpression)
-                    {
-                        substitutions[i] = sqlConstantExpression.TypeMapping!.GenerateSqlLiteral(sqlConstantExpression.Value);
+                        case RawRelationalParameter rawRelationalParameter:
+                            substitutions[i] = _sqlGenerationHelper.GenerateParameterNamePlaceholder(rawRelationalParameter.InvariantName);
+                            _relationalCommandBuilder.AddParameter(rawRelationalParameter);
+                            break;
+                        case SqlConstantExpression sqlConstantExpression:
+                            substitutions[i] = sqlConstantExpression.TypeMapping!.GenerateSqlLiteral(sqlConstantExpression.Value);
+                            break;
                     }
                 }
 
@@ -639,61 +639,23 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     /// <param name="sqlParameterExpression">The <see cref="SqlParameterExpression" /> for which to generate SQL.</param>
     protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
     {
-        var invariantName = sqlParameterExpression.Name;
-        var parameterName = sqlParameterExpression.Name;
-        var typeMapping = sqlParameterExpression.TypeMapping!;
+        var name = sqlParameterExpression.Name;
 
-        // Try to see if a parameter already exists - if so, just integrate the same placeholder into the SQL instead of sending the same
-        // data twice.
-        // Note that if the type mapping differs, we do send the same data twice (e.g. the same string may be sent once as Unicode, once as
-        // non-Unicode).
-        // TODO: Note that we perform Equals comparison on the value converter. We should be able to do reference comparison, but for
-        // that we need to ensure that there's only ever one type mapping instance (i.e. no type mappings are ever instantiated out of the
-        // type mapping source). See #30677.
-        var parameter = _relationalCommandBuilder.Parameters.FirstOrDefault(
-            p =>
-                p.InvariantName == parameterName
-                && p is TypeMappedRelationalParameter { RelationalTypeMapping: var existingTypeMapping }
-                && string.Equals(existingTypeMapping.StoreType, typeMapping.StoreType, StringComparison.OrdinalIgnoreCase)
-                && (existingTypeMapping.Converter is null && typeMapping.Converter is null
-                    || existingTypeMapping.Converter is not null && existingTypeMapping.Converter.Equals(typeMapping.Converter)));
-
-        if (parameter is null)
+        // Only add the parameter to the command the first time we see its (non-invariant) name, even though we may need to add its
+        // placeholder multiple times.
+        if (!_parameterNames.Contains(name))
         {
-            parameterName = GetUniqueParameterName(parameterName);
-
             _relationalCommandBuilder.AddParameter(
-                invariantName,
-                _sqlGenerationHelper.GenerateParameterName(parameterName),
+                sqlParameterExpression.InvariantName,
+                _sqlGenerationHelper.GenerateParameterName(name),
                 sqlParameterExpression.TypeMapping!,
                 sqlParameterExpression.IsNullable);
-        }
-        else
-        {
-            parameterName = ((TypeMappedRelationalParameter)parameter).Name;
+            _parameterNames.Add(name);
         }
 
-        _relationalCommandBuilder
-            .Append(_sqlGenerationHelper.GenerateParameterNamePlaceholder(parameterName));
+        _relationalCommandBuilder.Append(_sqlGenerationHelper.GenerateParameterNamePlaceholder(name));
 
         return sqlParameterExpression;
-
-        string GetUniqueParameterName(string currentName)
-        {
-            _repeatedParameterCounts ??= new Dictionary<string, int>();
-
-            if (!_repeatedParameterCounts.TryGetValue(currentName, out var currentCount))
-            {
-                _repeatedParameterCounts[currentName] = 0;
-
-                return currentName;
-            }
-
-            currentCount++;
-            _repeatedParameterCounts[currentName] = currentCount;
-
-            return currentName + "_" + currentCount;
-        }
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalParameterBasedSqlProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalParameterBasedSqlProcessor.cs
@@ -87,5 +87,5 @@ public class RelationalParameterBasedSqlProcessor
         Expression queryExpression,
         IReadOnlyDictionary<string, object?> parametersValues,
         out bool canCache)
-        => new FromSqlParameterExpandingExpressionVisitor(Dependencies).Expand(queryExpression, parametersValues, out canCache);
+        => new RelationalParameterProcessor(Dependencies).Expand(queryExpression, parametersValues, out canCache);
 }

--- a/src/EFCore.Relational/Query/RelationalParameterBasedSqlProcessorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalParameterBasedSqlProcessorDependencies.cs
@@ -50,10 +50,12 @@ public sealed record RelationalParameterBasedSqlProcessorDependencies
     public RelationalParameterBasedSqlProcessorDependencies(
         ISqlExpressionFactory sqlExpressionFactory,
         IRelationalTypeMappingSource typeMappingSource,
+        ISqlGenerationHelper sqlGenerationHelper,
         IParameterNameGeneratorFactory parameterNameGeneratorFactory)
     {
         SqlExpressionFactory = sqlExpressionFactory;
         TypeMappingSource = typeMappingSource;
+        SqlGenerationHelper = sqlGenerationHelper;
         ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
     }
 
@@ -66,6 +68,11 @@ public sealed record RelationalParameterBasedSqlProcessorDependencies
     ///     Relational type mapping source.
     /// </summary>
     public IRelationalTypeMappingSource TypeMappingSource { get; init; }
+
+    /// <summary>
+    ///     SQL generation helper.
+    /// </summary>
+    public ISqlGenerationHelper SqlGenerationHelper { get; init; }
 
     /// <summary>
     ///     Parameter name generator factory.

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 {
-    private const string ExecuteUpdateRuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "complex_type_";
+    private const string ExecuteUpdateRuntimeParameterPrefix = "complex_type_";
 
     private static readonly MethodInfo ParameterValueExtractorMethod =
         typeof(RelationalSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ParameterValueExtractor))!;
@@ -317,7 +317,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                                 QueryCompilationContext.QueryContextParameter);
 
                             var newParameterName =
-                                $"{ExecuteUpdateRuntimeParameterPrefix}{parameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                                $"{ExecuteUpdateRuntimeParameterPrefix}{parameterExpression.Name}_{property.Name}";
 
                             return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                         }
@@ -334,7 +334,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                                 QueryCompilationContext.QueryContextParameter);
 
                             var newParameterName =
-                                $"{ExecuteUpdateRuntimeParameterPrefix}{chainExpression.ParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                                $"{ExecuteUpdateRuntimeParameterPrefix}{chainExpression.ParameterExpression.Name}_{property.Name}";
 
                             return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                         }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// </summary>
 public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 {
-    private const string RuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "entity_equality_";
+    private const string RuntimeParameterPrefix = "entity_equality_";
 
     private static readonly List<MethodInfo> SingleResultMethodInfos =
     [
@@ -512,11 +512,20 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                         _queryCompilationContext.IsPrecompiling,
                         "Parameters can only be known to has non-nullable reference types in query precompilation.");
                     return new SqlParameterExpression(
-                        queryParameter.Name, queryParameter.Type, nullable: false, queryParameter.ShouldBeConstantized, typeMapping: null);
+                        invariantName: queryParameter.Name,
+                        name: queryParameter.Name,
+                        queryParameter.Type,
+                        nullable: false,
+                        queryParameter.ShouldBeConstantized,
+                        typeMapping: null);
                 }
 
                 return new SqlParameterExpression(
-                    queryParameter.Name, queryParameter.Type, queryParameter.Type.IsNullableType(), queryParameter.ShouldBeConstantized,
+                    invariantName: queryParameter.Name,
+                    name: queryParameter.Name,
+                    queryParameter.Type,
+                    queryParameter.Type.IsNullableType(),
+                    queryParameter.ShouldBeConstantized,
                     typeMapping: null);
 
             case StructuralTypeShaperExpression shaper:
@@ -1689,7 +1698,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     QueryCompilationContext.QueryContextParameter);
 
                 var newParameterName =
-                    $"{RuntimeParameterPrefix}{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                    $"{RuntimeParameterPrefix}{sqlParameterExpression.Name}_{property.Name}";
 
                 rewrittenSource = _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                 break;
@@ -2004,7 +2013,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     QueryCompilationContext.QueryContextParameter);
 
                 var newParameterName =
-                    $"{RuntimeParameterPrefix}{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
+                    $"{RuntimeParameterPrefix}{sqlParameterExpression.Name}_{property.Name}";
 
                 return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
             }
@@ -2021,7 +2030,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     QueryCompilationContext.QueryContextParameter);
 
                 var parameterNameBuilder = new StringBuilder(RuntimeParameterPrefix)
-                    .Append(chainExpression.ParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..])
+                    .Append(chainExpression.ParameterExpression.Name)
                     .Append('_');
 
                 foreach (var complexProperty in chainExpression.ComplexPropertyChain)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -17,28 +17,45 @@ public sealed class SqlParameterExpression : SqlExpression
     /// <param name="type">The <see cref="Type" /> of the expression.</param>
     /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
     public SqlParameterExpression(string name, Type type, RelationalTypeMapping? typeMapping)
-        : this(name, type.UnwrapNullableType(), type.IsNullableType(), shouldBeConstantized: false, typeMapping)
+        : this(invariantName: name, name: name, type.UnwrapNullableType(), type.IsNullableType(), shouldBeConstantized: false, typeMapping)
     {
     }
 
     /// <summary>
     ///     Creates a new instance of the <see cref="SqlParameterExpression" /> class.
     /// </summary>
-    /// <param name="name">The parameter name.</param>
+    /// <param name="invariantName">The name of the parameter as it is recorded in <see cref="QueryContext.ParameterValues" />.</param>
+    /// <param name="name">
+    ///     The name of the parameter as it will be set on <see cref="DbParameter.ParameterName" /> and inside the SQL as a placeholder
+    ///     (before any additional placeholder character prefixing).
+    /// </param>
     /// <param name="type">The <see cref="Type" /> of the expression.</param>
     /// <param name="nullable">Whether this parameter can have null values.</param>
     /// <param name="shouldBeConstantized">Whether the user has indicated that this query parameter should be inlined as a constant.</param>
     /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
-    public SqlParameterExpression(string name, Type type, bool nullable, bool shouldBeConstantized, RelationalTypeMapping? typeMapping)
+    public SqlParameterExpression(
+        string invariantName,
+        string name,
+        Type type,
+        bool nullable,
+        bool shouldBeConstantized,
+        RelationalTypeMapping? typeMapping)
         : base(type.UnwrapNullableType(), typeMapping)
     {
+        InvariantName = invariantName;
         Name = name;
         IsNullable = nullable;
         ShouldBeConstantized = shouldBeConstantized;
     }
 
     /// <summary>
-    ///     The name of the parameter.
+    ///     The name of the parameter as it is recorded in <see cref="QueryContext.ParameterValues" />.
+    /// </summary>
+    public string InvariantName { get; }
+
+    /// <summary>
+    ///     The name of the parameter as it will be set on <see cref="DbParameter.ParameterName" /> and inside the SQL as a placeholder
+    ///     (before any additional placeholder character prefixing).
     /// </summary>
     public string Name { get; }
 
@@ -58,7 +75,7 @@ public sealed class SqlParameterExpression : SqlExpression
     /// <param name="typeMapping">A relational type mapping to apply.</param>
     /// <returns>A new expression which has supplied type mapping.</returns>
     public SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
-        => new SqlParameterExpression(Name, Type, IsNullable, ShouldBeConstantized, typeMapping);
+        => new SqlParameterExpression(InvariantName, Name, Type, IsNullable, ShouldBeConstantized, typeMapping);
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)

--- a/src/EFCore.Relational/Storage/Internal/CompositeRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/CompositeRelationalParameter.cs
@@ -17,9 +17,7 @@ public class CompositeRelationalParameter : RelationalParameterBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public CompositeRelationalParameter(
-        string invariantName,
-        IReadOnlyList<IRelationalParameter> relationalParameters)
+    public CompositeRelationalParameter(string invariantName, IReadOnlyList<IRelationalParameter> relationalParameters)
         : base(invariantName)
         => RelationalParameters = relationalParameters;
 
@@ -39,23 +37,20 @@ public class CompositeRelationalParameter : RelationalParameterBase
     /// </summary>
     public override void AddDbParameter(DbCommand command, object? value)
     {
-        if (value is object[] innerValues)
-        {
-            if (innerValues.Length < RelationalParameters.Count)
-            {
-                throw new InvalidOperationException(
-                    RelationalStrings.MissingParameterValue(
-                        RelationalParameters[innerValues.Length].InvariantName));
-            }
-
-            for (var i = 0; i < RelationalParameters.Count; i++)
-            {
-                RelationalParameters[i].AddDbParameter(command, innerValues[i]);
-            }
-        }
-        else
+        if (value is not object[] innerValues)
         {
             throw new InvalidOperationException(RelationalStrings.ParameterNotObjectArray(InvariantName));
+        }
+
+        if (innerValues.Length < RelationalParameters.Count)
+        {
+            throw new InvalidOperationException(
+                RelationalStrings.MissingParameterValue(RelationalParameters[innerValues.Length].InvariantName));
+        }
+
+        for (var i = 0; i < RelationalParameters.Count; i++)
+        {
+            RelationalParameters[i].AddDbParameter(command, innerValues[i]);
         }
     }
 }

--- a/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
@@ -21,10 +21,7 @@ public class RawRelationalParameter : RelationalParameterBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public RawRelationalParameter(
-        string invariantName,
-        DbParameter parameter)
-        : base(invariantName)
+    public RawRelationalParameter(string invariantName, DbParameter parameter) : base(invariantName)
         => _parameter = parameter;
 
     /// <summary>

--- a/src/EFCore/Query/Internal/CompiledQueryBase.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryBase.cs
@@ -69,9 +69,7 @@ public abstract class CompiledQueryBase<TContext, TResult>
 
         for (var i = 0; i < parameters.Length; i++)
         {
-            queryContext.AddParameter(
-                QueryCompilationContext.QueryParameterPrefix + _queryExpression.Parameters[i + 1].Name,
-                parameters[i]);
+            queryContext.AddParameter(_queryExpression.Parameters[i + 1].Name!, parameters[i]);
         }
 
         return _executor.Executor(queryContext);
@@ -105,8 +103,7 @@ public abstract class CompiledQueryBase<TContext, TResult>
             => typeof(TContext).IsAssignableFrom(parameterExpression.Type)
                 ? Expression.Constant(context)
                 : parameters.Contains(parameterExpression)
-                    ? new QueryParameterExpression(
-                        QueryCompilationContext.QueryParameterPrefix + parameterExpression.Name, parameterExpression.Type)
+                    ? new QueryParameterExpression(parameterExpression.Name!, parameterExpression.Type)
                     : parameterExpression;
     }
 }

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -78,6 +78,11 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     private readonly Dictionary<Expression, QueryParameterExpression> _parameterizedValues = new(ExpressionEqualityComparer.Instance);
 
     /// <summary>
+    ///     A set of the names of parameters that have already been created. Used to ensure different parameters have unique names.
+    /// </summary>
+    private readonly HashSet<string> _parameterNames = new();
+
+    /// <summary>
     ///     Used only when evaluating arbitrary QueryRootExpressions (specifically SqlQueryRootExpression), to force any evaluatable nested
     ///     expressions to get evaluated as roots, since the query root itself is never evaluatable.
     /// </summary>
@@ -96,8 +101,6 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     private readonly IModel _model;
     private readonly ContextParameterReplacer _contextParameterReplacer;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
-
-    private static readonly IReadOnlySet<string> EmptyStringSet = new HashSet<string>();
 
     private static readonly MethodInfo ReadOnlyCollectionIndexerGetter = typeof(ReadOnlyCollection<Expression>).GetProperties()
         .Single(p => p.GetIndexParameters() is { Length: 1 } indexParameters && indexParameters[0].ParameterType == typeof(int)).GetMethod!;
@@ -238,7 +241,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         if (state.IsEvaluatable
             && IsParameterParameterizable(linqOperatorMethodCall.Method, linqOperatorMethodCall.Method.GetParameters()[argumentIndex]))
         {
-            _ = Evaluate(root, out var parameterName, out _);
+            _ = Evaluate(root, out var parameterName);
 
             state = new State
             {
@@ -276,7 +279,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         // parameterized since we're not inside a lambda (e.g. Skip/Take), except for [NotParameterized].
         if (state.IsEvaluatable)
         {
-            _ = Evaluate(root, out var parameterName, out _);
+            _ = Evaluate(root, out var parameterName);
 
             state = new State
             {
@@ -303,6 +306,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         if (clearParameterizedValues)
         {
             _parameterizedValues.Clear();
+            _parameterNames.Clear();
         }
     }
 
@@ -1862,7 +1866,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
             return result;
         }
 
-        var value = Evaluate(evaluatableRoot, out var parameterName, out var isContextAccessor);
+        var value = Evaluate(evaluatableRoot, ref evaluateAsParameter, out var parameterName, out var isContextAccessor);
 
         switch (value)
         {
@@ -1873,12 +1877,6 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
 
             case Expression innerExpression when !isContextAccessor:
                 return Visit(innerExpression);
-        }
-
-        if (isContextAccessor)
-        {
-            // Context accessors (query filters accessing the context) never get constantized
-            evaluateAsParameter = true;
         }
 
         if (evaluateAsParameter)
@@ -2002,30 +2000,53 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     }
 
     private object? Evaluate(Expression? expression)
-        => Evaluate(expression, out _, out _);
-
-    private object? Evaluate(Expression? expression, out string parameterName, out bool isContextAccessor)
     {
-        var value = EvaluateCore(expression, out var tempParameterName, out isContextAccessor);
-        parameterName = tempParameterName ?? "p";
+        var evaluateAsParameter = false;
+        return Evaluate(expression, ref evaluateAsParameter, out _, out _);
+    }
 
-        var compilerPrefixIndex = parameterName.LastIndexOf('>');
-        if (compilerPrefixIndex != -1)
+    private object? Evaluate(Expression? expression, out string parameterName)
+    {
+        var evaluateAsParameter = true;
+        return Evaluate(expression, ref evaluateAsParameter, out parameterName, out _);
+    }
+
+    private object? Evaluate(Expression? expression, ref bool evaluateAsParameter, out string parameterName, out bool isContextAccessor)
+    {
+        var value = EvaluateCore(expression, ref evaluateAsParameter, out var tempParameterName, out isContextAccessor);
+
+        if (evaluateAsParameter)
         {
-            parameterName = parameterName[(compilerPrefixIndex + 1)..];
-        }
+            parameterName = tempParameterName ?? "p";
 
-        // The VB compiler prefixes closure member names with $VB$Local_, remove that (#33150)
-        if (parameterName.StartsWith("$VB$Local_", StringComparison.Ordinal))
+            var compilerPrefixIndex = parameterName.LastIndexOf('>');
+            if (compilerPrefixIndex != -1)
+            {
+                parameterName = parameterName[(compilerPrefixIndex + 1)..];
+            }
+
+            // The VB compiler prefixes closure member names with $VB$Local_, remove that (#33150)
+            if (parameterName.StartsWith("$VB$Local_", StringComparison.Ordinal))
+            {
+                parameterName = parameterName.Substring("$VB$Local_".Length);
+            }
+
+            // Uniquify the parameter name
+            var originalParameterName = parameterName;
+            for (var i = 0; _parameterNames.Contains(parameterName); i++)
+            {
+                parameterName = originalParameterName + i;
+            }
+            _parameterNames.Add(parameterName);
+        }
+        else
         {
-            parameterName = parameterName.Substring("$VB$Local_".Length);
+            parameterName = string.Empty;
         }
-
-        parameterName = $"{QueryCompilationContext.QueryParameterPrefix}{parameterName}_{_parameterValues.ParameterValues.Count}";
 
         return value;
 
-        object? EvaluateCore(Expression? expression, out string? parameterName, out bool isContextAccessor)
+        object? EvaluateCore(Expression? expression, ref bool evaluateAsParameter, out string? parameterName, out bool isContextAccessor)
         {
             parameterName = null;
             isContextAccessor = false;
@@ -2045,6 +2066,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                         + (RemoveConvert(expression) is MemberExpression { Member.Name: var memberName } ? ("__" + memberName) : "__p");
                     isContextAccessor = true;
 
+                    // Context accessors (query filters accessing the context) never get constantized
+                    evaluateAsParameter = true;
+
                     return Lambda(visited, _contextParameterReplacer.ContextParameterExpression);
                 }
 
@@ -2057,7 +2081,8 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
             switch (expression)
             {
                 case MemberExpression memberExpression:
-                    var instanceValue = EvaluateCore(memberExpression.Expression, out parameterName, out isContextAccessor);
+                    var instanceValue = EvaluateCore(
+                        memberExpression.Expression, ref evaluateAsParameter, out parameterName, out isContextAccessor);
                     try
                     {
                         switch (memberExpression.Member)
@@ -2087,7 +2112,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
 
                 case UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression
                     when (unaryExpression.Type.UnwrapNullableType() == unaryExpression.Operand.Type):
-                    return EvaluateCore(unaryExpression.Operand, out parameterName, out isContextAccessor);
+                    return EvaluateCore(unaryExpression.Operand, ref evaluateAsParameter, out parameterName, out isContextAccessor);
             }
 
             try

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -22,17 +22,6 @@ public class QueryCompilationContext
 {
     /// <summary>
     ///     <para>
-    ///         Prefix for all the query parameters generated during parameter extraction in query pipeline.
-    ///     </para>
-    ///     <para>
-    ///         This property is typically used by database providers (and other extensions). It is generally
-    ///         not used in application code.
-    ///     </para>
-    /// </summary>
-    public const string QueryParameterPrefix = "__";
-
-    /// <summary>
-    ///     <para>
     ///         ParameterExpression representing <see cref="QueryContext" /> parameter in query expression.
     ///     </para>
     ///     <para>

--- a/src/EFCore/Query/QueryParameterExpression.cs
+++ b/src/EFCore/Query/QueryParameterExpression.cs
@@ -80,8 +80,7 @@ public class QueryParameterExpression : Expression, IPrintableExpression
 
     /// <inheritdoc />
     public void Print(ExpressionPrinter expressionPrinter)
-        // => expressionPrinter.Append("@").Append(Name);
-        => expressionPrinter.Append(Name);
+        => expressionPrinter.Append("@").Append(Name);
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -1508,11 +1508,11 @@ ReadItem([1.0,"One",true], 42)
             AssertSql(
                 context,
                 """
-@__p_0='42'
+@p='42'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["id"] = @__p_0)
+WHERE (c["id"] = @p)
 OFFSET 0 LIMIT 1
 """);
         }

--- a/test/EFCore.Cosmos.FunctionalTests/HierarchicalPartitionKeyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/HierarchicalPartitionKeyTest.cs
@@ -35,12 +35,12 @@ OFFSET 0 LIMIT 1
 
         const string read2Sql =
             """
-@__p_0='1'
+@p='1'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["PartitionKey1"]
-OFFSET @__p_0 LIMIT 1
+OFFSET @p LIMIT 1
 """;
 
         await PartitionKeyTestAsync(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -467,13 +467,13 @@ FROM (
                 AssertSql(
                     """
 @p0='London'
-@__contactTitle_1='Sales Representative'
+@contactTitle='Sales Representative'
 
 SELECT VALUE s
 FROM (
     SELECT * FROM root c WHERE c["$type"] = "Customer" AND c["City"] = @p0
 ) s
-WHERE (s["ContactTitle"] = @__contactTitle_1)
+WHERE (s["ContactTitle"] = @contactTitle)
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -787,11 +787,11 @@ WHERE ((c["Discriminator"] = "Basic") AND (c["OwnedCollectionRoot"][0]["Name"] !
 
                 AssertSql(
                     """
-@__prm_0='1'
+@prm='1'
 
 SELECT VALUE c["Id"]
 FROM root c
-WHERE ((c["Discriminator"] = "Basic") AND (c["OwnedCollectionRoot"][@__prm_0]["Name"] != "Foo"))
+WHERE ((c["Discriminator"] = "Basic") AND (c["OwnedCollectionRoot"][@prm]["Name"] != "Foo"))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
@@ -310,11 +310,11 @@ OFFSET 0 LIMIT 2
 
         AssertSql(
             """
-@__ints_0='1,2,3'
+@ints='1,2,3'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["Ints"] = @__ints_0)
+WHERE (c["Ints"] = @ints)
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -61,11 +61,11 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = 10248))
 
                 AssertSql(
                     """
-@__Select_0='["ABCDE","ALFKI"]'
+@Select='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__Select_0, c["id"])
+WHERE ARRAY_CONTAINS(@Select, c["id"])
 """);
             });
 
@@ -77,19 +77,19 @@ WHERE ARRAY_CONTAINS(@__Select_0, c["id"])
 
                 AssertSql(
                     """
-@__Select_0='["ABCDE","ALFKI"]'
+@Select='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__Select_0, c["id"])
+WHERE ARRAY_CONTAINS(@Select, c["id"])
 """,
                     //
                     """
-@__Select_0='["ABCDE","ANATR"]'
+@Select='["ABCDE","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__Select_0, c["id"])
+WHERE ARRAY_CONTAINS(@Select, c["id"])
 """);
             });
 
@@ -1189,12 +1189,12 @@ WHERE (((c["$type"] = "Order") AND (c["OrderID"] > 10)) AND (c["CustomerID"] != 
 
             AssertSql(
                 """
-@__p_0='10'
+@p='10'
 
 SELECT VALUE c
 FROM root c
 ORDER BY 42
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
         }
     }
@@ -1442,19 +1442,19 @@ OFFSET 0 LIMIT 1
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """,
                     //
                     """
-@__ids_0='["ABCDE"]'
+@ids='["ABCDE"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1474,19 +1474,19 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='[0,1]'
+@ids='[0,1]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["EmployeeID"])
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
 """,
                     //
                     """
-@__ids_0='[0]'
+@ids='[0]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["EmployeeID"])
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
 """);
             });
 
@@ -1498,19 +1498,19 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["EmployeeID"])
 
                 AssertSql(
                     """
-@__ids_0='[0,1]'
+@ids='[0,1]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["EmployeeID"])
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
 """,
                     //
                     """
-@__ids_0='[0]'
+@ids='[0]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["EmployeeID"])
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
 """);
             });
 
@@ -1536,11 +1536,11 @@ WHERE c["id"] IN ("ABCDE", "ALFKI")
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1552,11 +1552,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1568,11 +1568,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='[null,null]'
+@ids='[null,null]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1598,19 +1598,19 @@ WHERE c["id"] IN ("ABCDE", "ALFKI")
 
                 AssertSql(
                     """
-@__p_0='["ABCDE","ALFKI"]'
+@p='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__p_0, c["id"])
+WHERE ARRAY_CONTAINS(@p, c["id"])
 """,
                     //
                     """
-@__p_0='["ABCDE","ANATR"]'
+@p='["ABCDE","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__p_0, c["id"])
+WHERE ARRAY_CONTAINS(@p, c["id"])
 """);
             });
 
@@ -1621,19 +1621,19 @@ WHERE ARRAY_CONTAINS(@__p_0, c["id"])
                 await base.Contains_with_local_enumerable_closure(a);
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """,
                     //
                     """
-@__ids_0='["ABCDE"]'
+@ids='["ABCDE"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1645,11 +1645,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1661,11 +1661,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='[]'
+@ids='[]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1694,24 +1694,24 @@ WHERE EXISTS (
 
                 AssertSql(
                     """
-@__p_0='["ABCDE","ALFKI"]'
+@p='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
 WHERE EXISTS (
     SELECT 1
-    FROM p IN (SELECT VALUE @__p_0)
+    FROM p IN (SELECT VALUE @p)
     WHERE ((p != null) AND (p = c["id"])))
 """,
                     //
                     """
-@__p_0='["ABCDE","ANATR"]'
+@p='["ABCDE","ANATR"]'
 
 SELECT VALUE c
 FROM root c
 WHERE EXISTS (
     SELECT 1
-    FROM p IN (SELECT VALUE @__p_0)
+    FROM p IN (SELECT VALUE @p)
     WHERE ((p != null) AND (p = c["id"])))
 """);
             });
@@ -1724,19 +1724,19 @@ WHERE EXISTS (
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """,
                     //
                     """
-@__ids_0='["ABCDE"]'
+@ids='["ABCDE"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1748,11 +1748,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1764,11 +1764,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='[null,null]'
+@ids='[null,null]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1794,19 +1794,19 @@ WHERE c["id"] IN ("ABCDE", "ALFKI")
 
                 AssertSql(
                     """
-@__Order_0='["ABCDE","ALFKI"]'
+@Order='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__Order_0, c["id"])
+WHERE ARRAY_CONTAINS(@Order, c["id"])
 """,
                     //
                     """
-@__Order_0='["ABCDE","ANATR"]'
+@Order='["ABCDE","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__Order_0, c["id"])
+WHERE ARRAY_CONTAINS(@Order, c["id"])
 """);
             });
 
@@ -1818,19 +1818,19 @@ WHERE ARRAY_CONTAINS(@__Order_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """,
                     //
                     """
-@__ids_0='["ABCDE"]'
+@ids='["ABCDE"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1842,11 +1842,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1858,11 +1858,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='[null,null]'
+@ids='[null,null]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -1888,19 +1888,19 @@ WHERE c["id"] IN ("ABCDE", "ALFKI")
 
                 AssertSql(
                     """
-@__AsReadOnly_0='["ABCDE","ALFKI"]'
+@AsReadOnly='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__AsReadOnly_0, c["id"])
+WHERE ARRAY_CONTAINS(@AsReadOnly, c["id"])
 """,
                     //
                     """
-@__AsReadOnly_0='["ABCDE","ANATR"]'
+@AsReadOnly='["ABCDE","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__AsReadOnly_0, c["id"])
+WHERE ARRAY_CONTAINS(@AsReadOnly, c["id"])
 """);
             });
 
@@ -1912,11 +1912,11 @@ WHERE ARRAY_CONTAINS(@__AsReadOnly_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE NOT(ARRAY_CONTAINS(@ids, c["id"]))
 """);
             });
 
@@ -1928,11 +1928,11 @@ WHERE NOT(ARRAY_CONTAINS(@__ids_0, c["id"]))
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) AND ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) AND ARRAY_CONTAINS(@ids, c["id"]))
 """);
             });
 
@@ -1944,11 +1944,11 @@ WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) AND ARRAY_CONTAINS(@__ids_0,
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")))
+WHERE (ARRAY_CONTAINS(@ids, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")))
 """);
             });
 
@@ -1960,11 +1960,11 @@ WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) OR NOT(ARRAY_CONTAINS(@__ids_0, c["id"])))
+WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) OR NOT(ARRAY_CONTAINS(@ids, c["id"])))
 """);
             });
 
@@ -1976,11 +1976,11 @@ WHERE (((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")) OR NOT(ARRAY_CONTAINS(@__ids
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI"]'
+@ids='["ABCDE","ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) AND ((c["id"] != "ALFKI") AND (c["id"] != "ABCDE")))
+WHERE (ARRAY_CONTAINS(@ids, c["id"]) AND ((c["id"] != "ALFKI") AND (c["id"] != "ABCDE")))
 """);
             });
 
@@ -1992,11 +1992,11 @@ WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) AND ((c["id"] != "ALFKI") AND (c["id"] 
 
                 AssertSql(
                     """
-@__ids_0='["ALFKI","ABC')); GO; DROP TABLE Orders; GO; --"]'
+@ids='["ALFKI","ABC')); GO; DROP TABLE Orders; GO; --"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")))
+WHERE (ARRAY_CONTAINS(@ids, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "ABCDE")))
 """);
             });
 
@@ -2008,11 +2008,11 @@ WHERE (ARRAY_CONTAINS(@__ids_0, c["id"]) OR ((c["id"] = "ALFKI") OR (c["id"] = "
 
                 AssertSql(
                     """
-@__ids_0='[]'
+@ids='[]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -2042,12 +2042,12 @@ WHERE NOT(false)
 
             AssertSql(
                 """
-@__p_0='ALFKI'
+@p='ALFKI'
 
 SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE (c["id"] = @__p_0))
+    WHERE (c["id"] = @p))
 """);
         }
     }
@@ -2254,11 +2254,11 @@ WHERE (c["id"] = "ALFKI")
 
                 AssertSql(
                     """
-@__ids_0='["ALFKI"]'
+@ids='["ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -2270,11 +2270,11 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ALFKI"]'
+@ids='["ALFKI"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -2291,12 +2291,12 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
             AssertSql(
                 """
-@__entity_equality_p_0_OrderID=null
+@entity_equality_p_OrderID=null
 
 SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
-    WHERE (((c["$type"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @__entity_equality_p_0_OrderID)))
+    WHERE (((c["$type"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @entity_equality_p_OrderID)))
 """);
         }
     }
@@ -2343,11 +2343,11 @@ FROM root c
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -2373,11 +2373,11 @@ WHERE c["id"] IN ("ABCDE", "ALFKI", "ANATR")
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
+WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
@@ -2389,19 +2389,19 @@ WHERE ARRAY_CONTAINS(@__ids_0, c["id"])
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["City"] = "México D.F.") AND ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE ((c["City"] = "México D.F.") AND ARRAY_CONTAINS(@ids, c["id"]))
 """,
                     //
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["City"] = "México D.F.") AND ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE ((c["City"] = "México D.F.") AND ARRAY_CONTAINS(@ids, c["id"]))
 """);
             });
 
@@ -2413,11 +2413,11 @@ WHERE ((c["City"] = "México D.F.") AND ARRAY_CONTAINS(@__ids_0, c["id"]))
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE NOT(ARRAY_CONTAINS(@ids, c["id"]))
 """);
             });
 
@@ -2443,11 +2443,11 @@ WHERE c["id"] NOT IN ("ABCDE", "ALFKI", "ANATR")
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ids_0, c["id"]))
+WHERE NOT(ARRAY_CONTAINS(@ids, c["id"]))
 """);
             });
 
@@ -2459,19 +2459,19 @@ WHERE NOT(ARRAY_CONTAINS(@__ids_0, c["id"]))
 
                 AssertSql(
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["City"] = "México D.F.") AND NOT(ARRAY_CONTAINS(@__ids_0, c["id"])))
+WHERE ((c["City"] = "México D.F.") AND NOT(ARRAY_CONTAINS(@ids, c["id"])))
 """,
                     //
                     """
-@__ids_0='["ABCDE","ALFKI","ANATR"]'
+@ids='["ABCDE","ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["City"] = "México D.F.") AND NOT(ARRAY_CONTAINS(@__ids_0, c["id"])))
+WHERE ((c["City"] = "México D.F.") AND NOT(ARRAY_CONTAINS(@ids, c["id"])))
 """);
             });
 
@@ -2690,9 +2690,9 @@ FROM root c
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
-SELECT VALUE AVG((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1.0 : 0.0))
+SELECT VALUE AVG((ARRAY_CONTAINS(@cities, c["City"]) ? 1.0 : 0.0))
 FROM root c
 """);
             });
@@ -2705,9 +2705,9 @@ FROM root c
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
-SELECT VALUE SUM((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
+SELECT VALUE SUM((ARRAY_CONTAINS(@cities, c["City"]) ? 1 : 0))
 FROM root c
 """);
             });
@@ -2720,11 +2720,11 @@ FROM root c
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
 SELECT VALUE COUNT(1)
 FROM root c
-WHERE ARRAY_CONTAINS(@__cities_0, c["City"])
+WHERE ARRAY_CONTAINS(@cities, c["City"])
 """);
             });
 
@@ -2736,11 +2736,11 @@ WHERE ARRAY_CONTAINS(@__cities_0, c["City"])
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
 SELECT VALUE COUNT(1)
 FROM root c
-WHERE ARRAY_CONTAINS(@__cities_0, c["City"])
+WHERE ARRAY_CONTAINS(@cities, c["City"])
 """);
             });
 
@@ -2752,9 +2752,9 @@ WHERE ARRAY_CONTAINS(@__cities_0, c["City"])
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
-SELECT VALUE MAX((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
+SELECT VALUE MAX((ARRAY_CONTAINS(@cities, c["City"]) ? 1 : 0))
 FROM root c
 """);
             });
@@ -2767,9 +2767,9 @@ FROM root c
 
                 AssertSql(
                     """
-@__cities_0='["London","Berlin"]'
+@cities='["London","Berlin"]'
 
-SELECT VALUE MIN((ARRAY_CONTAINS(@__cities_0, c["City"]) ? 1 : 0))
+SELECT VALUE MIN((ARRAY_CONTAINS(@cities, c["City"]) ? 1 : 0))
 FROM root c
 """);
             });

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -48,11 +48,11 @@ WHERE STARTSWITH(c["ContactName"], "M")
 
                 AssertSql(
                     """
-@__pattern_0='M'
+@pattern='M'
 
 SELECT VALUE c
 FROM root c
-WHERE STARTSWITH(c["ContactName"], @__pattern_0)
+WHERE STARTSWITH(c["ContactName"], @pattern)
 """);
             });
 
@@ -161,11 +161,11 @@ WHERE ENDSWITH(c["ContactName"], "b")
 
                 AssertSql(
                     """
-@__pattern_0='b'
+@pattern='b'
 
 SELECT VALUE c
 FROM root c
-WHERE ENDSWITH(c["ContactName"], @__pattern_0)
+WHERE ENDSWITH(c["ContactName"], @pattern)
 """);
             });
 
@@ -1256,11 +1256,11 @@ WHERE (INDEX_OF(c["ContactName"], "a") = 1)
 
                 AssertSql(
                     """
-@__pattern_0='a'
+@pattern='a'
 
 SELECT VALUE c
 FROM root c
-WHERE (INDEX_OF(c["ContactName"], @__pattern_0) = 1)
+WHERE (INDEX_OF(c["ContactName"], @pattern) = 1)
 """);
             });
 
@@ -1286,11 +1286,11 @@ WHERE (INDEX_OF(c["ContactName"], "a", 2) = 4)
 
                 AssertSql(
                     """
-@__start_0='2'
+@start='2'
 
 SELECT VALUE c
 FROM root c
-WHERE (INDEX_OF(c["ContactName"], "a", @__start_0) = 4)
+WHERE (INDEX_OF(c["ContactName"], "a", @start) = 4)
 """);
             });
 
@@ -1358,11 +1358,11 @@ WHERE (SUBSTRING(c["id"], 1, LENGTH(c["id"])) = "LFKI")
 
                 AssertSql(
                     """
-@__start_0='2'
+@start='2'
 
 SELECT VALUE c["ContactName"]
 FROM root c
-WHERE (SUBSTRING(c["id"], @__start_0, LENGTH(c["id"])) = "FKI")
+WHERE (SUBSTRING(c["id"], @start, LENGTH(c["id"])) = "FKI")
 """);
             });
 
@@ -1416,9 +1416,9 @@ WHERE (c["id"] = "ALFKI")
 
                 AssertSql(
                     """
-@__start_0='2'
+@start='2'
 
-SELECT VALUE SUBSTRING(c["ContactName"], @__start_0, 3)
+SELECT VALUE SUBSTRING(c["ContactName"], @start, 3)
 FROM root c
 WHERE (c["id"] = "ALFKI")
 """);
@@ -1629,11 +1629,11 @@ ORDER BY LENGTH(c["id"]), c["id"]
 
                 AssertSql(
                     """
-@__arg_0='1996-07-04T00:00:00'
+@arg='1996-07-04T00:00:00'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["OrderDate"] = @__arg_0))
+WHERE ((c["$type"] = "Order") AND (c["OrderDate"] = @arg))
 """);
             });
 
@@ -1955,11 +1955,11 @@ WHERE CONTAINS(c["ContactName"], "     ")
 
                 AssertSql(
                     """
-@__pattern_0='     '
+@pattern='     '
 
 SELECT VALUE c
 FROM root c
-WHERE CONTAINS(c["ContactName"], @__pattern_0)
+WHERE CONTAINS(c["ContactName"], @pattern)
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -111,11 +111,11 @@ WHERE (c["id"] = c["id"])
 
                 AssertSql(
                     """
-@__entity_equality_local_0_CustomerID='ANATR'
+@entity_equality_local_CustomerID='ANATR'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE (c["id"] = @__entity_equality_local_0_CustomerID)
+WHERE (c["id"] = @entity_equality_local_CustomerID)
 """);
             });
 
@@ -556,13 +556,13 @@ ORDER BY ((c["UnitsInStock"] > 10) ? (c["ProductID"] > 40) : (c["ProductID"] <= 
 
                 AssertSql(
                     """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["ContactName"]
-OFFSET @__p_0 LIMIT @__p_1
+OFFSET @p LIMIT @p0
 """);
             });
 
@@ -687,11 +687,11 @@ FROM root c
 
                 AssertSql(
                     """
-@__p_0='91'
+@p='91'
 
 SELECT VALUE c["City"]
 FROM root c
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -703,11 +703,11 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-@__p_0='91'
+@p='91'
 
 SELECT VALUE c
 FROM root c
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -719,12 +719,12 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-@__p_0='10'
+@p='10'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -735,12 +735,12 @@ OFFSET 0 LIMIT @__p_0
                 await base.Take_simple_parameterized(a);
                 AssertSql(
                     """
-@__p_0='10'
+@p='10'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -751,12 +751,12 @@ OFFSET 0 LIMIT @__p_0
                 await base.Take_simple_projection(a);
                 AssertSql(
                     """
-@__p_0='10'
+@p='10'
 
 SELECT VALUE c["City"]
 FROM root c
 ORDER BY c["id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -767,12 +767,12 @@ OFFSET 0 LIMIT @__p_0
                 await base.Take_subquery_projection(a);
                 AssertSql(
                     """
-@__p_0='2'
+@p='2'
 
 SELECT VALUE c["City"]
 FROM root c
 ORDER BY c["id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -1297,14 +1297,14 @@ SELECT VALUE EXISTS (
 
             AssertSql(
                 """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT VALUE EXISTS (
     SELECT 1
     FROM root c
     ORDER BY c["ContactName"]
-    OFFSET @__p_0 LIMIT @__p_1)
+    OFFSET @p LIMIT @p0)
 """);
         }
     }
@@ -1394,11 +1394,11 @@ ORDER BY 3
 
             AssertSql(
                 """
-@__param_0='5'
+@param='5'
 
 SELECT VALUE c
 FROM root c
-ORDER BY @__param_0
+ORDER BY @param
 """);
         }
     }
@@ -1856,7 +1856,7 @@ WHERE (((c["ContactName"] != null) ? c["ContactName"] : c["CompanyName"]) = "Liz
 
             AssertSql(
                 """
-@__p_0='5'
+@p='5'
 
 SELECT VALUE
 {
@@ -1866,7 +1866,7 @@ SELECT VALUE
 }
 FROM root c
 ORDER BY ((c["Region"] != null) ? c["Region"] : "ZZ")
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
         }
     }
@@ -1937,11 +1937,11 @@ WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 
                 AssertSql(
                     """
-@__Parse_0='1998-01-01T12:00:00'
+@Parse='1998-01-01T12:00:00'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @__Parse_0))
+WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @Parse))
 """);
             });
 
@@ -1967,19 +1967,19 @@ WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > "1998-01-01T12:00:00"))
 
                 AssertSql(
                     """
-@__p_0='1998-01-01T12:00:00'
+@p='1998-01-01T12:00:00'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @__p_0))
+WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @p))
 """,
                     //
                     """
-@__p_0='1998-01-01T11:00:00'
+@p='1998-01-01T11:00:00'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @__p_0))
+WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @p))
 """);
             });
 
@@ -2038,14 +2038,14 @@ WHERE ((c["$type"] = "Order") AND (c["OrderDate"] > @__p_0))
                 await base.Environment_newline_is_funcletized(a);
 
                 var sql = Fixture.TestSqlLoggerFactory.SqlStatements[0];
-                Assert.StartsWith("@__NewLine_0='", sql);
+                Assert.StartsWith("@NewLine='", sql);
                 Assert.EndsWith(
                     """
 '
 
 SELECT VALUE c
 FROM root c
-WHERE CONTAINS(c["id"], @__NewLine_0)
+WHERE CONTAINS(c["id"], @NewLine)
 """,
                     sql);
             });
@@ -2212,11 +2212,11 @@ WHERE (((c["id"] = "ALFKI") & (c["id"] = "ANATR")) OR (c["id"] = "ANTON"))
 
                 AssertSql(
                     """
-@__negatedId_0='-10249'
+@negatedId='-10249'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (~(c["OrderID"]) = @__negatedId_0))
+WHERE ((c["$type"] = "Order") AND (~(c["OrderID"]) = @negatedId))
 """);
             });
 
@@ -2319,12 +2319,12 @@ ORDER BY c["id"]
                 // Optimize query SQL. Issue #13159.
                 AssertSql(
                     """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
+WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @dateFilter_Value_Month)) AND (DateTimePart("yyyy", c["OrderDate"]) = @dateFilter_Value_Year))))
 """,
                     //
                     """
@@ -2343,12 +2343,12 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] < 10400))
                 // Optimize query SQL. Issue #13159.
                 AssertSql(
                     """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
+WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) AND (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @dateFilter_Value_Month)) AND (DateTimePart("yyyy", c["OrderDate"]) = @dateFilter_Value_Year))))
 """,
                     //
                     """
@@ -2367,12 +2367,12 @@ WHERE ((c["$type"] = "Order") AND false)
                 // Optimize query SQL. Issue #13159.
                 AssertSql(
                     """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) OR (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @__dateFilter_Value_Month_0)) AND (DateTimePart("yyyy", c["OrderDate"]) = @__dateFilter_Value_Year_1))))
+WHERE ((c["$type"] = "Order") AND ((c["OrderID"] < 10400) OR (((c["OrderDate"] != null) AND (DateTimePart("mm", c["OrderDate"]) = @dateFilter_Value_Month)) AND (DateTimePart("yyyy", c["OrderDate"]) = @dateFilter_Value_Year))))
 """,
                     //
                     """
@@ -2595,11 +2595,11 @@ ORDER BY c["OrderID"]
 
                 AssertSql(
                     """
-@__nextYear_0='2017'
+@nextYear='2017'
 
 SELECT DISTINCT VALUE DateTimePart("yyyy", c["OrderDate"])
 FROM root c
-WHERE (((c["$type"] = "Order") AND (c["OrderDate"] != null)) AND (DateTimePart("yyyy", c["OrderDate"]) < @__nextYear_0))
+WHERE (((c["$type"] = "Order") AND (c["OrderDate"] != null)) AND (DateTimePart("yyyy", c["OrderDate"]) < @nextYear))
 """);
             });
 
@@ -2655,13 +2655,13 @@ WHERE (((c["$type"] = "Order") AND (c["OrderDate"] != null)) AND (DateTimePart("
 
             AssertSql(
                 """
-@__p_0='5'
-@__p_1='8'
+@p='5'
+@p0='8'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["ContactTitle"], c["ContactName"]
-OFFSET @__p_0 LIMIT @__p_1
+OFFSET @p LIMIT @p0
 """);
         }
     }
@@ -3201,11 +3201,11 @@ ORDER BY (c["id"] || c["City"])
                 await base.Comparing_to_fixed_string_parameter(a);
                 AssertSql(
                     """
-@__prefix_0='A'
+@prefix='A'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE STARTSWITH(c["id"], @__prefix_0)
+WHERE STARTSWITH(c["id"], @prefix)
 """);
             });
 
@@ -3385,13 +3385,13 @@ ORDER BY c["id"] DESC
                 await base.OrderBy_Dto_projection_skip_take(a);
                 AssertSql(
                     """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT VALUE c["id"]
 FROM root c
 ORDER BY c["id"]
-OFFSET @__p_0 LIMIT @__p_1
+OFFSET @p LIMIT @p0
 """);
             });
 
@@ -3412,11 +3412,11 @@ OFFSET @__p_0 LIMIT @__p_1
                 async () => await base.OrderBy_empty_list_contains(async));
             AssertSql(
                 """
-@__list_0='[]'
+@list='[]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY ARRAY_CONTAINS(@__list_0, c["id"])
+ORDER BY ARRAY_CONTAINS(@list, c["id"])
 """);
         }
     }
@@ -3431,11 +3431,11 @@ ORDER BY ARRAY_CONTAINS(@__list_0, c["id"])
 
             AssertSql(
                 """
-@__list_0='[]'
+@list='[]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY NOT(ARRAY_CONTAINS(@__list_0, c["id"]))
+ORDER BY NOT(ARRAY_CONTAINS(@list, c["id"]))
 """);
         }
     }
@@ -3765,11 +3765,11 @@ FROM root c
                 await base.Where_Property_when_shadow_unconstrained_generic_method(a);
                 AssertSql(
                     """
-@__value_0='Sales Representative'
+@value='Sales Representative'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["Title"] = @__value_0)
+WHERE (c["Title"] = @value)
 """);
             });
 
@@ -4496,19 +4496,19 @@ FROM root c
                 await base.Where_Property_shadow_closure(a);
                 AssertSql(
                     """
-@__value_0='Sales Representative'
+@value='Sales Representative'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["Title"] = @__value_0)
+WHERE (c["Title"] = @value)
 """,
                     //
                     """
-@__value_0='Steven'
+@value='Steven'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["FirstName"] = @__value_0)
+WHERE (c["FirstName"] = @value)
 """);
             });
 
@@ -4520,11 +4520,11 @@ WHERE (c["FirstName"] = @__value_0)
 
                 AssertSql(
                     """
-@__entity_equality_local_0_CustomerID='ANATR'
+@entity_equality_local_CustomerID='ANATR'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE ((c["id"] = @__entity_equality_local_0_CustomerID) AND (@__entity_equality_local_0_CustomerID = c["id"]))
+WHERE ((c["id"] = @entity_equality_local_CustomerID) AND (@entity_equality_local_CustomerID = c["id"]))
 """);
             });
 
@@ -4710,21 +4710,21 @@ FROM root c
 
                 AssertSql(
                     """
-@__p_0='0'
+@p='0'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["id"]
-OFFSET @__p_0 LIMIT @__p_0
+OFFSET @p LIMIT @p
 """,
                     //
                     """
-@__p_0='1'
+@p='1'
 
 SELECT VALUE c
 FROM root c
 ORDER BY c["id"]
-OFFSET @__p_0 LIMIT @__p_0
+OFFSET @p LIMIT @p
 """);
             });
 
@@ -4980,11 +4980,11 @@ OFFSET @__p_0 LIMIT @__p_0
                 await base.Contains_over_concatenated_columns_with_different_sizes(a);
                 AssertSql(
                     """
-@__data_0='["ALFKIAlfreds Futterkiste","ANATRAna Trujillo Emparedados y helados"]'
+@data='["ALFKIAlfreds Futterkiste","ANATRAna Trujillo Emparedados y helados"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__data_0, (c["id"] || c["CompanyName"]))
+WHERE ARRAY_CONTAINS(@data, (c["id"] || c["CompanyName"]))
 """);
             });
 
@@ -4996,11 +4996,11 @@ WHERE ARRAY_CONTAINS(@__data_0, (c["id"] || c["CompanyName"]))
 
                 AssertSql(
                     """
-@__data_0='["ALFKISomeConstant","ANATRSomeConstant","ALFKIX"]'
+@data='["ALFKISomeConstant","ANATRSomeConstant","ALFKIX"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__data_0, (c["id"] || "SomeConstant"))
+WHERE ARRAY_CONTAINS(@data, (c["id"] || "SomeConstant"))
 """);
             });
 
@@ -5019,12 +5019,12 @@ WHERE ARRAY_CONTAINS(@__data_0, (c["id"] || "SomeConstant"))
                 await base.Contains_over_concatenated_column_and_parameter(a);
                 AssertSql(
                     """
-@__data_1='["ALFKISomeVariable","ANATRSomeVariable","ALFKIX"]'
-@__someVariable_0='SomeVariable'
+@data='["ALFKISomeVariable","ANATRSomeVariable","ALFKIX"]'
+@someVariable='SomeVariable'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__data_1, (c["id"] || @__someVariable_0))
+WHERE ARRAY_CONTAINS(@data, (c["id"] || @someVariable))
 """);
             });
 
@@ -5036,11 +5036,11 @@ WHERE ARRAY_CONTAINS(@__data_1, (c["id"] || @__someVariable_0))
 
                 AssertSql(
                     """
-@__Contains_0='true'
+@Contains='true'
 
 SELECT VALUE c
 FROM root c
-WHERE @__Contains_0
+WHERE @Contains
 """);
             });
 
@@ -5051,12 +5051,12 @@ WHERE @__Contains_0
                 await base.Compiler_generated_local_closure_produces_valid_parameter_name(a);
                 AssertSql(
                     """
-@__customerId_0='ALFKI'
-@__details_City_1='Berlin'
+@customerId='ALFKI'
+@details_City='Berlin'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["id"] = @__customerId_0) AND (c["City"] = @__details_City_1))
+WHERE ((c["id"] = @customerId) AND (c["City"] = @details_City))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -203,11 +203,11 @@ WHERE (c["EmployeeID"] = 1)
 
             AssertSql(
                 """
-@__boolean_0='false'
+@boolean='false'
 
-SELECT VALUE @__boolean_0
+SELECT VALUE @boolean
 FROM root c
-ORDER BY @__boolean_0
+ORDER BY @boolean
 """);
         }
     }
@@ -359,9 +359,9 @@ FROM root c
                 await base.Select_local(a);
                 AssertSql(
                     """
-@__x_0='10'
+@x='10'
 
-SELECT VALUE @__x_0
+SELECT VALUE @x
 FROM root c
 """);
             });
@@ -374,11 +374,11 @@ FROM root c
 
                 AssertSql(
                     """
-@__p_0='9'
+@p='9'
 
 SELECT VALUE c["EmployeeID"]
 FROM root c
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -1402,12 +1402,12 @@ ORDER BY c["id"]
                 await base.Projection_take_projection_doesnt_project_intermittent_column(a);
                 AssertSql(
                     """
-@__p_0='10'
+@p='10'
 
 SELECT VALUE ((c["id"] || " ") || c["City"])
 FROM root c
 ORDER BY c["id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -488,11 +488,11 @@ WHERE (c["City"] = "London")
 
                 AssertSql(
                     """
-@__city_0='London'
+@city='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_0)
+WHERE (c["City"] = @city)
 """);
             });
 
@@ -507,11 +507,11 @@ WHERE (c["City"] = @__city_0)
 
                 AssertSql(
                     """
-@__p_0='London'
+@p='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__p_0)
+WHERE (c["City"] = @p)
 """);
             });
 
@@ -523,11 +523,11 @@ WHERE (c["City"] = @__p_0)
 
                 AssertSql(
                     """
-@__get_Item_0='London'
+@get_Item='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__get_Item_0)
+WHERE (c["City"] = @get_Item)
 """);
             });
 
@@ -539,11 +539,11 @@ WHERE (c["City"] = @__get_Item_0)
 
                 AssertSql(
                     """
-@__predicateTuple_Item2_0='London'
+@predicateTuple_Item2='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__predicateTuple_Item2_0)
+WHERE (c["City"] = @predicateTuple_Item2)
 """);
             });
 
@@ -555,11 +555,11 @@ WHERE (c["City"] = @__predicateTuple_Item2_0)
 
                 AssertSql(
                     """
-@__predicateTuple_Item2_0='London'
+@predicateTuple_Item2='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__predicateTuple_Item2_0)
+WHERE (c["City"] = @predicateTuple_Item2)
 """);
             });
 
@@ -571,11 +571,11 @@ WHERE (c["City"] = @__predicateTuple_Item2_0)
 
                 AssertSql(
                     """
-@__predicate_0='true'
+@predicate='true'
 
 SELECT VALUE c
 FROM root c
-WHERE @__predicate_0
+WHERE @predicate
 """);
             });
 
@@ -587,19 +587,19 @@ WHERE @__predicate_0
 
                 AssertSql(
                     """
-@__city_0='London'
+@city='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_0)
+WHERE (c["City"] = @city)
 """,
                     //
                     """
-@__city_0='Seattle'
+@city='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_0)
+WHERE (c["City"] = @city)
 """);
             });
 
@@ -627,19 +627,19 @@ WHERE (c["City"] = @__city_0)
 
                 AssertSql(
                     """
-@__GetCity_0='London'
+@GetCity='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__GetCity_0)
+WHERE (c["City"] = @GetCity)
 """,
                     //
                     """
-@__GetCity_0='Seattle'
+@GetCity='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__GetCity_0)
+WHERE (c["City"] = @GetCity)
 """);
             });
 
@@ -651,19 +651,19 @@ WHERE (c["City"] = @__GetCity_0)
 
                 AssertSql(
                     """
-@__city_InstanceFieldValue_0='London'
+@city_InstanceFieldValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_InstanceFieldValue_0)
+WHERE (c["City"] = @city_InstanceFieldValue)
 """,
                     //
                     """
-@__city_InstanceFieldValue_0='Seattle'
+@city_InstanceFieldValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_InstanceFieldValue_0)
+WHERE (c["City"] = @city_InstanceFieldValue)
 """);
             });
 
@@ -675,19 +675,19 @@ WHERE (c["City"] = @__city_InstanceFieldValue_0)
 
                 AssertSql(
                     """
-@__city_InstancePropertyValue_0='London'
+@city_InstancePropertyValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_InstancePropertyValue_0)
+WHERE (c["City"] = @city_InstancePropertyValue)
 """,
                     //
                     """
-@__city_InstancePropertyValue_0='Seattle'
+@city_InstancePropertyValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_InstancePropertyValue_0)
+WHERE (c["City"] = @city_InstancePropertyValue)
 """);
             });
 
@@ -699,19 +699,19 @@ WHERE (c["City"] = @__city_InstancePropertyValue_0)
 
                 AssertSql(
                     """
-@__StaticFieldValue_0='London'
+@StaticFieldValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__StaticFieldValue_0)
+WHERE (c["City"] = @StaticFieldValue)
 """,
                     //
                     """
-@__StaticFieldValue_0='Seattle'
+@StaticFieldValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__StaticFieldValue_0)
+WHERE (c["City"] = @StaticFieldValue)
 """);
             });
 
@@ -723,19 +723,19 @@ WHERE (c["City"] = @__StaticFieldValue_0)
 
                 AssertSql(
                     """
-@__StaticPropertyValue_0='London'
+@StaticPropertyValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__StaticPropertyValue_0)
+WHERE (c["City"] = @StaticPropertyValue)
 """,
                     //
                     """
-@__StaticPropertyValue_0='Seattle'
+@StaticPropertyValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__StaticPropertyValue_0)
+WHERE (c["City"] = @StaticPropertyValue)
 """);
             });
 
@@ -747,19 +747,19 @@ WHERE (c["City"] = @__StaticPropertyValue_0)
 
                 AssertSql(
                     """
-@__city_Nested_InstanceFieldValue_0='London'
+@city_Nested_InstanceFieldValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_Nested_InstanceFieldValue_0)
+WHERE (c["City"] = @city_Nested_InstanceFieldValue)
 """,
                     //
                     """
-@__city_Nested_InstanceFieldValue_0='Seattle'
+@city_Nested_InstanceFieldValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_Nested_InstanceFieldValue_0)
+WHERE (c["City"] = @city_Nested_InstanceFieldValue)
 """);
             });
 
@@ -771,19 +771,19 @@ WHERE (c["City"] = @__city_Nested_InstanceFieldValue_0)
 
                 AssertSql(
                     """
-@__city_Nested_InstancePropertyValue_0='London'
+@city_Nested_InstancePropertyValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_Nested_InstancePropertyValue_0)
+WHERE (c["City"] = @city_Nested_InstancePropertyValue)
 """,
                     //
                     """
-@__city_Nested_InstancePropertyValue_0='Seattle'
+@city_Nested_InstancePropertyValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_Nested_InstancePropertyValue_0)
+WHERE (c["City"] = @city_Nested_InstancePropertyValue)
 """);
             });
 
@@ -795,19 +795,19 @@ WHERE (c["City"] = @__city_Nested_InstancePropertyValue_0)
 
                 AssertSql(
                     """
-@__InstanceFieldValue_0='London'
+@InstanceFieldValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__InstanceFieldValue_0)
+WHERE (c["City"] = @InstanceFieldValue)
 """,
                     //
                     """
-@__InstanceFieldValue_0='Seattle'
+@InstanceFieldValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__InstanceFieldValue_0)
+WHERE (c["City"] = @InstanceFieldValue)
 """);
             });
 
@@ -819,19 +819,19 @@ WHERE (c["City"] = @__InstanceFieldValue_0)
 
                 AssertSql(
                     """
-@__InstanceFieldValue_0='London'
+@InstanceFieldValue='London'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__InstanceFieldValue_0)
+WHERE (c["City"] = @InstanceFieldValue)
 """,
                     //
                     """
-@__InstanceFieldValue_0='Seattle'
+@InstanceFieldValue='Seattle'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__InstanceFieldValue_0)
+WHERE (c["City"] = @InstanceFieldValue)
 """);
             });
 
@@ -1054,19 +1054,19 @@ WHERE false
 
                 AssertSql(
                     """
-@__intPrm_0='2'
+@intPrm='2'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["ReportsTo"] = @__intPrm_0)
+WHERE (c["ReportsTo"] = @intPrm)
 """,
                     //
                     """
-@__intPrm_0='2'
+@intPrm='2'
 
 SELECT VALUE c
 FROM root c
-WHERE (@__intPrm_0 = c["ReportsTo"])
+WHERE (@intPrm = c["ReportsTo"])
 """);
             });
 
@@ -1078,19 +1078,19 @@ WHERE (@__intPrm_0 = c["ReportsTo"])
 
                 AssertSql(
                     """
-@__nullableIntPrm_0='2'
+@nullableIntPrm='2'
 
 SELECT VALUE c
 FROM root c
-WHERE (@__nullableIntPrm_0 = c["ReportsTo"])
+WHERE (@nullableIntPrm = c["ReportsTo"])
 """,
                     //
                     """
-@__nullableIntPrm_0='2'
+@nullableIntPrm='2'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["ReportsTo"] = @__nullableIntPrm_0)
+WHERE (c["ReportsTo"] = @nullableIntPrm)
 """);
             });
 
@@ -1102,19 +1102,19 @@ WHERE (c["ReportsTo"] = @__nullableIntPrm_0)
 
                 AssertSql(
                     """
-@__nullableIntPrm_0=null
+@nullableIntPrm=null
 
 SELECT VALUE c
 FROM root c
-WHERE (@__nullableIntPrm_0 = c["ReportsTo"])
+WHERE (@nullableIntPrm = c["ReportsTo"])
 """,
                     //
                     """
-@__nullableIntPrm_0=null
+@nullableIntPrm=null
 
 SELECT VALUE c
 FROM root c
-WHERE (c["ReportsTo"] = @__nullableIntPrm_0)
+WHERE (c["ReportsTo"] = @nullableIntPrm)
 """);
             });
 
@@ -1218,11 +1218,11 @@ WHERE (SUBSTRING(c["City"], 1, 2) = "ea")
 
                 AssertSql(
                     """
-@__myDatetime_0='2015-04-10T00:00:00'
+@myDatetime='2015-04-10T00:00:00'
 
 SELECT VALUE c
 FROM root c
-WHERE (GetCurrentDateTime() != @__myDatetime_0)
+WHERE (GetCurrentDateTime() != @myDatetime)
 """);
             });
 
@@ -1234,11 +1234,11 @@ WHERE (GetCurrentDateTime() != @__myDatetime_0)
 
                 AssertSql(
                     """
-@__myDatetimeOffset_0='2015-04-10T00:00:00-08:00'
+@myDatetimeOffset='2015-04-10T00:00:00-08:00'
 
 SELECT VALUE c
 FROM root c
-WHERE (GetCurrentDateTime() != @__myDatetimeOffset_0)
+WHERE (GetCurrentDateTime() != @myDatetimeOffset)
 """);
             });
 
@@ -1725,11 +1725,11 @@ WHERE ((c["$type"] = "Product") AND (NOT(c["Discontinued"]) = (c["ProductID"] > 
 
                 AssertSql(
                     """
-@__prm_0='true'
+@prm='true'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Product") AND @__prm_0)
+WHERE ((c["$type"] = "Product") AND @prm)
 """);
             });
 
@@ -1741,11 +1741,11 @@ WHERE ((c["$type"] = "Product") AND @__prm_0)
 
                 AssertSql(
                     """
-@__prm_0='true'
+@prm='true'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Product") AND ((c["ProductID"] > 50) != @__prm_0))
+WHERE ((c["$type"] = "Product") AND ((c["ProductID"] > 50) != @prm))
 """);
             });
 
@@ -1757,11 +1757,11 @@ WHERE ((c["$type"] = "Product") AND ((c["ProductID"] > 50) != @__prm_0))
 
                 AssertSql(
                     """
-@__prm_0='true'
+@prm='true'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Product") AND (c["Discontinued"] = ((c["ProductID"] > 50) != @__prm_0)))
+WHERE ((c["$type"] = "Product") AND (c["Discontinued"] = ((c["ProductID"] > 50) != @prm)))
 """);
             });
 
@@ -1963,11 +1963,11 @@ WHERE (c["Fax"] = null)
 
                 AssertSql(
                     """
-@__i_0='A'
+@i='A'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE ((@__i_0 || c["id"]) = "AAROUT")
+WHERE ((@i || c["id"]) = "AAROUT")
 """);
             });
 
@@ -1979,12 +1979,12 @@ WHERE ((@__i_0 || c["id"]) = "AAROUT")
 
                 AssertSql(
                     """
-@__i_0='A'
-@__j_1='B'
+@i='A'
+@j='B'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE ((@__i_0 || (@__j_1 || c["id"])) = "ABANATR")
+WHERE ((@i || (@j || c["id"])) = "ABANATR")
 """);
             });
 
@@ -1996,13 +1996,13 @@ WHERE ((@__i_0 || (@__j_1 || c["id"])) = "ABANATR")
 
                 AssertSql(
                     """
-@__i_0='A'
-@__j_1='B'
-@__k_2='C'
+@i='A'
+@j='B'
+@k='C'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE ((@__i_0 || (@__j_1 || (@__k_2 || c["id"]))) = "ABCANTON")
+WHERE ((@i || (@j || (@k || c["id"]))) = "ABCANTON")
 """);
             });
 
@@ -2042,11 +2042,11 @@ WHERE ((c["$type"] = "Product") AND (c["UnitsInStock"] < 20))
 
                 AssertSql(
                     """
-@__productId_0='15'
+@productId='15'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Product") AND ((c["ProductID"] < @__productId_0) AND (c["UnitsInStock"] >= 20)))
+WHERE ((c["$type"] = "Product") AND ((c["ProductID"] < @productId) AND (c["UnitsInStock"] >= 20)))
 """);
             });
 
@@ -2290,11 +2290,11 @@ WHERE (c["$type"] = "Order")
 
                 AssertSql(
                     """
-@__p_0='false'
+@p='false'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND @__p_0)
+WHERE ((c["$type"] = "Order") AND @p)
 """);
             });
 
@@ -2347,6 +2347,14 @@ WHERE ((c["$type"] = "Product") AND (true ? false : true))
     public override async Task Using_same_parameter_twice_in_query_generates_one_sql_parameter(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Using_same_parameter_twice_in_query_generates_one_sql_parameter(async));
+
+        AssertSql();
+    }
+
+    public override async Task Two_parameters_with_same_name_get_uniquified(bool async)
+    {
+        // Concat with conversion, issue #34963.
         await AssertTranslationFailed(() => base.Using_same_parameter_twice_in_query_generates_one_sql_parameter(async));
 
         AssertSql();
@@ -2496,11 +2504,11 @@ WHERE ((c["$type"] = "Product") AND (true ? false : true))
 
                 AssertSql(
                     """
-@__orderIds_0='[10248,10249]'
+@orderIds='[10248,10249]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
+WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@orderIds, c["OrderID"]))
 """);
             });
 
@@ -2512,11 +2520,11 @@ WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 
                 AssertSql(
                     """
-@__orderIds_0='[10248,10249]'
+@orderIds='[10248,10249]'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
+WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@orderIds, c["OrderID"]))
 """);
             });
 
@@ -2674,11 +2682,11 @@ WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@__orderIds_0, c["OrderID"]))
 
                 AssertSql(
                     """
-@__customerIds_0='["ALFKI","FISSA","WHITC"]'
+@customerIds='["ALFKI","FISSA","WHITC"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__customerIds_0, c["id"]) AND (c["City"] = "Seattle"))
+WHERE (ARRAY_CONTAINS(@customerIds, c["id"]) AND (c["City"] = "Seattle"))
 """);
             });
 
@@ -2690,11 +2698,11 @@ WHERE (ARRAY_CONTAINS(@__customerIds_0, c["id"]) AND (c["City"] = "Seattle"))
 
                 AssertSql(
                     """
-@__customerIds_0='["ALFKI","FISSA"]'
+@customerIds='["ALFKI","FISSA"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__customerIds_0, c["id"]) OR (c["City"] = "Seattle"))
+WHERE (ARRAY_CONTAINS(@customerIds, c["id"]) OR (c["City"] = "Seattle"))
 """);
             });
 
@@ -2858,11 +2866,11 @@ WHERE (c["City"] = "London")
                 await base.Generic_Ilist_contains_translates_to_server(a);
                 AssertSql(
                     """
-@__cities_0='["Seattle"]'
+@cities='["Seattle"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__cities_0, c["City"])
+WHERE ARRAY_CONTAINS(@cities, c["City"])
 """);
             });
 
@@ -2956,13 +2964,13 @@ WHERE (c["id"] NOT IN ("ALFKI", "ANATR") AND c["id"] NOT IN ("ALFKI", "ANTON"))
 
                 AssertSql(
                     """
-@__prm1_0='ALFKI'
-@__prm2_1='ANATR'
-@__prm3_2='ANTON'
+@prm1='ALFKI'
+@prm2='ANATR'
+@prm3='ANTON'
 
 SELECT VALUE c
 FROM root c
-WHERE (((c["id"] != @__prm1_0) AND (c["id"] != @__prm2_1)) AND (c["id"] != @__prm3_2))
+WHERE (((c["id"] != @prm1) AND (c["id"] != @prm2)) AND (c["id"] != @prm3))
 """);
             });
 
@@ -2974,12 +2982,12 @@ WHERE (((c["id"] != @__prm1_0) AND (c["id"] != @__prm2_1)) AND (c["id"] != @__pr
 
                 AssertSql(
                     """
-@__prm1_0='ALFKI'
-@__prm2_1='ANATR'
+@prm1='ALFKI'
+@prm2='ANATR'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["id"] IN (@__prm1_0, @__prm2_1) OR (c["id"] = "ANTON"))
+WHERE (c["id"] IN (@prm1, @prm2) OR (c["id"] = "ANTON"))
 """);
             });
 
@@ -2991,11 +2999,11 @@ WHERE (c["id"] IN (@__prm1_0, @__prm2_1) OR (c["id"] = "ANTON"))
 
                 AssertSql(
                     """
-@__prm_0=null
+@prm=null
 
 SELECT VALUE c
 FROM root c
-WHERE ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = @__prm_0)) OR (c["Region"] = "BC"))
+WHERE ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = @prm)) OR (c["Region"] = "BC"))
 """);
             });
 
@@ -3007,11 +3015,11 @@ WHERE ((((c["Region"] = "WA") OR (c["Region"] = "OR")) OR (c["Region"] = @__prm_
 
                 AssertSql(
                     """
-@__array_0='["ALFKI","ANATR"]'
+@array='["ALFKI","ANATR"]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONTAINS(@__array_0, c["id"]) OR (c["id"] = "ANTON"))
+WHERE (ARRAY_CONTAINS(@array, c["id"]) OR (c["id"] = "ANTON"))
 """);
             });
 
@@ -3023,13 +3031,13 @@ WHERE (ARRAY_CONTAINS(@__array_0, c["id"]) OR (c["id"] = "ANTON"))
 
                 AssertSql(
                     """
-@__prm1_0='ANTON'
-@__array_1='["ALFKI","ANATR"]'
-@__prm2_2='ALFKI'
+@prm1='ANTON'
+@array='["ALFKI","ANATR"]'
+@prm2='ALFKI'
 
 SELECT VALUE c
 FROM root c
-WHERE (((c["id"] = @__prm1_0) OR ARRAY_CONTAINS(@__array_1, c["id"])) OR (c["id"] = @__prm2_2))
+WHERE (((c["id"] = @prm1) OR ARRAY_CONTAINS(@array, c["id"])) OR (c["id"] = @prm2))
 """);
             });
 
@@ -3124,19 +3132,19 @@ WHERE (c["Title"] = "Sales Representative")
                 await base.Where_poco_closure(a);
                 AssertSql(
                     """
-@__entity_equality_customer_0_CustomerID='ALFKI'
+@entity_equality_customer_CustomerID='ALFKI'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE (c["id"] = @__entity_equality_customer_0_CustomerID)
+WHERE (c["id"] = @entity_equality_customer_CustomerID)
 """,
                     //
                     """
-@__entity_equality_customer_0_CustomerID='ANATR'
+@entity_equality_customer_CustomerID='ANATR'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE (c["id"] = @__entity_equality_customer_0_CustomerID)
+WHERE (c["id"] = @entity_equality_customer_CustomerID)
 """);
             });
 
@@ -3148,11 +3156,11 @@ WHERE (c["id"] = @__entity_equality_customer_0_CustomerID)
 
                 AssertSql(
                     """
-@__i_0='A'
+@i='A'
 
 SELECT VALUE c["id"]
 FROM root c
-WHERE ((@__i_0 || c["id"]) = "AALFKI")
+WHERE ((@i || c["id"]) = "AALFKI")
 """);
             });
 
@@ -3213,11 +3221,11 @@ WHERE ((@__i_0 || c["id"]) = "AALFKI")
 
                 AssertSql(
                     """
-@__id_0='ALF'
+@id='ALF'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["id"] = (@__id_0 || "KI"))
+WHERE (c["id"] = (@id || "KI"))
 """);
             });
 
@@ -3242,27 +3250,27 @@ WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = "1337"))
 """,
                     //
                     """
-@__prm_Value_0='1337'
+@prm_Value='1337'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @__prm_Value_0))
+WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @prm_Value))
 """,
                     //
                     """
-@__ToString_0='1337'
+@ToString='1337'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @__ToString_0))
+WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @ToString))
 """,
                     //
                     """
-@__p_0='1337'
+@p='1337'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @__p_0))
+WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = @p))
 """,
                     //
                     """
@@ -3280,11 +3288,11 @@ WHERE ((c["$type"] = "Order") AND (c["CustomerID"] = "1337"))
 
                 AssertSql(
                     """
-@__id_0='10252'
+@id='10252'
 
 SELECT VALUE c["OrderID"]
 FROM root c
-WHERE ((c["$type"] = "Order") AND (c["OrderID"] = @__id_0))
+WHERE ((c["$type"] = "Order") AND (c["OrderID"] = @id))
 """,
                     //
                     """

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -866,15 +866,17 @@ ORDER BY c["PersonAddress"]["PlaceType"], c["Id"]
                 await base.Query_on_collection_entry_works_for_owned_collection(a);
 
                 AssertSql(
-                    """ReadItem(None, 1)""",
+                    """
+ReadItem(None, 1)
+""",
                     //
                     """
-@__p_0='1'
+@p='1'
 
 SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
-WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o["ClientId"] = @__p_0))
+WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o["ClientId"] = @p))
 """);
             });
 
@@ -978,14 +980,14 @@ WHERE c["Terminator"] IN ("HeliumBalloon", "HydrogenBalloon")
 
                 AssertSql(
                     """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT VALUE c
 FROM root c
 WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
-OFFSET @__p_0 LIMIT @__p_1
+OFFSET @p LIMIT @p0
 """);
             });
 
@@ -997,14 +999,14 @@ OFFSET @__p_0 LIMIT @__p_1
 
                 AssertSql(
                     """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT VALUE c
 FROM root c
 WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
-OFFSET @__p_0 LIMIT @__p_1
+OFFSET @p LIMIT @p0
 """);
             });
 
@@ -1095,13 +1097,13 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Id
 
                 AssertSql(
                     """
-@__p_0='2'
+@p='2'
 
 SELECT VALUE c
 FROM root c
 WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 
@@ -1115,13 +1117,13 @@ OFFSET 0 LIMIT @__p_0
 
                 AssertSql(
                     """
-@__p_0='2'
+@p='2'
 
 SELECT VALUE c
 FROM root c
 WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 ORDER BY c["Id"]
-OFFSET 0 LIMIT @__p_0
+OFFSET 0 LIMIT @p
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -188,12 +188,12 @@ WHERE c["Id"] IN (2, 999, 1000)
 
                 AssertSql(
                     """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT VALUE c
 FROM root c
-WHERE c["Id"] IN (@__i_0, @__j_1)
+WHERE c["Id"] IN (@i, @j)
 """);
             });
 
@@ -205,11 +205,11 @@ WHERE c["Id"] IN (@__i_0, @__j_1)
 
                 AssertSql(
                     """
-@__j_0='999'
+@j='999'
 
 SELECT VALUE c
 FROM root c
-WHERE c["Id"] IN (2, @__j_0)
+WHERE c["Id"] IN (2, @j)
 """);
             });
 
@@ -221,11 +221,11 @@ WHERE c["Id"] IN (2, @__j_0)
 
                 AssertSql(
                     """
-@__i_0='11'
+@i='11'
 
 SELECT VALUE c
 FROM root c
-WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
+WHERE c["Int"] IN (999, @i, c["Id"], (c["Id"] + c["Int"]))
 """);
             });
 
@@ -237,11 +237,11 @@ WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
 
                 AssertSql(
                     """
-@__i_0='11'
+@i='11'
 
 SELECT VALUE c
 FROM root c
-WHERE c["Int"] IN (999, @__i_0, c["Id"], (c["Id"] + c["Int"]))
+WHERE c["Int"] IN (999, @i, c["Id"], (c["Id"] + c["Int"]))
 """);
             });
 
@@ -345,13 +345,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='25'
+@i='25'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 25)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 25)
 """);
             });
 
@@ -363,13 +363,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='25'
+@i='25'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 25)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 25)
 """);
             });
 
@@ -381,13 +381,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='35'
+@i='35'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 35)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 35)
 """);
             });
 
@@ -399,13 +399,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='35'
+@i='35'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 35)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 35)
 """);
             });
 
@@ -417,13 +417,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='25'
+@i='25'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 25)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 25)
 """);
             });
 
@@ -435,13 +435,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0='35'
+@i='35'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
-    FROM a IN (SELECT VALUE [30, c["Int"], @__i_0])) = 35)
+    FROM a IN (SELECT VALUE [30, c["Int"], @i])) = 35)
 """);
             });
 
@@ -457,13 +457,13 @@ WHERE ((
 
             AssertSql(
                 """
-@__i_0=null
+@i=null
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MIN(a)
-    FROM a IN (SELECT VALUE [30, c["NullableInt"], @__i_0])) = 30)
+    FROM a IN (SELECT VALUE [30, c["NullableInt"], @i])) = 30)
 """);
         }
     }
@@ -476,13 +476,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__i_0=null
+@i=null
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE MAX(a)
-    FROM a IN (SELECT VALUE [30, c["NullableInt"], @__i_0])) = 30)
+    FROM a IN (SELECT VALUE [30, c["NullableInt"], @i])) = 30)
 """);
             });
 
@@ -506,13 +506,13 @@ ReadItem(None, 2)
 
                 AssertSql(
                     """
-@__i_0='2'
+@i='2'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
-    FROM a IN (SELECT VALUE [@__i_0])
+    FROM a IN (SELECT VALUE [@i])
     WHERE (a > c["Id"])) = 1)
 """);
             });
@@ -525,11 +525,11 @@ WHERE ((
 
                 AssertSql(
                     """
-@__p_0='[2,999,1000]'
+@p='[2,999,1000]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__p_0, c["Id"])
+WHERE ARRAY_CONTAINS(@p, c["Id"])
 """);
             });
 
@@ -541,13 +541,13 @@ WHERE ARRAY_CONTAINS(@__p_0, c["Id"])
 
                 AssertSql(
                     """
-@__p_0='[2,999,1000]'
+@p='[2,999,1000]'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
-    FROM p IN (SELECT VALUE @__p_0)
+    FROM p IN (SELECT VALUE @p)
     WHERE (p > c["Id"])) = 2)
 """);
             });
@@ -560,13 +560,13 @@ WHERE ((
 
                 AssertSql(
                     """
-@__ids_0='[2,999]'
+@ids='[2,999]'
 
 SELECT VALUE c
 FROM root c
 WHERE ((
     SELECT VALUE COUNT(1)
-    FROM i IN (SELECT VALUE @__ids_0)
+    FROM i IN (SELECT VALUE @ids)
     WHERE (i > c["Id"])) = 1)
 """);
             });
@@ -579,19 +579,19 @@ WHERE ((
 
                 AssertSql(
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
+WHERE ARRAY_CONTAINS(@ints, c["Int"])
 """,
                     //
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
+WHERE NOT(ARRAY_CONTAINS(@ints, c["Int"]))
 """);
             });
 
@@ -603,19 +603,19 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
 
                 AssertSql(
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
+WHERE ARRAY_CONTAINS(@ints, c["Int"])
 """,
                     //
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
+WHERE NOT(ARRAY_CONTAINS(@ints, c["Int"]))
 """);
             });
 
@@ -627,19 +627,19 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["Int"]))
 
                 AssertSql(
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ints_0, c["NullableInt"])
+WHERE ARRAY_CONTAINS(@ints, c["NullableInt"])
 """,
                     //
                     """
-@__ints_0='[10,999]'
+@ints='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["NullableInt"]))
+WHERE NOT(ARRAY_CONTAINS(@ints, c["NullableInt"]))
 """);
             });
 
@@ -651,19 +651,19 @@ WHERE NOT(ARRAY_CONTAINS(@__ints_0, c["NullableInt"]))
 
                 AssertSql(
                     """
-@__nullableInts_0='[10,999]'
+@nullableInts='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__nullableInts_0, c["Int"])
+WHERE ARRAY_CONTAINS(@nullableInts, c["Int"])
 """,
                     //
                     """
-@__nullableInts_0='[10,999]'
+@nullableInts='[10,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["Int"]))
+WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["Int"]))
 """);
             });
 
@@ -675,19 +675,19 @@ WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["Int"]))
 
                 AssertSql(
                     """
-@__nullableInts_0='[null,999]'
+@nullableInts='[null,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"])
+WHERE ARRAY_CONTAINS(@nullableInts, c["NullableInt"])
 """,
                     //
                     """
-@__nullableInts_0='[null,999]'
+@nullableInts='[null,999]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"]))
+WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["NullableInt"]))
 """);
             });
 
@@ -699,19 +699,19 @@ WHERE NOT(ARRAY_CONTAINS(@__nullableInts_0, c["NullableInt"]))
 
                 AssertSql(
                     """
-@__strings_0='["10","999"]'
+@strings='["10","999"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
+WHERE ARRAY_CONTAINS(@strings, c["String"])
 """,
                     //
                     """
-@__strings_0='["10","999"]'
+@strings='["10","999"]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
+WHERE NOT(ARRAY_CONTAINS(@strings, c["String"]))
 """);
             });
 
@@ -723,19 +723,19 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
 
                 AssertSql(
                     """
-@__strings_0='["10","999"]'
+@strings='["10","999"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
+WHERE ARRAY_CONTAINS(@strings, c["NullableString"])
 """,
                     //
                     """
-@__strings_0='["10","999"]'
+@strings='["10","999"]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
+WHERE NOT(ARRAY_CONTAINS(@strings, c["NullableString"]))
 """);
             });
 
@@ -747,19 +747,19 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
 
                 AssertSql(
                     """
-@__strings_0='["10",null]'
+@strings='["10",null]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_0, c["String"])
+WHERE ARRAY_CONTAINS(@strings, c["String"])
 """,
                     //
                     """
-@__strings_0='["10",null]'
+@strings='["10",null]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
+WHERE NOT(ARRAY_CONTAINS(@strings, c["String"]))
 """);
             });
 
@@ -771,19 +771,19 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["String"]))
 
                 AssertSql(
                     """
-@__strings_0='["999",null]'
+@strings='["999",null]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_0, c["NullableString"])
+WHERE ARRAY_CONTAINS(@strings, c["NullableString"])
 """,
                     //
                     """
-@__strings_0='["999",null]'
+@strings='["999",null]'
 
 SELECT VALUE c
 FROM root c
-WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
+WHERE NOT(ARRAY_CONTAINS(@strings, c["NullableString"]))
 """);
             });
 
@@ -795,11 +795,11 @@ WHERE NOT(ARRAY_CONTAINS(@__strings_0, c["NullableString"]))
 
                 AssertSql(
                     """
-@__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]'
+@dateTimes='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__dateTimes_0, c["DateTime"])
+WHERE ARRAY_CONTAINS(@dateTimes, c["DateTime"])
 """);
             });
 
@@ -811,11 +811,11 @@ WHERE ARRAY_CONTAINS(@__dateTimes_0, c["DateTime"])
 
                 AssertSql(
                     """
-@__bools_0='[true]'
+@bools='[true]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__bools_0, c["Bool"])
+WHERE ARRAY_CONTAINS(@bools, c["Bool"])
 """);
             });
 
@@ -827,11 +827,11 @@ WHERE ARRAY_CONTAINS(@__bools_0, c["Bool"])
 
                 AssertSql(
                     """
-@__enums_0='[0,3]'
+@enums='[0,3]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__enums_0, c["Enum"])
+WHERE ARRAY_CONTAINS(@enums, c["Enum"])
 """);
             });
 
@@ -843,11 +843,11 @@ WHERE ARRAY_CONTAINS(@__enums_0, c["Enum"])
 
                 AssertSql(
                     """
-@__ints_0=null
+@ints=null
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__ints_0, c["Int"])
+WHERE ARRAY_CONTAINS(@ints, c["Int"])
 """);
             });
 
@@ -1176,11 +1176,11 @@ WHERE ([1, c["Int"], 3][c["Int"]] = 1)
 
             AssertSql(
                 """
-@__ints_0='[0,2,3]'
+@ints='[0,2,3]'
 
 SELECT VALUE c
 FROM root c
-WHERE (@__ints_0[c["Int"]] = c["Int"])
+WHERE (@ints[c["Int"]] = c["Int"])
 """);
         }
     }
@@ -1197,11 +1197,11 @@ WHERE (@__ints_0[c["Int"]] = c["Int"])
 
             AssertSql(
                 """
-@__ints_0='[1,2,3]'
+@ints='[1,2,3]'
 
 SELECT VALUE c
 FROM root c
-WHERE (@__ints_0[c["Int"]] = 1)
+WHERE (@ints[c["Int"]] = 1)
 """);
         }
     }
@@ -1529,11 +1529,11 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-@__ints_0='[11,111]'
+@ints='[11,111]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_LENGTH(ARRAY_CONCAT(@__ints_0, c["Ints"])) = 2)
+WHERE (ARRAY_LENGTH(ARRAY_CONCAT(@ints, c["Ints"])) = 2)
 """);
             });
 
@@ -1550,9 +1550,9 @@ WHERE (ARRAY_LENGTH(ARRAY_CONCAT(@__ints_0, c["Ints"])) = 2)
 
             AssertSql(
                 """
-@__values_0='["one","two"]'
+@values='["one","two"]'
 
-SELECT VALUE ((c["Id"] != 0) ? @__values_0[(c["Int"] % 2)] : "foo")
+SELECT VALUE ((c["Id"] != 0) ? @values[(c["Int"] % 2)] : "foo")
 FROM root c
 """);
         }
@@ -1566,11 +1566,11 @@ FROM root c
 
                 AssertSql(
                     """
-@__ints_0='[11,111]'
+@ints='[11,111]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_LENGTH(SetUnion(c["Ints"], @__ints_0)) = 2)
+WHERE (ARRAY_LENGTH(SetUnion(c["Ints"], @ints)) = 2)
 """);
             });
 
@@ -1622,11 +1622,11 @@ WHERE (ARRAY_LENGTH(SetUnion(ARRAY(
 
                 AssertSql(
                     """
-@__ints_0='[1,10]'
+@ints='[1,10]'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["Ints"] = @__ints_0)
+WHERE (c["Ints"] = @ints)
 """);
             });
 
@@ -1638,11 +1638,11 @@ WHERE (c["Ints"] = @__ints_0)
 
                 AssertSql(
                     """
-@__ints_0='[1,10]'
+@ints='[1,10]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_CONCAT(c["Ints"], @__ints_0) = [1,11,111,1,10])
+WHERE (ARRAY_CONCAT(c["Ints"], @ints) = [1,11,111,1,10])
 """);
             });
 
@@ -1668,12 +1668,12 @@ WHERE (c["Ints"] = [1,10])
 
                 AssertSql(
                     """
-@__i_0='1'
-@__j_1='10'
+@i='1'
+@j='10'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["Ints"] = [@__i_0, @__j_1])
+WHERE (c["Ints"] = [@i, @j])
 """);
             });
 
@@ -1714,11 +1714,11 @@ WHERE (ARRAY(
 
                 AssertSql(
                     """
-@__Skip_0='[111]'
+@Skip='[111]'
 
 SELECT VALUE c
 FROM root c
-WHERE (ARRAY_LENGTH(SetUnion(@__Skip_0, c["Ints"])) = 3)
+WHERE (ARRAY_LENGTH(SetUnion(@Skip, c["Ints"])) = 3)
 """);
             });
 
@@ -2032,12 +2032,12 @@ FROM root c
 
                 AssertSql(
                     """
-@__strings_1='["one","two","three"]'
-@__ints_0='[1,2,3]'
+@strings='["one","two","three"]'
+@ints='[1,2,3]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two"))
+WHERE ARRAY_CONTAINS(@strings, (ARRAY_CONTAINS(@ints, c["Int"]) ? "one" : "two"))
 """);
             });
 
@@ -2049,12 +2049,12 @@ WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" 
 
                 AssertSql(
                     """
-@__strings_1='["one","two","three"]'
-@__ints_0='[1,2,3]'
+@strings='["one","two","three"]'
+@ints='[1,2,3]'
 
 SELECT VALUE c
 FROM root c
-WHERE ARRAY_CONTAINS(@__strings_1, (ARRAY_CONTAINS(@__ints_0, c["Int"]) ? "one" : "two"))
+WHERE ARRAY_CONTAINS(@strings, (ARRAY_CONTAINS(@ints, c["Int"]) ? "one" : "two"))
 """);
             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTestBase.cs
@@ -87,11 +87,11 @@ FROM root c
         {
             Assert.Equal(
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
-                    "Customers", "None", "@__city_0='Redmond'", Environment.NewLine,
+                    "Customers", "None", "@city='Redmond'", Environment.NewLine,
                     """
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_0)
+WHERE (c["City"] = @city)
 """),
                 Fixture.TestSqlLoggerFactory.Log[3].Message);
         }
@@ -99,11 +99,11 @@ WHERE (c["City"] = @__city_0)
         {
             Assert.Equal(
                 CosmosResources.LogExecutingSqlQuery(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(
-                    "Customers", "?", "@__city_0=?", Environment.NewLine,
+                    "Customers", "?", "@city=?", Environment.NewLine,
                     """
 SELECT VALUE c
 FROM root c
-WHERE (c["City"] = @__city_0)
+WHERE (c["City"] = @city)
 """),
                 Fixture.TestSqlLoggerFactory.Log[2].Message);
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
@@ -439,11 +439,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1a'
+@partitionKey='PK1a'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1a") AND (c["PartitionKey"] = @__partitionKey_0)))
+WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1a") AND (c["PartitionKey"] = @partitionKey)))
 """);
     }
 
@@ -855,11 +855,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d325
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1c'
+@partitionKey='PK1c'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1c") AND (c["PartitionKey"] = @__partitionKey_0)))
+WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1c") AND (c["PartitionKey"] = @partitionKey)))
 """);
     }
 
@@ -937,11 +937,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
         // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
-@__discriminator_0='SinglePartitionKeyEntity'
+@discriminator='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -972,11 +972,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d325
         // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
-@__discriminator_0='DerivedSinglePartitionKeyEntity'
+@discriminator='DerivedSinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
@@ -343,11 +343,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1a'
+@partitionKey='PK1a'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["id"] = "PK1a") AND (c["id"] = @__partitionKey_0)))
+WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["id"] = "PK1a") AND (c["id"] = @partitionKey)))
 """);
     }
 
@@ -725,11 +725,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d325
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1c'
+@partitionKey='PK1c'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["id"] = "PK1c") AND (c["id"] = @__partitionKey_0)))
+WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["id"] = "PK1c") AND (c["id"] = @partitionKey)))
 """);
     }
 
@@ -798,11 +798,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
 
         AssertSql(
             """
-@__discriminator_0='SinglePartitionKeyEntity'
+@discriminator='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -834,11 +834,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d325
         // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
-@__discriminator_0='DerivedSinglePartitionKeyEntity'
+@discriminator='DerivedSinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
@@ -345,11 +345,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1a'
+@partitionKey='PK1a'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1a") AND (c["PartitionKey"] = @__partitionKey_0)))
+WHERE (c["$type"] IN ("OnlySinglePartitionKeyEntity", "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1a") AND (c["PartitionKey"] = @partitionKey)))
 """);
     }
 
@@ -729,11 +729,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d325
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1c'
+@partitionKey='PK1c'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1c") AND (c["PartitionKey"] = @__partitionKey_0)))
+WHERE ((c["$type"] = "DerivedOnlySinglePartitionKeyEntity") AND ((c["PartitionKey"] = "PK1c") AND (c["PartitionKey"] = @partitionKey)))
 """);
     }
 
@@ -804,11 +804,11 @@ WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEnti
         // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
-@__discriminator_0='SinglePartitionKeyEntity'
+@discriminator='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0)))
+WHERE (c["$type"] IN ("SinglePartitionKeyEntity", "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }
@@ -840,11 +840,11 @@ WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d325
         // No ReadItem because discriminator check is parameterized
         AssertSql(
             """
-@__discriminator_0='DerivedSinglePartitionKeyEntity'
+@discriminator='DerivedSinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @__discriminator_0)))
+WHERE ((c["$type"] = "DerivedSinglePartitionKeyEntity") AND ((c["Id"] = "188d3253-81be-4a87-b58f-a2bd07e6b98c") AND (c["$type"] = @discriminator)))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
@@ -341,11 +341,11 @@ WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["id"] = "3307a3
         // Not ReadItem because conflicting primary key values
         AssertSql(
             """
-@__partitionKey_0='PK1a'
+@partitionKey='PK1a'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["id"] = "PK1a") AND (c["id"] = @__partitionKey_0))
+WHERE ((c["id"] = "PK1a") AND (c["id"] = @partitionKey))
 """);
     }
 
@@ -437,11 +437,11 @@ WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = "Der
 
         AssertSql(
             """
-@__discriminator_0='SinglePartitionKeyEntity'
+@discriminator='SinglePartitionKeyEntity'
 
 SELECT VALUE c
 FROM root c
-WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @__discriminator_0))
+WHERE ((c["id"] = "b29bced8-e1e5-420e-82d7-1c7a51703d34") AND (c["$type"] = @discriminator))
 OFFSET 0 LIMIT 2
 """);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/ReloadTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ReloadTest.cs
@@ -38,7 +38,7 @@ public class ReloadTest : IClassFixture<ReloadTest.CosmosReloadTestFixture>
 
         AssertSql(
             """
-@__p_0='1337'
+@p='1337'
 
 SELECT VALUE
 {
@@ -49,7 +49,7 @@ SELECT VALUE
     "" : c
 }
 FROM root c
-WHERE (c["Id"] = @__p_0)
+WHERE (c["Id"] = @p)
 OFFSET 0 LIMIT 1
 """);
 

--- a/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
@@ -38,9 +38,9 @@ public class VectorSearchCosmosTest : IClassFixture<VectorSearchCosmosTest.Vecto
 
         AssertSql(
             """
-@__inputVector_1='[2,-1,4,3,5,-2,5,-7,3,1]'
+@inputVector='[2,-1,4,3,5,-2,5,-7,3,1]'
 
-SELECT VALUE VectorDistance(c["SBytes"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
+SELECT VALUE VectorDistance(c["SBytes"], @inputVector, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
 FROM root c
 """);
     }
@@ -61,9 +61,9 @@ FROM root c
 
         AssertSql(
             """
-@__inputVector_1='[2,1,4,3,5,2,5,7,3,1]'
+@inputVector='[2,1,4,3,5,2,5,7,3,1]'
 
-SELECT VALUE VectorDistance(c["Bytes"], @__inputVector_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+SELECT VALUE VectorDistance(c["Bytes"], @inputVector, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 FROM root c
 """);
     }
@@ -85,9 +85,9 @@ FROM root c
 
         AssertSql(
             """
-@__inputVector_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
+@inputVector='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
 
-SELECT VALUE VectorDistance(c["Singles"], @__inputVector_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
+SELECT VALUE VectorDistance(c["Singles"], @inputVector, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
 FROM root c
 """);
     }
@@ -108,9 +108,9 @@ FROM root c
 
         AssertSql(
             """
-@__p_1='[2,1,4,3,5,2,5,7,3,1]'
+@p='[2,1,4,3,5,2,5,7,3,1]'
 
-SELECT VALUE VectorDistance(c["BytesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+SELECT VALUE VectorDistance(c["BytesArray"], @p, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 FROM root c
 """);
     }
@@ -132,9 +132,9 @@ FROM root c
 
         AssertSql(
             """
-@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
+@p='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78,0.86,-0.78]'
 
-SELECT VALUE VectorDistance(c["SinglesArray"], @__p_1, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
+SELECT VALUE VectorDistance(c["SinglesArray"], @p, false, {'distanceFunction':'dotproduct', 'dataType':'float32'})
 FROM root c
 """);
     }
@@ -154,11 +154,11 @@ FROM root c
 
         AssertSql(
             """
-@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+@p='[2,1,4,6,5,2,5,7,3,1]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["SBytes"], @__p_1, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
+ORDER BY VectorDistance(c["SBytes"], @p, false, {'distanceFunction':'dotproduct', 'dataType':'int8'})
 """);
     }
 
@@ -176,11 +176,11 @@ ORDER BY VectorDistance(c["SBytes"], @__p_1, false, {'distanceFunction':'dotprod
         Assert.Equal(3, booksFromStore.Count);
         AssertSql(
             """
-@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+@p='[2,1,4,6,5,2,5,7,3,1]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+ORDER BY VectorDistance(c["Bytes"], @p, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 """);
     }
 
@@ -198,11 +198,11 @@ ORDER BY VectorDistance(c["Bytes"], @__p_1, false, {'distanceFunction':'cosine',
         Assert.Equal(3, booksFromStore.Count);
         AssertSql(
             """
-@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
+@p='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
+ORDER BY VectorDistance(c["Singles"], @p, false, {'distanceFunction':'cosine', 'dataType':'float32'})
 """);
     }
 
@@ -220,11 +220,11 @@ ORDER BY VectorDistance(c["Singles"], @__p_1, false, {'distanceFunction':'cosine
         Assert.Equal(3, booksFromStore.Count);
         AssertSql(
             """
-@__p_1='[2,1,4,6,5,2,5,7,3,1]'
+@p='[2,1,4,6,5,2,5,7,3,1]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["BytesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
+ORDER BY VectorDistance(c["BytesArray"], @p, false, {'distanceFunction':'cosine', 'dataType':'uint8'})
 """);
     }
 
@@ -242,11 +242,11 @@ ORDER BY VectorDistance(c["BytesArray"], @__p_1, false, {'distanceFunction':'cos
         Assert.Equal(3, booksFromStore.Count);
         AssertSql(
             """
-@__p_1='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
+@p='[0.33,-0.52,0.45,-0.67,0.89,-0.34,0.86,-0.78]'
 
 SELECT VALUE c
 FROM root c
-ORDER BY VectorDistance(c["SinglesArray"], @__p_1, false, {'distanceFunction':'cosine', 'dataType':'float32'})
+ORDER BY VectorDistance(c["SinglesArray"], @p, false, {'distanceFunction':'cosine', 'dataType':'float32'})
 """);
     }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -887,6 +887,23 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task FromSqlRaw_with_dbParameter_and_regular_parameter_with_same_name(bool async)
+    {
+        var city = "London";
+        var foo = "Sales Representative";
+
+        var cityParameter = CreateDbParameter("@foo", city);
+
+        await AssertQuery(
+            async,
+            ss => ((DbSet<Customer>)ss.Set<Customer>())
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), cityParameter)
+                .Where(c => c.ContactTitle == foo),
+            ss => ss.Set<Customer>().Where(x => x.City == city && x.ContactTitle == foo));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Include_does_not_close_user_opened_connection_for_empty_result(bool async)
     {
         Fixture.TestStore.CloseConnection();
@@ -1383,21 +1400,30 @@ SELECT * FROM [Customers2]"))
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(bool async)
+    public virtual async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_two_parameters(bool async)
     {
         using var context = CreateContext();
         var city = "Seattle";
-        var fromSqlQuery = context.Customers.FromSqlRaw(
-            NormalizeDelimitersInRawString(@"SELECT * FROM [Customers] WHERE [City] = {0}"),
-            CreateDbParameter("city", city));
 
-        var query = fromSqlQuery.Intersect(fromSqlQuery);
+        var dbParameter1 = CreateDbParameter("city", city);
+        dbParameter1.Size = 7;
+        var subquery1 = context.Database.SqlQueryRaw<UnmappedCustomer>(
+            NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"),
+            dbParameter1);
+
+        var dbParameter2 = CreateDbParameter("city", city);
+        dbParameter2.Size = 3;
+        var subquery2 = context.Database.SqlQueryRaw<UnmappedCustomer>(
+            NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"),
+            dbParameter2);
+
+        var query = subquery1.Intersect(subquery2);
 
         var actual = async
             ? await query.ToArrayAsync()
             : query.ToArray();
 
-        Assert.Single(actual);
+        Assert.Empty(actual);
     }
 
     protected string NormalizeDelimitersInRawString(string sql)

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledSqlPregenerationQueryRelationalTestBase.cs
@@ -55,7 +55,7 @@ var blogs = await context.Blogs.Where(b => b.Id == id).ToListAsync();
 
                 AssertContains(
                     """
-if (parameters["__id_0"] == null)
+if (parameters["id"] == null)
 {
     result = relationalCommandTemplate;
 }
@@ -79,7 +79,7 @@ var blogs = await context.Blogs.Where(b => b.Name == name).ToListAsync();
 
                 AssertContains(
                     """
-if (parameters["__name_0"] == null)
+if (parameters["name"] == null)
 {
     result = relationalCommandTemplate;
 }
@@ -112,7 +112,7 @@ var blogs = await context.Blogs.Where(b => b.Id == id1 || b.Id == id2).ToListAsy
 
                 AssertContains(
                     """
-if (parameters["__id1_0"] == null)
+if (parameters["id1"] == null)
 {
     result = relationalCommandTemplate;
 }
@@ -137,9 +137,9 @@ var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2).T
 
                 AssertContains(
                     """
-if (parameters["__name1_0"] == null)
+if (parameters["name1"] == null)
 {
-    if (parameters["__name2_1"] == null)
+    if (parameters["name2"] == null)
     {
         result = relationalCommandTemplate;
     }
@@ -150,7 +150,7 @@ if (parameters["__name1_0"] == null)
 }
 else
 {
-    if (parameters["__name2_1"] == null)
+    if (parameters["name2"] == null)
     {
         result = relationalCommandTemplate1;
     }
@@ -185,7 +185,7 @@ var blogs = await context.Blogs.Where(b => b.Name == name1 || b.Name == name2).T
 
                 AssertContains(
                     """
-if (parameters["__name1_0"] == null)
+if (parameters["name1"] == null)
 {
     result = relationalCommandTemplate;
 }

--- a/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
@@ -409,7 +409,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase : NonSharedModelTestBas
 
             Assert.Equal(
                 CoreStrings.TranslationFailed(
-                    @"DbSet<MockEntity>()    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
+                    @"DbSet<MockEntity>()    .Cast<IDummyEntity>()    .Where(e => e.Id == @id)"),
                 message.Replace("\r", "").Replace("\n", ""));
         }
     }

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -1783,6 +1783,19 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Two_parameters_with_same_name_get_uniquified(bool async)
+    {
+        var i = 10;
+
+        // i+1 and i+2 each get parameterized using the same parameter name (since they're complex expressions).
+        // This exercises that query parameters are properly uniquified.
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => (c.CustomerID + (i + 1)) + (c.CustomerID + (i + 2)) == "ALFKI11ALFKI12"));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Queryable_ToList_Count(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -679,11 +679,11 @@ WHERE [m].[TimeSpanAsTime] = '00:01:02'
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_0='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE [m].[TimeSpanAsTime] = @__timeSpan_0
+WHERE [m].[TimeSpanAsTime] = @timeSpan
 """);
     }
 
@@ -732,11 +732,11 @@ WHERE [m].[Int] = 81
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(hour, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(hour, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 
@@ -755,11 +755,11 @@ WHERE DATEDIFF(hour, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(minute, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(minute, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 
@@ -778,11 +778,11 @@ WHERE DATEDIFF(minute, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(second, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(second, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 
@@ -801,11 +801,11 @@ WHERE DATEDIFF(second, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(millisecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(millisecond, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 
@@ -824,11 +824,11 @@ WHERE DATEDIFF(millisecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(microsecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(microsecond, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 
@@ -847,11 +847,11 @@ WHERE DATEDIFF(microsecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
         Assert.Empty(results);
         AssertSql(
             """
-@__timeSpan_1='02:01:00' (Nullable = true)
+@timeSpan='02:01:00' (Nullable = true)
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0
+WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @timeSpan) = 0
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/ComplexTypeBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/ComplexTypeBulkUpdatesSqlServerTest.cs
@@ -108,20 +108,20 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
-@__complex_type_newAddress_0_AddressLine1='New AddressLine1' (Size = 4000)
-@__complex_type_newAddress_0_AddressLine2='New AddressLine2' (Size = 4000)
-@__complex_type_newAddress_0_Tags='["new_tag1","new_tag2"]' (Size = 4000)
-@__complex_type_newAddress_0_ZipCode='99999' (Nullable = true)
-@__complex_type_newAddress_0_Code='FR' (Size = 4000)
-@__complex_type_newAddress_0_FullName='France' (Size = 4000)
+@complex_type_newAddress_AddressLine1='New AddressLine1' (Size = 4000)
+@complex_type_newAddress_AddressLine2='New AddressLine2' (Size = 4000)
+@complex_type_newAddress_Tags='["new_tag1","new_tag2"]' (Size = 4000)
+@complex_type_newAddress_ZipCode='99999' (Nullable = true)
+@complex_type_newAddress_Code='FR' (Size = 4000)
+@complex_type_newAddress_FullName='France' (Size = 4000)
 
 UPDATE [c]
-SET [c].[ShippingAddress_AddressLine1] = @__complex_type_newAddress_0_AddressLine1,
-    [c].[ShippingAddress_AddressLine2] = @__complex_type_newAddress_0_AddressLine2,
-    [c].[ShippingAddress_Tags] = @__complex_type_newAddress_0_Tags,
-    [c].[ShippingAddress_ZipCode] = @__complex_type_newAddress_0_ZipCode,
-    [c].[ShippingAddress_Country_Code] = @__complex_type_newAddress_0_Code,
-    [c].[ShippingAddress_Country_FullName] = @__complex_type_newAddress_0_FullName
+SET [c].[ShippingAddress_AddressLine1] = @complex_type_newAddress_AddressLine1,
+    [c].[ShippingAddress_AddressLine2] = @complex_type_newAddress_AddressLine2,
+    [c].[ShippingAddress_Tags] = @complex_type_newAddress_Tags,
+    [c].[ShippingAddress_ZipCode] = @complex_type_newAddress_ZipCode,
+    [c].[ShippingAddress_Country_Code] = @complex_type_newAddress_Code,
+    [c].[ShippingAddress_Country_FullName] = @complex_type_newAddress_FullName
 FROM [Customer] AS [c]
 """);
     }
@@ -132,12 +132,12 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
-@__complex_type_newCountry_0_Code='FR' (Size = 4000)
-@__complex_type_newCountry_0_FullName='France' (Size = 4000)
+@complex_type_newCountry_Code='FR' (Size = 4000)
+@complex_type_newCountry_FullName='France' (Size = 4000)
 
 UPDATE [c]
-SET [c].[ShippingAddress_Country_Code] = @__complex_type_newCountry_0_Code,
-    [c].[ShippingAddress_Country_FullName] = @__complex_type_newCountry_0_FullName
+SET [c].[ShippingAddress_Country_Code] = @complex_type_newCountry_Code,
+    [c].[ShippingAddress_Country_FullName] = @complex_type_newCountry_FullName
 FROM [Customer] AS [c]
 """);
     }
@@ -199,7 +199,7 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
-@__p_0='1'
+@p='1'
 
 UPDATE [c0]
 SET [c0].[ShippingAddress_AddressLine1] = [c1].[BillingAddress_AddressLine1],
@@ -213,7 +213,7 @@ INNER JOIN (
     SELECT [c].[Id], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
     FROM [Customer] AS [c]
     ORDER BY [c].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c1] ON [c0].[Id] = [c1].[Id]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -31,7 +31,7 @@ FROM [Owner] AS [o]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 DELETE FROM [o]
 FROM [Owner] AS [o]
@@ -39,7 +39,7 @@ WHERE [o].[Id] IN (
     SELECT [o0].[Id]
     FROM [Owner] AS [o0]
     ORDER BY [o0].[Title]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -46,11 +46,11 @@ WHERE [o].[OrderID] < 10300
 
         AssertSql(
             """
-@__quantity_0='1' (Nullable = true) (DbType = Int16)
+@quantity='1' (Nullable = true) (DbType = Int16)
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
-WHERE [o].[Quantity] = @__quantity_0
+WHERE [o].[Quantity] = @quantity
 """,
             //
             """
@@ -81,7 +81,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -92,7 +92,7 @@ WHERE EXISTS (
         FROM [Order Details] AS [o0]
         WHERE [o0].[OrderID] < 10300
         ORDER BY [o0].[OrderID]
-        OFFSET @__p_0 ROWS
+        OFFSET @p ROWS
     ) AS [o1]
     WHERE [o1].[OrderID] = [o].[OrderID] AND [o1].[ProductID] = [o].[ProductID])
 """);
@@ -104,14 +104,14 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
 WHERE EXISTS (
     SELECT 1
     FROM (
-        SELECT TOP(@__p_0) [o0].[OrderID], [o0].[ProductID]
+        SELECT TOP(@p) [o0].[OrderID], [o0].[ProductID]
         FROM [Order Details] AS [o0]
         WHERE [o0].[OrderID] < 10300
         ORDER BY [o0].[OrderID]
@@ -126,7 +126,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -137,7 +137,7 @@ WHERE EXISTS (
         FROM [Order Details] AS [o0]
         WHERE [o0].[OrderID] < 10300
         ORDER BY [o0].[OrderID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [o1]
     WHERE [o1].[OrderID] = [o].[OrderID] AND [o1].[ProductID] = [o].[ProductID])
 """);
@@ -149,7 +149,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -160,7 +160,7 @@ WHERE EXISTS (
         FROM [Order Details] AS [o0]
         WHERE [o0].[OrderID] < 10300
         ORDER BY (SELECT 1)
-        OFFSET @__p_0 ROWS
+        OFFSET @p ROWS
     ) AS [o1]
     WHERE [o1].[OrderID] = [o].[OrderID] AND [o1].[ProductID] = [o].[ProductID])
 """);
@@ -172,9 +172,9 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
-DELETE TOP(@__p_0) FROM [o]
+DELETE TOP(@p) FROM [o]
 FROM [Order Details] AS [o]
 WHERE [o].[OrderID] < 10300
 """);
@@ -186,7 +186,7 @@ WHERE [o].[OrderID] < 10300
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -197,7 +197,7 @@ WHERE EXISTS (
         FROM [Order Details] AS [o0]
         WHERE [o0].[OrderID] < 10300
         ORDER BY (SELECT 1)
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [o1]
     WHERE [o1].[OrderID] = [o].[OrderID] AND [o1].[ProductID] = [o].[ProductID])
 """);
@@ -263,9 +263,9 @@ WHERE [o0].[OrderID] IN (
 
         AssertSql(
             """
-@__p_0='100'
-@__p_1='20'
-@__p_2='5'
+@p='100'
+@p1='20'
+@p2='5'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -278,10 +278,10 @@ WHERE EXISTS (
             FROM [Order Details] AS [o1]
             WHERE [o1].[OrderID] < 10300
             ORDER BY (SELECT 1)
-            OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+            OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
         ) AS [o0]
         ORDER BY (SELECT 1)
-        OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
+        OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY
     ) AS [o2]
     WHERE [o2].[OrderID] = [o].[OrderID] AND [o2].[ProductID] = [o].[ProductID])
 """);
@@ -511,8 +511,8 @@ WHERE [c].[City] LIKE N'Se%'
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='100'
+@p='0'
+@p0='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -521,7 +521,7 @@ INNER JOIN (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] < 10300
     ORDER BY [o0].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1] ON [o].[OrderID] = [o1].[OrderID]
 """);
     }
@@ -532,8 +532,8 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='100'
+@p='0'
+@p0='100'
 
 DELETE FROM [o]
 FROM [Order Details] AS [o]
@@ -542,7 +542,7 @@ LEFT JOIN (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] < 10300
     ORDER BY [o0].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1] ON [o].[OrderID] = [o1].[OrderID]
 WHERE [o].[OrderID] < 10276
 """);
@@ -639,20 +639,20 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__customer_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customer='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customer_0
+WHERE [c].[CustomerID] = @customer
 """,
             //
             """
-@__customer_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customer='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customer_0
+WHERE [c].[CustomerID] = @customer
 """,
             //
             """
@@ -675,10 +675,10 @@ WHERE 0 = 1
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 30)
+@value='Abc' (Size = 30)
 
 UPDATE [c]
-SET [c].[ContactName] = @__value_0
+SET [c].[ContactName] = @value
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -690,10 +690,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__p_0='Abc' (Size = 30)
+@p='Abc' (Size = 30)
 
 UPDATE [c]
-SET [c].[ContactName] = @__p_0
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -718,10 +718,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__container_Containee_Property_0='Abc' (Size = 30)
+@container_Containee_Property='Abc' (Size = 30)
 
 UPDATE [c]
-SET [c].[ContactName] = @__container_Containee_Property_0
+SET [c].[ContactName] = @container_Containee_Property
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -733,7 +733,7 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE [c0]
 SET [c0].[ContactName] = N'Updated'
@@ -743,7 +743,7 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c1] ON [c0].[CustomerID] = [c1].[CustomerID]
 """);
     }
@@ -754,9 +754,9 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
-UPDATE TOP(@__p_0) [c]
+UPDATE TOP(@p) [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
@@ -769,8 +769,8 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__p_0='2'
-@__p_1='4'
+@p='2'
+@p0='4'
 
 UPDATE [c0]
 SET [c0].[ContactName] = N'Updated'
@@ -780,7 +780,7 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c1] ON [c0].[CustomerID] = [c1].[CustomerID]
 """);
     }
@@ -808,7 +808,7 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE [c0]
 SET [c0].[ContactName] = N'Updated'
@@ -818,7 +818,7 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[City]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c1] ON [c0].[CustomerID] = [c1].[CustomerID]
 """);
     }
@@ -829,13 +829,13 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE [c0]
 SET [c0].[ContactName] = N'Updated'
 FROM [Customers] AS [c0]
 INNER JOIN (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[City]
@@ -849,8 +849,8 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
-@__p_0='2'
-@__p_1='4'
+@p='2'
+@p0='4'
 
 UPDATE [c0]
 SET [c0].[ContactName] = N'Updated'
@@ -860,7 +860,7 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[City]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c1] ON [c0].[CustomerID] = [c1].[CustomerID]
 """);
     }
@@ -871,8 +871,8 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
-@__p_0='2'
-@__p_1='6'
+@p='2'
+@p0='6'
 
 UPDATE [c1]
 SET [c1].[ContactName] = N'Updated'
@@ -884,10 +884,10 @@ INNER JOIN (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'F%'
         ORDER BY [c].[City]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[City]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [c2] ON [c1].[CustomerID] = [c2].[CustomerID]
 """);
     }
@@ -1037,10 +1037,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 4000)
+@value='Abc' (Size = 4000)
 
 UPDATE [c]
-SET [c].[ContactName] = COALESCE([c].[ContactName], N'') + @__value_0
+SET [c].[ContactName] = COALESCE([c].[ContactName], N'') + @value
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -1105,11 +1105,11 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 30)
+@value='Abc' (Size = 30)
 
 UPDATE [c]
 SET [c].[City] = N'Seattle',
-    [c].[ContactName] = @__value_0
+    [c].[ContactName] = @value
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -117,8 +117,8 @@ WHERE [a].[CountryId] = 1 AND [a].[Id] IN (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='3'
+@p='0'
+@p0='3'
 
 DELETE FROM [a]
 FROM [Animals] AS [a]
@@ -127,7 +127,7 @@ WHERE [a].[Id] IN (
     FROM [Animals] AS [a0]
     WHERE [a0].[CountryId] = 1 AND [a0].[Name] = N'Great spotted kiwi'
     ORDER BY [a0].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqlServerTest.cs
@@ -115,8 +115,8 @@ WHERE [a].[Id] IN (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='3'
+@p='0'
+@p0='3'
 
 DELETE FROM [a]
 FROM [Animals] AS [a]
@@ -125,7 +125,7 @@ WHERE [a].[Id] IN (
     FROM [Animals] AS [a0]
     WHERE [a0].[Name] = N'Great spotted kiwi'
     ORDER BY [a0].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -229,11 +229,11 @@ User23059.MessageGroups ---> [nullable nvarchar] [MaxLength = -1]
 
         AssertSql(
             """
-@__blogId_0='1'
+@blogId='1'
 
 SELECT [b].[Url]
 FROM [Blog] AS [b]
-INNER JOIN [Post] AS [p] ON [b].[BlogId] = [p].[BlogId] AND [b].[IsVisible] = N'Y' AND [b].[BlogId] = @__blogId_0
+INNER JOIN [Post] AS [p] ON [b].[BlogId] = [p].[BlogId] AND [b].[IsVisible] = N'Y' AND [b].[BlogId] = @blogId
 WHERE [b].[IsVisible] = N'Y'
 """);
     }
@@ -245,11 +245,11 @@ WHERE [b].[IsVisible] = N'Y'
 
         AssertSql(
             """
-@__blogId_0='1'
+@blogId='1'
 
 SELECT [b].[Url]
 FROM [Blog] AS [b]
-LEFT JOIN [Post] AS [p] ON [b].[BlogId] = [p].[BlogId] AND [b].[IsVisible] = N'Y' AND [b].[BlogId] = @__blogId_0
+LEFT JOIN [Post] AS [p] ON [b].[BlogId] = [p].[BlogId] AND [b].[IsVisible] = N'Y' AND [b].[BlogId] = @blogId
 WHERE [b].[IsVisible] = N'Y'
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -39,13 +39,13 @@ public abstract class FindSqlServerTest : FindTestBase<FindSqlServerTest.FindSql
 
         AssertSql(
             """
-@__p_0='77'
+@p='77'
 
 SELECT [i3].[Id], [i3].[Foo], [s].[IntKeyId], [s].[Id], [s].[Prop], [s].[NestedOwned_Prop], [s].[Owned1IntKeyId], [s].[Owned1Id], [s].[Id0], [s].[Prop0], [i3].[OwnedReference_Prop], [i3].[OwnedReference_NestedOwned_Prop], [i2].[Owned1IntKeyId], [i2].[Id], [i2].[Prop]
 FROM (
     SELECT TOP(1) [i].[Id], [i].[Foo], [i].[OwnedReference_Prop], [i].[OwnedReference_NestedOwned_Prop]
     FROM [IntKey] AS [i]
-    WHERE [i].[Id] = @__p_0
+    WHERE [i].[Id] = @p
 ) AS [i3]
 LEFT JOIN (
     SELECT [i0].[IntKeyId], [i0].[Id], [i0].[Prop], [i0].[NestedOwned_Prop], [i1].[Owned1IntKeyId], [i1].[Owned1Id], [i1].[Id] AS [Id0], [i1].[Prop] AS [Prop0]
@@ -65,13 +65,13 @@ ORDER BY [i3].[Id], [s].[IntKeyId], [s].[Id], [s].[Owned1IntKeyId], [s].[Owned1I
 
         AssertSql(
             """
-@__p_0='99'
+@p='99'
 
 SELECT [i3].[Id], [i3].[Foo], [s].[IntKeyId], [s].[Id], [s].[Prop], [s].[NestedOwned_Prop], [s].[Owned1IntKeyId], [s].[Owned1Id], [s].[Id0], [s].[Prop0], [i3].[OwnedReference_Prop], [i3].[OwnedReference_NestedOwned_Prop], [i2].[Owned1IntKeyId], [i2].[Id], [i2].[Prop]
 FROM (
     SELECT TOP(1) [i].[Id], [i].[Foo], [i].[OwnedReference_Prop], [i].[OwnedReference_NestedOwned_Prop]
     FROM [IntKey] AS [i]
-    WHERE [i].[Id] = @__p_0
+    WHERE [i].[Id] = @p
 ) AS [i3]
 LEFT JOIN (
     SELECT [i0].[IntKeyId], [i0].[Id], [i0].[Prop], [i0].[NestedOwned_Prop], [i1].[Owned1IntKeyId], [i1].[Owned1Id], [i1].[Id] AS [Id0], [i1].[Prop] AS [Prop0]
@@ -98,11 +98,11 @@ ORDER BY [i3].[Id], [s].[IntKeyId], [s].[Id], [s].[Owned1IntKeyId], [s].[Owned1I
 
         AssertSql(
             """
-@__p_0='77' (Nullable = true)
+@p='77' (Nullable = true)
 
 SELECT TOP(1) [n].[Id], [n].[Foo]
 FROM [NullableIntKey] AS [n]
-WHERE [n].[Id] = @__p_0
+WHERE [n].[Id] = @p
 """);
     }
 
@@ -112,11 +112,11 @@ WHERE [n].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='99' (Nullable = true)
+@p='99' (Nullable = true)
 
 SELECT TOP(1) [n].[Id], [n].[Foo]
 FROM [NullableIntKey] AS [n]
-WHERE [n].[Id] = @__p_0
+WHERE [n].[Id] = @p
 """);
     }
 
@@ -133,11 +133,11 @@ WHERE [n].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='Cat' (Size = 450)
+@p='Cat' (Size = 450)
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [StringKey] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -147,11 +147,11 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='Fox' (Size = 450)
+@p='Fox' (Size = 450)
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [StringKey] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -168,12 +168,12 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='77'
-@__p_1='Dog' (Size = 450)
+@p='77'
+@p0='Dog' (Size = 450)
 
 SELECT TOP(1) [c].[Id1], [c].[Id2], [c].[Foo]
 FROM [CompositeKey] AS [c]
-WHERE [c].[Id1] = @__p_0 AND [c].[Id2] = @__p_1
+WHERE [c].[Id1] = @p AND [c].[Id2] = @p0
 """);
     }
 
@@ -183,12 +183,12 @@ WHERE [c].[Id1] = @__p_0 AND [c].[Id2] = @__p_1
 
         AssertSql(
             """
-@__p_0='77'
-@__p_1='Fox' (Size = 450)
+@p='77'
+@p0='Fox' (Size = 450)
 
 SELECT TOP(1) [c].[Id1], [c].[Id2], [c].[Foo]
 FROM [CompositeKey] AS [c]
-WHERE [c].[Id1] = @__p_0 AND [c].[Id2] = @__p_1
+WHERE [c].[Id1] = @p AND [c].[Id2] = @p0
 """);
     }
 
@@ -205,11 +205,11 @@ WHERE [c].[Id1] = @__p_0 AND [c].[Id2] = @__p_1
 
         AssertSql(
             """
-@__p_0='77'
+@p='77'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Id] = @__p_0
+WHERE [b].[Id] = @p
 """);
     }
 
@@ -219,11 +219,11 @@ WHERE [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='99'
+@p='99'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Id] = @__p_0
+WHERE [b].[Id] = @p
 """);
     }
 
@@ -240,11 +240,11 @@ WHERE [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='78'
+@p='78'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
+WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @p
 """);
     }
 
@@ -254,11 +254,11 @@ WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='99'
+@p='99'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
+WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @p
 """);
     }
 
@@ -268,11 +268,11 @@ WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='88'
+@p='88'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
+WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @p
 """);
     }
 
@@ -282,11 +282,11 @@ WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='77'
+@p='77'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
+WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @p
 """);
     }
 
@@ -303,11 +303,11 @@ WHERE [b].[Discriminator] = N'DerivedType' AND [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='78'
+@p='78'
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Id] = @__p_0
+WHERE [b].[Id] = @p
 """);
     }
 
@@ -324,11 +324,11 @@ WHERE [b].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='77'
+@p='77'
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [ShadowKey] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -338,11 +338,11 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='99'
+@p='99'
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [ShadowKey] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
@@ -19,11 +19,11 @@ public class LazyLoadProxySqlServerTest : LazyLoadProxyTestBase<LazyLoadProxySql
             state == EntityState.Detached && useAttach
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -35,11 +35,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached && useAttach
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -51,11 +51,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && useAttach
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -67,11 +67,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && useAttach
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -81,11 +81,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -95,11 +95,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [s].[Id], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [SinglePkToPk] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -123,11 +123,11 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -137,11 +137,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -151,11 +151,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -165,11 +165,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -225,11 +225,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -239,11 +239,11 @@ WHERE [p].[AlternateId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -253,11 +253,11 @@ WHERE [p].[AlternateId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [SingleAk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -281,11 +281,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [ChildShadowFk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -297,11 +297,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -313,11 +313,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -327,11 +327,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [SingleShadowFk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -355,12 +355,12 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [ChildCompositeKey] AS [c]
-WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
+WHERE [c].[ParentAlternateId] = @p AND [c].[ParentId] = @p0
 """);
     }
 
@@ -370,12 +370,12 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -385,12 +385,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rating], [p].[Culture_Species], [p].[Culture_Subspecies], [p].[Culture_Validation], [p].[Culture_License_Charge], [p].[Culture_License_Title], [p].[Culture_License_Tag_Text], [p].[Culture_License_Tog_Text], [p].[Culture_Manufacturer_Name], [p].[Culture_Manufacturer_Rating], [p].[Culture_Manufacturer_Tag_Text], [p].[Culture_Manufacturer_Tog_Text], [p].[Milk_Rating], [p].[Milk_Species], [p].[Milk_Subspecies], [p].[Milk_Validation], [p].[Milk_License_Charge], [p].[Milk_License_Title], [p].[Milk_License_Tag_Text], [p].[Milk_License_Tog_Text], [p].[Milk_Manufacturer_Name], [p].[Milk_Manufacturer_Rating], [p].[Milk_Manufacturer_Tag_Text], [p].[Milk_Manufacturer_Tog_Text]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -400,12 +400,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [SingleCompositeKey] AS [s]
-WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
+WHERE [s].[ParentAlternateId] = @p AND [s].[ParentId] = @p0
 """);
     }
 
@@ -431,11 +431,11 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
         {
             AssertSql(
                 """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
         }
     }
@@ -451,11 +451,11 @@ SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator], [p].[Culture_Rat
 FROM [Parent] AS [p]
 ORDER BY [p].[Id]
 
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId], [s].[Culture_Rating], [s].[Culture_Species], [s].[Culture_Subspecies], [s].[Culture_Validation], [s].[Culture_License_Charge], [s].[Culture_License_Title], [s].[Culture_License_Tag_Text], [s].[Culture_License_Tog_Text], [s].[Culture_Manufacturer_Name], [s].[Culture_Manufacturer_Rating], [s].[Culture_Manufacturer_Tag_Text], [s].[Culture_Manufacturer_Tog_Text], [s].[Milk_Rating], [s].[Milk_Species], [s].[Milk_Subspecies], [s].[Milk_Validation], [s].[Milk_License_Charge], [s].[Milk_License_Title], [s].[Milk_License_Tag_Text], [s].[Milk_License_Tog_Text], [s].[Milk_Manufacturer_Name], [s].[Milk_Manufacturer_Rating], [s].[Milk_Manufacturer_Tag_Text], [s].[Milk_Manufacturer_Tog_Text]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -465,12 +465,12 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__entity_equality_called_0_Id='707' (Nullable = true)
+@entity_equality_called_Id='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId], [c].[Culture_Rating], [c].[Culture_Species], [c].[Culture_Subspecies], [c].[Culture_Validation], [c].[Culture_License_Charge], [c].[Culture_License_Title], [c].[Culture_License_Tag_Text], [c].[Culture_License_Tog_Text], [c].[Culture_Manufacturer_Name], [c].[Culture_Manufacturer_Rating], [c].[Culture_Manufacturer_Tag_Text], [c].[Culture_Manufacturer_Tog_Text], [c].[Milk_Rating], [c].[Milk_Species], [c].[Milk_Subspecies], [c].[Milk_Validation], [c].[Milk_License_Charge], [c].[Milk_License_Title], [c].[Milk_License_Tag_Text], [c].[Milk_License_Tog_Text], [c].[Milk_Manufacturer_Name], [c].[Milk_Manufacturer_Rating], [c].[Milk_Manufacturer_Tag_Text], [c].[Milk_Manufacturer_Tog_Text]
 FROM [Child] AS [c]
 LEFT JOIN [Parent] AS [p] ON [c].[ParentId] = [p].[Id]
-WHERE [p].[Id] = @__entity_equality_called_0_Id
+WHERE [p].[Id] = @entity_equality_called_Id
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -19,11 +19,11 @@ public class LoadSqlServerTest : LoadTestBase<LoadSqlServerTest.LoadSqlServerFix
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -38,11 +38,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -57,11 +57,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -76,11 +76,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -94,11 +94,11 @@ WHERE [s].[ParentId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -112,11 +112,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -148,11 +148,11 @@ WHERE [s].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -167,11 +167,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -186,11 +186,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -205,11 +205,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -283,11 +283,11 @@ WHERE [s].[ParentId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -301,11 +301,11 @@ WHERE [p].[AlternateId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -319,11 +319,11 @@ WHERE [p].[AlternateId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -353,11 +353,11 @@ WHERE [s].[ParentId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -371,11 +371,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -389,11 +389,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -407,11 +407,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -441,12 +441,12 @@ WHERE [s].[ParentId] = @__p_0
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
+WHERE [c].[ParentAlternateId] = @p AND [c].[ParentId] = @p0
 """);
     }
 
@@ -460,12 +460,12 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -479,12 +479,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -498,12 +498,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
             state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
+WHERE [s].[ParentAlternateId] = @p AND [s].[ParentId] = @p0
 """);
     }
 
@@ -531,11 +531,11 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -545,11 +545,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -559,11 +559,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -573,11 +573,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -587,11 +587,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -601,11 +601,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -615,11 +615,11 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -629,11 +629,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -643,11 +643,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -659,11 +659,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -673,11 +673,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -689,11 +689,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -741,11 +741,11 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -755,11 +755,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -769,11 +769,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -783,11 +783,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -797,11 +797,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -811,11 +811,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -825,11 +825,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -839,11 +839,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -904,11 +904,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -920,11 +920,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Deleted
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -936,11 +936,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Deleted
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -953,11 +953,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -967,11 +967,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -981,11 +981,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE [s].[Id] = @__p_0
+WHERE [s].[Id] = @p
 """);
     }
 
@@ -995,11 +995,11 @@ WHERE [s].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1009,11 +1009,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1023,11 +1023,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1037,11 +1037,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1051,11 +1051,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1065,11 +1065,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1079,11 +1079,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707'
+@p='707'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1095,11 +1095,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1109,11 +1109,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1123,11 +1123,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1137,11 +1137,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1151,11 +1151,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1165,11 +1165,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1179,11 +1179,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1193,11 +1193,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='787'
+@p='787'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1207,11 +1207,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='767' (Nullable = true)
+@p='767' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1255,11 +1255,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1271,11 +1271,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Deleted
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1287,11 +1287,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Deleted
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1304,11 +1304,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1318,11 +1318,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildAk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1332,11 +1332,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -1346,11 +1346,11 @@ WHERE [p].[AlternateId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -1360,11 +1360,11 @@ WHERE [p].[AlternateId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1374,11 +1374,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildAk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1388,11 +1388,11 @@ WHERE [c].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -1402,11 +1402,11 @@ WHERE [p].[AlternateId] = @__p_0
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0
+WHERE [p].[AlternateId] = @p
 """);
     }
 
@@ -1418,11 +1418,11 @@ WHERE [p].[AlternateId] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
+@p='Root' (Size = 450)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1470,11 +1470,11 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1486,11 +1486,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1502,11 +1502,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1516,11 +1516,11 @@ WHERE [p].[Id] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1530,11 +1530,11 @@ WHERE [s].[ParentId] = @__p_0
 
         AssertSql(
             """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE [c].[ParentId] = @__p_0
+WHERE [c].[ParentId] = @p
 """);
     }
 
@@ -1546,11 +1546,11 @@ WHERE [c].[ParentId] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1562,11 +1562,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707'
+@p='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[Id] = @__p_0
+WHERE [p].[Id] = @p
 """);
     }
 
@@ -1578,11 +1578,11 @@ WHERE [p].[Id] = @__p_0
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='707' (Nullable = true)
+@p='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE [s].[ParentId] = @__p_0
+WHERE [s].[ParentId] = @p
 """);
     }
 
@@ -1634,12 +1634,12 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
+WHERE [c].[ParentAlternateId] = @p AND [c].[ParentId] = @p0
 """);
     }
 
@@ -1649,12 +1649,12 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -1664,12 +1664,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -1679,12 +1679,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
+WHERE [s].[ParentAlternateId] = @p AND [s].[ParentId] = @p0
 """);
     }
 
@@ -1694,12 +1694,12 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
+WHERE [c].[ParentAlternateId] = @p AND [c].[ParentId] = @p0
 """);
     }
 
@@ -1709,12 +1709,12 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -1724,12 +1724,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 
         AssertSql(
             """
-@__p_0='Root' (Size = 450)
-@__p_1='707'
+@p='Root' (Size = 450)
+@p0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
+WHERE [p].[AlternateId] = @p AND [p].[Id] = @p0
 """);
     }
 
@@ -1741,12 +1741,12 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
             state == EntityState.Detached
                 ? ""
                 : """
-@__p_0='Root' (Size = 450)
-@__p_1='707' (Nullable = true)
+@p='Root' (Size = 450)
+@p0='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
+WHERE [s].[ParentAlternateId] = @p AND [s].[ParentId] = @p0
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
@@ -17,7 +17,7 @@ public class ManyToManyFieldsLoadSqlServerTest(ManyToManyFieldsLoadSqlServerTest
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneId], [s].[TwoId], [s0].[OneId], [s0].[TwoId], [s0].[Id], [s0].[Name]
 FROM [EntityOnes] AS [e]
@@ -30,9 +30,9 @@ LEFT JOIN (
     SELECT [j0].[OneId], [j0].[TwoId], [e1].[Id], [e1].[Name]
     FROM [JoinOneToTwo] AS [j0]
     INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
-    WHERE [e1].[Id] = @__p_0
+    WHERE [e1].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneId], [s].[TwoId], [s].[Id], [s0].[OneId], [s0].[TwoId]
 """);
     }
@@ -43,7 +43,7 @@ ORDER BY [e].[Id], [s].[OneId], [s].[TwoId], [s].[Id], [s0].[OneId], [s0].[TwoId
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name]
 FROM [EntityOnes] AS [e]
@@ -56,9 +56,9 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId]
 """);
     }
@@ -69,7 +69,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id], [s1].[Name], [s1].[OneSkipSharedId0], [s1].[TwoSkipSharedId0], [s1].[Id0], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -87,9 +87,9 @@ LEFT JOIN (
         FROM [EntityOneEntityTwo] AS [e4]
         INNER JOIN [EntityTwos] AS [e5] ON [e4].[TwoSkipSharedId] = [e5].[Id]
     ) AS [s0] ON [e3].[Id] = [s0].[OneSkipSharedId]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s1] ON [s].[Id] = [s1].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id], [s1].[OneSkipSharedId0], [s1].[TwoSkipSharedId0]
 """);
     }
@@ -100,7 +100,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name], [s1].[ThreeId], [s1].[TwoId], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -113,14 +113,14 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
 LEFT JOIN (
     SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
 ) AS [s1] ON [s].[Id] = [s1].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s1].[ThreeId], [s1].[TwoId]
 """);
     }
@@ -131,7 +131,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name], [s1].[ThreeId], [s1].[TwoId], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -144,7 +144,7 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
 LEFT JOIN (
     SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
@@ -152,7 +152,7 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
     WHERE [e4].[Id] IN (13, 11)
 ) AS [s1] ON [s].[Id] = [s1].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s1].[ThreeId], [s1].[TwoId]
 """);
     }
@@ -163,7 +163,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[Name], (
     SELECT COUNT(*)
@@ -180,7 +180,7 @@ INNER JOIN (
     FROM [EntityOneEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
 ) AS [s] ON [e].[Id] = [s].[OneSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [s].[Id]
 """);
     }
@@ -191,7 +191,7 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s1].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id0], [s2].[OneSkipSharedId], [s2].[TwoSkipSharedId], [s2].[Id], [s2].[Name], [s1].[CollectionInverseId], [s1].[Name0], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -213,9 +213,9 @@ LEFT JOIN (
     SELECT [e5].[OneSkipSharedId], [e5].[TwoSkipSharedId], [e6].[Id], [e6].[Name]
     FROM [EntityOneEntityTwo] AS [e5]
     INNER JOIN [EntityOnes] AS [e6] ON [e5].[OneSkipSharedId] = [e6].[Id]
-    WHERE [e6].[Id] = @__p_0
+    WHERE [e6].[Id] = @p
 ) AS [s2] ON [s].[Id] = [s2].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id0], [s2].[OneSkipSharedId], [s2].[TwoSkipSharedId]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -17,7 +17,7 @@ public class ManyToManyLoadSqlServerTest(ManyToManyLoadSqlServerTest.ManyToManyL
         AssertSql(
             state == EntityState.Detached
                 ? """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneId], [s].[TwoId], [s0].[Id], [s0].[Name], [s0].[OneId], [s0].[TwoId]
 FROM [EntityOnes] AS [e]
@@ -30,13 +30,13 @@ LEFT JOIN (
     SELECT [e1].[Id], [e1].[Name], [j0].[OneId], [j0].[TwoId]
     FROM [JoinOneToTwo] AS [j0]
     INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
-    WHERE [e1].[Id] = @__p_0
+    WHERE [e1].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneId], [s].[TwoId], [s].[Id], [s0].[OneId], [s0].[TwoId]
 """
                 : """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneId], [s].[TwoId], [s0].[OneId], [s0].[TwoId], [s0].[JoinOneToTwoExtraId], [s0].[Id], [s0].[Name]
 FROM [EntityOnes] AS [e]
@@ -49,9 +49,9 @@ LEFT JOIN (
     SELECT [j0].[OneId], [j0].[TwoId], [j0].[JoinOneToTwoExtraId], [e1].[Id], [e1].[Name]
     FROM [JoinOneToTwo] AS [j0]
     INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
-    WHERE [e1].[Id] = @__p_0
+    WHERE [e1].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneId], [s].[TwoId], [s].[Id], [s0].[OneId], [s0].[TwoId]
 """);
     }
@@ -62,7 +62,7 @@ ORDER BY [e].[Id], [s].[OneId], [s].[TwoId], [s].[Id], [s0].[OneId], [s0].[TwoId
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name]
 FROM [EntityOnes] AS [e]
@@ -75,9 +75,9 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId]
 """);
     }
@@ -88,7 +88,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id], [s1].[Name], [s1].[OneSkipSharedId0], [s1].[TwoSkipSharedId0], [s1].[Id0], [s1].[CollectionInverseId], [s1].[ExtraId], [s1].[Name0], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -106,9 +106,9 @@ LEFT JOIN (
         FROM [EntityOneEntityTwo] AS [e4]
         INNER JOIN [EntityTwos] AS [e5] ON [e4].[TwoSkipSharedId] = [e5].[Id]
     ) AS [s0] ON [e3].[Id] = [s0].[OneSkipSharedId]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s1] ON [s].[Id] = [s1].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id], [s1].[OneSkipSharedId0], [s1].[TwoSkipSharedId0]
 """);
     }
@@ -119,7 +119,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name], [s1].[ThreeId], [s1].[TwoId], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -132,14 +132,14 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
 LEFT JOIN (
     SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
 ) AS [s1] ON [s].[Id] = [s1].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s1].[ThreeId], [s1].[TwoId]
 """);
     }
@@ -150,7 +150,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s0].[Name], [s1].[ThreeId], [s1].[TwoId], [s1].[Id], [s1].[CollectionInverseId], [s1].[Name], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -163,7 +163,7 @@ LEFT JOIN (
     SELECT [e2].[OneSkipSharedId], [e2].[TwoSkipSharedId], [e3].[Id], [e3].[Name]
     FROM [EntityOneEntityTwo] AS [e2]
     INNER JOIN [EntityOnes] AS [e3] ON [e2].[OneSkipSharedId] = [e3].[Id]
-    WHERE [e3].[Id] = @__p_0
+    WHERE [e3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[TwoSkipSharedId]
 LEFT JOIN (
     SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
@@ -171,7 +171,7 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
     WHERE [e4].[Id] IN (13, 11)
 ) AS [s1] ON [s].[Id] = [s1].[TwoId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].[OneSkipSharedId], [s0].[TwoSkipSharedId], [s0].[Id], [s1].[ThreeId], [s1].[TwoId]
 """);
     }
@@ -182,7 +182,7 @@ ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s0].
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[Name], (
     SELECT COUNT(*)
@@ -199,7 +199,7 @@ INNER JOIN (
     FROM [EntityOneEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
 ) AS [s] ON [e].[Id] = [s].[OneSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [s].[Id]
 """);
     }
@@ -210,7 +210,7 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s].[Id], [s].[CollectionInverseId], [s].[ExtraId], [s].[Name], [s].[ReferenceInverseId], [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s1].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id0], [s2].[OneSkipSharedId], [s2].[TwoSkipSharedId], [s2].[Id], [s2].[Name], [s1].[CollectionInverseId], [s1].[ExtraId], [s1].[Name0], [s1].[ReferenceInverseId]
 FROM [EntityOnes] AS [e]
@@ -232,9 +232,9 @@ LEFT JOIN (
     SELECT [e5].[OneSkipSharedId], [e5].[TwoSkipSharedId], [e6].[Id], [e6].[Name]
     FROM [EntityOneEntityTwo] AS [e5]
     INNER JOIN [EntityOnes] AS [e6] ON [e5].[OneSkipSharedId] = [e6].[Id]
-    WHERE [e6].[Id] = @__p_0
+    WHERE [e6].[Id] = @p
 ) AS [s2] ON [s].[Id] = [s2].[TwoSkipSharedId]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 ORDER BY [e].[Id], [s].[OneSkipSharedId], [s].[TwoSkipSharedId], [s].[Id], [s1].[Id], [s1].[OneSkipSharedId], [s1].[TwoSkipSharedId], [s1].[Id0], [s2].[OneSkipSharedId], [s2].[TwoSkipSharedId]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
@@ -91,11 +91,11 @@ WHERE [r].[OwnedEntity_OwnedValue] = N'Abc'
 """,
             //
             """
-@__id_0='1'
+@id='1'
 
 SELECT [p].[Id], [p].[RemovableEntityId]
 FROM [Parents] AS [p]
-WHERE [p].[Id] = @__id_0
+WHERE [p].[Id] = @id
 """);
     }
 
@@ -105,14 +105,14 @@ WHERE [p].[Id] = @__id_0
 
         AssertSql(
             """
-@__action_0='1'
+@action='1'
 
 SELECT COUNT(*)
 FROM [Offers] AS [o]
 WHERE EXISTS (
     SELECT 1
     FROM [OfferActions] AS [o0]
-    WHERE [o].[Id] = [o0].[OfferId] AND [o0].[Action] = @__action_0)
+    WHERE [o].[Id] = [o0].[OfferId] AND [o0].[Action] = @action)
 """);
     }
 
@@ -122,11 +122,11 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__id_0='1'
+@id='1'
 
 SELECT TOP(1) [m].[Id], [m].[Name], [m].[NavigationEntityId]
 FROM [MockEntities] AS [m]
-WHERE [m].[Id] = @__id_0
+WHERE [m].[Id] = @id
 """,
             //
             """
@@ -152,11 +152,11 @@ FROM [Businesses] AS [b]
 
         AssertSql(
             $"""
-@__parameter_0='2021-11-12T13:14:15.1234567'{postfix}
+@parameter='2021-11-12T13:14:15.1234567'{postfix}
 
 SELECT TOP(1) [e].[DateTime]
 FROM [Entities] AS [e]
-WHERE [e].[DateTime] = @__parameter_0
+WHERE [e].[DateTime] = @parameter
 """);
     }
 
@@ -166,11 +166,11 @@ WHERE [e].[DateTime] = @__parameter_0
 
         AssertSql(
             $"""
-@__parameter_0='2021-11-12T13:14:15.1234567+10:00'{postfix}
+@parameter='2021-11-12T13:14:15.1234567+10:00'{postfix}
 
 SELECT TOP(1) [e].[DateTimeOffset]
 FROM [Entities] AS [e]
-WHERE [e].[DateTimeOffset] = @__parameter_0
+WHERE [e].[DateTimeOffset] = @parameter
 """);
     }
 
@@ -180,11 +180,11 @@ WHERE [e].[DateTimeOffset] = @__parameter_0
 
         AssertSql(
             $"""
-@__parameter_0='12:34:56.7890123'{postfix}
+@parameter='12:34:56.7890123'{postfix}
 
 SELECT TOP(1) [e].[TimeSpan]
 FROM [Entities] AS [e]
-WHERE [e].[TimeSpan] = @__parameter_0
+WHERE [e].[TimeSpan] = @parameter
 """);
     }
 
@@ -294,11 +294,11 @@ ORDER BY [o0].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [a].[Id], [s].[Info_Created0] AS [Created]
 FROM (
-    SELECT TOP(@__p_0) [c].[Id], [b].[AId], [b].[Info_Created] AS [Info_Created0]
+    SELECT TOP(@p) [c].[Id], [b].[AId], [b].[Info_Created] AS [Info_Created0]
     FROM [Cs] AS [c]
     INNER JOIN [Bs] AS [b] ON [c].[BId] = [b].[Id]
     WHERE [b].[AId] = 1

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -11,13 +11,13 @@ public class AdHocComplexTypeQuerySqlServerTest : AdHocComplexTypeQueryTestBase
 
         AssertSql(
             """
-@__entity_equality_container_0_Id='1' (Nullable = true)
-@__entity_equality_container_0_Containee1_Id='2' (Nullable = true)
-@__entity_equality_container_0_Containee2_Id='3' (Nullable = true)
+@entity_equality_container_Id='1' (Nullable = true)
+@entity_equality_container_Containee1_Id='2' (Nullable = true)
+@entity_equality_container_Containee2_Id='3' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ComplexContainer_Id], [e].[ComplexContainer_Containee1_Id], [e].[ComplexContainer_Containee2_Id]
 FROM [EntityType] AS [e]
-WHERE [e].[ComplexContainer_Id] = @__entity_equality_container_0_Id AND [e].[ComplexContainer_Containee1_Id] = @__entity_equality_container_0_Containee1_Id AND [e].[ComplexContainer_Containee2_Id] = @__entity_equality_container_0_Containee2_Id
+WHERE [e].[ComplexContainer_Id] = @entity_equality_container_Id AND [e].[ComplexContainer_Containee1_Id] = @entity_equality_container_Containee1_Id AND [e].[ComplexContainer_Containee2_Id] = @entity_equality_container_Containee2_Id
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocManyToManyQuerySqlServerTest.cs
@@ -43,15 +43,15 @@ CROSS JOIN (
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [m].[Id]
 FROM [ManyM_DB] AS [m]
-WHERE [m].[Id] = @__p_0
+WHERE [m].[Id] = @p
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [s].[Id], [m].[Id], [s].[Id0], [s0].[Id], [s0].[ManyM_Id], [s0].[ManyN_Id], [s0].[Id0]
 FROM [ManyM_DB] AS [m]
@@ -64,22 +64,22 @@ LEFT JOIN (
     SELECT [m2].[Id], [m2].[ManyM_Id], [m2].[ManyN_Id], [m3].[Id] AS [Id0]
     FROM [ManyMN_DB] AS [m2]
     INNER JOIN [ManyM_DB] AS [m3] ON [m2].[ManyM_Id] = [m3].[Id]
-    WHERE [m3].[Id] = @__p_0
+    WHERE [m3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[ManyN_Id]
-WHERE [m].[Id] = @__p_0
+WHERE [m].[Id] = @p
 ORDER BY [m].[Id], [s].[Id0], [s].[Id], [s0].[Id]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [m].[Id]
 FROM [ManyN_DB] AS [m]
-WHERE [m].[Id] = @__p_0
+WHERE [m].[Id] = @p
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [s].[Id], [m].[Id], [s].[Id0], [s0].[Id], [s0].[ManyM_Id], [s0].[ManyN_Id], [s0].[Id0]
 FROM [ManyN_DB] AS [m]
@@ -92,9 +92,9 @@ LEFT JOIN (
     SELECT [m2].[Id], [m2].[ManyM_Id], [m2].[ManyN_Id], [m3].[Id] AS [Id0]
     FROM [ManyMN_DB] AS [m2]
     INNER JOIN [ManyN_DB] AS [m3] ON [m2].[ManyN_Id] = [m3].[Id]
-    WHERE [m3].[Id] = @__p_0
+    WHERE [m3].[Id] = @p
 ) AS [s0] ON [s].[Id] = [s0].[ManyM_Id]
-WHERE [m].[Id] = @__p_0
+WHERE [m].[Id] = @p
 ORDER BY [m].[Id], [s].[Id0], [s].[Id], [s0].[Id]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -176,19 +176,19 @@ FROM [Customers] AS [c]
 """,
             //
             """
-@__id_0='1'
+@id='1'
 
 SELECT TOP(2) [c].[Id], [c].[Name]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__id_0
+WHERE [c].[Id] = @id
 """,
             //
             """
-@__id_0='2'
+@id='2'
 
 SELECT TOP(2) [c].[Id], [c].[Name]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__id_0
+WHERE [c].[Id] = @id
 """);
     }
 
@@ -541,13 +541,13 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__testDateList_0='["2018-10-07T00:00:00"]' (Size = 4000)
+@testDateList='["2018-10-07T00:00:00"]' (Size = 4000)
 
 SELECT [r].[Id], [r].[MyTime]
 FROM [ReproEntity] AS [r]
 WHERE [r].[MyTime] IN (
     SELECT [t].[value]
-    FROM OPENJSON(@__testDateList_0) WITH ([value] smalldatetime '$') AS [t]
+    FROM OPENJSON(@testDateList) WITH ([value] smalldatetime '$') AS [t]
 )
 """);
     }
@@ -715,53 +715,53 @@ WHERE [d].[SmallDateTime] = '1970-09-03T12:00:00' AND [d].[DateTime] = '1971-09-
 
         AssertSql(
             """
-@__dateTimes_0='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_1='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_2='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_3='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_4='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_5='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_6='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_7='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_8='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_9='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
-@__dateTimes_0_10='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes0='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes1='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes2='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes3='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes4='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes5='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes6='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes7='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes8='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
+@dateTimes9='["1970-09-03T12:00:00","1971-09-03T12:00:10.22","1972-09-03T12:00:10.333","1973-09-03T12:00:10","1974-09-03T12:00:10.5","1975-09-03T12:00:10.66","1976-09-03T12:00:10.777","1977-09-03T12:00:10.888","1978-09-03T12:00:10.999","1979-09-03T12:00:10.111","1980-09-03T12:00:10.222"]' (Size = 4000)
 
 SELECT [d].[Id], [d].[DateTime], [d].[DateTime2], [d].[DateTime2_0], [d].[DateTime2_1], [d].[DateTime2_2], [d].[DateTime2_3], [d].[DateTime2_4], [d].[DateTime2_5], [d].[DateTime2_6], [d].[DateTime2_7], [d].[SmallDateTime]
 FROM [Dates] AS [d]
 WHERE [d].[SmallDateTime] IN (
     SELECT [d0].[value]
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] smalldatetime '$') AS [d0]
+    FROM OPENJSON(@dateTimes) WITH ([value] smalldatetime '$') AS [d0]
 ) AND [d].[DateTime] IN (
     SELECT [d1].[value]
-    FROM OPENJSON(@__dateTimes_0_1) WITH ([value] datetime '$') AS [d1]
+    FROM OPENJSON(@dateTimes0) WITH ([value] datetime '$') AS [d1]
 ) AND [d].[DateTime2] IN (
     SELECT [d2].[value]
-    FROM OPENJSON(@__dateTimes_0_2) WITH ([value] datetime2 '$') AS [d2]
+    FROM OPENJSON(@dateTimes1) WITH ([value] datetime2 '$') AS [d2]
 ) AND [d].[DateTime2_0] IN (
     SELECT [d3].[value]
-    FROM OPENJSON(@__dateTimes_0_3) WITH ([value] datetime2(0) '$') AS [d3]
+    FROM OPENJSON(@dateTimes2) WITH ([value] datetime2(0) '$') AS [d3]
 ) AND [d].[DateTime2_1] IN (
     SELECT [d4].[value]
-    FROM OPENJSON(@__dateTimes_0_4) WITH ([value] datetime2(1) '$') AS [d4]
+    FROM OPENJSON(@dateTimes3) WITH ([value] datetime2(1) '$') AS [d4]
 ) AND [d].[DateTime2_2] IN (
     SELECT [d5].[value]
-    FROM OPENJSON(@__dateTimes_0_5) WITH ([value] datetime2(2) '$') AS [d5]
+    FROM OPENJSON(@dateTimes4) WITH ([value] datetime2(2) '$') AS [d5]
 ) AND [d].[DateTime2_3] IN (
     SELECT [d6].[value]
-    FROM OPENJSON(@__dateTimes_0_6) WITH ([value] datetime2(3) '$') AS [d6]
+    FROM OPENJSON(@dateTimes5) WITH ([value] datetime2(3) '$') AS [d6]
 ) AND [d].[DateTime2_4] IN (
     SELECT [d7].[value]
-    FROM OPENJSON(@__dateTimes_0_7) WITH ([value] datetime2(4) '$') AS [d7]
+    FROM OPENJSON(@dateTimes6) WITH ([value] datetime2(4) '$') AS [d7]
 ) AND [d].[DateTime2_5] IN (
     SELECT [d8].[value]
-    FROM OPENJSON(@__dateTimes_0_8) WITH ([value] datetime2(5) '$') AS [d8]
+    FROM OPENJSON(@dateTimes7) WITH ([value] datetime2(5) '$') AS [d8]
 ) AND [d].[DateTime2_6] IN (
     SELECT [d9].[value]
-    FROM OPENJSON(@__dateTimes_0_9) WITH ([value] datetime2(6) '$') AS [d9]
+    FROM OPENJSON(@dateTimes8) WITH ([value] datetime2(6) '$') AS [d9]
 ) AND [d].[DateTime2_7] IN (
     SELECT [d10].[value]
-    FROM OPENJSON(@__dateTimes_0_10) WITH ([value] datetime2(7) '$') AS [d10]
+    FROM OPENJSON(@dateTimes9) WITH ([value] datetime2(7) '$') AS [d10]
 )
 """);
     }
@@ -1157,14 +1157,14 @@ end
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT (
     SELECT TOP(1) [g0].[Description]
     FROM [Gender] AS [g0]
     WHERE [g0].[Id] = [g].[GenderId]) AS [Gender]
 FROM (
-    SELECT TOP(@__p_0) [m].[Id], [m].[PersonId], [m].[Timestamp]
+    SELECT TOP(@p) [m].[Id], [m].[PersonId], [m].[Timestamp]
     FROM [Message] AS [m]
     ORDER BY [m].[Id]
 ) AS [m0]
@@ -1579,58 +1579,58 @@ WHERE [e].[PermissionByte] & [e].[PermissionByte] = [e].[PermissionByte]
 
         AssertSql(
             """
-@__id_0='1'
+@id='1'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE [e].[Id] = @__id_0
+WHERE [e].[Id] = @id
 """,
             //
             """
-@__id_0='2'
+@id='2'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE [e].[Id] = @__id_0
+WHERE [e].[Id] = @id
 """,
             //
             """
-@__id_0='1'
+@id='1'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE [e].[Id] = @__id_0
+WHERE [e].[Id] = @id
 """,
             //
             """
-@__id_0='2'
+@id='2'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE [e].[Id] = @__id_0
+WHERE [e].[Id] = @id
 """,
             //
             """
-@__id_0='1'
+@id='1'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
 WHERE [e].[Id] IN (
     SELECT [e0].[Id]
     FROM [Entities] AS [e0]
-    WHERE [e0].[Id] = @__id_0
+    WHERE [e0].[Id] = @id
 )
 """,
             //
             """
-@__id_0='2'
+@id='2'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
 WHERE [e].[Id] IN (
     SELECT [e0].[Id]
     FROM [Entities] AS [e0]
-    WHERE [e0].[Id] = @__id_0
+    WHERE [e0].[Id] = @id
 )
 """);
     }
@@ -1641,11 +1641,11 @@ WHERE [e].[Id] IN (
 
         AssertSql(
             """
-@__name_0='A' (Size = 4000)
+@name='A' (Size = 4000)
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE [e].[Name] = @__name_0
+WHERE [e].[Name] = @name
 """,
             //
             """
@@ -1782,16 +1782,16 @@ FROM [Entities] AS [e]
 
         AssertSql(
             """
-@__id1_0='1'
-@__id2_1='2'
+@id1='1'
+@id2='2'
 
 SELECT [t].[Id]
 FROM [Tables1] AS [t]
-WHERE [t].[Id] = @__id1_0
+WHERE [t].[Id] = @id1
 UNION
 SELECT [t0].[Id]
 FROM [Tables2] AS [t0]
-WHERE [t0].[Id] = @__id2_1
+WHERE [t0].[Id] = @id2
 """,
             //
             """
@@ -1817,30 +1817,30 @@ DEFAULT VALUES;
 
         AssertSql(
             """
-@__k_0='1'
+@k='1'
 
 SELECT TOP(1) [a].[Id], [a].[Name]
 FROM [Autos] AS [a]
-WHERE [a].[Id] = @__k_0
+WHERE [a].[Id] = @k
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT TOP(1) [a].[Id], [a].[Name]
 FROM [Autos] AS [a]
-WHERE [a].[Id] = @__p_0
+WHERE [a].[Id] = @p
 """,
             //
             """
-@__entity_equality_a_0_Id='1' (Nullable = true)
-@__entity_equality_b_1_Id='2' (Nullable = true)
+@entity_equality_a_Id='1' (Nullable = true)
+@entity_equality_b_Id='2' (Nullable = true)
 
 SELECT [e].[Id], [e].[AnotherAutoId], [e].[AutoId]
 FROM [EqualAutos] AS [e]
 LEFT JOIN [Autos] AS [a] ON [e].[AutoId] = [a].[Id]
 LEFT JOIN [Autos] AS [a0] ON [e].[AnotherAutoId] = [a0].[Id]
-WHERE ([a].[Id] = @__entity_equality_a_0_Id AND [a0].[Id] = @__entity_equality_b_1_Id) OR ([a].[Id] = @__entity_equality_b_1_Id AND [a0].[Id] = @__entity_equality_a_0_Id)
+WHERE ([a].[Id] = @entity_equality_a_Id AND [a0].[Id] = @entity_equality_b_Id) OR ([a].[Id] = @entity_equality_b_Id AND [a0].[Id] = @entity_equality_a_Id)
 """);
     }
 
@@ -2010,11 +2010,11 @@ LEFT JOIN [Postcodes] AS [p] ON [c].[PostcodeID] = [p].[PostcodeID]
 
         AssertSql(
             """
-@__bitterTaste_0='1'
+@bitterTaste='1'
 
 SELECT [i].[IceCreamId], [i].[Name], [i].[Taste]
 FROM [IceCreams] AS [i]
-WHERE [i].[Taste] = @__bitterTaste_0
+WHERE [i].[Taste] = @bitterTaste
 """);
     }
 
@@ -2095,7 +2095,7 @@ SELECT cast(null as int) AS MyValue
 
         AssertSql(
             """
-@__currentUserId_0='1'
+@currentUserId='1'
 
 SELECT CASE
     WHEN [u].[Id] IN (
@@ -2105,7 +2105,7 @@ SELECT CASE
         WHERE [m].[GroupId] IN (
             SELECT [m0].[GroupId]
             FROM [Memberships] AS [m0]
-            WHERE [m0].[UserId] = @__currentUserId_0
+            WHERE [m0].[UserId] = @currentUserId
         )
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
@@ -2120,7 +2120,7 @@ FROM [Users] AS [u]
 
         AssertSql(
             """
-@__currentUserId_0='1'
+@currentUserId='1'
 
 SELECT CASE
     WHEN [u].[Id] IN (
@@ -2132,7 +2132,7 @@ SELECT CASE
             SELECT [g0].[Id]
             FROM [Memberships] AS [m0]
             INNER JOIN [Groups] AS [g0] ON [m0].[GroupId] = [g0].[Id]
-            WHERE [m0].[UserId] = @__currentUserId_0
+            WHERE [m0].[UserId] = @currentUserId
         )
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
@@ -2147,7 +2147,7 @@ FROM [Users] AS [u]
 
         AssertSql(
             """
-@__currentUserId_0='1'
+@currentUserId='1'
 
 SELECT CASE
     WHEN EXISTS (
@@ -2157,7 +2157,7 @@ SELECT CASE
         WHERE [m].[GroupId] IN (
             SELECT [m0].[GroupId]
             FROM [Memberships] AS [m0]
-            WHERE [m0].[UserId] = @__currentUserId_0
+            WHERE [m0].[UserId] = @currentUserId
         ) AND [u0].[Id] = [u].[Id]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [HasAccess]
@@ -2171,17 +2171,17 @@ FROM [Users] AS [u]
 
         AssertSql(
             """
-@__orderId_0='123456'
+@orderId='123456'
 
 SELECT [o].[Id], [o].[CancellationDate], [o].[OrderId], [o].[ShippingDate]
 FROM [OrderItems] AS [o]
 INNER JOIN (
     SELECT [o0].[OrderId] AS [Key]
     FROM [OrderItems] AS [o0]
-    WHERE [o0].[OrderId] = @__orderId_0
+    WHERE [o0].[OrderId] = @orderId
     GROUP BY [o0].[OrderId]
 ) AS [o1] ON [o].[OrderId] = [o1].[Key]
-WHERE [o].[OrderId] = @__orderId_0
+WHERE [o].[OrderId] = @orderId
 ORDER BY [o].[OrderId]
 """);
     }
@@ -2192,15 +2192,15 @@ ORDER BY [o].[OrderId]
 
         AssertSql(
             """
-@__orderItemType_1='MyType1' (Nullable = false) (Size = 4000)
-@__p_0='1'
+@orderItemType='MyType1' (Nullable = false) (Size = 4000)
+@p='1'
 
 SELECT [o1].[Id], COALESCE((
     SELECT TOP(1) [o3].[Price]
     FROM [OrderItems] AS [o3]
-    WHERE [o1].[Id] = [o3].[OrderId] AND [o3].[Type] = @__orderItemType_1), 0.0E0) AS [SpecialSum]
+    WHERE [o1].[Id] = [o3].[OrderId] AND [o3].[Type] = @orderItemType), 0.0E0) AS [SpecialSum]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id]
+    SELECT TOP(@p) [o].[Id]
     FROM [Orders] AS [o]
     WHERE EXISTS (
         SELECT 1
@@ -2349,19 +2349,19 @@ LEFT JOIN [Child] AS [c] ON [p].[Id] = [c].[Id]
 
         AssertSql(
             """
-@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+@date='2012-12-12T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [m].[Id], [m].[SomeDate]
 FROM [MyEntities] AS [m]
-WHERE [m].[SomeDate] = @__date_0
+WHERE [m].[SomeDate] = @date
 """,
             //
             """
-@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+@date='2012-12-12T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [m].[Id], [m].[SomeDate]
 FROM [MyEntities] AS [m]
-WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @__date_0
+WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @date
 """);
     }
 
@@ -2371,9 +2371,9 @@ WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @__date_0
 
         AssertSql(
             """
-@__p_0='123456'
+@p='123456'
 
-SELECT TOP(@__p_0) [t].[JSON]
+SELECT TOP(@p) [t].[JSON]
 FROM [TableDatas] AS [t]
 INNER JOIN (
     SELECT DISTINCT [i].[Parcel]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocNavigationsQuerySqlServerTest.cs
@@ -405,14 +405,14 @@ WHERE [b].[Discriminator] = N'ClassA'
 
         AssertSql(
             """
-@__referenceId_0='a' (Size = 4000)
-@__customerId_1='1115c816-6c4c-4016-94df-d8b60a22ffa1'
+@referenceId='a' (Size = 4000)
+@customerId='1115c816-6c4c-4016-94df-d8b60a22ffa1'
 
 SELECT [o0].[Id], [s0].[Id], [s0].[Image], [s0].[Id0], [s0].[Id00]
 FROM (
     SELECT TOP(2) [o].[Id]
     FROM [Orders] AS [o]
-    WHERE [o].[ExternalReferenceId] = @__referenceId_0 AND [o].[CustomerId] = @__customerId_1
+    WHERE [o].[ExternalReferenceId] = @referenceId AND [o].[CustomerId] = @customerId
 ) AS [o0]
 OUTER APPLY (
     SELECT [i].[Id], [s].[Image], [s].[Id] AS [Id0], [s].[Id0] AS [Id00]
@@ -586,7 +586,7 @@ ORDER BY [m].[Id], [p].[Id], [s0].[Id]
 
         AssertSql(
             """
-@__id_0='1'
+@id='1'
 
 SELECT [s].[Id], [s].[Name], [s].[Surname], [s].[Birthday], [s].[Hometown], [s].[Bio], [s].[AvatarUrl], [s].[Id0], [s].[Id1], [p0].[Id], [p0].[ImageUrl], [p0].[Height], [p0].[Width], [u].[Id], [u].[Name], [u].[PosterUrl], [u].[Rating]
 FROM (
@@ -594,7 +594,7 @@ FROM (
     FROM [Persons] AS [p]
     LEFT JOIN [ActorEntity] AS [a] ON [p].[Id] = [a].[PersonId]
     LEFT JOIN [DirectorEntity] AS [d] ON [p].[Id] = [d].[PersonId]
-    WHERE [p].[Id] = @__id_0
+    WHERE [p].[Id] = @id
 ) AS [s]
 LEFT JOIN [PersonImageEntity] AS [p0] ON [s].[Id] = [p0].[PersonId]
 OUTER APPLY (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
@@ -29,11 +29,11 @@ WHERE CAST(JSON_VALUE([j].[IntList], '$[' + CAST([j].[Id] AS nvarchar(max)) + ']
 
         AssertSql(
             """
-@__id_0='1'
+@id='1'
 
 SELECT [j].[Id], [j].[IntList], [j].[JsonThing]
 FROM [JsonEntities] AS [j]
-WHERE CAST(JSON_VALUE([j].[IntList], '$[' + CAST(@__id_0 AS nvarchar(max)) + ']') AS int) = 2
+WHERE CAST(JSON_VALUE([j].[IntList], '$[' + CAST(@id AS nvarchar(max)) + ']') AS int) = 2
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
@@ -127,13 +127,13 @@ WHERE ([t].[Name] <> N'Bar') OR [t].[Name] IS NULL
 
         AssertSql(
             """
-@__ef_filter___ids_0='[1,7]' (Size = 4000)
+@ef_filter___ids='[1,7]' (Size = 4000)
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
 WHERE [e].[Id] NOT IN (
     SELECT [e0].[value]
-    FROM OPENJSON(@__ef_filter___ids_0) WITH ([value] int '$') AS [e0]
+    FROM OPENJSON(@ef_filter___ids) WITH ([value] int '$') AS [e0]
 )
 """);
     }
@@ -144,27 +144,27 @@ WHERE [e].[Id] NOT IN (
 
         AssertSql(
             """
-@__ef_filter__Tenant_0='0'
+@ef_filter__Tenant='0'
 
 SELECT [b].[Id], [b].[SomeValue]
 FROM [Blogs] AS [b]
-WHERE [b].[SomeValue] = @__ef_filter__Tenant_0
+WHERE [b].[SomeValue] = @ef_filter__Tenant
 """,
             //
             """
-@__ef_filter__Tenant_0='1'
+@ef_filter__Tenant='1'
 
 SELECT [b].[Id], [b].[SomeValue]
 FROM [Blogs] AS [b]
-WHERE [b].[SomeValue] = @__ef_filter__Tenant_0
+WHERE [b].[SomeValue] = @ef_filter__Tenant
 """,
             //
             """
-@__ef_filter__Tenant_0='2'
+@ef_filter__Tenant='2'
 
 SELECT COUNT(*)
 FROM [Blogs] AS [b]
-WHERE [b].[SomeValue] = @__ef_filter__Tenant_0
+WHERE [b].[SomeValue] = @ef_filter__Tenant
 """);
     }
 
@@ -235,19 +235,19 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__ef_filter__p_0='1'
+@ef_filter__p='1'
 
 SELECT [e].[Id], [e].[Name], [e].[TenantId]
 FROM [Entities] AS [e]
-WHERE ([e].[Name] <> N'Foo' OR [e].[Name] IS NULL) AND [e].[TenantId] = @__ef_filter__p_0
+WHERE ([e].[Name] <> N'Foo' OR [e].[Name] IS NULL) AND [e].[TenantId] = @ef_filter__p
 """,
             //
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [e].[Id], [e].[Name], [e].[TenantId]
 FROM [Entities] AS [e]
-WHERE ([e].[Name] <> N'Foo' OR [e].[Name] IS NULL) AND [e].[TenantId] = @__ef_filter__p_0
+WHERE ([e].[Name] <> N'Foo' OR [e].[Name] IS NULL) AND [e].[TenantId] = @ef_filter__p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -205,15 +205,15 @@ ORDER BY [l].[Id], [l0].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id], [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
@@ -228,15 +228,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l2].[Id], [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Optional_Self_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToMany_Required_Self_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l4].[OneToOne_Optional_Self3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Required_Id]
@@ -252,15 +252,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id], [l3].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id], [l3].[Id], [l3].[Level3_Optional_Id], [l3].[Level3_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse4Id], [l3].[OneToMany_Optional_Self_Inverse4Id], [l3].[OneToMany_Required_Inverse4Id], [l3].[OneToMany_Required_Self_Inverse4Id], [l3].[OneToOne_Optional_PK_Inverse4Id], [l3].[OneToOne_Optional_Self4Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Required_Id]
@@ -1175,11 +1175,11 @@ ORDER BY [l].[Id], [s].[Id], [s].[Id0]
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l2].[Id], [l4].[Id], [l1].[Id], [l4].[c]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
 ) AS [l2]
 LEFT JOIN (
@@ -1216,7 +1216,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT CASE
     WHEN [l0].[Id] IS NULL THEN 0
@@ -1227,7 +1227,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [l0].[Id]
 """);
@@ -1745,7 +1745,7 @@ ORDER BY [l].[Id], [s0].[Id], [s0].[Id0], [s0].[Id00]
 
         AssertSql(
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
@@ -1754,7 +1754,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE [l0].[Name] <> @__prm_0 OR [l0].[Name] IS NULL
+        WHERE [l0].[Name] <> @prm OR [l0].[Name] IS NULL
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1773,7 +1773,7 @@ FROM [LevelOne] AS [l]
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
@@ -1782,7 +1782,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE @__p_0 = CAST(1 AS bit)
+        WHERE @p = CAST(1 AS bit)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1914,11 +1914,11 @@ ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [s].[Id], [s].[I
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -1942,14 +1942,14 @@ ORDER BY [l3].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[Name], [l2].[OneToMany_Required_Inverse2Id] AS [Level1Id], [l2].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id]
@@ -1989,11 +1989,11 @@ ORDER BY [l1].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -2017,15 +2017,15 @@ ORDER BY [l3].[Id], [s].[Name] DESC, [s].[Id]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id] DESC
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l1].[Id] AS [Id0], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id]
@@ -2075,11 +2075,11 @@ ORDER BY [l3].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='30'
+@p='30'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -2332,7 +2332,7 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l1].[Date], [l2].[Id]
 FROM (
@@ -2340,7 +2340,7 @@ FROM (
     FROM [LevelOne] AS [l]
     WHERE [l].[Name] IN (
         SELECT [v].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
     )
     GROUP BY [l].[Date]
 ) AS [l1]
@@ -2349,7 +2349,7 @@ LEFT JOIN (
     FROM [LevelOne] AS [l0]
     WHERE [l0].[Name] IN (
         SELECT [v0].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v0]
     )
 ) AS [l2] ON [l1].[Date] = [l2].[Date]
 ORDER BY [l1].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -108,11 +108,11 @@ ORDER BY [l].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[Id1]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -142,14 +142,14 @@ ORDER BY [l3].[Id], [s].[c], [s].[Id1]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[Id1]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT CASE
@@ -340,11 +340,11 @@ ORDER BY [l].[Id], [l1].[Id], [l3].[Id], [l5].[Id], [l7].[Id], [l9].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]
@@ -525,15 +525,15 @@ ORDER BY [l].[Id], [l1].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id], [l7].[Id], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[Level3_Name], [l7].[OneToMany_Optional_Inverse3Id], [l7].[OneToMany_Required_Inverse3Id], [l7].[OneToOne_Optional_PK_Inverse3Id], [l4].[OneToOne_Required_PK_Date], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Level2_Name], [l4].[OneToMany_Optional_Inverse2Id], [l4].[OneToMany_Required_Inverse2Id], [l4].[OneToOne_Optional_PK_Inverse2Id], [l8].[Id], [l8].[Level2_Optional_Id], [l8].[Level2_Required_Id], [l8].[Level3_Name], [l8].[OneToMany_Optional_Inverse3Id], [l8].[OneToMany_Required_Inverse3Id], [l8].[OneToOne_Optional_PK_Inverse3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
@@ -1221,15 +1221,15 @@ ORDER BY [l4].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Level3_Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l6].[Id], [l6].[Level3_Optional_Id], [l6].[Level3_Required_Id], [l6].[Level4_Name], [l6].[OneToMany_Optional_Inverse4Id], [l6].[OneToMany_Required_Inverse4Id], [l6].[OneToOne_Optional_PK_Inverse4Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
@@ -1369,11 +1369,11 @@ ORDER BY [l].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l2].[Id], [l4].[Id0], [l5].[Id], [l5].[Id0], [l4].[Id], [l4].[c]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] AS [l]
 ) AS [l2]
 LEFT JOIN (
@@ -1544,7 +1544,7 @@ FROM [Level1] AS [l]
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id]
 FROM [Level1] AS [l]
@@ -1557,7 +1557,7 @@ LEFT JOIN (
             WHEN [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
         END AS [c]
         FROM [Level1] AS [l0]
-        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND @__p_0 = CAST(1 AS bit)
+        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND @p = CAST(1 AS bit)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1595,15 +1595,15 @@ ORDER BY [l].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l5].[Id], [l5].[Level2_Optional_Id], [l5].[Level2_Required_Id], [l5].[Level3_Name], [l5].[OneToMany_Optional_Inverse3Id], [l5].[OneToMany_Required_Inverse3Id], [l5].[OneToOne_Optional_PK_Inverse3Id], [l6].[Id], [l6].[Level2_Optional_Id], [l6].[Level2_Required_Id], [l6].[Level3_Name], [l6].[OneToMany_Optional_Inverse3Id], [l6].[OneToMany_Required_Inverse3Id], [l6].[OneToOne_Optional_PK_Inverse3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
@@ -1634,15 +1634,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l2].[Id], [l5].[Id]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id] DESC
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l4]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l3].[Id] AS [Id0], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Level3_Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id]
@@ -2116,11 +2116,11 @@ ORDER BY [l].[Id], [l2].[OneToMany_Optional_Inverse2Id], [l2].[c]
 
         AssertSql(
             """
-@__p_0='30'
+@p='30'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]
@@ -2459,7 +2459,7 @@ ORDER BY [l2].[Name], [l4].[Id]
 
         AssertSql(
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id]
 FROM [Level1] AS [l]
@@ -2472,7 +2472,7 @@ LEFT JOIN (
             WHEN [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
         END AS [c]
         FROM [Level1] AS [l0]
-        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level2_Name] <> @__prm_0 OR [l0].[Level2_Name] IS NULL)
+        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level2_Name] <> @prm OR [l0].[Level2_Name] IS NULL)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -2846,7 +2846,7 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NULL OR [s].[Level1_Required_Id] IS NULL OR [s].[OneToMany_Required_Inverse2Id] IS NULL THEN 0
@@ -2874,7 +2874,7 @@ LEFT JOIN (
 END = [l4].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [s].[Id], [s].[Id0]
 """);
@@ -3012,7 +3012,7 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l1].[Date], [l2].[Id]
 FROM (
@@ -3020,7 +3020,7 @@ FROM (
     FROM [Level1] AS [l]
     WHERE [l].[Name] IN (
         SELECT [v].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
     )
     GROUP BY [l].[Date]
 ) AS [l1]
@@ -3029,7 +3029,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[Name] IN (
         SELECT [v0].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v0]
     )
 ) AS [l2] ON [l1].[Date] = [l2].[Date]
 ORDER BY [l1].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -770,7 +770,7 @@ ORDER BY [l].[Id]
 """,
             //
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l].[Id]
 FROM [LevelOne] AS [l]
@@ -779,7 +779,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE [l0].[Name] <> @__prm_0 OR [l0].[Name] IS NULL
+        WHERE [l0].[Name] <> @prm OR [l0].[Name] IS NULL
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -804,7 +804,7 @@ ORDER BY [l].[Id]
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l].[Id]
 FROM [LevelOne] AS [l]
@@ -813,7 +813,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE @__p_0 = CAST(1 AS bit)
+        WHERE @p = CAST(1 AS bit)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1351,11 +1351,11 @@ ORDER BY [l].[Id], [l0].[Id]
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l1].[Id], [l3].[Id], [l3].[c]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
 ) AS [l1]
 LEFT JOIN (
@@ -1370,11 +1370,11 @@ ORDER BY [l1].[Id]
 """,
             //
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l4].[Id], [l5].[Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
 ) AS [l5]
 INNER JOIN [LevelTwo] AS [l4] ON [l5].[Id] = [l4].[OneToMany_Required_Inverse2Id]
@@ -1620,19 +1620,19 @@ ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [s].[Id], [s].[I
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+SELECT TOP(@p) [l].[Id], [l].[Name]
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l9].[Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l9]
@@ -1656,23 +1656,23 @@ ORDER BY [l9].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l].[Id], [l].[Name]
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l9].[Id]
 FROM (
     SELECT [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [l9]
 CROSS APPLY (
     SELECT [l8].[Id], [l8].[Name], [l8].[OneToMany_Required_Inverse2Id] AS [Level1Id], [l8].[Level1_Required_Id] AS [Level2Id], [l7].[Id] AS [Id0], [l7].[Date], [l7].[Name] AS [Name0], [l7].[OneToMany_Optional_Self_Inverse1Id], [l7].[OneToMany_Required_Self_Inverse1Id], [l7].[OneToOne_Optional_Self1Id]
@@ -1984,30 +1984,30 @@ ORDER BY [l].[Id], [l0].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Required_Id]
 ORDER BY [l1].[Name], [l1].[Id], [l0].[Id]
 """,
             //
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id], [l1].[Id], [l0].[Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
@@ -2015,15 +2015,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id]
 """,
             //
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id], [l1].[Id], [l0].[Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l3] ON [l0].[Id] = [l3].[OneToMany_Required_Inverse3Id]
@@ -2037,15 +2037,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Required_Id]
@@ -2053,15 +2053,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id]
 """,
             //
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id], [l1].[Id], [l0].[Id], [l2].[Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Required_Id]
@@ -2070,15 +2070,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id]
 """,
             //
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Optional_Self_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToMany_Required_Self_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l4].[OneToOne_Optional_Self3Id], [l1].[Id], [l0].[Id], [l2].[Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Required_Id]
@@ -2093,15 +2093,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Required_Id]
@@ -2109,15 +2109,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l0].[Id], [l2].[Id]
 """,
             //
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l3].[Id], [l3].[Level3_Optional_Id], [l3].[Level3_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse4Id], [l3].[OneToMany_Optional_Self_Inverse4Id], [l3].[OneToMany_Required_Inverse4Id], [l3].[OneToMany_Required_Self_Inverse4Id], [l3].[OneToOne_Optional_PK_Inverse4Id], [l3].[OneToOne_Optional_Self4Id], [l1].[Id], [l0].[Id], [l2].[Id]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Required_Id]
@@ -3189,7 +3189,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT CASE
     WHEN [l0].[Id] IS NULL THEN 0
@@ -3199,13 +3199,13 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [l0].[Id]
 """,
             //
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], [l].[Id], [l0].[Id]
 FROM [LevelOne] AS [l]
@@ -3213,7 +3213,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [l0].[Id]
 """);
@@ -3280,19 +3280,19 @@ ORDER BY [l].[Id], [l2].[OneToMany_Optional_Inverse2Id], [l2].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [l3].[Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -3316,25 +3316,25 @@ ORDER BY [l3].[Id], [s].[Name] DESC
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id] DESC
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """,
             //
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [l3].[Id]
 FROM (
     SELECT [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id] DESC
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l3]
 CROSS APPLY (
     SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l1].[Id] AS [Id0], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id]
@@ -3390,19 +3390,19 @@ ORDER BY [l3].[Id]
 
         AssertSql(
             """
-@__p_0='30'
+@p='30'
 
-SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id]
 """,
             //
             """
-@__p_0='30'
+@p='30'
 
 SELECT [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [l3].[Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -3747,20 +3747,20 @@ ORDER BY [l].[Id], [l15].[Date], [l17].[Name], [l17].[Date]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l].[Date]
 FROM [LevelOne] AS [l]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 GROUP BY [l].[Date]
 ORDER BY [l].[Date]
 """,
             //
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l5].[Id], [l4].[Date]
 FROM (
@@ -3768,7 +3768,7 @@ FROM (
     FROM [LevelOne] AS [l]
     WHERE [l].[Name] IN (
         SELECT [v].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
     )
     GROUP BY [l].[Date]
 ) AS [l4]
@@ -3777,7 +3777,7 @@ INNER JOIN (
     FROM [LevelOne] AS [l3]
     WHERE [l3].[Name] IN (
         SELECT [v3].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v3]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v3]
     )
 ) AS [l5] ON [l4].[Date] = [l5].[Date]
 ORDER BY [l4].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
@@ -1552,11 +1552,11 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l0].[Id] AS [Id0], [l0].[Level1_Required_Id]
+    SELECT TOP(@p) [l0].[Id] AS [Id0], [l0].[Level1_Required_Id]
     FROM [LevelThree] AS [l]
     INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
     ORDER BY [l0].[Id]
@@ -1573,9 +1573,9 @@ ORDER BY [s].[Id0]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelThree] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
 ORDER BY [l0].[Id]
@@ -1588,11 +1588,11 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l0].[Id] AS [Id0]
+    SELECT TOP(@p) [l0].[Id] AS [Id0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l0].[Id]
@@ -1608,9 +1608,9 @@ ORDER BY [s].[Id0]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 WHERE [l0].[Name] = N'L1 03'
@@ -1624,9 +1624,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
@@ -1641,9 +1641,9 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
@@ -1657,9 +1657,9 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE [l0].[Name] = N'L2 03'
@@ -2273,11 +2273,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2300,11 +2300,11 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2321,11 +2321,11 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2341,9 +2341,9 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [l].[Id], [l0].[Name] AS [Brand]
+SELECT TOP(@p) [l].[Id], [l0].[Name] AS [Brand]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 ORDER BY [l0].[Name], [l].[Id]
@@ -2356,12 +2356,12 @@ ORDER BY [l0].[Name], [l].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l].[Id], [s].[Name]
 FROM [LevelTwo] AS [l]
 LEFT JOIN (
-    SELECT TOP(@__p_0) [l0].[Id], [l0].[Name]
+    SELECT TOP(@p) [l0].[Id], [l0].[Name]
     FROM [LevelOne] AS [l0]
     LEFT JOIN [LevelTwo] AS [l1] ON [l0].[Id] = [l1].[Level1_Optional_Id]
     ORDER BY [l1].[Name]
@@ -2525,9 +2525,9 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
@@ -2541,9 +2541,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
@@ -2586,9 +2586,9 @@ WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
-SELECT TOP(@__p_0) [s].[Id]
+SELECT TOP(@p) [s].[Id]
 FROM (
     SELECT DISTINCT [l].[Id]
     FROM [LevelOne] AS [l]
@@ -2639,8 +2639,8 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l].[Name]
 FROM [LevelThree] AS [l]
@@ -2648,7 +2648,7 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[OneToMany_Required_Inverse3Id] = [l0].[Id]
 INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
 WHERE [l1].[Name] IN (N'L1 10', N'L1 01')
 ORDER BY [l].[Level2_Required_Id]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -2682,11 +2682,11 @@ INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Id] AS [Id0]
+    SELECT TOP(@p) [l].[Id], [l0].[Id] AS [Id0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -3141,14 +3141,14 @@ WHERE [l0].[Id] IS NOT NULL
 
         AssertSql(
             """
-@__names_0='["Name1","Name2"]' (Size = 4000)
+@names='["Name1","Name2"]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 ) OR [l0].[Name] IS NULL
 """);
     }
@@ -3369,11 +3369,11 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3406,11 +3406,11 @@ LEFT JOIN [LevelTwo] AS [l1] ON [s].[Id] = [l1].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3427,11 +3427,11 @@ ORDER BY [s].[Name0]
         // issue #15783
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3448,11 +3448,11 @@ ORDER BY [s].[Name0]
         // issue #15783
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3501,11 +3501,11 @@ LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l1]
@@ -4251,11 +4251,11 @@ WHERE [l].[Id] < 2
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id1] AS [Foo], [s].[Id2] AS [Bar], [s].[Id3] AS [Baz]
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [l].[Id] AS [Id1], [l0].[Id] AS [Id2], [l1].[Id] AS [Id3], [l].[Name] AS [Name1], [l0].[Name] AS [Name2]
+    SELECT DISTINCT TOP(@p) [l].[Id] AS [Id1], [l0].[Id] AS [Id2], [l1].[Id] AS [Id3], [l].[Name] AS [Name1], [l0].[Name] AS [Name2]
     FROM [LevelOne] AS [l]
     INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
@@ -4364,9 +4364,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY [l].[Id]
@@ -4631,14 +4631,14 @@ LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 """);
     }
@@ -4649,14 +4649,14 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 """);
     }
@@ -4667,20 +4667,20 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm1_0
+    WHERE [l0].[Id] <> @prm1
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm2_1
+    WHERE [l2].[Id] <> @prm2
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4691,20 +4691,20 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm1_0
+    WHERE [l0].[Id] <> @prm1
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm2_1
+    WHERE [l2].[Id] <> @prm2
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4715,19 +4715,19 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm_0
+    WHERE [l2].[Id] <> @prm
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4738,19 +4738,19 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm_0
+    WHERE [l2].[Id] <> @prm
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4821,11 +4821,11 @@ ORDER BY [l].[Id], [s].[Id0]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l4].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Result]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1552,11 +1552,11 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l0].[Id] AS [Id0], [l0].[Level1_Required_Id]
+    SELECT TOP(@p) [l0].[Id] AS [Id0], [l0].[Level1_Required_Id]
     FROM [LevelThree] AS [l]
     INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
     ORDER BY [l0].[Id]
@@ -1573,9 +1573,9 @@ ORDER BY [s].[Id0]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelThree] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
 ORDER BY [l0].[Id]
@@ -1588,11 +1588,11 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l0].[Id] AS [Id0]
+    SELECT TOP(@p) [l0].[Id] AS [Id0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l0].[Id]
@@ -1608,9 +1608,9 @@ ORDER BY [s].[Id0]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 WHERE [l0].[Name] = N'L1 03'
@@ -1624,9 +1624,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
@@ -1641,9 +1641,9 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[Level1_Required_Id] = [l0].[Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
@@ -1657,9 +1657,9 @@ ORDER BY [l0].[Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE [l0].[Name] = N'L2 03'
@@ -2273,11 +2273,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2300,11 +2300,11 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2321,11 +2321,11 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -2341,9 +2341,9 @@ ORDER BY [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [l].[Id], [l0].[Name] AS [Brand]
+SELECT TOP(@p) [l].[Id], [l0].[Name] AS [Brand]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 ORDER BY [l0].[Name], [l].[Id]
@@ -2356,12 +2356,12 @@ ORDER BY [l0].[Name], [l].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l].[Id], [s].[Name]
 FROM [LevelTwo] AS [l]
 LEFT JOIN (
-    SELECT TOP(@__p_0) [l0].[Id], [l0].[Name]
+    SELECT TOP(@p) [l0].[Id], [l0].[Name]
     FROM [LevelOne] AS [l0]
     LEFT JOIN [LevelTwo] AS [l1] ON [l0].[Id] = [l1].[Level1_Optional_Id]
     ORDER BY [l1].[Name]
@@ -2525,9 +2525,9 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
@@ -2541,9 +2541,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
@@ -2586,9 +2586,9 @@ WHERE [l0].[Name] <> N'Foo' OR [l0].[Name] IS NULL
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
-SELECT TOP(@__p_0) [s].[Id]
+SELECT TOP(@p) [s].[Id]
 FROM (
     SELECT DISTINCT [l].[Id]
     FROM [LevelOne] AS [l]
@@ -2639,8 +2639,8 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l].[Name]
 FROM [LevelThree] AS [l]
@@ -2648,7 +2648,7 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[OneToMany_Required_Inverse3Id] = [l0].[Id]
 INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
 WHERE [l1].[Name] IN (N'L1 10', N'L1 01')
 ORDER BY [l].[Level2_Required_Id]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -2682,11 +2682,11 @@ INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l1].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l0].[Id] AS [Id0]
+    SELECT TOP(@p) [l].[Id], [l0].[Id] AS [Id0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
@@ -3141,14 +3141,14 @@ WHERE [l0].[Id] IS NOT NULL
 
         AssertSql(
             """
-@__names_0='["Name1","Name2"]' (Size = 4000)
+@names='["Name1","Name2"]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l0].[Name] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 ) OR [l0].[Name] IS NULL
 """);
     }
@@ -3369,11 +3369,11 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3406,11 +3406,11 @@ LEFT JOIN [LevelTwo] AS [l1] ON [s].[Id] = [l1].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3427,11 +3427,11 @@ ORDER BY [s].[Name0]
         // issue #15783
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3448,11 +3448,11 @@ ORDER BY [s].[Name0]
         // issue #15783
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Name] AS [Name0]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
     ORDER BY [l0].[Name]
@@ -3501,11 +3501,11 @@ LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l1]
@@ -4251,11 +4251,11 @@ WHERE [l].[Id] < 2
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id1] AS [Foo], [s].[Id2] AS [Bar], [s].[Id3] AS [Baz]
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [l].[Id] AS [Id1], [l0].[Id] AS [Id2], [l1].[Id] AS [Id3], [l].[Name] AS [Name1], [l0].[Name] AS [Name2]
+    SELECT DISTINCT TOP(@p) [l].[Id] AS [Id1], [l0].[Id] AS [Id2], [l1].[Id] AS [Id3], [l].[Name] AS [Name1], [l0].[Name] AS [Name2]
     FROM [LevelOne] AS [l]
     INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
@@ -4364,9 +4364,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [l0].[Name]
+SELECT TOP(@p) [l0].[Name]
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY [l].[Id]
@@ -4631,14 +4631,14 @@ LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 """);
     }
@@ -4649,14 +4649,14 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 """);
     }
@@ -4667,20 +4667,20 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm1_0
+    WHERE [l0].[Id] <> @prm1
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm2_1
+    WHERE [l2].[Id] <> @prm2
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4691,20 +4691,20 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm1_0
+    WHERE [l0].[Id] <> @prm1
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm2_1
+    WHERE [l2].[Id] <> @prm2
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4715,19 +4715,19 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm_0
+    WHERE [l2].[Id] <> @prm
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4738,19 +4738,19 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], [l1].[Id] AS [Id2], [l3].[Id] AS [Id3]
 FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Level1_Optional_Id]
     FROM [LevelTwo] AS [l0]
-    WHERE [l0].[Id] <> @__prm_0
+    WHERE [l0].[Id] <> @prm
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id]
     FROM [LevelThree] AS [l2]
-    WHERE [l2].[Id] <> @__prm_0
+    WHERE [l2].[Id] <> @prm
 ) AS [l3] ON [l1].[Id] = [l3].[Level2_Optional_Id]
 """);
     }
@@ -4821,11 +4821,11 @@ ORDER BY [l].[Id], [s].[Id0]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l4].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Result]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
@@ -297,11 +297,11 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s1].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Id0] AS [Id00], [s].[OneToOne_Required_PK_Date], [s].[Level1_Required_Id], [s].[OneToMany_Required_Inverse2Id]
+    SELECT TOP(@p) [l].[Id], [s].[Id0] AS [Id00], [s].[OneToOne_Required_PK_Date], [s].[Level1_Required_Id], [s].[OneToMany_Required_Inverse2Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Id] AS [Id0], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[OneToMany_Required_Inverse2Id]
@@ -1630,11 +1630,11 @@ CROSS APPLY (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s1].[Id1] AS [Foo], [s1].[Id2] AS [Bar], [s1].[Id3] AS [Baz]
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [l].[Id] AS [Id1], CASE
+    SELECT DISTINCT TOP(@p) [l].[Id] AS [Id1], CASE
         WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
     END AS [Id2], CASE
         WHEN [s0].[Level2_Required_Id] IS NOT NULL AND [s0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [s0].[Id1]
@@ -1930,11 +1930,11 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l3].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [s].[Level1_Optional_Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2410,9 +2410,9 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [l].[Id], [l1].[Level2_Name] AS [Brand]
+SELECT TOP(@p) [l].[Id], [l1].[Level2_Name] AS [Brand]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Optional_Id], [l0].[Level2_Name]
@@ -2586,11 +2586,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l3].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [s].[Level1_Optional_Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2702,11 +2702,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s1].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2979,9 +2979,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l1].[Level2_Name]
+SELECT TOP(@p) [l1].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id]
@@ -3004,9 +3004,9 @@ END
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l1].[Level2_Name]
+SELECT TOP(@p) [l1].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id]
@@ -3096,11 +3096,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l6].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l5].[Level1_Required_Id] AS [Level1_Required_Id0], CASE
+    SELECT TOP(@p) [l5].[Level1_Required_Id] AS [Level1_Required_Id0], CASE
         WHEN [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l5].[Id]
     END AS [c]
     FROM [Level1] AS [l]
@@ -3192,11 +3192,11 @@ ORDER BY [l1].[Level2_Name], [l].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l4].[Id], [l4].[OneToOne_Required_PK_Date], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Level2_Name], [l4].[OneToMany_Optional_Inverse2Id], [l4].[OneToMany_Required_Inverse2Id], [l4].[OneToOne_Optional_PK_Inverse2Id], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l1]
@@ -3683,9 +3683,9 @@ END = 7
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
-SELECT TOP(@__p_0) [s0].[Id]
+SELECT TOP(@p) [s0].[Id]
 FROM (
     SELECT DISTINCT [l].[Id]
     FROM [Level1] AS [l]
@@ -3842,11 +3842,11 @@ WHERE [s].[Level2_Name] <> N'Foo' OR [s].[Level2_Name] IS NULL
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -4273,9 +4273,9 @@ WHERE [l1].[Level2_Name] IS NOT NULL AND LEFT([l1].[Level2_Name], LEN([l1].[Leve
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [l1].[Name]
+SELECT TOP(@p) [l1].[Name]
 FROM [Level1] AS [l]
 INNER JOIN (
     SELECT [l0].[Level2_Name] AS [Name], [l0].[OneToMany_Optional_Inverse2Id]
@@ -4967,7 +4967,7 @@ WHERE [l1].[Level2_Name] <> N'L2 05' OR [l1].[Level2_Name] IS NULL
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT CASE
     WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
@@ -4981,7 +4981,7 @@ LEFT JOIN (
     WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
 END
 LEFT JOIN (
-    SELECT TOP(@__p_0) [l2].[Id], [l2].[Name]
+    SELECT TOP(@p) [l2].[Id], [l2].[Name]
     FROM [Level1] AS [l2]
     LEFT JOIN (
         SELECT [l3].[Level1_Optional_Id], [l3].[Level2_Name]
@@ -5231,9 +5231,9 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -5304,8 +5304,8 @@ WHERE [l5].[Level3_Required_Id] IS NULL OR [l5].[OneToMany_Required_Inverse4Id] 
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l3].[Level3_Name]
 FROM [Level1] AS [l]
@@ -5335,7 +5335,7 @@ END
 LEFT JOIN [Level1] AS [l6] ON [l5].[Level1_Required_Id] = [l6].[Id]
 WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l3].[Level2_Required_Id] IS NOT NULL AND [l3].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l6].[Name] IN (N'L1 10', N'L1 01')
 ORDER BY [l3].[Level2_Required_Id]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -5346,9 +5346,9 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l2].[Name]
+SELECT TOP(@p) [l2].[Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
@@ -5564,7 +5564,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__names_0='["Name1","Name2"]' (Size = 4000)
+@names='["Name1","Name2"]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name]
 FROM [Level1] AS [l]
@@ -5575,7 +5575,7 @@ LEFT JOIN (
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 WHERE [l1].[Level2_Name] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 ) OR [l1].[Level2_Name] IS NULL
 """);
     }
@@ -6765,9 +6765,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Optional_Id], [l0].[Level2_Name]
@@ -6917,9 +6917,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [l5].[Level2_Name]
+SELECT TOP(@p) [l5].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
@@ -7035,11 +7035,11 @@ END
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -7242,11 +7242,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l3].[Level3_Name]
 FROM (
-    SELECT TOP(@__p_0) [l1].[Id] AS [Id0], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id], CASE
+    SELECT TOP(@p) [l1].[Id] AS [Id0], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id], CASE
         WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
     END AS [c]
     FROM [Level1] AS [l]
@@ -7299,11 +7299,11 @@ END = [l3].[OneToMany_Optional_Inverse3Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -7349,9 +7349,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l2].[Level1_Optional_Id], [l2].[Level2_Name]
@@ -7442,11 +7442,11 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -8028,7 +8028,7 @@ END = [l5].[Level3_Required_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8044,7 +8044,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 """);
     }
@@ -8055,7 +8055,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8071,7 +8071,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 """);
     }
@@ -8082,8 +8082,8 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8101,7 +8101,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm1_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm1 OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8122,7 +8122,7 @@ LEFT JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm2_1 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm2 OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8135,8 +8135,8 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8154,7 +8154,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm1_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm1 OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8175,7 +8175,7 @@ INNER JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm2_1 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm2 OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8188,7 +8188,7 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8206,7 +8206,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8227,7 +8227,7 @@ LEFT JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm_0 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8240,7 +8240,7 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8258,7 +8258,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8279,7 +8279,7 @@ INNER JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm_0 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8370,11 +8370,11 @@ ORDER BY [l].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l6].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Result], [s].[Id2], [s].[Id3], [s].[Id4]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l6]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -299,11 +299,11 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s1].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Id0] AS [Id00], [s].[OneToOne_Required_PK_Date], [s].[Level1_Required_Id], [s].[OneToMany_Required_Inverse2Id]
+    SELECT TOP(@p) [l].[Id], [s].[Id0] AS [Id00], [s].[OneToOne_Required_PK_Date], [s].[Level1_Required_Id], [s].[OneToMany_Required_Inverse2Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Id] AS [Id0], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[OneToMany_Required_Inverse2Id]
@@ -1632,11 +1632,11 @@ CROSS APPLY (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s1].[Id1] AS [Foo], [s1].[Id2] AS [Bar], [s1].[Id3] AS [Baz]
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [l].[Id] AS [Id1], CASE
+    SELECT DISTINCT TOP(@p) [l].[Id] AS [Id1], CASE
         WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
     END AS [Id2], CASE
         WHEN [s0].[Level2_Required_Id] IS NOT NULL AND [s0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [s0].[Id1]
@@ -1932,11 +1932,11 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l3].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [s].[Level1_Optional_Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2412,9 +2412,9 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [l].[Id], [l1].[Level2_Name] AS [Brand]
+SELECT TOP(@p) [l].[Id], [l1].[Level2_Name] AS [Brand]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Optional_Id], [l0].[Level2_Name]
@@ -2588,11 +2588,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l3].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [s].[Level1_Optional_Id]
+    SELECT TOP(@p) [l].[Id], [s].[Level1_Optional_Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2704,11 +2704,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s1].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l2].[Level1_Optional_Id]
@@ -2981,9 +2981,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l1].[Level2_Name]
+SELECT TOP(@p) [l1].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id]
@@ -3006,9 +3006,9 @@ END
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l1].[Level2_Name]
+SELECT TOP(@p) [l1].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id]
@@ -3098,11 +3098,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l6].[Name]
 FROM (
-    SELECT TOP(@__p_0) [l5].[Level1_Required_Id] AS [Level1_Required_Id0], CASE
+    SELECT TOP(@p) [l5].[Level1_Required_Id] AS [Level1_Required_Id0], CASE
         WHEN [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l5].[Id]
     END AS [c]
     FROM [Level1] AS [l]
@@ -3194,11 +3194,11 @@ ORDER BY [l1].[Level2_Name], [l].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l4].[Id], [l4].[OneToOne_Required_PK_Date], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Level2_Name], [l4].[OneToMany_Optional_Inverse2Id], [l4].[OneToMany_Required_Inverse2Id], [l4].[OneToOne_Optional_PK_Inverse2Id], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l1]
@@ -3685,9 +3685,9 @@ END = 7
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
-SELECT TOP(@__p_0) [s0].[Id]
+SELECT TOP(@p) [s0].[Id]
 FROM (
     SELECT DISTINCT [l].[Id]
     FROM [Level1] AS [l]
@@ -3844,11 +3844,11 @@ WHERE [s].[Level2_Name] <> N'Foo' OR [s].[Level2_Name] IS NULL
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -4275,9 +4275,9 @@ WHERE [l1].[Level2_Name] IS NOT NULL AND LEFT([l1].[Level2_Name], LEN([l1].[Leve
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [l1].[Name]
+SELECT TOP(@p) [l1].[Name]
 FROM [Level1] AS [l]
 INNER JOIN (
     SELECT [l0].[Level2_Name] AS [Name], [l0].[OneToMany_Optional_Inverse2Id]
@@ -4969,7 +4969,7 @@ WHERE [l1].[Level2_Name] <> N'L2 05' OR [l1].[Level2_Name] IS NULL
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT CASE
     WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
@@ -4983,7 +4983,7 @@ LEFT JOIN (
     WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
 END
 LEFT JOIN (
-    SELECT TOP(@__p_0) [l2].[Id], [l2].[Name]
+    SELECT TOP(@p) [l2].[Id], [l2].[Name]
     FROM [Level1] AS [l2]
     LEFT JOIN (
         SELECT [l3].[Level1_Optional_Id], [l3].[Level2_Name]
@@ -5233,9 +5233,9 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l].[Name]
+SELECT TOP(@p) [l].[Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -5306,8 +5306,8 @@ WHERE [l5].[Level3_Required_Id] IS NULL OR [l5].[OneToMany_Required_Inverse4Id] 
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l3].[Level3_Name]
 FROM [Level1] AS [l]
@@ -5337,7 +5337,7 @@ END
 LEFT JOIN [Level1] AS [l6] ON [l5].[Level1_Required_Id] = [l6].[Id]
 WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l3].[Level2_Required_Id] IS NOT NULL AND [l3].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l6].[Name] IN (N'L1 10', N'L1 01')
 ORDER BY [l3].[Level2_Required_Id]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -5348,9 +5348,9 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [l2].[Name]
+SELECT TOP(@p) [l2].[Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
@@ -5566,7 +5566,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__names_0='["Name1","Name2"]' (Size = 4000)
+@names='["Name1","Name2"]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name]
 FROM [Level1] AS [l]
@@ -5577,7 +5577,7 @@ LEFT JOIN (
 ) AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 WHERE [l1].[Level2_Name] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 ) OR [l1].[Level2_Name] IS NULL
 """);
     }
@@ -6766,9 +6766,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Level1_Optional_Id], [l0].[Level2_Name]
@@ -6918,9 +6918,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [l5].[Level2_Name]
+SELECT TOP(@p) [l5].[Level2_Name]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
@@ -7036,11 +7036,11 @@ END
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -7243,11 +7243,11 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [l3].[Level3_Name]
 FROM (
-    SELECT TOP(@__p_0) [l1].[Id] AS [Id0], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id], CASE
+    SELECT TOP(@p) [l1].[Id] AS [Id0], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id], CASE
         WHEN [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l1].[Id]
     END AS [c]
     FROM [Level1] AS [l]
@@ -7300,11 +7300,11 @@ END = [l3].[OneToMany_Optional_Inverse3Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -7350,9 +7350,9 @@ WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id]
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
-SELECT TOP(@__p_0) [l].[Id]
+SELECT TOP(@p) [l].[Id]
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l2].[Level1_Optional_Id], [l2].[Level2_Name]
@@ -7443,11 +7443,11 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Id], [s].[Date], [s].[Name], [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l1].[Level2_Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
         SELECT [l0].[Level1_Required_Id], [l0].[Level2_Name]
@@ -8029,7 +8029,7 @@ END = [l5].[Level3_Required_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8045,7 +8045,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 """);
     }
@@ -8056,7 +8056,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8072,7 +8072,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 """);
     }
@@ -8083,8 +8083,8 @@ INNER JOIN (
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8102,7 +8102,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm1_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm1 OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8123,7 +8123,7 @@ LEFT JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm2_1 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm2 OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8136,8 +8136,8 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm1_0='10'
-@__prm2_1='20'
+@prm1='10'
+@prm2='20'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8155,7 +8155,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm1_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm1 OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8176,7 +8176,7 @@ INNER JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm2_1 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm2 OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8189,7 +8189,7 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8207,7 +8207,7 @@ LEFT JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 LEFT JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8228,7 +8228,7 @@ LEFT JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm_0 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8241,7 +8241,7 @@ END = [s0].[Level2_Optional_Id]
 
         AssertSql(
             """
-@__prm_0='10'
+@prm='10'
 
 SELECT [l].[Id] AS [Id1], CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
@@ -8259,7 +8259,7 @@ INNER JOIN (
     ) AS [l2] ON [l0].[Id] = CASE
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
-    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @__prm_0 OR [l2].[Id] IS NULL)
+    WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Id] <> @prm OR [l2].[Id] IS NULL)
 ) AS [s] ON [l].[Id] = [s].[Level1_Optional_Id]
 INNER JOIN (
     SELECT [l7].[Id] AS [Id1], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[OneToMany_Required_Inverse3Id]
@@ -8280,7 +8280,7 @@ INNER JOIN (
     END = CASE
         WHEN [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [l7].[Id]
     END
-    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @__prm_0 OR [l7].[Id] IS NULL)
+    WHERE [l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l7].[Level2_Required_Id] IS NOT NULL AND [l7].[OneToMany_Required_Inverse3Id] IS NOT NULL AND ([l7].[Id] <> @prm OR [l7].[Id] IS NULL)
 ) AS [s0] ON CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [s].[Id0]
 END = [s0].[Level2_Optional_Id]
@@ -8371,11 +8371,11 @@ ORDER BY [l].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [l6].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Result], [s].[Id2], [s].[Id3], [s].[Id4]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] AS [l]
     ORDER BY [l].[Id]
 ) AS [l6]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -47,14 +47,14 @@ WHERE [c].[ShippingAddress_Country_Code] = N'DE'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_Tags], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
     FROM [Customer] AS [c]
     ORDER BY [c].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 WHERE [c0].[ShippingAddress_ZipCode] = 7728
 """);
@@ -66,14 +66,14 @@ WHERE [c0].[ShippingAddress_ZipCode] = 7728
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_Tags], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
     FROM [Customer] AS [c]
     ORDER BY [c].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 WHERE [c0].[ShippingAddress_Country_Code] = N'DE'
 """);
@@ -135,14 +135,14 @@ INNER JOIN [Customer] AS [c0] ON [c].[RequiredCustomerId] = [c0].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_Tags], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
     FROM [Customer] AS [c]
     ORDER BY [c].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -233,15 +233,15 @@ WHERE [c].[ShippingAddress_AddressLine1] = N'804 S. Lakeshore Road' AND [c].[Shi
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
-@__entity_equality_address_0_Tags='["foo","bar"]' (Size = 4000)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 4000)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@entity_equality_address_Tags='["foo","bar"]' (Size = 4000)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 4000)
+@entity_equality_address_Country_FullName='United States' (Size = 4000)
 
 SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
 FROM [Customer] AS [c]
-WHERE [c].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c].[ShippingAddress_AddressLine2] IS NULL AND [c].[ShippingAddress_Tags] = @__entity_equality_address_0_Tags AND [c].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [c].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName
+WHERE [c].[ShippingAddress_AddressLine1] = @entity_equality_address_AddressLine1 AND [c].[ShippingAddress_AddressLine2] IS NULL AND [c].[ShippingAddress_Tags] = @entity_equality_address_Tags AND [c].[ShippingAddress_ZipCode] = @entity_equality_address_ZipCode AND [c].[ShippingAddress_Country_Code] = @entity_equality_address_Country_Code AND [c].[ShippingAddress_Country_FullName] = @entity_equality_address_Country_FullName
 """);
     }
 
@@ -265,18 +265,18 @@ WHERE [c].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressL
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
-@__entity_equality_address_0_Tags='["foo","bar"]' (Size = 4000)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 4000)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@entity_equality_address_Tags='["foo","bar"]' (Size = 4000)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 4000)
+@entity_equality_address_Country_FullName='United States' (Size = 4000)
 
 SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
 FROM [Customer] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Customer] AS [c0]
-    WHERE [c0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [c0].[ShippingAddress_AddressLine2] IS NULL AND [c0].[ShippingAddress_Tags] = @__entity_equality_address_0_Tags AND [c0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [c0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [c0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName)
+    WHERE [c0].[ShippingAddress_AddressLine1] = @entity_equality_address_AddressLine1 AND [c0].[ShippingAddress_AddressLine2] IS NULL AND [c0].[ShippingAddress_Tags] = @entity_equality_address_Tags AND [c0].[ShippingAddress_ZipCode] = @entity_equality_address_ZipCode AND [c0].[ShippingAddress_Country_Code] = @entity_equality_address_Country_Code AND [c0].[ShippingAddress_Country_FullName] = @entity_equality_address_Country_FullName)
 """);
     }
 
@@ -416,14 +416,14 @@ WHERE [v].[ShippingAddress_Country_Code] = N'DE'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
     FROM [ValuedCustomer] AS [v]
     ORDER BY [v].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [v0]
 WHERE [v0].[ShippingAddress_ZipCode] = 7728
 """);
@@ -435,14 +435,14 @@ WHERE [v0].[ShippingAddress_ZipCode] = 7728
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
     FROM [ValuedCustomer] AS [v]
     ORDER BY [v].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [v0]
 WHERE [v0].[ShippingAddress_Country_Code] = N'DE'
 """);
@@ -505,14 +505,14 @@ INNER JOIN [ValuedCustomer] AS [v0] ON [v].[RequiredCustomerId] = [v0].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
 FROM (
     SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
     FROM [ValuedCustomer] AS [v]
     ORDER BY [v].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [v0]
 """);
     }
@@ -603,14 +603,14 @@ WHERE [v].[ShippingAddress_AddressLine1] = N'804 S. Lakeshore Road' AND [v].[Shi
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 4000)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 4000)
+@entity_equality_address_Country_FullName='United States' (Size = 4000)
 
 SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
 FROM [ValuedCustomer] AS [v]
-WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [v].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName
+WHERE [v].[ShippingAddress_AddressLine1] = @entity_equality_address_AddressLine1 AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = @entity_equality_address_ZipCode AND [v].[ShippingAddress_Country_Code] = @entity_equality_address_Country_Code AND [v].[ShippingAddress_Country_FullName] = @entity_equality_address_Country_FullName
 """);
     }
 
@@ -627,17 +627,17 @@ WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressL
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 4000)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 4000)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 4000)
+@entity_equality_address_Country_FullName='United States' (Size = 4000)
 
 SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
 FROM [ValuedCustomer] AS [v]
 WHERE EXISTS (
     SELECT 1
     FROM [ValuedCustomer] AS [v0]
-    WHERE [v0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v0].[ShippingAddress_AddressLine2] IS NULL AND [v0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Country_Code AND [v0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_Country_FullName)
+    WHERE [v0].[ShippingAddress_AddressLine1] = @entity_equality_address_AddressLine1 AND [v0].[ShippingAddress_AddressLine2] IS NULL AND [v0].[ShippingAddress_ZipCode] = @entity_equality_address_ZipCode AND [v0].[ShippingAddress_Country_Code] = @entity_equality_address_Country_Code AND [v0].[ShippingAddress_Country_FullName] = @entity_equality_address_Country_FullName)
 """);
     }
 
@@ -898,13 +898,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT [s0].[Id], [s0].[Name], [s0].[BillingAddress_AddressLine1], [s0].[BillingAddress_AddressLine2], [s0].[BillingAddress_Tags], [s0].[BillingAddress_ZipCode], [s0].[BillingAddress_Country_Code], [s0].[BillingAddress_Country_FullName], [s0].[ShippingAddress_AddressLine1], [s0].[ShippingAddress_AddressLine2], [s0].[ShippingAddress_Tags], [s0].[ShippingAddress_ZipCode], [s0].[ShippingAddress_Country_Code], [s0].[ShippingAddress_Country_FullName], [s0].[Id0], [s0].[Name0], [s0].[BillingAddress_AddressLine10], [s0].[BillingAddress_AddressLine20], [s0].[BillingAddress_Tags0], [s0].[BillingAddress_ZipCode0], [s0].[BillingAddress_Country_Code0], [s0].[BillingAddress_Country_FullName0], [s0].[ShippingAddress_AddressLine10], [s0].[ShippingAddress_AddressLine20], [s0].[ShippingAddress_Tags0], [s0].[ShippingAddress_ZipCode0], [s0].[ShippingAddress_Country_Code0], [s0].[ShippingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [s].[Id], [s].[Name], [s].[BillingAddress_AddressLine1], [s].[BillingAddress_AddressLine2], [s].[BillingAddress_Tags], [s].[BillingAddress_ZipCode], [s].[BillingAddress_Country_Code], [s].[BillingAddress_Country_FullName], [s].[ShippingAddress_AddressLine1], [s].[ShippingAddress_AddressLine2], [s].[ShippingAddress_Tags], [s].[ShippingAddress_ZipCode], [s].[ShippingAddress_Country_Code], [s].[ShippingAddress_Country_FullName], [s].[Id0], [s].[Name0], [s].[BillingAddress_AddressLine10], [s].[BillingAddress_AddressLine20], [s].[BillingAddress_Tags0], [s].[BillingAddress_ZipCode0], [s].[BillingAddress_Country_Code0], [s].[BillingAddress_Country_FullName0], [s].[ShippingAddress_AddressLine10], [s].[ShippingAddress_AddressLine20], [s].[ShippingAddress_Tags0], [s].[ShippingAddress_ZipCode0], [s].[ShippingAddress_Country_Code0], [s].[ShippingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_Tags] AS [ShippingAddress_Tags0], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+        SELECT TOP(@p) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_Tags] AS [ShippingAddress_Tags0], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
         FROM [Customer] AS [c]
         CROSS JOIN [Customer] AS [c0]
         ORDER BY [c].[Id], [c0].[Id]
@@ -919,13 +919,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT [s0].[BillingAddress_AddressLine1], [s0].[BillingAddress_AddressLine2], [s0].[BillingAddress_Tags], [s0].[BillingAddress_ZipCode], [s0].[BillingAddress_Country_Code], [s0].[BillingAddress_Country_FullName], [s0].[BillingAddress_AddressLine10], [s0].[BillingAddress_AddressLine20], [s0].[BillingAddress_Tags0], [s0].[BillingAddress_ZipCode0], [s0].[BillingAddress_Country_Code0], [s0].[BillingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [s].[BillingAddress_AddressLine1], [s].[BillingAddress_AddressLine2], [s].[BillingAddress_Tags], [s].[BillingAddress_ZipCode], [s].[BillingAddress_Country_Code], [s].[BillingAddress_Country_FullName], [s].[BillingAddress_AddressLine10], [s].[BillingAddress_AddressLine20], [s].[BillingAddress_Tags0], [s].[BillingAddress_ZipCode0], [s].[BillingAddress_Country_Code0], [s].[BillingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+        SELECT TOP(@p) [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
         FROM [Customer] AS [c]
         CROSS JOIN [Customer] AS [c0]
         ORDER BY [c].[Id], [c0].[Id]
@@ -970,13 +970,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT [s0].[Id], [s0].[Name], [s0].[BillingAddress_AddressLine1], [s0].[BillingAddress_AddressLine2], [s0].[BillingAddress_ZipCode], [s0].[BillingAddress_Country_Code], [s0].[BillingAddress_Country_FullName], [s0].[ShippingAddress_AddressLine1], [s0].[ShippingAddress_AddressLine2], [s0].[ShippingAddress_ZipCode], [s0].[ShippingAddress_Country_Code], [s0].[ShippingAddress_Country_FullName], [s0].[Id0], [s0].[Name0], [s0].[BillingAddress_AddressLine10], [s0].[BillingAddress_AddressLine20], [s0].[BillingAddress_ZipCode0], [s0].[BillingAddress_Country_Code0], [s0].[BillingAddress_Country_FullName0], [s0].[ShippingAddress_AddressLine10], [s0].[ShippingAddress_AddressLine20], [s0].[ShippingAddress_ZipCode0], [s0].[ShippingAddress_Country_Code0], [s0].[ShippingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [s].[Id], [s].[Name], [s].[BillingAddress_AddressLine1], [s].[BillingAddress_AddressLine2], [s].[BillingAddress_ZipCode], [s].[BillingAddress_Country_Code], [s].[BillingAddress_Country_FullName], [s].[ShippingAddress_AddressLine1], [s].[ShippingAddress_AddressLine2], [s].[ShippingAddress_ZipCode], [s].[ShippingAddress_Country_Code], [s].[ShippingAddress_Country_FullName], [s].[Id0], [s].[Name0], [s].[BillingAddress_AddressLine10], [s].[BillingAddress_AddressLine20], [s].[BillingAddress_ZipCode0], [s].[BillingAddress_Country_Code0], [s].[BillingAddress_Country_FullName0], [s].[ShippingAddress_AddressLine10], [s].[ShippingAddress_AddressLine20], [s].[ShippingAddress_ZipCode0], [s].[ShippingAddress_Country_Code0], [s].[ShippingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName], [v0].[Id] AS [Id0], [v0].[Name] AS [Name0], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [v0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [v0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [v0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [v0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [v0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
+        SELECT TOP(@p) [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName], [v0].[Id] AS [Id0], [v0].[Name] AS [Name0], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [v0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [v0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [v0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [v0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [v0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
         FROM [ValuedCustomer] AS [v]
         CROSS JOIN [ValuedCustomer] AS [v0]
         ORDER BY [v].[Id], [v0].[Id]
@@ -991,13 +991,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT [s0].[BillingAddress_AddressLine1], [s0].[BillingAddress_AddressLine2], [s0].[BillingAddress_ZipCode], [s0].[BillingAddress_Country_Code], [s0].[BillingAddress_Country_FullName], [s0].[BillingAddress_AddressLine10], [s0].[BillingAddress_AddressLine20], [s0].[BillingAddress_ZipCode0], [s0].[BillingAddress_Country_Code0], [s0].[BillingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [s].[BillingAddress_AddressLine1], [s].[BillingAddress_AddressLine2], [s].[BillingAddress_ZipCode], [s].[BillingAddress_Country_Code], [s].[BillingAddress_Country_FullName], [s].[BillingAddress_AddressLine10], [s].[BillingAddress_AddressLine20], [s].[BillingAddress_ZipCode0], [s].[BillingAddress_Country_Code0], [s].[BillingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
+        SELECT TOP(@p) [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [v0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [v0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [v0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [v0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
         FROM [ValuedCustomer] AS [v]
         CROSS JOIN [ValuedCustomer] AS [v0]
         ORDER BY [v].[Id], [v0].[Id]
@@ -1012,9 +1012,9 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
-SELECT TOP(@__p_0) [u].[Id], [u].[Name], [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[ShippingAddress_AddressLine1], [u].[ShippingAddress_AddressLine2], [u].[ShippingAddress_Tags], [u].[ShippingAddress_ZipCode], [u].[ShippingAddress_Country_Code], [u].[ShippingAddress_Country_FullName], [u].[Id0], [u].[Name0], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0], [u].[ShippingAddress_AddressLine10], [u].[ShippingAddress_AddressLine20], [u].[ShippingAddress_Tags0], [u].[ShippingAddress_ZipCode0], [u].[ShippingAddress_Country_Code0], [u].[ShippingAddress_Country_FullName0]
+SELECT TOP(@p) [u].[Id], [u].[Name], [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[ShippingAddress_AddressLine1], [u].[ShippingAddress_AddressLine2], [u].[ShippingAddress_Tags], [u].[ShippingAddress_ZipCode], [u].[ShippingAddress_Country_Code], [u].[ShippingAddress_Country_FullName], [u].[Id0], [u].[Name0], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0], [u].[ShippingAddress_AddressLine10], [u].[ShippingAddress_AddressLine20], [u].[ShippingAddress_Tags0], [u].[ShippingAddress_ZipCode0], [u].[ShippingAddress_Country_Code0], [u].[ShippingAddress_Country_FullName0]
 FROM (
     SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_Tags] AS [ShippingAddress_Tags0], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
     FROM [Customer] AS [c]
@@ -1034,13 +1034,13 @@ ORDER BY [u].[Id], [u].[Id0]
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
-SELECT TOP(@__p_0) [u1].[Id], [u1].[Name], [u1].[BillingAddress_AddressLine1], [u1].[BillingAddress_AddressLine2], [u1].[BillingAddress_Tags], [u1].[BillingAddress_ZipCode], [u1].[BillingAddress_Country_Code], [u1].[BillingAddress_Country_FullName], [u1].[ShippingAddress_AddressLine1], [u1].[ShippingAddress_AddressLine2], [u1].[ShippingAddress_Tags], [u1].[ShippingAddress_ZipCode], [u1].[ShippingAddress_Country_Code], [u1].[ShippingAddress_Country_FullName], [u1].[Id0], [u1].[Name0], [u1].[BillingAddress_AddressLine10], [u1].[BillingAddress_AddressLine20], [u1].[BillingAddress_Tags0], [u1].[BillingAddress_ZipCode0], [u1].[BillingAddress_Country_Code0], [u1].[BillingAddress_Country_FullName0], [u1].[ShippingAddress_AddressLine10], [u1].[ShippingAddress_AddressLine20], [u1].[ShippingAddress_Tags0], [u1].[ShippingAddress_ZipCode0], [u1].[ShippingAddress_Country_Code0], [u1].[ShippingAddress_Country_FullName0]
+SELECT TOP(@p) [u1].[Id], [u1].[Name], [u1].[BillingAddress_AddressLine1], [u1].[BillingAddress_AddressLine2], [u1].[BillingAddress_Tags], [u1].[BillingAddress_ZipCode], [u1].[BillingAddress_Country_Code], [u1].[BillingAddress_Country_FullName], [u1].[ShippingAddress_AddressLine1], [u1].[ShippingAddress_AddressLine2], [u1].[ShippingAddress_Tags], [u1].[ShippingAddress_ZipCode], [u1].[ShippingAddress_Country_Code], [u1].[ShippingAddress_Country_FullName], [u1].[Id0], [u1].[Name0], [u1].[BillingAddress_AddressLine10], [u1].[BillingAddress_AddressLine20], [u1].[BillingAddress_Tags0], [u1].[BillingAddress_ZipCode0], [u1].[BillingAddress_Country_Code0], [u1].[BillingAddress_Country_FullName0], [u1].[ShippingAddress_AddressLine10], [u1].[ShippingAddress_AddressLine20], [u1].[ShippingAddress_Tags0], [u1].[ShippingAddress_ZipCode0], [u1].[ShippingAddress_Country_Code0], [u1].[ShippingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [u0].[Id], [u0].[Name], [u0].[BillingAddress_AddressLine1], [u0].[BillingAddress_AddressLine2], [u0].[BillingAddress_Tags], [u0].[BillingAddress_ZipCode], [u0].[BillingAddress_Country_Code], [u0].[BillingAddress_Country_FullName], [u0].[ShippingAddress_AddressLine1], [u0].[ShippingAddress_AddressLine2], [u0].[ShippingAddress_Tags], [u0].[ShippingAddress_ZipCode], [u0].[ShippingAddress_Country_Code], [u0].[ShippingAddress_Country_FullName], [u0].[Id0], [u0].[Name0], [u0].[BillingAddress_AddressLine10], [u0].[BillingAddress_AddressLine20], [u0].[BillingAddress_Tags0], [u0].[BillingAddress_ZipCode0], [u0].[BillingAddress_Country_Code0], [u0].[BillingAddress_Country_FullName0], [u0].[ShippingAddress_AddressLine10], [u0].[ShippingAddress_AddressLine20], [u0].[ShippingAddress_Tags0], [u0].[ShippingAddress_ZipCode0], [u0].[ShippingAddress_Country_Code0], [u0].[ShippingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [u].[Id], [u].[Name], [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[ShippingAddress_AddressLine1], [u].[ShippingAddress_AddressLine2], [u].[ShippingAddress_Tags], [u].[ShippingAddress_ZipCode], [u].[ShippingAddress_Country_Code], [u].[ShippingAddress_Country_FullName], [u].[Id0], [u].[Name0], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0], [u].[ShippingAddress_AddressLine10], [u].[ShippingAddress_AddressLine20], [u].[ShippingAddress_Tags0], [u].[ShippingAddress_ZipCode0], [u].[ShippingAddress_Country_Code0], [u].[ShippingAddress_Country_FullName0]
+        SELECT TOP(@p) [u].[Id], [u].[Name], [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[ShippingAddress_AddressLine1], [u].[ShippingAddress_AddressLine2], [u].[ShippingAddress_Tags], [u].[ShippingAddress_ZipCode], [u].[ShippingAddress_Country_Code], [u].[ShippingAddress_Country_FullName], [u].[Id0], [u].[Name0], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0], [u].[ShippingAddress_AddressLine10], [u].[ShippingAddress_AddressLine20], [u].[ShippingAddress_Tags0], [u].[ShippingAddress_ZipCode0], [u].[ShippingAddress_Country_Code0], [u].[ShippingAddress_Country_FullName0]
         FROM (
             SELECT [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName], [c0].[Id] AS [Id0], [c0].[Name] AS [Name0], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0], [c0].[ShippingAddress_AddressLine1] AS [ShippingAddress_AddressLine10], [c0].[ShippingAddress_AddressLine2] AS [ShippingAddress_AddressLine20], [c0].[ShippingAddress_Tags] AS [ShippingAddress_Tags0], [c0].[ShippingAddress_ZipCode] AS [ShippingAddress_ZipCode0], [c0].[ShippingAddress_Country_Code] AS [ShippingAddress_Country_Code0], [c0].[ShippingAddress_Country_FullName] AS [ShippingAddress_Country_FullName0]
             FROM [Customer] AS [c]
@@ -1063,9 +1063,9 @@ ORDER BY [u1].[Id], [u1].[Id0]
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
-SELECT TOP(@__p_0) [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0]
+SELECT TOP(@p) [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0]
 FROM (
     SELECT [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
     FROM [Customer] AS [c]
@@ -1085,13 +1085,13 @@ ORDER BY [u].[BillingAddress_ZipCode], [u].[BillingAddress_ZipCode0]
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
-SELECT TOP(@__p_0) [u1].[BillingAddress_AddressLine1], [u1].[BillingAddress_AddressLine2], [u1].[BillingAddress_Tags], [u1].[BillingAddress_ZipCode], [u1].[BillingAddress_Country_Code], [u1].[BillingAddress_Country_FullName], [u1].[BillingAddress_AddressLine10], [u1].[BillingAddress_AddressLine20], [u1].[BillingAddress_Tags0], [u1].[BillingAddress_ZipCode0], [u1].[BillingAddress_Country_Code0], [u1].[BillingAddress_Country_FullName0]
+SELECT TOP(@p) [u1].[BillingAddress_AddressLine1], [u1].[BillingAddress_AddressLine2], [u1].[BillingAddress_Tags], [u1].[BillingAddress_ZipCode], [u1].[BillingAddress_Country_Code], [u1].[BillingAddress_Country_FullName], [u1].[BillingAddress_AddressLine10], [u1].[BillingAddress_AddressLine20], [u1].[BillingAddress_Tags0], [u1].[BillingAddress_ZipCode0], [u1].[BillingAddress_Country_Code0], [u1].[BillingAddress_Country_FullName0]
 FROM (
     SELECT DISTINCT [u0].[BillingAddress_AddressLine1], [u0].[BillingAddress_AddressLine2], [u0].[BillingAddress_Tags], [u0].[BillingAddress_ZipCode], [u0].[BillingAddress_Country_Code], [u0].[BillingAddress_Country_FullName], [u0].[BillingAddress_AddressLine10], [u0].[BillingAddress_AddressLine20], [u0].[BillingAddress_Tags0], [u0].[BillingAddress_ZipCode0], [u0].[BillingAddress_Country_Code0], [u0].[BillingAddress_Country_FullName0]
     FROM (
-        SELECT TOP(@__p_0) [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0]
+        SELECT TOP(@p) [u].[BillingAddress_AddressLine1], [u].[BillingAddress_AddressLine2], [u].[BillingAddress_Tags], [u].[BillingAddress_ZipCode], [u].[BillingAddress_Country_Code], [u].[BillingAddress_Country_FullName], [u].[BillingAddress_AddressLine10], [u].[BillingAddress_AddressLine20], [u].[BillingAddress_Tags0], [u].[BillingAddress_ZipCode0], [u].[BillingAddress_Country_Code0], [u].[BillingAddress_Country_FullName0]
         FROM (
             SELECT [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c0].[BillingAddress_AddressLine1] AS [BillingAddress_AddressLine10], [c0].[BillingAddress_AddressLine2] AS [BillingAddress_AddressLine20], [c0].[BillingAddress_Tags] AS [BillingAddress_Tags0], [c0].[BillingAddress_ZipCode] AS [BillingAddress_ZipCode0], [c0].[BillingAddress_Country_Code] AS [BillingAddress_Country_Code0], [c0].[BillingAddress_Country_FullName] AS [BillingAddress_Country_FullName0]
             FROM [Customer] AS [c]
@@ -1217,13 +1217,13 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT [s0].[ShippingAddress_ZipCode]
 FROM (
     SELECT DISTINCT [s].[ShippingAddress_AddressLine1], [s].[ShippingAddress_AddressLine2], [s].[ShippingAddress_Tags], [s].[ShippingAddress_ZipCode], [s].[ShippingAddress_Country_Code], [s].[ShippingAddress_Country_FullName]
     FROM (
-        SELECT TOP(@__p_0) [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
+        SELECT TOP(@p) [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
         FROM [CustomerGroup] AS [c]
         LEFT JOIN [Customer] AS [c0] ON [c].[OptionalCustomerId] = [c0].[Id]
         ORDER BY [c0].[ShippingAddress_ZipCode]
@@ -1238,14 +1238,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='30'
+@p='20'
+@p0='30'
 
 SELECT [c3].[BillingAddress_ZipCode] AS [Zip1], [c4].[ShippingAddress_ZipCode] AS [Zip2]
 FROM (
     SELECT DISTINCT [c0].[Id], [c0].[Name], [c0].[BillingAddress_AddressLine1], [c0].[BillingAddress_AddressLine2], [c0].[BillingAddress_Tags], [c0].[BillingAddress_ZipCode], [c0].[BillingAddress_Country_Code], [c0].[BillingAddress_Country_FullName], [c0].[ShippingAddress_AddressLine1], [c0].[ShippingAddress_AddressLine2], [c0].[ShippingAddress_Tags], [c0].[ShippingAddress_ZipCode], [c0].[ShippingAddress_Country_Code], [c0].[ShippingAddress_Country_FullName]
     FROM (
-        SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+        SELECT TOP(@p) [c].[Id], [c].[Name], [c].[BillingAddress_AddressLine1], [c].[BillingAddress_AddressLine2], [c].[BillingAddress_Tags], [c].[BillingAddress_ZipCode], [c].[BillingAddress_Country_Code], [c].[BillingAddress_Country_FullName], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_Tags], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
         FROM [Customer] AS [c]
         ORDER BY [c].[Id]
     ) AS [c0]
@@ -1253,7 +1253,7 @@ FROM (
 LEFT JOIN (
     SELECT DISTINCT [c2].[Id], [c2].[Name], [c2].[BillingAddress_AddressLine1], [c2].[BillingAddress_AddressLine2], [c2].[BillingAddress_Tags], [c2].[BillingAddress_ZipCode], [c2].[BillingAddress_Country_Code], [c2].[BillingAddress_Country_FullName], [c2].[ShippingAddress_AddressLine1], [c2].[ShippingAddress_AddressLine2], [c2].[ShippingAddress_Tags], [c2].[ShippingAddress_ZipCode], [c2].[ShippingAddress_Country_Code], [c2].[ShippingAddress_Country_FullName]
     FROM (
-        SELECT TOP(@__p_1) [c1].[Id], [c1].[Name], [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_Tags], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c1].[ShippingAddress_AddressLine1], [c1].[ShippingAddress_AddressLine2], [c1].[ShippingAddress_Tags], [c1].[ShippingAddress_ZipCode], [c1].[ShippingAddress_Country_Code], [c1].[ShippingAddress_Country_FullName]
+        SELECT TOP(@p0) [c1].[Id], [c1].[Name], [c1].[BillingAddress_AddressLine1], [c1].[BillingAddress_AddressLine2], [c1].[BillingAddress_Tags], [c1].[BillingAddress_ZipCode], [c1].[BillingAddress_Country_Code], [c1].[BillingAddress_Country_FullName], [c1].[ShippingAddress_AddressLine1], [c1].[ShippingAddress_AddressLine2], [c1].[ShippingAddress_Tags], [c1].[ShippingAddress_ZipCode], [c1].[ShippingAddress_Country_Code], [c1].[ShippingAddress_Country_FullName]
         FROM [Customer] AS [c1]
         ORDER BY [c1].[Id] DESC
     ) AS [c2]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
@@ -762,7 +762,7 @@ ORDER BY [p1].[FirstName], [p3].[Id]
 
         AssertSql(
             """
-@__size_0='11'
+@size='11'
 
 SELECT [p0].[LastName], [f].[Size], (
     SELECT MIN([f1].[Size])
@@ -770,11 +770,11 @@ SELECT [p0].[LastName], [f].[Size], (
     LEFT JOIN [Feet] AS [f0] ON [p1].[Id] = [f0].[Id]
     LEFT JOIN [Person] AS [p2] ON [f0].[Id] = [p2].[Id]
     LEFT JOIN [Feet] AS [f1] ON [p1].[Id] = [f1].[Id]
-    WHERE [f0].[Size] = @__size_0 AND [p1].[MiddleInitial] IS NOT NULL AND ([f0].[Id] <> 1 OR [f0].[Id] IS NULL) AND ([f].[Size] = [f0].[Size] OR ([f].[Size] IS NULL AND [f0].[Size] IS NULL)) AND ([p0].[LastName] = [p2].[LastName] OR ([p0].[LastName] IS NULL AND [p2].[LastName] IS NULL))) AS [Min]
+    WHERE [f0].[Size] = @size AND [p1].[MiddleInitial] IS NOT NULL AND ([f0].[Id] <> 1 OR [f0].[Id] IS NULL) AND ([f].[Size] = [f0].[Size] OR ([f].[Size] IS NULL AND [f0].[Size] IS NULL)) AND ([p0].[LastName] = [p2].[LastName] OR ([p0].[LastName] IS NULL AND [p2].[LastName] IS NULL))) AS [Min]
 FROM [Person] AS [p]
 LEFT JOIN [Feet] AS [f] ON [p].[Id] = [f].[Id]
 LEFT JOIN [Person] AS [p0] ON [f].[Id] = [p0].[Id]
-WHERE [f].[Size] = @__size_0 AND [p].[MiddleInitial] IS NOT NULL AND ([f].[Id] <> 1 OR [f].[Id] IS NULL)
+WHERE [f].[Size] = @size AND [p].[MiddleInitial] IS NOT NULL AND ([f].[Id] <> 1 OR [f].[Id] IS NULL)
 GROUP BY [f].[Size], [p0].[LastName]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -446,13 +446,13 @@ SELECT * FROM "Employees" WHERE "ReportsTo" = @p0 OR ("ReportsTo" IS NULL AND @p
         AssertSql(
             """
 p0='London' (Size = 4000)
-@__contactTitle_1='Sales Representative' (Size = 30)
+@contactTitle='Sales Representative' (Size = 30)
 
 SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
 ) AS [m]
-WHERE [m].[ContactTitle] = @__contactTitle_1
+WHERE [m].[ContactTitle] = @contactTitle
 """);
 
         return null;
@@ -615,9 +615,26 @@ SELECT * FROM "Customers" WHERE "City" = @p0 AND "ContactTitle" = @title
             //
             """
 @city='London' (Nullable = false) (Size = 6)
-p1='Sales Representative' (Size = 4000)
+p0='Sales Representative' (Size = 4000)
 
-SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
+SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p0
+""");
+    }
+
+    public override async Task FromSqlRaw_with_dbParameter_and_regular_parameter_with_same_name(bool async)
+    {
+        await base.FromSqlRaw_with_dbParameter_and_regular_parameter_with_same_name(async);
+
+        AssertSql(
+            """
+@foo='London' (Nullable = false) (Size = 6)
+@foo0='Sales Representative' (Size = 30)
+
+SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+FROM (
+    SELECT * FROM "Customers" WHERE "City" = @foo
+) AS [m]
+WHERE [m].[ContactTitle] = @foo0
 """);
     }
 
@@ -738,12 +755,12 @@ FROM (
 """,
             //
             """
-@__max_0='10400'
+@max='10400'
 p0='10300'
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__max_0 AND [o].[OrderID] IN (
+WHERE [o].[OrderID] <= @max AND [o].[OrderID] IN (
     SELECT [m].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
@@ -752,12 +769,12 @@ WHERE [o].[OrderID] <= @__max_0 AND [o].[OrderID] IN (
 """,
             //
             """
-@__max_0='10400'
+@max='10400'
 p0='10300'
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__max_0 AND [o].[OrderID] IN (
+WHERE [o].[OrderID] <= @max AND [o].[OrderID] IN (
     SELECT [m].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
@@ -943,35 +960,36 @@ WHERE [o].[CustomerID] IN (
             //
             """
 @city='London' (Nullable = false) (Size = 6)
-p1='Sales Representative' (Size = 4000)
+p0='Sales Representative' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] IN (
     SELECT [m].[CustomerID]
     FROM (
-        SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
+        SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p0
     ) AS [m]
 )
 """);
     }
 
-    public override async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(bool async)
+    public override async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_two_parameters(bool async)
     {
-        await base.Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(async);
+        await base.Multiple_occurrences_of_FromSql_with_db_parameter_adds_two_parameters(async);
 
         AssertSql(
             """
 city='Seattle' (Nullable = false) (Size = 7)
+city0='Seattle' (Nullable = false) (Size = 3)
 
-SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @city
 ) AS [m]
 INTERSECT
-SELECT [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region]
+SELECT [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[CustomerID], [m0].[Fax], [m0].[Phone], [m0].[Region], [m0].[PostalCode]
 FROM (
-    SELECT * FROM "Customers" WHERE "City" = @city
+    SELECT * FROM "Customers" WHERE "City" = @city0
 ) AS [m0]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQueryAzureSynapseTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQueryAzureSynapseTest.cs
@@ -71,60 +71,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0='%B' (Size = 4000)
+@prm1='%B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0 OR @__prm1_0 LIKE N'')
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@prm1, [f].[FirstName]) > 0 OR @prm1 LIKE N'')
 """,
-                //
-                """
-@__prm2_0='a_' (Size = 4000)
+            //
+            """
+@prm2='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0 OR @__prm2_0 LIKE N'')
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@prm2, [f].[FirstName]) > 0 OR @prm2 LIKE N'')
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-                //
-                """
-@__prm4_0='' (Size = 4000)
+            //
+            """
+@prm4='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0 OR @__prm4_0 LIKE N'')
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@prm4, [f].[FirstName]) > 0 OR @prm4 LIKE N'')
 """,
-                //
-                """
-@__prm5_0='_Ba_' (Size = 4000)
+            //
+            """
+@prm5='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0 OR @__prm5_0 LIKE N'')
+WHERE [f].[FirstName] IS NOT NULL AND (CHARINDEX(@prm5, [f].[FirstName]) > 0 OR @prm5 LIKE N'')
 """,
-                //
-                """
-@__prm6_0='%B%a%r' (Size = 4000)
+            //
+            """
+@prm6='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@__prm6_0, [f].[FirstName]) <= 0 AND @__prm6_0 NOT LIKE N'')
+WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@prm6, [f].[FirstName]) <= 0 AND @prm6 NOT LIKE N'')
 """,
-                //
-                """
-@__prm7_0='' (Size = 4000)
+            //
+            """
+@prm7='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@__prm7_0, [f].[FirstName]) <= 0 AND @__prm7_0 NOT LIKE N'')
+WHERE [f].[FirstName] IS NULL OR (CHARINDEX(@prm7, [f].[FirstName]) <= 0 AND @prm7 NOT LIKE N'')
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -215,60 +215,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0='%B' (Size = 4000)
+@prm1='%B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm1)) = @prm1
 """,
-                //
-                """
-@__prm2_0='_B' (Size = 4000)
+            //
+            """
+@prm2='_B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm2)) = @prm2
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-                //
-                """
-@__prm4_0='' (Size = 4000)
+            //
+            """
+@prm4='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm4)) = @prm4
 """,
-                //
-                """
-@__prm5_0='_Ba_' (Size = 4000)
+            //
+            """
+@prm5='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm5)) = @prm5
 """,
-                //
-                """
-@__prm6_0='%B%a%r' (Size = 4000)
+            //
+            """
+@prm6='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
+WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@prm6)) <> @prm6
 """,
-                //
-                """
-@__prm7_0='' (Size = 4000)
+            //
+            """
+@prm7='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
+WHERE [f].[FirstName] IS NULL OR LEFT([f].[FirstName], LEN(@prm7)) <> @prm7
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -284,44 +284,44 @@ SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'[')) = N'['
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'B[')) = N'B['
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(N'B[[a^')) = N'B[[a^'
 """,
-                //
-                """
-@__prm1_0='[' (Size = 4000)
+            //
+            """
+@prm1='[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm1)) = @prm1
 """,
-                //
-                """
-@__prm2_0='B[' (Size = 4000)
+            //
+            """
+@prm2='B[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm2)) = @prm2
 """,
-                //
-                """
-@__prm3_0='B[[a^' (Size = 4000)
+            //
+            """
+@prm3='B[[a^' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0
+WHERE [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@prm3)) = @prm3
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
 WHERE [f].[FirstName] IS NOT NULL AND [f].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName]
@@ -413,60 +413,60 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0='%r' (Size = 4000)
+@prm1='%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@prm1)) = @prm1
 """,
-                //
-                """
-@__prm2_0='r_' (Size = 4000)
+            //
+            """
+@prm2='r_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@prm2)) = @prm2
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-                //
-                """
-@__prm4_0='' (Size = 4000)
+            //
+            """
+@prm4='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@prm4)) = @prm4
 """,
-                //
-                """
-@__prm5_0='_r_' (Size = 4000)
+            //
+            """
+@prm5='_r_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0
+WHERE [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@prm5)) = @prm5
 """,
-                //
-                """
-@__prm6_0='a%r%' (Size = 4000)
+            //
+            """
+@prm6='a%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
+WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@prm6)) <> @prm6
 """,
-                //
-                """
-@__prm7_0='' (Size = 4000)
+            //
+            """
+@prm7='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
+WHERE [f].[FirstName] IS NULL OR RIGHT([f].[FirstName], LEN(@prm7)) <> @prm7
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -580,11 +580,11 @@ ORDER BY [f].[Id]
 
         AssertSql(
             """
-@__s_0='B' (Size = 4000)
+@s='B' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE ([f].[FirstName] IS NOT NULL AND (CHARINDEX(@__s_0, [f].[FirstName]) > 0 OR @__s_0 LIKE N'')) OR ([f].[LastName] IS NOT NULL AND LEFT([f].[LastName], LEN(@__s_0)) = @__s_0)
+WHERE ([f].[FirstName] IS NOT NULL AND (CHARINDEX(@s, [f].[FirstName]) > 0 OR @s LIKE N'')) OR ([f].[LastName] IS NOT NULL AND LEFT([f].[LastName], LEN(@s)) = @s)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -71,19 +71,19 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_contains='%\%B%' (Size = 4000)
+@prm1_contains='%\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm1_contains ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_contains='%a\_%' (Size = 4000)
+@prm2_contains='%a\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm2_contains ESCAPE N'\'
 """,
             //
             """
@@ -93,35 +93,35 @@ WHERE 0 = 1
 """,
             //
             """
-@__prm4_0_contains='%' (Size = 4000)
+@prm4_contains='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm4_contains ESCAPE N'\'
 """,
             //
             """
-@__prm5_0_contains='%\_Ba\_%' (Size = 4000)
+@prm5_contains='%\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_contains ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm5_contains ESCAPE N'\'
 """,
             //
             """
-@__prm6_0_contains='%\%B\%a\%r%' (Size = 4000)
+@prm6_contains='%\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm6_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
-@__prm7_0_contains='%' (Size = 4000)
+@prm7_contains='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm7_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
@@ -215,19 +215,19 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_startswith='\%B%' (Size = 4000)
+@prm1_startswith='\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm1_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_startswith='\_B%' (Size = 4000)
+@prm2_startswith='\_B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm2_startswith ESCAPE N'\'
 """,
             //
             """
@@ -237,35 +237,35 @@ WHERE 0 = 1
 """,
             //
             """
-@__prm4_0_startswith='%' (Size = 4000)
+@prm4_startswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm4_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm5_0_startswith='\_Ba\_%' (Size = 4000)
+@prm5_startswith='\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm5_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm6_0_startswith='\%B\%a\%r%' (Size = 4000)
+@prm6_startswith='\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm6_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
-@__prm7_0_startswith='%' (Size = 4000)
+@prm7_startswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm7_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
@@ -298,27 +298,27 @@ WHERE [f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\'
 """,
             //
             """
-@__prm1_0_startswith='\[%' (Size = 4000)
+@prm1_startswith='\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm1_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_startswith='B\[%' (Size = 4000)
+@prm2_startswith='B\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm2_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm3_0_startswith='B\[\[a^%' (Size = 4000)
+@prm3_startswith='B\[\[a^%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm3_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm3_startswith ESCAPE N'\'
 """,
             //
             """
@@ -413,19 +413,19 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_endswith='%\%r' (Size = 4000)
+@prm1_endswith='%\%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm1_endswith ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_endswith='%r\_' (Size = 4000)
+@prm2_endswith='%r\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm2_endswith ESCAPE N'\'
 """,
             //
             """
@@ -435,35 +435,35 @@ WHERE 0 = 1
 """,
             //
             """
-@__prm4_0_endswith='%' (Size = 4000)
+@prm4_endswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm4_endswith ESCAPE N'\'
 """,
             //
             """
-@__prm5_0_endswith='%\_r\_' (Size = 4000)
+@prm5_endswith='%\_r\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_endswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @prm5_endswith ESCAPE N'\'
 """,
             //
             """
-@__prm6_0_endswith='%a\%r\%' (Size = 4000)
+@prm6_endswith='%a\%r\%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm6_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
-@__prm7_0_endswith='%' (Size = 4000)
+@prm7_endswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @prm7_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
@@ -580,12 +580,12 @@ ORDER BY [f].[Id]
 
         AssertSql(
             """
-@__s_0_contains='%B%' (Size = 4000)
-@__s_0_startswith='B%' (Size = 4000)
+@s_contains='%B%' (Size = 4000)
+@s_startswith='B%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__s_0_contains ESCAPE N'\' OR [f].[LastName] LIKE @__s_0_startswith ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @s_contains ESCAPE N'\' OR [f].[LastName] LIKE @s_startswith ESCAPE N'\'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -208,14 +208,14 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -231,7 +231,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Gears] AS [g]
@@ -239,7 +239,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -255,14 +255,14 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -407,11 +407,11 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """);
     }
 
@@ -421,11 +421,11 @@ WHERE [w].[AmmunitionType] = @__ammunitionType_0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -507,11 +507,11 @@ WHERE [w].[AmmunitionType] & NULL > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """);
     }
 
@@ -521,11 +521,11 @@ WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """,
             //
             """
@@ -688,11 +688,11 @@ WHERE [g].[Rank] & (
 
         AssertSql(
             """
-@__parameter_0='2'
+@parameter='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -702,11 +702,11 @@ WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
 
         AssertSql(
             """
-@__parameter_0='2' (Nullable = true)
+@parameter='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -781,14 +781,14 @@ FROM [Factions] AS [f]
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] = @__ammunitionType_0 AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [w].[AmmunitionType] = @ammunitionType AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -807,9 +807,9 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -819,9 +819,9 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__ammunitionType_0='2' (Nullable = true)
+@ammunitionType='2' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -2047,11 +2047,11 @@ WHERE 'Unknown' = [c].[Location]
 
         AssertSql(
             """
-@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
+@value='Unknown' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Location] = @__value_0
+WHERE [c].[Location] = @value
 """);
     }
 
@@ -2061,13 +2061,13 @@ WHERE [c].[Location] = @__value_0
 
         AssertSql(
             """
-@__cities_0='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
+@cities='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] varchar(100) '$') AS [c0]
 )
 """);
     }
@@ -2697,11 +2697,11 @@ WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)
 
         AssertSql(
             """
-@__Date_0='0001-01-01T00:00:00.0000000'
+@Date='0001-01-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) > @__Date_0
+WHERE CONVERT(date, [m].[Timeline]) > @Date
 """);
     }
 
@@ -2923,12 +2923,12 @@ WHERE [m].[Timeline] = CAST('0010-05-03T12:00:00.0000000' AS datetime2) AT TIME 
 
         AssertSql(
             """
-@__dateTime_1='0010-05-03T12:00:00.0000000'
-@__timeZone_2='UTC' (Size = 8000) (DbType = AnsiString)
+@dateTime='0010-05-03T12:00:00.0000000'
+@timeZone='UTC' (Size = 8000) (DbType = AnsiString)
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE [m].[Timeline] = @__dateTime_1 AT TIME ZONE @__timeZone_2
+WHERE [m].[Timeline] = @dateTime AT TIME ZONE @timeZone
 """);
     }
 
@@ -3069,13 +3069,13 @@ END
 
         AssertSql(
             """
-@__ids_0='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
+@ids='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -3239,11 +3239,11 @@ ORDER BY [g].[FullName]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
@@ -3258,7 +3258,7 @@ ORDER BY [g0].[Rank]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [g0].[FullName]
 FROM (
@@ -3266,7 +3266,7 @@ FROM (
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [g0]
 ORDER BY [g0].[Rank]
 """);
@@ -3278,11 +3278,11 @@ ORDER BY [g0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -3296,11 +3296,11 @@ ORDER BY [g0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -3314,11 +3314,11 @@ ORDER BY [g0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -3592,14 +3592,14 @@ ORDER BY [g].[Nickname], [g1].[Nickname]
 
         AssertSql(
             """
-@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
+@cities_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND ([c].[Name] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+    FROM OPENJSON(@cities_without_nulls) AS [c0]
 ) OR [c].[Name] IS NULL)
 """);
     }
@@ -5048,11 +5048,11 @@ WHERE [f0].[Eradicated] = CAST(0 AS bit) OR [f0].[Eradicated] IS NULL
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Name], [s].[Discriminator], [s].[LocustHordeId], [s].[ThreatLevel], [s].[ThreatLevelByte], [s].[ThreatLevelNullableByte], [s].[DefeatedByNickname], [s].[DefeatedBySquadId], [s].[HighCommandId], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[Discriminator0], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator] AS [Discriminator0], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[Note]
+    SELECT TOP(@p) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator] AS [Discriminator0], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[Note]
     FROM [LocustLeaders] AS [l]
     LEFT JOIN [Gears] AS [g] ON [l].[DefeatedByNickname] = [g].[Nickname] AND [l].[DefeatedBySquadId] = [g].[SquadId]
     LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName] OR ([g].[Nickname] IS NULL AND [t].[GearNickName] IS NULL)) AND ([g].[SquadId] = [t].[GearSquadId] OR ([g].[SquadId] IS NULL AND [t].[GearSquadId] IS NULL))
@@ -5949,7 +5949,7 @@ ORDER BY [c].[Name], [g].[Nickname] DESC
 
         AssertSql(
             """
-@__nicknames_0='[]' (Size = 4000)
+@nicknames='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] AS [g]
@@ -5957,7 +5957,7 @@ LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN [g].[Nickname] IN (
         SELECT [n].[value]
-        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        FROM OPENJSON(@nicknames) WITH ([value] nvarchar(450) '$') AS [n]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
@@ -6480,19 +6480,19 @@ WHERE [t].[Id] = 'df36f493-463f-4123-83f9-6b135deeb7ba'
 
         AssertSql(
             """
-@__p_0='df36f493-463f-4123-83f9-6b135deeb7bd'
+@p='df36f493-463f-4123-83f9-6b135deeb7bd'
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
 FROM [Tags] AS [t]
-WHERE [t].[Id] = @__p_0
+WHERE [t].[Id] = @p
 """,
             //
             """
-@__p_0='b39a6fba-9026-4d69-828e-fd7068673e57'
+@p='b39a6fba-9026-4d69-828e-fd7068673e57'
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
 FROM [Tags] AS [t]
-WHERE [t].[Id] = @__p_0
+WHERE [t].[Id] = @p
 """);
     }
 
@@ -6647,11 +6647,11 @@ ORDER BY (
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName]
+    SELECT TOP(@p) [g].[FullName]
     FROM [Gears] AS [g]
 ) AS [g0]
 LEFT JOIN (
@@ -6686,15 +6686,15 @@ WHERE (
 
         AssertSql(
             """
-@__start_0='1902-01-01T10:00:00.1234567+01:30'
-@__end_1='1902-01-03T10:00:00.1234567+01:30'
-@__dates_2='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
+@start='1902-01-01T10:00:00.1234567+01:30'
+@end='1902-01-03T10:00:00.1234567+01:30'
+@dates='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
+WHERE @start <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @end AND [m].[Timeline] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -6800,7 +6800,7 @@ ORDER BY [t].[Id], [g].[Nickname]
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -6810,7 +6810,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] = @__isAutomatic_0
+    WHERE [w].[IsAutomatic] = @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -6821,7 +6821,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -6831,7 +6831,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] <> @__isAutomatic_0
+    WHERE [w].[IsAutomatic] <> @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -6842,7 +6842,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -6852,7 +6852,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[Id] > @__prm_0
+    WHERE [w].[Id] > @prm
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -7127,13 +7127,13 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__prm_Inner_Nickname_0='Marcus' (Size = 450)
+@prm_Inner_Nickname='Marcus' (Size = 450)
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
-    WHERE [g].[Nickname] <> @__prm_Inner_Nickname_0
+    WHERE [g].[Nickname] <> @prm_Inner_Nickname
 ) AS [g0]
 ORDER BY [g0].[FullName]
 """);
@@ -7145,7 +7145,7 @@ ORDER BY [g0].[FullName]
 
         AssertSql(
             """
-@__squadId_0='1'
+@squadId='1'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[Discriminator], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank]
 FROM (
@@ -7155,7 +7155,7 @@ FROM (
     WHERE [s].[Id] IN (
         SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0
+        WHERE [s0].[Id] = @squadId
     )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
@@ -7164,7 +7164,7 @@ FROM (
     WHERE [s1].[Id] IN (
         SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0
+        WHERE [s2].[Id] = @squadId
     )
 ) AS [u]
 ORDER BY [u].[FullName]
@@ -7177,14 +7177,14 @@ ORDER BY [u].[FullName]
 
         AssertSql(
             """
-@__gearId_0='1'
+@gearId='1'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE EXISTS (
     SELECT 1
     FROM [Gears] AS [g]
-    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @__gearId_0 AND [g].[SquadId] = @__gearId_0)
+    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @gearId AND [g].[SquadId] = @gearId)
 """);
     }
 
@@ -7194,17 +7194,17 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__entity_equality_prm_Inner_Squad_0_Id='1' (Nullable = true)
+@entity_equality_prm_Inner_Squad_Id='1' (Nullable = true)
 
 SELECT [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[Discriminator], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank]
 FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE [s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+    WHERE [s].[Id] = @entity_equality_prm_Inner_Squad_Id
 ) AS [s1]
 INNER JOIN [Squads] AS [s0] ON [s1].[SquadId] = [s0].[Id]
-WHERE [s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+WHERE [s0].[Id] = @entity_equality_prm_Inner_Squad_Id
 ORDER BY [s1].[FullName]
 """);
     }
@@ -7365,9 +7365,9 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
-SELECT @__p_0
+SELECT @p
 FROM [Gears] AS [g]
 """);
     }
@@ -7378,11 +7378,11 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -7404,14 +7404,14 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -7424,11 +7424,11 @@ END
 
         AssertSql(
             """
-@__rank_0='1' (Nullable = true)
+@rank='1' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Rank] & @__rank_0 = @__rank_0
+WHERE [g].[Rank] & @rank = @rank
 """,
             //
             """
@@ -7437,11 +7437,11 @@ FROM [Gears] AS [g]
 """,
             //
             """
-@__rank_0='2' (Nullable = true)
+@rank='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Rank] | @__rank_0 <> @__rank_0
+WHERE [g].[Rank] | @rank <> @rank
 """,
             //
             """
@@ -7478,24 +7478,24 @@ WHERE [c].[Name] = (
 
         AssertSql(
             """
-@__ranks_0='134'
+@ranks='134'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Rank] & @__ranks_0 <> 0
+WHERE [g].[Rank] & @ranks <> 0
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] AS [g]
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | [g].[Rank] | @__ranks_0 | [g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | [g].[Rank] | @ranks | [g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] AS [g]
 """);
     }
@@ -7529,19 +7529,19 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__prm_0='2' (Nullable = true)
+@prm='2' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 <> 0 OR [w].[AmmunitionType] IS NULL
+WHERE [w].[AmmunitionType] & @prm <> 0 OR [w].[AmmunitionType] IS NULL
 """,
             //
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
+WHERE [w].[AmmunitionType] & @prm = @prm
 """);
     }
 
@@ -7551,19 +7551,19 @@ WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """);
     }
 
@@ -7628,11 +7628,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @p
 """);
     }
 
@@ -7642,11 +7642,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 8000)
+@byteArrayParam='0x2A80' (Size = 8000)
 
 SELECT COUNT(*)
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@byteArrayParam) AS int)
 """);
     }
 
@@ -7656,11 +7656,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam)
 
         AssertSql(
             """
-@__someByte_0='1' (Size = 1)
+@someByte='1' (Size = 1)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0
+WHERE CHARINDEX(CAST(@someByte AS varbinary(max)), [s].[Banner]) > 0
 """);
     }
 
@@ -7682,12 +7682,12 @@ WHERE DATALENGTH([s].[Banner5]) = 5
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    WHEN [g].[HasSoulPatch] = @prm THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -7699,16 +7699,16 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-@__prm_0='True'
-@__prm2_1='Marcus' Lancer' (Size = 4000)
+@prm='True'
+@prm2='Marcus' Lancer' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 AND (
+    WHEN [g].[HasSoulPatch] = @prm AND (
         SELECT TOP(1) [w].[Name]
         FROM [Weapons] AS [w]
-        WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1 THEN CAST(1 AS bit)
+        WHERE [w].[Id] = [g].[SquadId]) = @prm2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -7733,11 +7733,11 @@ ORDER BY [w0].[IsAutomatic]
 
         AssertSql(
             """
-@__dateTimeOffset_Date_0='0002-03-01T00:00:00.0000000'
+@dateTimeOffset_Date='0002-03-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0
+WHERE CONVERT(date, [m].[Timeline]) >= @dateTimeOffset_Date
 """);
     }
 
@@ -7780,11 +7780,11 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE [s].[Banner5] = @__byteArrayParam_0
+WHERE [s].[Banner5] = @byteArrayParam
 """);
     }
 
@@ -8094,11 +8094,11 @@ CROSS APPLY (
 
         AssertSql(
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE @__prm_0 = [w].[AmmunitionType]
+WHERE @prm = [w].[AmmunitionType]
 """);
     }
 
@@ -8108,11 +8108,11 @@ WHERE @__prm_0 = [w].[AmmunitionType]
 
         AssertSql(
             """
-@__prm_0='133'
+@prm='133'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 
@@ -8122,11 +8122,11 @@ WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
 
         AssertSql(
             """
-@__prm_0='5'
+@prm='5'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE @__prm_0 & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
 """);
     }
 
@@ -8136,9 +8136,9 @@ WHERE @__prm_0 & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & 1
+SELECT TOP(@p) [g].[Rank] & 1
 FROM [Gears] AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -8150,14 +8150,14 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__types_0_without_nulls='[1]' (Size = 4000)
+@types_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
     SELECT [t].[value]
-    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+    FROM OPENJSON(@types_without_nulls) AS [t]
 ) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
@@ -9268,12 +9268,12 @@ WHERE CAST([t].[IssueDate] AS time) = [m].[Time]
 
         AssertSql(
             """
-@__time_0='02:00' (DbType = Time)
+@time='02:00' (DbType = Time)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([g].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @__time_0
+WHERE [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([g].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @time
 """);
     }
 
@@ -9307,11 +9307,11 @@ WHERE CAST([m].[Duration] AS time) < [m].[Time]
 
         AssertSql(
             """
-@__time_0='01:02' (DbType = Time)
+@time='01:02' (DbType = Time)
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Duration] AS time) = @__time_0
+WHERE CAST([m].[Duration] AS time) = @time
 """);
     }
 
@@ -9346,11 +9346,11 @@ WHERE CAST([t].[IssueDate] AS date) > [m].[Date]
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
-WHERE CAST([t].[IssueDate] AS date) IN (@__prm_0, '0015-03-07')
+WHERE CAST([t].[IssueDate] AS date) IN (@prm, '0015-03-07')
 """);
     }
 
@@ -9444,8 +9444,8 @@ LEFT JOIN [LocustHighCommands] AS [l0] ON [l].[HighCommandId] = [l0].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[Discriminator], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[HasSoulPatch0], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
@@ -9458,7 +9458,7 @@ FROM (
         GROUP BY [g0].[HasSoulPatch]
     ) AS [g1] ON CAST(LEN([g].[Nickname]) AS int) = [g1].[c]
     ORDER BY [g].[Nickname]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [s]
 LEFT JOIN [Weapons] AS [w] ON [s].[FullName] = [w].[OwnerFullName]
 ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
@@ -9471,13 +9471,13 @@ ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -9488,13 +9488,13 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -9505,11 +9505,11 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__place_0='Ephyra's location' (Size = 4000), @__place_0_1='Ephyra's location' (Size = 100) (DbType = AnsiString)
+@place='Ephyra's location' (Size = 4000), @place0='Ephyra's location' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @place OR [c].[Location] = @place0 OR [c].[Location] = @place
 """);
     }
 
@@ -9519,10 +9519,10 @@ WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Locatio
 
         AssertSql(
             """
-@__p_0='1'
-@__value_1='1'
+@p='1'
+@value='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & @__value_1
+SELECT TOP(@p) [g].[Rank] & @value
 FROM [Gears] AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -10084,12 +10084,12 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -10099,12 +10099,12 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -10114,12 +10114,12 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -10174,7 +10174,7 @@ FROM [Squads] AS [s]
 
         AssertSql(
             """
-@__unixEpochMilliseconds_0='0'
+@unixEpochMilliseconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM [Gears] AS [g]
@@ -10184,7 +10184,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochMilliseconds_0 = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochMilliseconds = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -10195,7 +10195,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 
         AssertSql(
             """
-@__unixEpochSeconds_0='0'
+@unixEpochSeconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM [Gears] AS [g]
@@ -10205,7 +10205,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochSeconds_0 = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochSeconds = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -10247,7 +10247,7 @@ GROUP BY [s].[Name]
 
         AssertSql(
             """
-@__numbers_0='[1,-1]' (Size = 4000)
+@numbers='[1,-1]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
@@ -10259,7 +10259,7 @@ WHERE CASE
     ELSE 0
 END IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -10270,7 +10270,7 @@ END IN (
 
         AssertSql(
             """
-@__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
+@weapons='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
@@ -10280,7 +10280,7 @@ WHERE (
     WHERE [g].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]) IN (
     SELECT [w].[value]
-    FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w]
+    FROM OPENJSON(@weapons) WITH ([value] nvarchar(max) '$') AS [w]
 )
 """);
     }
@@ -10291,7 +10291,7 @@ WHERE (
 
         AssertSql(
             """
-@__numbers_0='[0,1,2]' (Size = 4000)
+@numbers='[0,1,2]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM [Gears] AS [g]
@@ -10303,7 +10303,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= COALESCE((
         SELECT [n].[value]
-        FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+        FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
         ORDER BY [n].[value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]
@@ -10467,40 +10467,40 @@ LEFT JOIN [LocustHighCommands] AS [l0] ON [l].[HighCommandId] = [l0].[Id]
 
         AssertSql(
             """
-@__ranks_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ranks='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE CASE
     WHEN [g].[Rank] IN (
         SELECT [r].[value]
-        FROM OPENJSON(@__ranks_0) WITH ([value] int '$') AS [r]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ranks) WITH ([value] int '$') AS [r]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """,
             //
             """
-@__ammoTypes_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ammoTypes='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 WHERE CASE
     WHEN [w].[AmmunitionType] IN (
         SELECT [a].[value]
-        FROM OPENJSON(@__ammoTypes_0) WITH ([value] int '$') AS [a]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ammoTypes) WITH ([value] int '$') AS [a]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -508,11 +508,11 @@ WHERE ([t].[FoundOn] = CAST(0 AS tinyint)) AND [t].[FoundOn] IS NOT NULL
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[FoundOn]
 FROM (
-    SELECT TOP(@__p_0) [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
+    SELECT TOP(@p) [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
     FROM [Animals] AS [a]
     WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
     ORDER BY [a].[Species]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
@@ -359,13 +359,13 @@ WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Fraction
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT CAST(LEN([j1].[c]) AS int)
 FROM (
     SELECT DISTINCT [j0].[c]
     FROM (
-        SELECT TOP(@__p_0) JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
+        SELECT TOP(@p) JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -382,13 +382,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j1].[c], '$.OwnedReferenceBranch'), [j1].[Id]
 FROM (
     SELECT DISTINCT [j0].[c] AS [c], [j0].[Id]
     FROM (
-        SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+        SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -402,13 +402,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch'), [t0].[Id], CAST(LEN([t0].[c0]) AS int)
 FROM (
     SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[c0]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
+        SELECT TOP(@p) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [t]
@@ -422,17 +422,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceSharedLeaf'), [t2].[Id], JSON_QUERY([t2].[c], '$.OwnedCollectionSharedLeaf'), [t2].[Length]
 FROM (
     SELECT DISTINCT JSON_QUERY([t1].[c],'$') AS [c], [t1].[Id], [t1].[Length]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
+        SELECT TOP(@p) JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
         FROM (
             SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[Scalar]
             FROM (
-                SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
+                SELECT TOP(@p) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [t]
@@ -453,17 +453,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j3].[c], '$.OwnedReferenceLeaf'), [j3].[Id]
 FROM (
     SELECT DISTINCT [j2].[c] AS [c], [j2].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
+        SELECT TOP(@p) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
         FROM (
             SELECT DISTINCT [j0].[c] AS [c], [j0].[Id], [j0].[c] AS [c0]
             FROM (
-                SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+                SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [j0]
@@ -484,17 +484,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j3].[c], '$.OwnedCollectionLeaf'), [j3].[Id]
 FROM (
     SELECT DISTINCT [j2].[c] AS [c], [j2].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
+        SELECT TOP(@p) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
         FROM (
             SELECT DISTINCT [j0].[c] AS [c], [j0].[Id], [j0].[c] AS [c0]
             FROM (
-                SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+                SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [j0]
@@ -514,13 +514,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_VALUE([j1].[c], '$.SomethingSomething')
 FROM (
     SELECT DISTINCT [j0].[c] AS [c], [j0].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
+        SELECT TOP(@p) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -900,9 +900,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1010,9 +1010,9 @@ ORDER BY [j].[Id]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1024,9 +1024,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].Date') AS datetime2)
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1038,9 +1038,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1052,9 +1052,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
 """);
@@ -1067,9 +1067,9 @@ ORDER BY [j].[Id]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1093,11 +1093,11 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') <> N'Foo' OR JSON_VALUE
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') IS NULL
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].Name') IS NULL
 """);
     }
 
@@ -1164,11 +1164,11 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') <> N'Foo' OR JSON_VALUE
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
 """);
     }
 
@@ -1722,11 +1722,11 @@ WHERE N'e1_r1' IN (
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
 SELECT [j].[Id], (
     SELECT N'Foo'
-    FROM OPENJSON(CAST([j].[OwnedCollectionRoot] AS nvarchar(max)), '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch') AS [o]
+    FROM OPENJSON(CAST([j].[OwnedCollectionRoot] AS nvarchar(max)), '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch') AS [o]
     ORDER BY CAST([o].[key] AS int)
     OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [CollectionElement]
 FROM [JsonEntitiesBasic] AS [j]
@@ -1740,9 +1740,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 + [j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[0].OwnedReferenceLeaf.SomethingSomething')
+SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm + [j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[0].OwnedReferenceLeaf.SomethingSomething')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1822,9 +1822,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1836,9 +1836,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0, JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0]')
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm, JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0]')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1872,9 +1872,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1886,9 +1886,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1922,9 +1922,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1936,9 +1936,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1950,9 +1950,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1964,9 +1964,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -2000,9 +2000,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @__prm_0, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @prm, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -2014,9 +2014,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @__prm_0, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @prm, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3151,9 +3151,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3184,10 +3184,10 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm1_0='0'
-@__prm2_1='1'
+@prm1='0'
+@prm2='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm1_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST(@__prm2_1 AS nvarchar(max)) + ']'), @__prm1_0, @__prm2_1
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm1 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST(@prm2 AS nvarchar(max)) + ']'), @prm1, @prm2
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3229,9 +3229,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT [j].[Id], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[1]'), @__prm_0
+SELECT [j].[Id], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf[1]'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -359,13 +359,13 @@ WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Fraction
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT CAST(LEN([j1].[c]) AS int)
 FROM (
     SELECT DISTINCT [j0].[c]
     FROM (
-        SELECT TOP(@__p_0) JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
+        SELECT TOP(@p) JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -379,13 +379,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j1].[c], '$.OwnedReferenceBranch'), [j1].[Id]
 FROM (
     SELECT DISTINCT [j0].[c] AS [c], [j0].[Id]
     FROM (
-        SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+        SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -399,13 +399,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch'), [t0].[Id], CAST(LEN([t0].[c0]) AS int)
 FROM (
     SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[c0]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
+        SELECT TOP(@p) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [t]
@@ -419,17 +419,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceSharedLeaf'), [t2].[Id], JSON_QUERY([t2].[c], '$.OwnedCollectionSharedLeaf'), [t2].[Length]
 FROM (
     SELECT DISTINCT JSON_QUERY([t1].[c],'$') AS [c], [t1].[Id], [t1].[Length]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
+        SELECT TOP(@p) JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
         FROM (
             SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[Scalar]
             FROM (
-                SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
+                SELECT TOP(@p) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [t]
@@ -446,17 +446,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j3].[c], '$.OwnedReferenceLeaf'), [j3].[Id]
 FROM (
     SELECT DISTINCT [j2].[c] AS [c], [j2].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
+        SELECT TOP(@p) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
         FROM (
             SELECT DISTINCT [j0].[c] AS [c], [j0].[Id], [j0].[c] AS [c0]
             FROM (
-                SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+                SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [j0]
@@ -473,17 +473,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_QUERY([j3].[c], '$.OwnedCollectionLeaf'), [j3].[Id]
 FROM (
     SELECT DISTINCT [j2].[c] AS [c], [j2].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
+        SELECT TOP(@p) JSON_QUERY([j1].[c], '$.OwnedReferenceBranch') AS [c], [j1].[Id]
         FROM (
             SELECT DISTINCT [j0].[c] AS [c], [j0].[Id], [j0].[c] AS [c0]
             FROM (
-                SELECT TOP(@__p_0) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
+                SELECT TOP(@p) [j].[OwnedReferenceRoot] AS [c], [j].[Id]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [j0]
@@ -500,13 +500,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT JSON_VALUE([j1].[c], '$.SomethingSomething')
 FROM (
     SELECT DISTINCT [j0].[c] AS [c], [j0].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
+        SELECT TOP(@p) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [j0]
@@ -847,9 +847,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -931,9 +931,9 @@ ORDER BY [j].[Id]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -945,9 +945,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].Date') AS datetime2)
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -959,9 +959,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -973,9 +973,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @prm
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
 """);
@@ -988,9 +988,9 @@ ORDER BY [j].[Id]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1014,11 +1014,11 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') <> N'Foo' OR JSON_VALUE
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') IS NULL
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].Name') IS NULL
 """);
     }
 
@@ -1085,11 +1085,11 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') <> N'Foo' OR JSON_VALUE
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
 """);
     }
 
@@ -1642,11 +1642,11 @@ WHERE N'e1_r1' IN (
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
 SELECT [j].[Id], (
     SELECT N'Foo'
-    FROM OPENJSON([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch') AS [o]
+    FROM OPENJSON([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch') AS [o]
     ORDER BY CAST([o].[key] AS int)
     OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) AS [CollectionElement]
 FROM [JsonEntitiesBasic] AS [j]
@@ -1660,9 +1660,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 + [j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[0].OwnedReferenceLeaf.SomethingSomething')
+SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@prm + [j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[0].OwnedReferenceLeaf.SomethingSomething')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1742,9 +1742,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1756,9 +1756,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0, JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0]')
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), [j].[Id], @prm, JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0]')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1792,9 +1792,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1806,9 +1806,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1842,9 +1842,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1856,9 +1856,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1870,9 +1870,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1884,9 +1884,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1920,9 +1920,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @__prm_0, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @prm, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1934,9 +1934,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @__prm_0, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @prm, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3044,9 +3044,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@prm AS nvarchar(max)) + ']'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3077,10 +3077,10 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm1_0='0'
-@__prm2_1='1'
+@prm1='0'
+@prm2='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm1_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST(@__prm2_1 AS nvarchar(max)) + ']'), @__prm1_0, @__prm2_1
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm1 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST(@prm2 AS nvarchar(max)) + ']'), @prm1, @prm2
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -3122,9 +3122,9 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
-SELECT [j].[Id], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[1]'), @__prm_0
+SELECT [j].[Id], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@prm AS nvarchar(max)) + '].OwnedCollectionLeaf[1]'), @prm
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -1790,7 +1790,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
@@ -1798,7 +1798,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @__entity_equality_two_0_Id)
+    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @entity_equality_two_Id)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -714,11 +714,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='1,2,3' (Size = 4000)
+@ints='1,2,3' (Size = 4000)
 
 SELECT TOP(2) [t].[Id], [t].[Ints]
 FROM [TestEntity] AS [t]
-WHERE [t].[Ints] = @__ints_0
+WHERE [t].[Ints] = @ints
 """);
     }
 
@@ -825,13 +825,13 @@ WHERE [t].[Id] IN (2, 999)
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 4000)
+@ids='[2,999]' (Size = 4000)
 
 SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     WHERE [i].[value] > [t].[Id]) = 1
 """);
     }
@@ -842,13 +842,13 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[2,999]' (Size = 4000)
+@ints='[2,999]' (Size = 4000)
 
 SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -859,13 +859,13 @@ WHERE [t].[Id] IN (
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 4000)
+@ids='[2,999]' (Size = 4000)
 
 SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     WHERE [i].[value] > [t].[Id]) = 1
 """);
     }
@@ -876,13 +876,13 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[2,999]' (Size = 4000)
+@ints='[2,999]' (Size = 4000)
 
 SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -938,17 +938,17 @@ WHERE [t].[Id] IN (2, 999)
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-01T12:30:00","2020-01-02T12:30:00"]' (Size = 4000)
-@__dateTimes_0_1='["2020-01-01T12:30:00","2020-01-02T12:30:00"]' (Size = 4000)
+@dateTimes='["2020-01-01T12:30:00","2020-01-02T12:30:00"]' (Size = 4000)
+@dateTimes0='["2020-01-01T12:30:00","2020-01-02T12:30:00"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[DateTime], [t].[DateTime2], [t].[Ints]
 FROM [TestEntity] AS [t]
 WHERE [t].[DateTime] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dateTimes) WITH ([value] datetime '$') AS [d]
 ) AND [t].[DateTime2] IN (
     SELECT [d0].[value]
-    FROM OPENJSON(@__dateTimes_0_1) WITH ([value] datetime2 '$') AS [d0]
+    FROM OPENJSON(@dateTimes0) WITH ([value] datetime2 '$') AS [d0]
 )
 """);
     }
@@ -969,13 +969,13 @@ WHERE [t].[DateTime] IN (
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-01T12:30:00","2020-01-02T12:30:00",null]' (Size = 4000)
+@dateTimes='["2020-01-01T12:30:00","2020-01-02T12:30:00",null]' (Size = 4000)
 
 SELECT [t].[Id], [t].[DateTime], [t].[Ints]
 FROM [TestEntity] AS [t]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime2 '$') AS [d]
+    FROM OPENJSON(@dateTimes) WITH ([value] datetime2 '$') AS [d]
     WHERE [d].[value] = [t].[DateTime] AND [d].[value] IS NOT NULL)
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -465,9 +465,9 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 ORDER BY (SELECT 1)
 """);
@@ -956,11 +956,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT AVG([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -988,11 +988,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT AVG([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1111,11 +1111,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT MIN([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1140,11 +1140,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT MIN([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1220,11 +1220,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT MAX([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1249,11 +1249,11 @@ OUTER APPLY (
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT MAX([s0].[value])
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1629,24 +1629,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE"]' (Size = 4000)
+@ids='["ABCDE"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1657,7 +1657,7 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["London","Buenos Aires"]' (Size = 4000)
+@ids='["London","Buenos Aires"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1666,12 +1666,12 @@ WHERE EXISTS (
     FROM [Customers] AS [c0]
     WHERE [c0].[City] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] nvarchar(15) '$') AS [i]
     ) AND [c0].[CustomerID] = [c].[CustomerID])
 """,
             //
             """
-@__ids_0='["London"]' (Size = 4000)
+@ids='["London"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1680,7 +1680,7 @@ WHERE EXISTS (
     FROM [Customers] AS [c0]
     WHERE [c0].[City] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] nvarchar(15) '$') AS [i]
     ) AND [c0].[CustomerID] = [c].[CustomerID])
 """);
     }
@@ -1691,24 +1691,24 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__ids_0='[0,1]' (Size = 4000)
+@ids='[0,1]' (Size = 4000)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='[0]' (Size = 4000)
+@ids='[0]' (Size = 4000)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -1719,24 +1719,24 @@ WHERE [e].[EmployeeID] IN (
 
         AssertSql(
             """
-@__ids_0='[0,1]' (Size = 4000)
+@ids='[0,1]' (Size = 4000)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='[0]' (Size = 4000)
+@ids='[0]' (Size = 4000)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -1759,13 +1759,13 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1776,13 +1776,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1793,13 +1793,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='[null,null]' (Size = 4000)
+@ids='[null,null]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1822,24 +1822,24 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 
         AssertSql(
             """
-@__p_0='["ABCDE","ALFKI"]' (Size = 4000)
+@p='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [p].[value]
-    FROM OPENJSON(@__p_0) WITH ([value] nchar(5) '$') AS [p]
+    FROM OPENJSON(@p) WITH ([value] nchar(5) '$') AS [p]
 )
 """,
             //
             """
-@__p_0='["ABCDE","ANATR"]' (Size = 4000)
+@p='["ABCDE","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [p].[value]
-    FROM OPENJSON(@__p_0) WITH ([value] nchar(5) '$') AS [p]
+    FROM OPENJSON(@p) WITH ([value] nchar(5) '$') AS [p]
 )
 """);
     }
@@ -1850,24 +1850,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__Select_0='["ABCDE","ALFKI"]' (Size = 4000)
+@Select='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
+    FROM OPENJSON(@Select) WITH ([value] nchar(5) '$') AS [s]
 )
 """,
             //
             """
-@__Select_0='["ABCDE","ANATR"]' (Size = 4000)
+@Select='["ABCDE","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
+    FROM OPENJSON(@Select) WITH ([value] nchar(5) '$') AS [s]
 )
 """);
     }
@@ -1878,24 +1878,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE"]' (Size = 4000)
+@ids='["ABCDE"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1906,13 +1906,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1923,13 +1923,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1960,24 +1960,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE"]' (Size = 4000)
+@ids='["ABCDE"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1988,13 +1988,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2005,13 +2005,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='[null,null]' (Size = 4000)
+@ids='[null,null]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2034,24 +2034,24 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 
         AssertSql(
             """
-@__Order_0='["ABCDE","ALFKI"]' (Size = 4000)
+@Order='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [o].[value]
-    FROM OPENJSON(@__Order_0) WITH ([value] nchar(5) '$') AS [o]
+    FROM OPENJSON(@Order) WITH ([value] nchar(5) '$') AS [o]
 )
 """,
             //
             """
-@__Order_0='["ABCDE","ANATR"]' (Size = 4000)
+@Order='["ABCDE","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [o].[value]
-    FROM OPENJSON(@__Order_0) WITH ([value] nchar(5) '$') AS [o]
+    FROM OPENJSON(@Order) WITH ([value] nchar(5) '$') AS [o]
 )
 """);
     }
@@ -2062,24 +2062,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE"]' (Size = 4000)
+@ids='["ABCDE"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2090,13 +2090,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2107,13 +2107,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='[null,null]' (Size = 4000)
+@ids='[null,null]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2136,24 +2136,24 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 
         AssertSql(
             """
-@__AsReadOnly_0='["ABCDE","ALFKI"]' (Size = 4000)
+@AsReadOnly='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__AsReadOnly_0) WITH ([value] nchar(5) '$') AS [a]
+    FROM OPENJSON(@AsReadOnly) WITH ([value] nchar(5) '$') AS [a]
 )
 """,
             //
             """
-@__AsReadOnly_0='["ABCDE","ANATR"]' (Size = 4000)
+@AsReadOnly='["ABCDE","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__AsReadOnly_0) WITH ([value] nchar(5) '$') AS [a]
+    FROM OPENJSON(@AsReadOnly) WITH ([value] nchar(5) '$') AS [a]
 )
 """);
     }
@@ -2164,13 +2164,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__Select_0='["ABCDE","ALFKI"]' (Size = 4000)
+@Select='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
+    FROM OPENJSON(@Select) WITH ([value] nchar(5) '$') AS [s]
 )
 """);
     }
@@ -2181,13 +2181,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2198,13 +2198,13 @@ WHERE [c].[CustomerID] NOT IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+@ids='["ABCDE","ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ALFKI', N'ABCDE') AND [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2239,13 +2239,13 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ABCDE') AND [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ALFKI","ABC\u0027)); GO; DROP TABLE Orders; GO; --"]' (Size = 4000)
+@ids='["ALFKI","ABC\u0027)); GO; DROP TABLE Orders; GO; --"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 ) OR [c].[CustomerID] IN (N'ALFKI', N'ABCDE')
 """);
     }
@@ -2256,13 +2256,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2284,10 +2284,10 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT CASE
-    WHEN @__p_0 IN (
+    WHEN @p IN (
         SELECT [c].[CustomerID]
         FROM [Customers] AS [c]
     ) THEN CAST(1 AS bit)
@@ -2371,11 +2371,11 @@ WHERE [o].[CustomerID] LIKE N'A%'
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT TOP(1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -2389,14 +2389,14 @@ ORDER BY [c0].[CustomerID] DESC
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT TOP(1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 ORDER BY [c0].[CustomerID] DESC
 """);
@@ -2414,13 +2414,13 @@ WHERE [o].[OrderID] = 10248
 """,
             //
             """
-@__entity_equality_p_0_OrderID='10248' (Nullable = true)
+@entity_equality_p_OrderID='10248' (Nullable = true)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o]
-        WHERE [o].[CustomerID] = N'VINET' AND [o].[OrderID] = @__entity_equality_p_0_OrderID) THEN CAST(1 AS bit)
+        WHERE [o].[CustomerID] = N'VINET' AND [o].[OrderID] = @entity_equality_p_OrderID) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -2432,14 +2432,14 @@ END
 
         AssertSql(
             """
-@__entity_equality_someOrder_0_OrderID='10248' (Nullable = true)
+@entity_equality_someOrder_OrderID='10248' (Nullable = true)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @__entity_equality_someOrder_0_OrderID)
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_someOrder_OrderID)
 """);
     }
 
@@ -2521,13 +2521,13 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__ids_0='["ALFKI"]' (Size = 4000)
+@ids='["ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2538,13 +2538,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ALFKI"]' (Size = 4000)
+@ids='["ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2723,13 +2723,13 @@ FROM [Employees] AS [e]
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2752,13 +2752,13 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2769,24 +2769,24 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2797,13 +2797,13 @@ WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2826,13 +2826,13 @@ WHERE [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2843,24 +2843,24 @@ WHERE [c].[CustomerID] NOT IN (
 
         AssertSql(
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
+@ids='["ABCDE","ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2989,11 +2989,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Orders] AS [o]
 ) AS [o0]
 """);
@@ -3026,7 +3026,7 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT COUNT([s].[value])
 FROM [Customers] AS [c]
@@ -3034,7 +3034,7 @@ OUTER APPLY (
     SELECT CASE
         WHEN [c].[City] IN (
             SELECT [c0].[value]
-            FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+            FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
         ) THEN 1
     END AS [value]
 ) AS [s]
@@ -3048,7 +3048,7 @@ GROUP BY [c].[Country]
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT AVG([s].[value])
 FROM [Customers] AS [c]
@@ -3056,7 +3056,7 @@ OUTER APPLY (
     SELECT CASE
         WHEN [c].[City] IN (
             SELECT [c0].[value]
-            FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+            FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
         ) THEN 1.0E0
         ELSE 0.0E0
     END AS [value]
@@ -3070,7 +3070,7 @@ OUTER APPLY (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT COALESCE(SUM([s].[value]), 0)
 FROM [Customers] AS [c]
@@ -3078,7 +3078,7 @@ OUTER APPLY (
     SELECT CASE
         WHEN [c].[City] IN (
             SELECT [c0].[value]
-            FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+            FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
         ) THEN 1
         ELSE 0
     END AS [value]
@@ -3092,13 +3092,13 @@ OUTER APPLY (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
 WHERE [c].[City] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
 )
 """);
     }
@@ -3109,13 +3109,13 @@ WHERE [c].[City] IN (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT COUNT_BIG(*)
 FROM [Customers] AS [c]
 WHERE [c].[City] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
 )
 """);
     }
@@ -3126,7 +3126,7 @@ WHERE [c].[City] IN (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT MAX([s].[value])
 FROM [Customers] AS [c]
@@ -3134,7 +3134,7 @@ OUTER APPLY (
     SELECT CASE
         WHEN [c].[City] IN (
             SELECT [c0].[value]
-            FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+            FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
         ) THEN 1
         ELSE 0
     END AS [value]
@@ -3148,7 +3148,7 @@ OUTER APPLY (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 4000)
+@cities='["London","Berlin"]' (Size = 4000)
 
 SELECT MIN([s].[value])
 FROM [Customers] AS [c]
@@ -3156,7 +3156,7 @@ OUTER APPLY (
     SELECT CASE
         WHEN [c].[City] IN (
             SELECT [c0].[value]
-            FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+            FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
         ) THEN 1
         ELSE 0
     END AS [value]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindChangeTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindChangeTrackingQuerySqlServerTest.cs
@@ -73,20 +73,20 @@ FROM [Employees] AS [e]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """,
             //
             """
@@ -102,11 +102,11 @@ ORDER BY [e].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT TOP(1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -114,23 +114,23 @@ ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='2'
-@__p_1='1'
+@p='2'
+@p0='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
 ORDER BY [c0].[CustomerID]
-OFFSET @__p_1 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p0 ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -182,11 +182,11 @@ FROM [Employees] AS [e]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT TOP(1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -194,23 +194,23 @@ ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='2'
-@__p_1='1'
+@p='2'
+@p0='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
 ORDER BY [c0].[CustomerID]
-OFFSET @__p_1 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p0 ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -246,20 +246,20 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -90,19 +90,19 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -112,19 +112,19 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -134,19 +134,19 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -156,19 +156,19 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -178,24 +178,24 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__args='["ALFKI"]' (Size = 4000)
+@args='["ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__args) WITH ([value] nchar(5) '$') AS [a]
+    FROM OPENJSON(@args) WITH ([value] nchar(5) '$') AS [a]
 )
 """,
             //
             """
-@__args='["ANATR"]' (Size = 4000)
+@args='["ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__args) WITH ([value] nchar(5) '$') AS [a]
+    FROM OPENJSON(@args) WITH ([value] nchar(5) '$') AS [a]
 )
 """);
     }
@@ -224,11 +224,11 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -238,160 +238,160 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
-@__s15='RANDM' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s15='RANDM' (Size = 5) (DbType = StringFixedLength)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14 OR [c].[CustomerID] = @__s15
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14 OR [c].[CustomerID] = @s15
 """,
             //
             """
-@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__s3='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__s4='AROUT' (Size = 5) (DbType = StringFixedLength)
-@__s5='BERGS' (Size = 5) (DbType = StringFixedLength)
-@__s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
-@__s7='BLONP' (Size = 5) (DbType = StringFixedLength)
-@__s8='BOLID' (Size = 5) (DbType = StringFixedLength)
-@__s9='BONAP' (Size = 5) (DbType = StringFixedLength)
-@__s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
-@__s11='CACTU' (Size = 5) (DbType = StringFixedLength)
-@__s12='CENTC' (Size = 5) (DbType = StringFixedLength)
-@__s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
-@__s14='CONSH' (Size = 5) (DbType = StringFixedLength)
+@s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@s2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@s3='ANTON' (Size = 5) (DbType = StringFixedLength)
+@s4='AROUT' (Size = 5) (DbType = StringFixedLength)
+@s5='BERGS' (Size = 5) (DbType = StringFixedLength)
+@s6='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@s7='BLONP' (Size = 5) (DbType = StringFixedLength)
+@s8='BOLID' (Size = 5) (DbType = StringFixedLength)
+@s9='BONAP' (Size = 5) (DbType = StringFixedLength)
+@s10='BSBEV' (Size = 5) (DbType = StringFixedLength)
+@s11='CACTU' (Size = 5) (DbType = StringFixedLength)
+@s12='CENTC' (Size = 5) (DbType = StringFixedLength)
+@s13='CHOPS' (Size = 5) (DbType = StringFixedLength)
+@s14='CONSH' (Size = 5) (DbType = StringFixedLength)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] = @__s3 OR [c].[CustomerID] = @__s4 OR [c].[CustomerID] = @__s5 OR [c].[CustomerID] = @__s6 OR [c].[CustomerID] = @__s7 OR [c].[CustomerID] = @__s8 OR [c].[CustomerID] = @__s9 OR [c].[CustomerID] = @__s10 OR [c].[CustomerID] = @__s11 OR [c].[CustomerID] = @__s12 OR [c].[CustomerID] = @__s13 OR [c].[CustomerID] = @__s14
+WHERE [c].[CustomerID] = @s1 OR [c].[CustomerID] = @s2 OR [c].[CustomerID] = @s3 OR [c].[CustomerID] = @s4 OR [c].[CustomerID] = @s5 OR [c].[CustomerID] = @s6 OR [c].[CustomerID] = @s7 OR [c].[CustomerID] = @s8 OR [c].[CustomerID] = @s9 OR [c].[CustomerID] = @s10 OR [c].[CustomerID] = @s11 OR [c].[CustomerID] = @s12 OR [c].[CustomerID] = @s13 OR [c].[CustomerID] = @s14
 """);
     }
 
@@ -401,19 +401,19 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
 
         AssertSql(
             """
-@__args='["ALFKI"]' (Size = 4000)
+@args='["ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = JSON_VALUE(@__args, '$[0]')
+WHERE [c].[CustomerID] = JSON_VALUE(@args, '$[0]')
 """,
             //
             """
-@__args='["ANATR"]' (Size = 4000)
+@args='["ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = JSON_VALUE(@__args, '$[0]')
+WHERE [c].[CustomerID] = JSON_VALUE(@args, '$[0]')
 """);
     }
 
@@ -423,19 +423,19 @@ WHERE [c].[CustomerID] = JSON_VALUE(@__args, '$[0]')
 
         AssertSql(
             """
-@__args='["ALFKI"]' (Size = 4000)
+@args='["ALFKI"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = JSON_VALUE(@__args, '$[0]')
+WHERE [c].[CustomerID] = JSON_VALUE(@args, '$[0]')
 """,
             //
             """
-@__args='["ANATR"]' (Size = 4000)
+@args='["ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = JSON_VALUE(@__args, '$[0]')
+WHERE [c].[CustomerID] = JSON_VALUE(@args, '$[0]')
 """);
     }
 
@@ -493,19 +493,19 @@ WHERE [c].[CustomerID] LIKE N'A%'
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -527,19 +527,19 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -575,19 +575,19 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -597,19 +597,19 @@ WHERE [c].[CustomerID] = @__customerID
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -633,19 +633,19 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 """);
     }
 
@@ -745,22 +745,22 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 
         AssertSql(
             """
-@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] = @__customerID
+WHERE [c].[CustomerID] = @customerID
 ORDER BY [c].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServer160Test.cs
@@ -1031,17 +1031,17 @@ WHERE '2018-12-29T23:20:40.000' > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), 1
 
         AssertSql(
             """
-@__dateTime_7='1919-12-12T10:20:15.0000000' (DbType = DateTime)
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='10'
-@__dateTime_Minute_4='20'
-@__dateTime_Second_5='15'
-@__dateTime_Millisecond_6='0'
+@dateTime='1919-12-12T10:20:15.0000000' (DbType = DateTime)
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='10'
+@dateTime_Minute='20'
+@dateTime_Second='15'
+@dateTime_Millisecond='0'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_7 > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4, @__dateTime_Second_5, @__dateTime_Millisecond_6)
+WHERE @dateTime > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute, @dateTime_Second, @dateTime_Millisecond)
 """);
     }
 
@@ -1097,13 +1097,13 @@ WHERE '2018-12-29' > DATEFROMPARTS(DATEPART(year, GETDATE()), 12, 31)
 
         AssertSql(
             """
-@__date_3='1919-12-12T00:00:00.0000000' (DbType = Date)
-@__date_Month_1='12'
-@__date_Day_2='12'
+@date='1919-12-12T00:00:00.0000000' (DbType = Date)
+@date_Month='12'
+@date_Day='12'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__date_3 > DATEFROMPARTS(DATEPART(year, GETDATE()), @__date_Month_1, @__date_Day_2)
+WHERE @date > DATEFROMPARTS(DATEPART(year, GETDATE()), @date_Month, @date_Day)
 """);
     }
 
@@ -1165,17 +1165,17 @@ WHERE '2018-12-29T23:20:40.0000000' > DATETIME2FROMPARTS(DATEPART(year, GETDATE(
 
             AssertSql(
                 """
-@__dateTime_7='1919-12-12T10:20:15.0000000'
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='10'
-@__dateTime_Minute_4='20'
-@__dateTime_Second_5='15'
-@__fractions_6='9999999'
+@dateTime='1919-12-12T10:20:15.0000000'
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='10'
+@dateTime_Minute='20'
+@dateTime_Second='15'
+@fractions='9999999'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_7 > DATETIME2FROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4, @__dateTime_Second_5, @__fractions_6, 7)
+WHERE @dateTime > DATETIME2FROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute, @dateTime_Second, @fractions, 7)
 """);
         }
     }
@@ -1240,19 +1240,19 @@ WHERE '2018-12-29T23:20:40.0000000+01:00' > DATETIMEOFFSETFROMPARTS(DATEPART(yea
 
             AssertSql(
                 """
-@__dateTimeOffset_9='1919-12-12T10:20:15.0000000+01:30'
-@__dateTimeOffset_Month_1='12'
-@__dateTimeOffset_Day_2='12'
-@__dateTimeOffset_Hour_3='10'
-@__dateTimeOffset_Minute_4='20'
-@__dateTimeOffset_Second_5='15'
-@__fractions_6='5'
-@__hourOffset_7='1'
-@__minuteOffset_8='30'
+@dateTimeOffset='1919-12-12T10:20:15.0000000+01:30'
+@dateTimeOffset_Month='12'
+@dateTimeOffset_Day='12'
+@dateTimeOffset_Hour='10'
+@dateTimeOffset_Minute='20'
+@dateTimeOffset_Second='15'
+@fractions='5'
+@hourOffset='1'
+@minuteOffset='30'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTimeOffset_9 > DATETIMEOFFSETFROMPARTS(DATEPART(year, GETDATE()), @__dateTimeOffset_Month_1, @__dateTimeOffset_Day_2, @__dateTimeOffset_Hour_3, @__dateTimeOffset_Minute_4, @__dateTimeOffset_Second_5, @__fractions_6, @__hourOffset_7, @__minuteOffset_8, 7)
+WHERE @dateTimeOffset > DATETIMEOFFSETFROMPARTS(DATEPART(year, GETDATE()), @dateTimeOffset_Month, @dateTimeOffset_Day, @dateTimeOffset_Hour, @dateTimeOffset_Minute, @dateTimeOffset_Second, @fractions, @hourOffset, @minuteOffset, 7)
 """);
         }
     }
@@ -1310,15 +1310,15 @@ WHERE '2018-12-29T23:20:00' > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), 
 
         AssertSql(
             """
-@__dateTime_5='1919-12-12T23:20:00.0000000' (DbType = DateTime)
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='23'
-@__dateTime_Minute_4='20'
+@dateTime='1919-12-12T23:20:00.0000000' (DbType = DateTime)
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='23'
+@dateTime_Minute='20'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_5 > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4)
+WHERE @dateTime > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute)
 """);
     }
 
@@ -1409,11 +1409,11 @@ WHERE 100 < DATALENGTH([o].[OrderDate])
 
             AssertSql(
                 """
-@__length_1='100' (Nullable = true)
+@length='100' (Nullable = true)
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__length_1 < DATALENGTH([o].[OrderDate])
+WHERE @length < DATALENGTH([o].[OrderDate])
 """);
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -998,17 +998,17 @@ WHERE '2018-12-29T23:20:40.000' > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), 1
 
         AssertSql(
             """
-@__dateTime_7='1919-12-12T10:20:15.0000000' (DbType = DateTime)
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='10'
-@__dateTime_Minute_4='20'
-@__dateTime_Second_5='15'
-@__dateTime_Millisecond_6='0'
+@dateTime='1919-12-12T10:20:15.0000000' (DbType = DateTime)
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='10'
+@dateTime_Minute='20'
+@dateTime_Second='15'
+@dateTime_Millisecond='0'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_7 > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4, @__dateTime_Second_5, @__dateTime_Millisecond_6)
+WHERE @dateTime > DATETIMEFROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute, @dateTime_Second, @dateTime_Millisecond)
 """);
     }
 
@@ -1064,13 +1064,13 @@ WHERE '2018-12-29' > DATEFROMPARTS(DATEPART(year, GETDATE()), 12, 31)
 
         AssertSql(
             """
-@__date_3='1919-12-12T00:00:00.0000000' (DbType = Date)
-@__date_Month_1='12'
-@__date_Day_2='12'
+@date='1919-12-12T00:00:00.0000000' (DbType = Date)
+@date_Month='12'
+@date_Day='12'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__date_3 > DATEFROMPARTS(DATEPART(year, GETDATE()), @__date_Month_1, @__date_Day_2)
+WHERE @date > DATEFROMPARTS(DATEPART(year, GETDATE()), @date_Month, @date_Day)
 """);
     }
 
@@ -1132,17 +1132,17 @@ WHERE '2018-12-29T23:20:40.0000000' > DATETIME2FROMPARTS(DATEPART(year, GETDATE(
 
             AssertSql(
                 """
-@__dateTime_7='1919-12-12T10:20:15.0000000'
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='10'
-@__dateTime_Minute_4='20'
-@__dateTime_Second_5='15'
-@__fractions_6='9999999'
+@dateTime='1919-12-12T10:20:15.0000000'
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='10'
+@dateTime_Minute='20'
+@dateTime_Second='15'
+@fractions='9999999'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_7 > DATETIME2FROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4, @__dateTime_Second_5, @__fractions_6, 7)
+WHERE @dateTime > DATETIME2FROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute, @dateTime_Second, @fractions, 7)
 """);
         }
     }
@@ -1207,19 +1207,19 @@ WHERE '2018-12-29T23:20:40.0000000+01:00' > DATETIMEOFFSETFROMPARTS(DATEPART(yea
 
             AssertSql(
                 """
-@__dateTimeOffset_9='1919-12-12T10:20:15.0000000+01:30'
-@__dateTimeOffset_Month_1='12'
-@__dateTimeOffset_Day_2='12'
-@__dateTimeOffset_Hour_3='10'
-@__dateTimeOffset_Minute_4='20'
-@__dateTimeOffset_Second_5='15'
-@__fractions_6='5'
-@__hourOffset_7='1'
-@__minuteOffset_8='30'
+@dateTimeOffset='1919-12-12T10:20:15.0000000+01:30'
+@dateTimeOffset_Month='12'
+@dateTimeOffset_Day='12'
+@dateTimeOffset_Hour='10'
+@dateTimeOffset_Minute='20'
+@dateTimeOffset_Second='15'
+@fractions='5'
+@hourOffset='1'
+@minuteOffset='30'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTimeOffset_9 > DATETIMEOFFSETFROMPARTS(DATEPART(year, GETDATE()), @__dateTimeOffset_Month_1, @__dateTimeOffset_Day_2, @__dateTimeOffset_Hour_3, @__dateTimeOffset_Minute_4, @__dateTimeOffset_Second_5, @__fractions_6, @__hourOffset_7, @__minuteOffset_8, 7)
+WHERE @dateTimeOffset > DATETIMEOFFSETFROMPARTS(DATEPART(year, GETDATE()), @dateTimeOffset_Month, @dateTimeOffset_Day, @dateTimeOffset_Hour, @dateTimeOffset_Minute, @dateTimeOffset_Second, @fractions, @hourOffset, @minuteOffset, 7)
 """);
         }
     }
@@ -1277,15 +1277,15 @@ WHERE '2018-12-29T23:20:00' > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), 
 
         AssertSql(
             """
-@__dateTime_5='1919-12-12T23:20:00.0000000' (DbType = DateTime)
-@__dateTime_Month_1='12'
-@__dateTime_Day_2='12'
-@__dateTime_Hour_3='23'
-@__dateTime_Minute_4='20'
+@dateTime='1919-12-12T23:20:00.0000000' (DbType = DateTime)
+@dateTime_Month='12'
+@dateTime_Day='12'
+@dateTime_Hour='23'
+@dateTime_Minute='20'
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__dateTime_5 > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), @__dateTime_Month_1, @__dateTime_Day_2, @__dateTime_Hour_3, @__dateTime_Minute_4)
+WHERE @dateTime > SMALLDATETIMEFROMPARTS(DATEPART(year, GETDATE()), @dateTime_Month, @dateTime_Day, @dateTime_Hour, @dateTime_Minute)
 """);
     }
 
@@ -1376,11 +1376,11 @@ WHERE 100 < DATALENGTH([o].[OrderDate])
 
             AssertSql(
                 """
-@__length_1='100' (Nullable = true)
+@length='100' (Nullable = true)
 
 SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE @__length_1 < DATALENGTH([o].[OrderDate])
+WHERE @length < DATALENGTH([o].[OrderDate])
 """);
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
@@ -146,15 +146,15 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -263,11 +263,11 @@ ORDER BY [c].[CustomerID], [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -288,11 +288,11 @@ ORDER BY [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle]
 ) AS [c0]
@@ -328,11 +328,11 @@ ORDER BY [c0].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
@@ -383,14 +383,14 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -413,11 +413,11 @@ ORDER BY [s].[CustomerID], [s].[CustomerID0]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -497,11 +497,11 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -615,15 +615,15 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -632,11 +632,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -681,11 +681,11 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -719,7 +719,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -727,7 +727,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -755,13 +755,13 @@ ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -852,11 +852,11 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -934,7 +934,7 @@ ORDER BY [o1].[OrderID], [s].[OrderID], [s].[ProductID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -944,7 +944,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -963,15 +963,15 @@ ORDER BY [c1].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -980,11 +980,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1101,11 +1101,11 @@ ORDER BY [c].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -1359,15 +1359,15 @@ ORDER BY [s].[OrderID], [s1].[OrderID], [s1].[OrderID0], [s1].[ProductID], [o3].
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1376,11 +1376,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1393,7 +1393,7 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c0].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -1401,7 +1401,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
@@ -1418,11 +1418,11 @@ ORDER BY [c0].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1486,14 +1486,14 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -1568,14 +1568,14 @@ FROM [Products] AS [p]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -1644,11 +1644,11 @@ ORDER BY [o2].[OrderID], [o4].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1721,11 +1721,11 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1838,15 +1838,15 @@ ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1855,11 +1855,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2018,14 +2018,14 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -2073,8 +2073,8 @@ ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -2082,7 +2082,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -2095,11 +2095,11 @@ ORDER BY [o1].[OrderID], [o1].[ProductID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServer160Test.cs
@@ -27,51 +27,51 @@ public class NorthwindFunctionsQuerySqlServer160Test
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__myDatetime_0
+WHERE [o].[OrderDate] = @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <> @__myDatetime_0 OR [o].[OrderDate] IS NULL
+WHERE [o].[OrderDate] <> @myDatetime OR [o].[OrderDate] IS NULL
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """);
     }
 
@@ -95,11 +95,11 @@ WHERE [c].[ContactName] LIKE N'M%'
 
         AssertSql(
             """
-@__pattern_0_startswith='M%' (Size = 30)
+@pattern_startswith='M%' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_startswith ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_startswith ESCAPE N'\'
 """);
     }
 
@@ -182,11 +182,11 @@ WHERE [c].[ContactName] LIKE N'%b'
 
         AssertSql(
             """
-@__pattern_0_endswith='%b' (Size = 30)
+@pattern_endswith='%b' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_endswith ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_endswith ESCAPE N'\'
 """);
     }
 
@@ -306,11 +306,11 @@ WHERE [c].[ContactName] LIKE N'%     %'
 
         AssertSql(
             """
-@__pattern_0_contains='%     %' (Size = 30)
+@pattern_contains='%     %' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_contains ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_contains ESCAPE N'\'
 """);
     }
 
@@ -414,11 +414,11 @@ GROUP BY [c].[City]
 
         AssertSql(
             """
-@__foo_0='foo' (Size = 4000)
+@foo='foo' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CONCAT_WS(N'|', [c].[CompanyName], @__foo_0, N'', N'bar') = N'Around the Horn|foo||bar'
+WHERE CONCAT_WS(N'|', [c].[CompanyName], @foo, N'', N'bar') = N'Around the Horn|foo||bar'
 """);
     }
 
@@ -525,51 +525,51 @@ WHERE [c].[CustomerID] >= N'AROUT'
 
         AssertSql(
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] > @__customer_CustomerID_0
+WHERE [c].[CustomerID] > @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] < @__customer_CustomerID_0
+WHERE [c].[CustomerID] < @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """);
     }
 
@@ -759,51 +759,51 @@ WHERE [c].[CustomerID] >= N'AROUT'
 
         AssertSql(
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] > @__customer_CustomerID_0
+WHERE [c].[CustomerID] > @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] < @__customer_CustomerID_0
+WHERE [c].[CustomerID] < @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """);
     }
 
@@ -909,51 +909,51 @@ WHERE [c].[ContactTitle] = N'Owner' AND ([c].[Country] <> N'USA' OR [c].[Country
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__myDatetime_0
+WHERE [o].[OrderDate] = @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <> @__myDatetime_0 OR [o].[OrderDate] IS NULL
+WHERE [o].[OrderDate] <> @myDatetime OR [o].[OrderDate] IS NULL
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """);
     }
 
@@ -963,51 +963,51 @@ WHERE [o].[OrderDate] <= @__myDatetime_0
 
         AssertSql(
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__orderId_0
+WHERE [o].[OrderID] = @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <> @__orderId_0
+WHERE [o].[OrderID] <> @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] > @__orderId_0
+WHERE [o].[OrderID] > @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__orderId_0
+WHERE [o].[OrderID] <= @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] > @__orderId_0
+WHERE [o].[OrderID] > @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__orderId_0
+WHERE [o].[OrderID] <= @orderId
 """);
     }
 
@@ -2399,12 +2399,12 @@ WHERE CHARINDEX(N'a', [c].[ContactName]) - 1 = 1
 
         AssertSql(
             """
-@__pattern_0='a' (Size = 30)
+@pattern='a' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(@__pattern_0, [c].[ContactName]) - CASE
-    WHEN @__pattern_0 = N'' THEN 0
+WHERE CHARINDEX(@pattern, [c].[ContactName]) - CASE
+    WHEN @pattern = N'' THEN 0
     ELSE 1
 END = 1
 """);
@@ -2428,11 +2428,11 @@ WHERE CHARINDEX(N'a', [c].[ContactName], 3) - 1 = 4
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(N'a', [c].[ContactName], @__start_0 + 1) - 1 = 4
+WHERE CHARINDEX(N'a', [c].[ContactName], @start + 1) - 1 = 4
 """);
     }
 
@@ -2490,11 +2490,11 @@ WHERE SUBSTRING([c].[CustomerID], 1 + 1, LEN([c].[CustomerID])) = N'LFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
 SELECT [c].[ContactName]
 FROM [Customers] AS [c]
-WHERE SUBSTRING([c].[CustomerID], @__start_0 + 1, LEN([c].[CustomerID])) = N'FKI'
+WHERE SUBSTRING([c].[CustomerID], @start + 1, LEN([c].[CustomerID])) = N'FKI'
 """);
     }
 
@@ -2540,9 +2540,9 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
-SELECT SUBSTRING([c].[ContactName], @__start_0 + 1, 3)
+SELECT SUBSTRING([c].[ContactName], @start + 1, 3)
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'
 """);
@@ -2779,11 +2779,11 @@ WHERE [c].[CustomerID] = N'ANATR'
 
         AssertSql(
             """
-@__arg_0='1996-07-04T00:00:00.0000000' (DbType = DateTime)
+@arg='1996-07-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__arg_0
+WHERE [o].[OrderDate] = @arg
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -29,51 +29,51 @@ public class NorthwindFunctionsQuerySqlServerTest : NorthwindFunctionsQueryRelat
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__myDatetime_0
+WHERE [o].[OrderDate] = @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <> @__myDatetime_0 OR [o].[OrderDate] IS NULL
+WHERE [o].[OrderDate] <> @myDatetime OR [o].[OrderDate] IS NULL
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """);
     }
 
@@ -97,11 +97,11 @@ WHERE [c].[ContactName] LIKE N'M%'
 
         AssertSql(
             """
-@__pattern_0_startswith='M%' (Size = 30)
+@pattern_startswith='M%' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_startswith ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_startswith ESCAPE N'\'
 """);
     }
 
@@ -184,11 +184,11 @@ WHERE [c].[ContactName] LIKE N'%b'
 
         AssertSql(
             """
-@__pattern_0_endswith='%b' (Size = 30)
+@pattern_endswith='%b' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_endswith ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_endswith ESCAPE N'\'
 """);
     }
 
@@ -308,11 +308,11 @@ WHERE [c].[ContactName] LIKE N'%     %'
 
         AssertSql(
             """
-@__pattern_0_contains='%     %' (Size = 30)
+@pattern_contains='%     %' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_contains ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @pattern_contains ESCAPE N'\'
 """);
     }
 
@@ -416,11 +416,11 @@ GROUP BY [c].[City]
 
         AssertSql(
             """
-@__foo_0='foo' (Size = 4000)
+@foo='foo' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CONCAT_WS(N'|', [c].[CompanyName], @__foo_0, N'', N'bar') = N'Around the Horn|foo||bar'
+WHERE CONCAT_WS(N'|', [c].[CompanyName], @foo, N'', N'bar') = N'Around the Horn|foo||bar'
 """);
     }
 
@@ -527,51 +527,51 @@ WHERE [c].[CustomerID] >= N'AROUT'
 
         AssertSql(
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] > @__customer_CustomerID_0
+WHERE [c].[CustomerID] > @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] < @__customer_CustomerID_0
+WHERE [c].[CustomerID] < @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """);
     }
 
@@ -761,51 +761,51 @@ WHERE [c].[CustomerID] >= N'AROUT'
 
         AssertSql(
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] > @__customer_CustomerID_0
+WHERE [c].[CustomerID] > @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] < @__customer_CustomerID_0
+WHERE [c].[CustomerID] < @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+WHERE [c].[CustomerID] <= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """,
             //
             """
-@__customer_CustomerID_0='AROUT' (Size = 5) (DbType = StringFixedLength)
+@customer_CustomerID='AROUT' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+WHERE [c].[CustomerID] >= @customer_CustomerID
 """);
     }
 
@@ -911,51 +911,51 @@ WHERE [c].[ContactTitle] = N'Owner' AND ([c].[Country] <> N'USA' OR [c].[Country
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__myDatetime_0
+WHERE [o].[OrderDate] = @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <> @__myDatetime_0 OR [o].[OrderDate] IS NULL
+WHERE [o].[OrderDate] <> @myDatetime OR [o].[OrderDate] IS NULL
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__myDatetime_0
+WHERE [o].[OrderDate] > @myDatetime
 """,
             //
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] <= @__myDatetime_0
+WHERE [o].[OrderDate] <= @myDatetime
 """);
     }
 
@@ -965,51 +965,51 @@ WHERE [o].[OrderDate] <= @__myDatetime_0
 
         AssertSql(
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__orderId_0
+WHERE [o].[OrderID] = @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <> @__orderId_0
+WHERE [o].[OrderID] <> @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] > @__orderId_0
+WHERE [o].[OrderID] > @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__orderId_0
+WHERE [o].[OrderID] <= @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] > @__orderId_0
+WHERE [o].[OrderID] > @orderId
 """,
             //
             """
-@__orderId_0='10250'
+@orderId='10250'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] <= @__orderId_0
+WHERE [o].[OrderID] <= @orderId
 """);
     }
 
@@ -2347,12 +2347,12 @@ WHERE CHARINDEX(N'a', [c].[ContactName]) - 1 = 1
 
         AssertSql(
             """
-@__pattern_0='a' (Size = 30)
+@pattern='a' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(@__pattern_0, [c].[ContactName]) - CASE
-    WHEN @__pattern_0 = N'' THEN 0
+WHERE CHARINDEX(@pattern, [c].[ContactName]) - CASE
+    WHEN @pattern = N'' THEN 0
     ELSE 1
 END = 1
 """);
@@ -2376,11 +2376,11 @@ WHERE CHARINDEX(N'a', [c].[ContactName], 3) - 1 = 4
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(N'a', [c].[ContactName], @__start_0 + 1) - 1 = 4
+WHERE CHARINDEX(N'a', [c].[ContactName], @start + 1) - 1 = 4
 """);
     }
 
@@ -2438,11 +2438,11 @@ WHERE SUBSTRING([c].[CustomerID], 1 + 1, LEN([c].[CustomerID])) = N'LFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
 SELECT [c].[ContactName]
 FROM [Customers] AS [c]
-WHERE SUBSTRING([c].[CustomerID], @__start_0 + 1, LEN([c].[CustomerID])) = N'FKI'
+WHERE SUBSTRING([c].[CustomerID], @start + 1, LEN([c].[CustomerID])) = N'FKI'
 """);
     }
 
@@ -2488,9 +2488,9 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
-SELECT SUBSTRING([c].[ContactName], @__start_0 + 1, 3)
+SELECT SUBSTRING([c].[ContactName], @start + 1, 3)
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'
 """);
@@ -2691,11 +2691,11 @@ WHERE [c].[CustomerID] = N'ANATR'
 
         AssertSql(
             """
-@__arg_0='1996-07-04T00:00:00.0000000' (DbType = DateTime)
+@arg='1996-07-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = @__arg_0
+WHERE [o].[OrderDate] = @arg
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -754,11 +754,11 @@ ORDER BY [o0].[Key]
 
         AssertSql(
             """
-@__a_0='2'
+@a='2'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0) AS [Sum], MIN([o0].[OrderID]) AS [Min], [o0].[Key], MAX([o0].[OrderID]) AS [Max], AVG(CAST([o0].[OrderID] AS float)) AS [Avg]
 FROM (
-    SELECT [o].[OrderID], @__a_0 AS [Key]
+    SELECT [o].[OrderID], @a AS [Key]
     FROM [Orders] AS [o]
 ) AS [o0]
 GROUP BY [o0].[Key]
@@ -771,11 +771,11 @@ GROUP BY [o0].[Key]
 
         AssertSql(
             """
-@__a_0='2'
+@a='2'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0) AS [Sum]
 FROM (
-    SELECT [o].[OrderID], @__a_0 AS [Key]
+    SELECT [o].[OrderID], @a AS [Key]
     FROM [Orders] AS [o]
 ) AS [o0]
 GROUP BY [o0].[Key]
@@ -788,11 +788,11 @@ GROUP BY [o0].[Key]
 
         AssertSql(
             """
-@__a_0='2'
+@a='2'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0) AS [Sum]
 FROM (
-    SELECT [o].[OrderID], @__a_0 AS [Key]
+    SELECT [o].[OrderID], @a AS [Key]
     FROM [Orders] AS [o]
 ) AS [o0]
 GROUP BY [o0].[Key]
@@ -805,11 +805,11 @@ GROUP BY [o0].[Key]
 
         AssertSql(
             """
-@__a_0='2'
+@a='2'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0) AS [Sum]
 FROM (
-    SELECT [o].[OrderID], @__a_0 AS [Key]
+    SELECT [o].[OrderID], @a AS [Key]
     FROM [Orders] AS [o]
 ) AS [o0]
 GROUP BY [o0].[Key]
@@ -822,11 +822,11 @@ GROUP BY [o0].[Key]
 
         AssertSql(
             """
-@__a_0='2'
+@a='2'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0) AS [Sum], [o0].[Key]
 FROM (
-    SELECT [o].[OrderID], @__a_0 AS [Key]
+    SELECT [o].[OrderID], @a AS [Key]
     FROM [Orders] AS [o]
 ) AS [o0]
 GROUP BY [o0].[Key]
@@ -1149,14 +1149,14 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT AVG(CAST([o0].[OrderID] AS float))
 FROM (
     SELECT [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 GROUP BY [o0].[CustomerID]
 """);
@@ -1168,11 +1168,11 @@ GROUP BY [o0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='500'
+@p='500'
 
 SELECT MIN([o0].[OrderID])
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -1186,15 +1186,15 @@ GROUP BY [o0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
-@__p_1='500'
+@p='80'
+@p0='500'
 
 SELECT MAX([o0].[OrderID])
 FROM (
     SELECT [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o0]
 GROUP BY [o0].[CustomerID]
 """);
@@ -1275,13 +1275,13 @@ GROUP BY [o0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='100'
-@__p_1='10'
-@__p_2='50'
+@p='100'
+@p0='10'
+@p1='50'
 
 SELECT [c0].[CustomerID] AS [Key], AVG(CAST([o0].[OrderID] AS float)) AS [Count]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10400
     ORDER BY [o].[OrderDate]
@@ -1291,7 +1291,7 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] NOT IN (N'DRACD', N'FOLKO')
     ORDER BY [c].[City]
-    OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
+    OFFSET @p0 ROWS FETCH NEXT @p1 ROWS ONLY
 ) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
 GROUP BY [c0].[CustomerID]
 """);
@@ -1382,9 +1382,9 @@ GROUP BY [c].[Country]
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='50'
-@__p_2='100'
+@p='10'
+@p0='50'
+@p1='100'
 
 SELECT [o0].[CustomerID] AS [Key], AVG(CAST([o0].[OrderID] AS float)) AS [Count]
 FROM (
@@ -1392,10 +1392,10 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] NOT IN (N'DRACD', N'FOLKO')
     ORDER BY [c].[City]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 INNER JOIN (
-    SELECT TOP(@__p_2) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p1) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10400
     ORDER BY [o].[OrderDate]
@@ -1601,19 +1601,19 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='4'
+@p='20'
+@p0='4'
 
 SELECT [o0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [o].[CustomerID]
+    SELECT TOP(@p) [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 10
     ORDER BY [o].[CustomerID]
 ) AS [o0]
 ORDER BY [o0].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -1623,19 +1623,19 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='4'
+@p='20'
+@p0='4'
 
 SELECT [o0].[Key], [o0].[Max]
 FROM (
-    SELECT TOP(@__p_0) [o].[CustomerID] AS [Key], MAX([o].[CustomerID]) AS [Max]
+    SELECT TOP(@p) [o].[CustomerID] AS [Key], MAX([o].[CustomerID]) AS [Max]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 10
     ORDER BY [o].[CustomerID]
 ) AS [o0]
 ORDER BY [o0].[Key]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -1645,19 +1645,19 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='4'
+@p='20'
+@p0='4'
 
 SELECT CAST(LEN([o0].[CustomerID]) AS int)
 FROM (
-    SELECT TOP(@__p_0) [o].[CustomerID]
+    SELECT TOP(@p) [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 10
     ORDER BY [o].[CustomerID]
 ) AS [o0]
 ORDER BY [o0].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -1667,19 +1667,19 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='4'
+@p='20'
+@p0='4'
 
 SELECT 5
 FROM (
-    SELECT TOP(@__p_0) [o].[CustomerID]
+    SELECT TOP(@p) [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 10
     ORDER BY [o].[CustomerID]
 ) AS [o0]
 ORDER BY [o0].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -2892,14 +2892,14 @@ GROUP BY [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0)
 FROM (
     SELECT [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 GROUP BY [o0].[CustomerID]
 """);
@@ -3034,7 +3034,7 @@ INNER JOIN [Orders] AS [o0] ON ([o1].[Key] = [o0].[CustomerID] OR ([o1].[Key] IS
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[Max]
 FROM [Customers] AS [c]
@@ -3044,7 +3044,7 @@ INNER JOIN (
     GROUP BY [o].[CustomerID]
 ) AS [o0] ON [c].[CustomerID] = [o0].[Key]
 ORDER BY [o0].[Max], [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
@@ -28,11 +28,11 @@ public class NorthwindIncludeNoTrackingQuerySqlServerTest : NorthwindIncludeNoTr
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -169,15 +169,15 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -186,11 +186,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -362,14 +362,14 @@ END
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -393,11 +393,11 @@ ORDER BY [s].[CustomerID], [s].[CustomerID0], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -418,11 +418,11 @@ ORDER BY [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle]
 ) AS [c0]
@@ -451,15 +451,15 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -468,11 +468,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -533,7 +533,7 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c0].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -541,7 +541,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
@@ -577,15 +577,15 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -617,8 +617,8 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -626,7 +626,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -639,11 +639,11 @@ ORDER BY [o1].[OrderID], [o1].[ProductID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -684,11 +684,11 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -748,11 +748,11 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
@@ -766,14 +766,14 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -786,13 +786,13 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -858,14 +858,14 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -941,11 +941,11 @@ ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC
 ) AS [c0]
@@ -1058,11 +1058,11 @@ ORDER BY [s].[OrderID], [s1].[OrderID0], [s1].[ProductID], [s1].[OrderID], [o3].
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -1258,7 +1258,7 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -1266,7 +1266,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -1279,11 +1279,11 @@ ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1303,11 +1303,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -1367,7 +1367,7 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -1377,7 +1377,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -1463,11 +1463,11 @@ ORDER BY [c].[CustomerID], [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1705,14 +1705,14 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -1785,11 +1785,11 @@ ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -2052,15 +2052,15 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2069,11 +2069,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2086,15 +2086,15 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2103,11 +2103,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -106,14 +106,14 @@ ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -126,11 +126,11 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
@@ -144,15 +144,15 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -365,11 +365,11 @@ ORDER BY [c].[PostalCode], [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle]
 ) AS [c0]
@@ -384,7 +384,7 @@ ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -392,7 +392,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -657,11 +657,11 @@ ORDER BY [c].[CustomerID], [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -681,11 +681,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -707,14 +707,14 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -773,11 +773,11 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -792,8 +792,8 @@ ORDER BY [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -801,7 +801,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -814,14 +814,14 @@ ORDER BY [o1].[OrderID], [o1].[ProductID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -871,11 +871,11 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -897,11 +897,11 @@ ORDER BY [o1].[CustomerID], [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -922,11 +922,11 @@ ORDER BY [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1057,11 +1057,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC
 ) AS [c0]
@@ -1076,14 +1076,14 @@ ORDER BY [c0].[ContactName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -1096,11 +1096,11 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -1501,15 +1501,15 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1518,11 +1518,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1535,15 +1535,15 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1552,11 +1552,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1569,15 +1569,15 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1586,11 +1586,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1603,15 +1603,15 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1620,11 +1620,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1654,7 +1654,7 @@ ORDER BY [e].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c0].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -1662,7 +1662,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
@@ -1679,13 +1679,13 @@ ORDER BY [c0].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -1707,7 +1707,7 @@ ORDER BY [c1].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -1717,7 +1717,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -1793,11 +1793,11 @@ ORDER BY [c].[CustomerID], [o2].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -1889,11 +1889,11 @@ WHERE [e0].[EmployeeID] IS NULL
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -97,12 +97,12 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[ContactName], [o0].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
@@ -129,12 +129,12 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
@@ -165,12 +165,12 @@ WHERE [o0].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[ContactName], [o0].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] > 0
     ORDER BY [o].[OrderID]
@@ -292,12 +292,12 @@ ORDER BY [c].[City]
 
         AssertSql(
             """
-@__p_0='4'
+@p='4'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
@@ -400,11 +400,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -551,14 +551,14 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 SELECT [c].[CustomerID], [o1].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
     SELECT [o0].[OrderID], [o0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+        SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
         FROM [Orders] AS [o]
         ORDER BY [o].[OrderID]
     ) AS [o0]
@@ -622,16 +622,16 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [o0].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
 CROSS JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -645,16 +645,16 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [o0].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
 LEFT JOIN (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0] ON 1 = 1
@@ -857,11 +857,11 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c3].[CustomerID], [c3].[Address], [c3].[City], [c3].[CompanyName], [c3].[ContactName], [c3].[ContactTitle], [c3].[Country], [c3].[Fax], [c3].[Phone], [c3].[PostalCode], [c3].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c2]
@@ -939,19 +939,19 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 
         AssertSql(
             """
-@__p_0='[1,2]' (Size = 4000)
+@p='[1,2]' (Size = 4000)
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]
-INNER JOIN OPENJSON(@__p_0) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
+INNER JOIN OPENJSON(@p) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
 """,
             //
             """
-@__p_0='[3]' (Size = 4000)
+@p='[3]' (Size = 4000)
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]
-INNER JOIN OPENJSON(@__p_0) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
+INNER JOIN OPENJSON(@p) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
 """);
     }
 
@@ -999,12 +999,12 @@ INNER JOIN [Employees] AS [e] ON [c].[City] = [e].[City]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [e0].[Title], [e0].[EmployeeID] AS [Id]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[City]
 ) AS [e0] ON [c].[City] = [e0].[City]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
@@ -174,9 +174,9 @@ LEFT JOIN [Alphabetical list of products] AS [a] ON [o].[CustomerID] = [a].[Cate
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [m].[City], [m].[ContactName]
+SELECT TOP(@p) [m].[City], [m].[ContactName]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
 ) AS [m]
@@ -250,11 +250,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
     ) AS [m]
@@ -269,11 +269,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
     ) AS [m]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -68,14 +68,14 @@ WHERE [c].[City] IS NOT NULL
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c1].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -91,14 +91,14 @@ ORDER BY [s].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c1].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -117,11 +117,11 @@ ORDER BY [s].[CustomerID]
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__p_0
+WHERE [c].[CustomerID] = @p
 """);
     }
 
@@ -142,11 +142,11 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__entity_equality_local_0_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_local_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID
+WHERE [c].[CustomerID] = @entity_equality_local_CustomerID
 """);
     }
 
@@ -156,12 +156,12 @@ WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID
 
         AssertSql(
             """
-@__entity_equality_local_0_OrderID='10248' (Nullable = true)
-@__entity_equality_local_0_ProductID='11' (Nullable = true)
+@entity_equality_local_OrderID='10248' (Nullable = true)
+@entity_equality_local_ProductID='11' (Nullable = true)
 
 SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
-WHERE [o].[OrderID] = @__entity_equality_local_0_OrderID AND [o].[ProductID] = @__entity_equality_local_0_ProductID
+WHERE [o].[OrderID] = @entity_equality_local_OrderID AND [o].[ProductID] = @entity_equality_local_ProductID
 """);
     }
 
@@ -171,11 +171,11 @@ WHERE [o].[OrderID] = @__entity_equality_local_0_OrderID AND [o].[ProductID] = @
 
         AssertSql(
             """
-@__entity_equality_local_0_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_local_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID AND @__entity_equality_local_0_CustomerID = [c].[CustomerID]
+WHERE [c].[CustomerID] = @entity_equality_local_CustomerID AND @entity_equality_local_CustomerID = [c].[CustomerID]
 """);
     }
 
@@ -185,16 +185,16 @@ WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID AND @__entity_equ
 
         AssertSql(
             """
-@__entity_equality_local_0_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_local_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 INNER JOIN (
     SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] = @__entity_equality_local_0_CustomerID
+    WHERE [c0].[CustomerID] = @entity_equality_local_CustomerID
 ) AS [c1] ON [c].[CustomerID] = [c1].[CustomerID]
-WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID
+WHERE [c].[CustomerID] = @entity_equality_local_CustomerID
 """);
     }
 
@@ -500,11 +500,11 @@ WHERE [e].[FirstName] = (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e1]
@@ -522,15 +522,15 @@ ORDER BY [e1].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='4'
-@__p_1='3'
+@p='4'
+@p0='3'
 
 SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM (
     SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [e1]
 WHERE EXISTS (
     SELECT 1
@@ -727,11 +727,11 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e1]
 WHERE [e1].[FirstName] = (
@@ -747,11 +747,11 @@ WHERE [e1].[FirstName] = (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e1]
 WHERE [e1].[FirstName] = (
@@ -767,11 +767,11 @@ WHERE [e1].[FirstName] = (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e1]
 WHERE [e1].[FirstName] = (
@@ -787,11 +787,11 @@ WHERE [e1].[FirstName] = (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[ProductID]
+    SELECT TOP(@p) [o].[OrderID], [o].[ProductID]
     FROM [Order Details] AS [o]
     ORDER BY [o].[ProductID], [o].[OrderID]
 ) AS [o1]
@@ -813,9 +813,9 @@ ORDER BY [o1].[ProductID], [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+SELECT TOP(@p) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
 WHERE [o].[OrderID] = 10344 AND (
     SELECT TOP(1) (
@@ -833,9 +833,9 @@ WHERE [o].[OrderID] = 10344 AND (
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+SELECT TOP(@p) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
 WHERE (
     SELECT TOP(1) (
@@ -853,11 +853,11 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o3]
@@ -897,11 +897,11 @@ ORDER BY [o3].[OrderID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e0]
@@ -921,11 +921,11 @@ ORDER BY [e0].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e0]
@@ -1051,12 +1051,12 @@ END, [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -1066,12 +1066,12 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY (SELECT 1)
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -1081,12 +1081,12 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY (SELECT 1)
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -1096,13 +1096,13 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -1112,14 +1112,14 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c].[ContactName], [o].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [o].[OrderID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -1129,14 +1129,14 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT N'Foo'
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [o].[OrderID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -1146,14 +1146,14 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT COALESCE([c].[ContactName], N'') + N' ' + COALESCE([c].[ContactTitle], N'') AS [Contact], [o].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [o].[OrderID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -1163,15 +1163,15 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [o].[OrderID], [c].[CustomerID] AS [CustomerIDA], [c0].[CustomerID] AS [CustomerIDB], [c].[ContactName] AS [ContactNameA], [c0].[ContactName] AS [ContactNameB]
 FROM [Orders] AS [o]
 INNER JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ORDER BY [o].[OrderID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -1203,17 +1203,17 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
 ) AS [c0]
 ORDER BY [c0].[ContactName]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -1223,19 +1223,19 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT DISTINCT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactName]
     ) AS [c0]
     ORDER BY [c0].[ContactName]
-    OFFSET @__p_1 ROWS
+    OFFSET @p0 ROWS
 ) AS [c1]
 """);
     }
@@ -1246,36 +1246,36 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT DISTINCT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactName]
     ) AS [c0]
     ORDER BY [c0].[ContactName]
-    OFFSET @__p_1 ROWS
+    OFFSET @p0 ROWS
 ) AS [c1]
 """,
             //
             """
-@__p_0='15'
-@__p_1='10'
+@p='15'
+@p0='10'
 
 SELECT DISTINCT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactName]
     ) AS [c0]
     ORDER BY [c0].[ContactName]
-    OFFSET @__p_1 ROWS
+    OFFSET @p0 ROWS
 ) AS [c1]
 """);
     }
@@ -1286,13 +1286,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
     SELECT DISTINCT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
     FROM (
-        SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+        SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
         FROM [Orders] AS [o]
     ) AS [o0]
 ) AS [o1]
@@ -1305,13 +1305,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
     SELECT DISTINCT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
     FROM (
-        SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+        SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
         FROM [Orders] AS [o]
         WHERE [o].[CustomerID] = N'FRANK'
     ) AS [o0]
@@ -1358,9 +1358,9 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='91'
+@p='91'
 
-SELECT TOP(@__p_0) [c].[City]
+SELECT TOP(@p) [c].[City]
 FROM [Customers] AS [c]
 """);
     }
@@ -1371,9 +1371,9 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='91'
+@p='91'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 """);
     }
@@ -1384,9 +1384,9 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -1398,9 +1398,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -1412,9 +1412,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[City]
+SELECT TOP(@p) [c].[City]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -1426,9 +1426,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [c].[City]
+SELECT TOP(@p) [c].[City]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -1440,11 +1440,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -1457,11 +1457,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Orders] AS [o]
 ) AS [o0]
 """);
@@ -1783,13 +1783,13 @@ WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle', N'Lisboa')
 
         AssertSql(
             """
-@__london_0='London' (Size = 15)
-@__lisboa_1='Lisboa' (Size = 15)
+@london='London' (Size = 15)
+@lisboa='Lisboa' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] = @__london_0 OR [c].[City] = N'Berlin' OR [c].[City] = N'Seattle' OR [c].[City] = @__lisboa_1
+WHERE [c].[City] = @london OR [c].[City] = N'Berlin' OR [c].[City] = N'Seattle' OR [c].[City] = @lisboa
 """);
     }
 
@@ -1799,11 +1799,11 @@ WHERE [c].[City] = @__london_0 OR [c].[City] = N'Berlin' OR [c].[City] = N'Seatt
 
         AssertSql(
             """
-@__p_0='9'
+@p='9'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e0]
 CROSS JOIN [Customers] AS [c]
@@ -2151,11 +2151,11 @@ INNER JOIN (
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(2) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -2169,11 +2169,11 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(2) [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[OrderID], [s].[CustomerID0], [s].[EmployeeID], [s].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], [o].[EmployeeID], [o].[OrderDate]
     FROM [Customers] AS [c]
     CROSS JOIN [Orders] AS [o]
     ORDER BY [c].[CustomerID], [o].[OrderID]
@@ -2188,7 +2188,7 @@ ORDER BY [s].[CustomerID], [s].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
@@ -2196,7 +2196,7 @@ FROM (
     FROM [Customers] AS [c]
 ) AS [c0]
 ORDER BY [c0].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -2206,8 +2206,8 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
@@ -2215,7 +2215,7 @@ FROM (
     FROM [Customers] AS [c]
 ) AS [c0]
 ORDER BY [c0].[ContactName]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -2225,14 +2225,14 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -2243,15 +2243,15 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 """);
     }
@@ -2262,15 +2262,15 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactName]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY) THEN CAST(1 AS bit)
+        OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -2282,8 +2282,8 @@ END
 
         AssertSql(
             """
-@__p_0='4'
-@__p_1='7'
+@p='4'
+@p0='7'
 
 SELECT CASE
     WHEN NOT EXISTS (
@@ -2292,7 +2292,7 @@ SELECT CASE
             SELECT [c].[CustomerID]
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
-            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+            OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
         ) AS [c0]
         WHERE [c0].[CustomerID] NOT LIKE N'B%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
@@ -2306,13 +2306,13 @@ END
 
         AssertSql(
             """
-@__p_0='4'
+@p='4'
 
 SELECT CASE
     WHEN NOT EXISTS (
         SELECT 1
         FROM (
-            SELECT TOP(@__p_0) [c].[CustomerID]
+            SELECT TOP(@p) [c].[CustomerID]
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [c0]
@@ -2328,8 +2328,8 @@ END
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='7'
+@p='5'
+@p0='7'
 
 SELECT CASE
     WHEN EXISTS (
@@ -2338,7 +2338,7 @@ SELECT CASE
             SELECT [c].[CustomerID]
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
-            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+            OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
         ) AS [c0]
         WHERE [c0].[CustomerID] LIKE N'C%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
@@ -2352,13 +2352,13 @@ END
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM (
-            SELECT TOP(@__p_0) [c].[CustomerID]
+            SELECT TOP(@p) [c].[CustomerID]
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [c0]
@@ -2443,9 +2443,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+SELECT TOP(@p) [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
     SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
@@ -2460,11 +2460,11 @@ ORDER BY [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT DISTINCT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
 ) AS [o0]
 """);
@@ -2748,11 +2748,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [c0].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -2925,19 +2925,19 @@ WHERE COALESCE([c].[ContactName], [c].[CompanyName]) = N'Liz Nixon'
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT DISTINCT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
         FROM [Customers] AS [c]
         ORDER BY COALESCE([c].[Region], N'ZZ')
     ) AS [c0]
     ORDER BY [c0].[c]
-    OFFSET @__p_1 ROWS
+    OFFSET @p0 ROWS
 ) AS [c1]
 """);
     }
@@ -2947,8 +2947,8 @@ FROM (
 
     // issue #16038
     //            AssertSql(
-    //                @"@__p_0='5'
-    //SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Region]
+    //                @"@p='5'
+    //SELECT TOP(@p) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Region]
     //FROM [Customers] AS [c]
     //ORDER BY [Region]");
     public override async Task Select_take_skip_null_coalesce_operator(bool async)
@@ -2957,17 +2957,17 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[CompanyName], COALESCE([c0].[Region], N'ZZ') AS [Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
+    SELECT TOP(@p) [c].[CustomerID], [c].[CompanyName], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
     ORDER BY COALESCE([c].[Region], N'ZZ')
 ) AS [c0]
 ORDER BY [c0].[c]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -2977,17 +2977,17 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[CompanyName], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
+    SELECT TOP(@p) [c].[CustomerID], [c].[CompanyName], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
     ORDER BY COALESCE([c].[Region], N'ZZ')
 ) AS [c0]
 ORDER BY [c0].[c]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -2997,17 +2997,17 @@ OFFSET @__p_1 ROWS
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
     ORDER BY COALESCE([c].[Region], N'ZZ')
 ) AS [c0]
 ORDER BY [c0].[c]
-OFFSET @__p_1 ROWS
+OFFSET @p0 ROWS
 """);
     }
 
@@ -3041,11 +3041,11 @@ WHERE [o].[OrderDate] > '1998-01-01T12:00:00.000'
 
         AssertSql(
             """
-@__Parse_0='1998-01-01T12:00:00.0000000' (Nullable = true) (DbType = DateTime)
+@Parse='1998-01-01T12:00:00.0000000' (Nullable = true) (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__Parse_0
+WHERE [o].[OrderDate] > @Parse
 """);
     }
 
@@ -3067,19 +3067,19 @@ WHERE [o].[OrderDate] > '1998-01-01T12:00:00.000'
 
         AssertSql(
             """
-@__p_0='1998-01-01T12:00:00.0000000' (Nullable = true) (DbType = DateTime)
+@p='1998-01-01T12:00:00.0000000' (Nullable = true) (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__p_0
+WHERE [o].[OrderDate] > @p
 """,
             //
             """
-@__p_0='1998-01-01T11:00:00.0000000' (Nullable = true) (DbType = DateTime)
+@p='1998-01-01T11:00:00.0000000' (Nullable = true) (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] > @__p_0
+WHERE [o].[OrderDate] > @p
 """);
     }
 
@@ -3089,12 +3089,12 @@ WHERE [o].[OrderDate] > @__p_0
 
         AssertSql(
             """
-@__NewLine_0_contains='%
+@NewLine_contains='%
 %' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE @__NewLine_0_contains ESCAPE N'\'
+WHERE [c].[CustomerID] LIKE @NewLine_contains ESCAPE N'\'
 """);
     }
 
@@ -3126,9 +3126,9 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__parameter_0='-' (Size = 4000)
+@parameter='-' (Size = 4000)
 
-SELECT @__parameter_0 + CAST([o].[OrderID] AS nvarchar(max))
+SELECT @parameter + CAST([o].[OrderID] AS nvarchar(max))
 FROM [Orders] AS [o]
 """);
     }
@@ -3279,11 +3279,11 @@ WHERE [c].[CustomerID] = N'ANTON'
 
         AssertSql(
             """
-@__negatedId_0='-10249'
+@negatedId='-10249'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ~[o].[OrderID] = @__negatedId_0
+WHERE ~[o].[OrderID] = @negatedId
 """);
     }
 
@@ -3370,12 +3370,12 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10400 AND [o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0 AND DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1
+WHERE [o].[OrderID] < 10400 AND [o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @dateFilter_Value_Month AND DATEPART(year, [o].[OrderDate]) = @dateFilter_Value_Year
 """,
             //
             """
@@ -3391,12 +3391,12 @@ WHERE [o].[OrderID] < 10400
 
         AssertSql(
             """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10400 AND [o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0 AND DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1
+WHERE [o].[OrderID] < 10400 AND [o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @dateFilter_Value_Month AND DATEPART(year, [o].[OrderDate]) = @dateFilter_Value_Year
 """,
             //
             """
@@ -3412,12 +3412,12 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+@dateFilter_Value_Month='7'
+@dateFilter_Value_Year='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10400 OR ([o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0 AND DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1)
+WHERE [o].[OrderID] < 10400 OR ([o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) = @dateFilter_Value_Month AND DATEPART(year, [o].[OrderDate]) = @dateFilter_Value_Year)
 """,
             //
             """
@@ -3432,14 +3432,14 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [o0].[OrderID] AS [OrderId], (
     SELECT TOP(1) [c0].[City]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] = [o0].[CustomerID]) AS [City]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -3456,14 +3456,14 @@ ORDER BY (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [o0].[OrderID] AS [OrderId], (
     SELECT TOP(1) [c0].[City]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] = [o0].[CustomerID]) AS [City]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -3630,9 +3630,9 @@ WHERE [o].[OrderDate] IS NOT NULL
 
         AssertSql(
             """
-@__millisecondsPerDay_0='86400000'
+@millisecondsPerDay='86400000'
 
-SELECT DATEADD(millisecond, CAST(CAST(CAST(DATEPART(millisecond, [o].[OrderDate]) AS bigint) % @__millisecondsPerDay_0 AS float) AS int), DATEADD(day, CAST(CAST(CAST(DATEPART(millisecond, [o].[OrderDate]) AS bigint) / @__millisecondsPerDay_0 AS float) AS int), [o].[OrderDate])) AS [OrderDate]
+SELECT DATEADD(millisecond, CAST(CAST(CAST(DATEPART(millisecond, [o].[OrderDate]) AS bigint) % @millisecondsPerDay AS float) AS int), DATEADD(day, CAST(CAST(CAST(DATEPART(millisecond, [o].[OrderDate]) AS bigint) / @millisecondsPerDay AS float) AS int), [o].[OrderDate])) AS [OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderDate] IS NOT NULL
 """);
@@ -3657,11 +3657,11 @@ ORDER BY [o].[OrderID]
 
         AssertSql(
             """
-@__nextYear_0='2017'
+@nextYear='2017'
 
 SELECT DISTINCT DATEPART(year, [o].[OrderDate])
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] IS NOT NULL AND DATEPART(year, [o].[OrderDate]) < @__nextYear_0
+WHERE [o].[OrderDate] IS NOT NULL AND DATEPART(year, [o].[OrderDate]) < @nextYear
 """);
     }
 
@@ -3779,13 +3779,13 @@ ORDER BY [s].[OrderID], [o2].[OrderDate]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='8'
+@p='5'
+@p0='8'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactTitle], [c].[ContactName]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -3795,19 +3795,19 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='8'
-@__p_2='3'
+@p='5'
+@p0='8'
+@p1='3'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle], [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 ORDER BY [c0].[ContactTitle], [c0].[ContactName]
-OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
+OFFSET @p0 ROWS FETCH NEXT @p1 ROWS ONLY
 """);
     }
 
@@ -3817,16 +3817,16 @@ OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
 
         AssertSql(
             """
-@__p_2='3'
-@__p_0='5'
-@__p_1='8'
+@p1='3'
+@p='5'
+@p0='8'
 
-SELECT TOP(@__p_2) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+SELECT TOP(@p1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle], [c].[ContactName]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 ORDER BY [c0].[ContactTitle], [c0].[ContactName]
 """);
@@ -3838,21 +3838,21 @@ ORDER BY [c0].[ContactTitle], [c0].[ContactName]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_3='8'
-@__p_2='10'
-@__p_1='15'
+@p='5'
+@p2='8'
+@p1='10'
+@p0='15'
 
-SELECT TOP(@__p_0) [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+SELECT TOP(@p) [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_3) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    SELECT TOP(@p2) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
     FROM (
-        SELECT TOP(@__p_2) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        SELECT TOP(@p1) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM (
             SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
             FROM [Customers] AS [c]
             ORDER BY [c].[ContactTitle], [c].[ContactName]
-            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+            OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
         ) AS [c0]
         ORDER BY [c0].[ContactTitle], [c0].[ContactName]
     ) AS [c1]
@@ -3868,10 +3868,10 @@ ORDER BY [c2].[ContactTitle], [c2].[ContactName]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='15'
-@__p_2='2'
-@__p_3='8'
+@p='5'
+@p0='15'
+@p1='2'
+@p2='8'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
@@ -3880,13 +3880,13 @@ FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactTitle], [c].[ContactName]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[ContactTitle], [c0].[ContactName]
-    OFFSET @__p_2 ROWS FETCH NEXT @__p_3 ROWS ONLY
+    OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY
 ) AS [c1]
 ORDER BY [c1].[ContactTitle], [c1].[ContactName]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -3896,15 +3896,15 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='15'
+@p='5'
+@p0='15'
 
 SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle], [c].[ContactName]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 """);
     }
@@ -3915,11 +3915,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='15'
+@p='15'
 
 SELECT DISTINCT [p0].[ProductID], [p0].[Discontinued], [p0].[ProductName], [p0].[SupplierID], [p0].[UnitPrice], [p0].[UnitsInStock]
 FROM (
-    SELECT TOP(@__p_0) [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+    SELECT TOP(@p) [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
     FROM [Products] AS [p]
     ORDER BY COALESCE([p].[UnitPrice], 0.0)
 ) AS [p0]
@@ -3932,15 +3932,15 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='15'
+@p='5'
+@p0='15'
 
 SELECT DISTINCT [p0].[ProductID], [p0].[Discontinued], [p0].[ProductName], [p0].[SupplierID], [p0].[UnitPrice], [p0].[UnitsInStock]
 FROM (
     SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
     FROM [Products] AS [p]
     ORDER BY COALESCE([p].[UnitPrice], 0.0)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [p0]
 """);
     }
@@ -3951,15 +3951,15 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='15'
+@p='5'
+@p0='15'
 
-SELECT DISTINCT TOP(@__p_0) [p0].[ProductID], [p0].[Discontinued], [p0].[ProductName], [p0].[SupplierID], [p0].[UnitPrice], [p0].[UnitsInStock]
+SELECT DISTINCT TOP(@p) [p0].[ProductID], [p0].[Discontinued], [p0].[ProductName], [p0].[SupplierID], [p0].[UnitPrice], [p0].[UnitsInStock]
 FROM (
     SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
     FROM [Products] AS [p]
     ORDER BY COALESCE([p].[UnitPrice], 0.0)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [p0]
 """);
     }
@@ -3970,18 +3970,18 @@ FROM (
 
         AssertSql(
             """
-@__p_2='8'
-@__p_0='5'
-@__p_1='15'
+@p1='8'
+@p='5'
+@p0='15'
 
-SELECT TOP(@__p_2) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+SELECT TOP(@p1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
     SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactTitle], [c].[ContactName]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
     ) AS [c0]
 ) AS [c1]
 ORDER BY [c1].[ContactTitle]
@@ -4036,24 +4036,24 @@ LEFT JOIN [Employees] AS [e0] ON [e].[EmployeeID] = [e0].[ReportsTo]
 
         AssertSql(
             """
-@__dates_0='["1996-07-04T00:00:00","1996-07-16T00:00:00"]' (Size = 4000)
+@dates='["1996-07-04T00:00:00","1996-07-16T00:00:00"]' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE CONVERT(date, [o].[OrderDate]) IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetime '$') AS [d]
 )
 """,
             //
             """
-@__dates_0='["1996-07-04T00:00:00"]' (Size = 4000)
+@dates='["1996-07-04T00:00:00"]' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE CONVERT(date, [o].[OrderDate]) IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -4358,8 +4358,8 @@ ORDER BY (
 
         AssertSql(
             """
-@__p_0='40'
-@__p_1='5'
+@p='40'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -4367,7 +4367,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
     ORDER BY [c].[City], [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[City], [c0].[CustomerID]
@@ -4424,11 +4424,11 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT AVG(CAST([o0].[OrderID] AS float))
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -4441,11 +4441,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Customers] AS [c]
 ) AS [c0]
 """);
@@ -4457,11 +4457,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [c0]
@@ -4474,11 +4474,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Customers] AS [c]
 ) AS [c0]
 """);
@@ -4490,11 +4490,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [c0]
@@ -4507,11 +4507,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT MAX([o0].[OrderID])
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -4524,11 +4524,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT MIN([o0].[OrderID])
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -4541,11 +4541,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -4558,14 +4558,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT AVG(CAST([o0].[OrderID] AS float))
 FROM (
     SELECT [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 """);
     }
@@ -4576,14 +4576,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -4594,14 +4594,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -4612,14 +4612,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT_BIG(*)
 FROM (
     SELECT 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -4630,14 +4630,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT_BIG(*)
 FROM (
     SELECT 1 AS empty
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 """);
     }
@@ -4648,14 +4648,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT MAX([o0].[OrderID])
 FROM (
     SELECT [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 """);
     }
@@ -4666,14 +4666,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT MIN([o0].[OrderID])
 FROM (
     SELECT [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 """);
     }
@@ -4684,14 +4684,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT COALESCE(SUM([o0].[OrderID]), 0)
 FROM (
     SELECT [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 """);
     }
@@ -4780,11 +4780,11 @@ FROM (
 
         AssertSql(
             """
-@__prefix_0_startswith='A%' (Size = 5)
+@prefix_startswith='A%' (Size = 5)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE @__prefix_0_startswith ESCAPE N'\'
+WHERE [c].[CustomerID] LIKE @prefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -5037,13 +5037,13 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [c].[CustomerID] AS [Id]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -5053,11 +5053,11 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) 1 AS empty
+    SELECT TOP(@p) 1 AS empty
     FROM [Orders] AS [o]
     INNER JOIN (
         SELECT [c].[CustomerID]
@@ -5075,14 +5075,14 @@ FROM (
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
+@list='[]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -5095,14 +5095,14 @@ END
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
+@list='[]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -5266,14 +5266,14 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='20'
+@p='0'
+@p0='20'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID], [o].[OrderDate], [c].[CustomerID], [c].[City]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """);
     }
 
@@ -5326,7 +5326,7 @@ END
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o1].[OrderID], [o0].[ProductID], [o0].[OrderID]
 FROM (
@@ -5334,7 +5334,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o1]
 LEFT JOIN [Order Details] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o0].[OrderID]
@@ -5347,11 +5347,11 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o1].[OrderID], [o0].[ProductID], [o0].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
@@ -5367,8 +5367,8 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [o1].[OrderID], [o0].[ProductID], [o0].[OrderID]
 FROM (
@@ -5376,7 +5376,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 LEFT JOIN [Order Details] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o0].[OrderID]
@@ -5389,7 +5389,7 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c].[City]
 FROM (
@@ -5397,7 +5397,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [o0].[OrderID]
@@ -5410,11 +5410,11 @@ ORDER BY [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c].[City]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
@@ -5430,8 +5430,8 @@ ORDER BY [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [c].[City]
 FROM (
@@ -5439,7 +5439,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [o0].[OrderID]
@@ -5452,7 +5452,7 @@ ORDER BY [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
@@ -5460,7 +5460,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o1]
 LEFT JOIN [Order Details] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o0].[OrderID]
@@ -5473,11 +5473,11 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
@@ -5493,8 +5493,8 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
-@__p_1='10'
+@p='5'
+@p0='10'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
@@ -5502,7 +5502,7 @@ FROM (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
     ORDER BY [o].[OrderID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 LEFT JOIN [Order Details] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o0].[OrderID]
@@ -5515,7 +5515,7 @@ ORDER BY [o1].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
@@ -5523,7 +5523,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = N'FISSA'
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN (
     SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -5542,11 +5542,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = N'FISSA'
 ) AS [c0]
@@ -5567,8 +5567,8 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='1'
+@p='0'
+@p0='1'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
@@ -5576,7 +5576,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = N'FISSA'
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN (
     SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -5619,11 +5619,11 @@ FROM [Order Details] AS [o]
 
         AssertSql(
             """
-@__entity_equality_a_0_CustomerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_a_CustomerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__entity_equality_a_0_CustomerID
+WHERE [c].[CustomerID] = @entity_equality_a_CustomerID
 """);
     }
 
@@ -5824,17 +5824,17 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_1='5'
-@__searchTerm_0='c' (Size = 15)
+@p='5'
+@searchTerm='c' (Size = 15)
 
-SELECT TOP(@__p_1) [c0].[City]
+SELECT TOP(@p) [c0].[City]
 FROM (
     SELECT DISTINCT [c].[City]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
 ) AS [c0]
-ORDER BY CHARINDEX(@__searchTerm_0, [c0].[City]) - CASE
-    WHEN @__searchTerm_0 = N'' THEN 0
+ORDER BY CHARINDEX(@searchTerm, [c0].[City]) - CASE
+    WHEN @searchTerm = N'' THEN 0
     ELSE 1
 END, [c0].[City]
 """);
@@ -5945,13 +5945,13 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='91'
+@p='91'
 
 SELECT [c1].[City] AS [c1], [e0].[City], [e0].[c1]
 FROM (
     SELECT DISTINCT [c0].[City]
     FROM (
-        SELECT TOP(@__p_0) [c].[City]
+        SELECT TOP(@p) [c].[City]
         FROM [Customers] AS [c]
     ) AS [c0]
 ) AS [c1]
@@ -5980,12 +5980,12 @@ WHERE 0 = 1
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """);
     }
 
@@ -6189,9 +6189,9 @@ END
 """,
             //
             """
-@__Any_0='True'
+@Any='True'
 
-SELECT @__Any_0
+SELECT @Any
 FROM [Employees] AS [e]
 CROSS JOIN [Employees] AS [e0]
 """);
@@ -6258,11 +6258,11 @@ ORDER BY [c].[CustomerID] DESC
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -6282,14 +6282,14 @@ WHERE [c].[CustomerID] = N'ALFKI'
 """,
             //
             """
-@__orderIds_0='[10643,10692,10702,10835,10952,11011]' (Size = 4000)
+@orderIds='[10643,10692,10702,10835,10952,11011]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [o].[OrderID] IN (
     SELECT [o0].[value]
-    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
+    FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
 )
 """);
     }
@@ -6419,19 +6419,19 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__value_0='Sales Representative' (Size = 30)
+@value='Sales Representative' (Size = 30)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[Title] = @__value_0
+WHERE [e].[Title] = @value
 """,
             //
             """
-@__value_0='Steven' (Size = 10)
+@value='Steven' (Size = 10)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[FirstName] = @__value_0
+WHERE [e].[FirstName] = @value
 """);
     }
 
@@ -6556,11 +6556,11 @@ WHERE [e].[Title] = N'Sales Representative'
 
         AssertSql(
             """
-@__value_0='Sales Representative' (Size = 30)
+@value='Sales Representative' (Size = 30)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[Title] = @__value_0
+WHERE [e].[Title] = @value
 """);
     }
 
@@ -6665,23 +6665,23 @@ FROM [Orders] AS [o]
 """,
             //
             """
-@__firstOrder_OrderID_0='10248'
+@firstOrder_OrderID='10248'
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o]
-        WHERE [o].[OrderID] = @__firstOrder_OrderID_0) THEN CAST(1 AS bit)
+        WHERE [o].[OrderID] = @firstOrder_OrderID) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """,
             //
             """
-@__Any_0='True'
+@Any='True'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE @__Any_0 = CAST(1 AS bit)
+WHERE @Any = CAST(1 AS bit)
 """);
     }
 
@@ -6725,14 +6725,14 @@ ORDER BY [o].[OrderID]
 """,
             //
             """
-@__firstOrder_OrderID_0='10248'
+@firstOrder_OrderID='10248'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] = @__firstOrder_OrderID_0 AND ([o0].[CustomerID] = [o].[CustomerID] OR ([o0].[CustomerID] IS NULL AND [o].[CustomerID] IS NULL)))
+    WHERE [o0].[OrderID] = @firstOrder_OrderID AND ([o0].[CustomerID] = [o].[CustomerID] OR ([o0].[CustomerID] IS NULL AND [o].[CustomerID] IS NULL)))
 """);
     }
 
@@ -7247,7 +7247,7 @@ WHERE NOT EXISTS (
 
         AssertSql(
             """
-@__prm_0='2'
+@prm='2'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -7256,7 +7256,7 @@ WHERE NOT EXISTS (
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
     ORDER BY [o].[OrderID]
-    OFFSET @__prm_0 ROWS)
+    OFFSET @prm ROWS)
 """);
     }
 
@@ -7283,7 +7283,7 @@ WHERE (
 
         AssertSql(
             """
-@__ids_0='[10248,10249]' (Size = 4000)
+@ids='[10248,10249]' (Size = 4000)
 
 SELECT [o].[Quantity] AS [Key], (
     SELECT MAX([o1].[OrderDate])
@@ -7291,12 +7291,12 @@ SELECT [o].[Quantity] AS [Key], (
     INNER JOIN [Orders] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
     WHERE [o0].[OrderID] IN (
         SELECT [i0].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i0]
     ) AND [o].[Quantity] = [o0].[Quantity]) AS [MaxTimestamp]
 FROM [Order Details] AS [o]
 WHERE [o].[OrderID] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 GROUP BY [o].[Quantity]
 ORDER BY (
@@ -7305,7 +7305,7 @@ ORDER BY (
     INNER JOIN [Orders] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
     WHERE [o0].[OrderID] IN (
         SELECT [i0].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i0]
     ) AND [o].[Quantity] = [o0].[Quantity])
 """);
     }
@@ -7316,13 +7316,13 @@ ORDER BY (
 
         AssertSql(
             """
-@__data_0='["ALFKIAlfreds Futterkiste","ANATRAna Trujillo Emparedados y helados"]' (Size = 4000)
+@data='["ALFKIAlfreds Futterkiste","ANATRAna Trujillo Emparedados y helados"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] + [c].[CompanyName] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__data_0) WITH ([value] nvarchar(45) '$') AS [d]
+    FROM OPENJSON(@data) WITH ([value] nvarchar(45) '$') AS [d]
 )
 """);
     }
@@ -7333,13 +7333,13 @@ WHERE [c].[CustomerID] + [c].[CompanyName] IN (
 
         AssertSql(
             """
-@__data_0='["ALFKISomeConstant","ANATRSomeConstant","ALFKIX"]' (Size = 4000)
+@data='["ALFKISomeConstant","ANATRSomeConstant","ALFKIX"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] + N'SomeConstant' IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__data_0) WITH ([value] nvarchar(max) '$') AS [d]
+    FROM OPENJSON(@data) WITH ([value] nvarchar(max) '$') AS [d]
 )
 """);
     }
@@ -7350,14 +7350,14 @@ WHERE [c].[CustomerID] + N'SomeConstant' IN (
 
         AssertSql(
             """
-@__data_0='["ALFKIALFKI","ALFKI","ANATRAna Trujillo Emparedados y helados","ANATRANATR"]' (Size = 4000)
+@data='["ALFKIALFKI","ALFKI","ANATRAna Trujillo Emparedados y helados","ANATRANATR"]' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE COALESCE([o].[CustomerID], N'') + COALESCE([c].[CustomerID], N'') IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__data_0) WITH ([value] nchar(10) '$') AS [d]
+    FROM OPENJSON(@data) WITH ([value] nchar(10) '$') AS [d]
 )
 """);
     }
@@ -7368,14 +7368,14 @@ WHERE COALESCE([o].[CustomerID], N'') + COALESCE([c].[CustomerID], N'') IN (
 
         AssertSql(
             """
-@__someVariable_0='SomeVariable' (Size = 4000)
-@__data_1='["ALFKISomeVariable","ANATRSomeVariable","ALFKIX"]' (Size = 4000)
+@someVariable='SomeVariable' (Size = 4000)
+@data='["ALFKISomeVariable","ANATRSomeVariable","ALFKIX"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] + @__someVariable_0 IN (
+WHERE [c].[CustomerID] + @someVariable IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__data_1) WITH ([value] nvarchar(max) '$') AS [d]
+    FROM OPENJSON(@data) WITH ([value] nvarchar(max) '$') AS [d]
 )
 """);
     }
@@ -7386,11 +7386,11 @@ WHERE [c].[CustomerID] + @__someVariable_0 IN (
 
         AssertSql(
             """
-@__Contains_0='True'
+@Contains='True'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__Contains_0 = CAST(1 AS bit)
+WHERE @Contains = CAST(1 AS bit)
 """);
     }
 
@@ -7405,11 +7405,11 @@ WHERE @__Contains_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__p_0
+WHERE [c].[CustomerID] = @p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -53,9 +53,9 @@ WHERE [c].[City] LIKE N'%Sea%'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+SELECT TOP(@p) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
@@ -70,11 +70,11 @@ ORDER BY [o].[OrderID], [o].[ProductID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -96,9 +96,9 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) (
+SELECT TOP(@p) (
     SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
@@ -114,9 +114,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) (
+SELECT TOP(@p) (
     SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
@@ -132,11 +132,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[CustomerID], [o1].[OrderID], [o1].[c]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[CustomerID]
@@ -159,11 +159,11 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[CustomerID], [o1].[OrderID], [o1].[c]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[CustomerID]
@@ -186,11 +186,11 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -212,14 +212,14 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM (
     SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN (
     SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -773,7 +773,7 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__orderIds_0='[10643,10692,10702,10835,10952,11011]' (Size = 4000)
+@orderIds='[10643,10692,10702,10835,10952,11011]' (Size = 4000)
 
 SELECT [s0].[CustomerID], [s0].[Address], [s0].[City], [s0].[CompanyName], [s0].[ContactName], [s0].[ContactTitle], [s0].[Country], [s0].[Fax], [s0].[Phone], [s0].[PostalCode], [s0].[Region]
 FROM [Customers] AS [c]
@@ -785,7 +785,7 @@ LEFT JOIN (
         LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
         WHERE [o].[OrderID] IN (
             SELECT [o0].[value]
-            FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
+            FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
         )
     ) AS [s]
     WHERE [s].[row] <= 1
@@ -988,7 +988,7 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [o0].[OrderID], COALESCE((
     SELECT TOP(1) [o1].[OrderID]
@@ -996,7 +996,7 @@ SELECT [o0].[OrderID], COALESCE((
     WHERE [o0].[OrderID] = [o1].[OrderID]
     ORDER BY [o1].[OrderID], [o1].[ProductID]), 0) AS [OrderDetail], [c].[City]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -29,11 +29,11 @@ public class NorthwindQueryFiltersQuerySqlServerTest : NorthwindQueryFiltersQuer
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -43,11 +43,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -57,12 +57,12 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__p_0
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\' AND [c].[CustomerID] = @p
 """);
     }
 
@@ -72,11 +72,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='F%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='F%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -86,19 +86,19 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """,
             //
             """
-@__ef_filter__TenantPrefix_0_startswith='T%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='T%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -108,11 +108,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='F%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='F%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -122,11 +122,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -136,7 +136,7 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0]
 FROM [Customers] AS [c]
@@ -146,11 +146,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+        WHERE [c0].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
     ) AS [c1] ON [o].[CustomerID] = [c1].[CustomerID]
     WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL
 ) AS [s] ON [c].[CustomerID] = [s].[CustomerID]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ORDER BY [c].[CustomerID], [s].[OrderID]
 """);
     }
@@ -174,14 +174,14 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 """);
@@ -193,8 +193,8 @@ WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_1_startswith='B%' (Size = 40)
-@__ef_filter___quantity_0='50'
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+@ef_filter___quantity='50'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate]
 FROM [Order Details] AS [o]
@@ -204,11 +204,11 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[CompanyName]
         FROM [Customers] AS [c]
-        WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_1_startswith ESCAPE N'\'
+        WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
     ) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
     WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 ) AS [s] ON [o].[OrderID] = [s].[OrderID]
-WHERE [o].[Quantity] > @__ef_filter___quantity_0
+WHERE [o].[Quantity] > @ef_filter___quantity
 """);
     }
 
@@ -218,8 +218,8 @@ WHERE [o].[Quantity] > @__ef_filter___quantity_0
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
-@__ef_filter___quantity_1='50'
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+@ef_filter___quantity='50'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -229,7 +229,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+        WHERE [c0].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
     ) AS [c1] ON [o].[CustomerID] = [c1].[CustomerID]
     WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL
 ) AS [s] ON [c].[CustomerID] = [s].[CustomerID]
@@ -242,13 +242,13 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [c2].[CustomerID], [c2].[CompanyName]
             FROM [Customers] AS [c2]
-            WHERE [c2].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+            WHERE [c2].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
         ) AS [c3] ON [o1].[CustomerID] = [c3].[CustomerID]
         WHERE [c3].[CustomerID] IS NOT NULL AND [c3].[CompanyName] IS NOT NULL
     ) AS [s0] ON [o0].[OrderID] = [s0].[OrderID]
-    WHERE [o0].[Quantity] > @__ef_filter___quantity_1
+    WHERE [o0].[Quantity] > @ef_filter___quantity
 ) AS [s1] ON [s].[OrderID] = [s1].[OrderID]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [s1].[Discount] < CAST(10 AS real)
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\' AND [s1].[Discount] < CAST(10 AS real)
 """);
     }
 
@@ -264,13 +264,13 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
 FROM (
     select * from Customers
 ) AS [m]
-WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+WHERE [m].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 """);
     }
 
@@ -286,7 +286,7 @@ WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [m].[OrderID], [m].[CustomerID], [m].[EmployeeID], [m].[OrderDate]
 FROM (
@@ -295,7 +295,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [m].[CustomerID] = [c0].[CustomerID]
 WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 """);
@@ -307,21 +307,21 @@ WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
-@__customerID='BERGS' (Size = 5) (DbType = StringFixedLength)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+@customerID='BERGS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\' AND [c].[CustomerID] = @customerID
 """,
             //
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
-@__customerID='BLAUS' (Size = 5) (DbType = StringFixedLength)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+@customerID='BLAUS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\' AND [c].[CustomerID] = @customerID
 """);
     }
 
@@ -331,14 +331,14 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 """);
@@ -357,14 +357,14 @@ WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -49,11 +49,11 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT CAST([e0].[EmployeeID] AS bigint) + CAST([o0].[OrderID] AS bigint) AS [Add], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], 42 AS [Literal], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -159,9 +159,9 @@ WHERE [e].[EmployeeID] = 1
 
         AssertSql(
             """
-@__boolean_0='False'
+@boolean='False'
 
-SELECT @__boolean_0
+SELECT @boolean
 FROM [Customers] AS [c]
 """);
     }
@@ -274,9 +274,9 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__x_0='10'
+@x='10'
 
-SELECT @__x_0
+SELECT @x
 FROM [Customers] AS [c]
 """);
     }
@@ -287,9 +287,9 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='9'
+@p='9'
 
-SELECT TOP(@__p_0) [e].[EmployeeID]
+SELECT TOP(@p) [e].[EmployeeID]
 FROM [Employees] AS [e]
 """);
     }
@@ -732,12 +732,12 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -847,12 +847,12 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__i_0='1'
+@i='1'
 
 SELECT (
     SELECT TOP(1) [o0].[CustomerID]
     FROM (
-        SELECT TOP(@__i_0) [o].[CustomerID], [o].[OrderID]
+        SELECT TOP(@i) [o].[CustomerID], [o].[OrderID]
         FROM [Orders] AS [o]
         WHERE [c].[CustomerID] = [o].[CustomerID]
         ORDER BY [o].[OrderID]
@@ -1710,13 +1710,13 @@ ORDER BY [e].[EmployeeID] DESC, [e].[City]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [e1].[EmployeeID], [e1].[City]
 FROM (
     SELECT DISTINCT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
     FROM (
-        SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+        SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
         FROM [Employees] AS [e]
         ORDER BY [e].[EmployeeID] DESC
     ) AS [e0]
@@ -1730,11 +1730,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [e0].[EmployeeID], [e0].[City]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e0]
@@ -1761,11 +1761,11 @@ ORDER BY [c].[City], [c].[CustomerID] DESC
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT [c0].[CustomerID], [o].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1793,7 +1793,7 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c].[CustomerID], [o0].[OrderID]
 FROM [Customers] AS [c]
@@ -1801,7 +1801,7 @@ LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID] DESC
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 ORDER BY [c].[CustomerID]
 """);
@@ -1826,11 +1826,11 @@ ORDER BY [c].[CustomerID] DESC
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID] DESC
 ) AS [c0]
@@ -2017,9 +2017,9 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID] + N' ' + COALESCE([c].[City], N'') AS [Aggregate]
+SELECT TOP(@p) [c].[CustomerID] + N' ' + COALESCE([c].[City], N'') AS [Aggregate]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """);
@@ -2031,12 +2031,12 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT [c].[CustomerID] + N' ' + COALESCE([c].[City], N'') AS [Aggregate]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -2060,11 +2060,11 @@ FROM (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID] + N' ' + COALESCE([c0].[City], N'') AS [Aggregate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[City]
+    SELECT TOP(@p) [c].[CustomerID], [c].[City]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -2132,7 +2132,7 @@ ORDER BY [o].[OrderID]
 
         AssertSql(
             """
-@__filteredOrderIds_0='[10248,10249,10250]' (Size = 4000)
+@filteredOrderIds='[10248,10249,10250]' (Size = 4000)
 
 SELECT [s].[CustomerID], [o1].[CustomerID], [o1].[OrderID], [o1].[OrderDate]
 FROM (
@@ -2145,7 +2145,7 @@ OUTER APPLY (
     FROM [Orders] AS [o0]
     WHERE [s].[CustomerID] IS NOT NULL AND [s].[CustomerID] = [o0].[CustomerID] AND [o0].[OrderID] IN (
         SELECT [f].[value]
-        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
+        FROM OPENJSON(@filteredOrderIds) WITH ([value] int '$') AS [f]
     )
 ) AS [o1]
 ORDER BY [s].[CustomerID], [o1].[OrderID]
@@ -2158,7 +2158,7 @@ ORDER BY [s].[CustomerID], [o1].[OrderID]
 
         AssertSql(
             """
-@__filteredOrderIds_0='[10248,10249,10250]' (Size = 4000)
+@filteredOrderIds='[10248,10249,10250]' (Size = 4000)
 
 SELECT [o0].[OrderID], [o0].[Complex], [o2].[Outer], [o2].[Inner], [o2].[OrderDate]
 FROM (
@@ -2170,7 +2170,7 @@ OUTER APPLY (
     FROM [Orders] AS [o1]
     WHERE [o1].[OrderID] = [o0].[OrderID] AND [o1].[OrderID] IN (
         SELECT [f].[value]
-        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
+        FROM OPENJSON(@filteredOrderIds) WITH ([value] int '$') AS [f]
     )
 ) AS [o2]
 ORDER BY [o0].[OrderID]
@@ -2183,7 +2183,7 @@ ORDER BY [o0].[OrderID]
 
         AssertSql(
             """
-@__filteredOrderIds_0='[10248,10249,10250]' (Size = 4000)
+@filteredOrderIds='[10248,10249,10250]' (Size = 4000)
 
 SELECT [o0].[OrderDate], [o0].[CustomerID], [o2].[Outer1], [o2].[Outer2], [o2].[Inner], [o2].[OrderDate]
 FROM (
@@ -2195,7 +2195,7 @@ OUTER APPLY (
     FROM [Orders] AS [o1]
     WHERE ([o1].[CustomerID] = [o0].[CustomerID] OR ([o1].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) AND [o1].[OrderID] IN (
         SELECT [f].[value]
-        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
+        FROM OPENJSON(@filteredOrderIds) WITH ([value] int '$') AS [f]
     )
 ) AS [o2]
 ORDER BY [o0].[OrderDate], [o0].[CustomerID]
@@ -2220,7 +2220,7 @@ ORDER BY [o0].[OrderDate], [o0].[CustomerID]
 
         AssertSql(
             """
-@__filteredOrderIds_0='[10248,10249,10250]' (Size = 4000)
+@filteredOrderIds='[10248,10249,10250]' (Size = 4000)
 
 SELECT [o2].[OrderID], [o2].[Complex], [o3].[Outer], [o3].[Inner], [o3].[OrderDate]
 FROM (
@@ -2236,7 +2236,7 @@ OUTER APPLY (
     FROM [Orders] AS [o1]
     WHERE [o1].[OrderID] = [o2].[OrderID] AND [o1].[OrderID] IN (
         SELECT [f].[value]
-        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
+        FROM OPENJSON(@filteredOrderIds) WITH ([value] int '$') AS [f]
     )
 ) AS [o3]
 ORDER BY [o2].[OrderID]
@@ -2328,11 +2328,11 @@ ORDER BY [c].[CustomerID], [s].[OrderID], [s].[OrderID0], [s].[ProductID], [o4].
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[OrderID], [s].[OrderID0], [s].[CustomerID0], [s].[EmployeeID], [s].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[CustomerID]
@@ -2497,11 +2497,11 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT CAST([e0].[EmployeeID] AS bigint) + CAST([o0].[OrderID] AS bigint) AS [Add], [e0].[Square], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], 42 AS [Literal], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o0].[OrderID] % 2 AS [Mod]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o0]
@@ -2660,7 +2660,7 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__filteredOrderIds_0='[10248,10249,10250]' (Size = 4000)
+@filteredOrderIds='[10248,10249,10250]' (Size = 4000)
 
 SELECT [o2].[CustomerID], [o2].[Complex], [o3].[Outer], [o3].[Inner], [o3].[OrderDate]
 FROM (
@@ -2676,7 +2676,7 @@ OUTER APPLY (
     FROM [Orders] AS [o1]
     WHERE ([o1].[CustomerID] = [o2].[CustomerID] OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL)) AND [o1].[OrderID] IN (
         SELECT [f].[value]
-        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
+        FROM OPENJSON(@filteredOrderIds) WITH ([value] int '$') AS [f]
     )
 ) AS [o3]
 ORDER BY [o2].[CustomerID], [o2].[Complex]
@@ -2803,11 +2803,11 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [u].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -93,7 +93,7 @@ WHERE [c0].[ContactName] LIKE N'%Thomas%'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [u].[CustomerID], [u].[Address], [u].[City], [u].[CompanyName], [u].[ContactName], [u].[ContactTitle], [u].[Country], [u].[Fax], [u].[Phone], [u].[PostalCode], [u].[Region]
 FROM (
@@ -106,7 +106,7 @@ FROM (
     WHERE [c0].[City] = N'London'
 ) AS [u]
 ORDER BY [u].[ContactName]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 """);
     }
 
@@ -136,7 +136,7 @@ WHERE [u].[ContactName] LIKE N'%Thomas%'
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT [u0].[CustomerID], [u0].[Address], [u0].[City], [u0].[CompanyName], [u0].[ContactName], [u0].[ContactTitle], [u0].[Country], [u0].[Fax], [u0].[Phone], [u0].[PostalCode], [u0].[Region]
 FROM (
@@ -151,7 +151,7 @@ FROM (
         WHERE [c0].[City] = N'London'
     ) AS [u]
     ORDER BY [u].[Region], [u].[City]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [u0]
 WHERE [u0].[ContactName] LIKE N'%Thomas%'
 ORDER BY [u0].[Region], [u0].[City]
@@ -206,15 +206,15 @@ WHERE [c1].[ContactName] LIKE N'%Thomas%'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [u2].[CustomerID], [u2].[Address], [u2].[City], [u2].[CompanyName], [u2].[ContactName], [u2].[ContactTitle], [u2].[Country], [u2].[Fax], [u2].[Phone], [u2].[PostalCode], [u2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [u1].[CustomerID], [u1].[Address], [u1].[City], [u1].[CompanyName], [u1].[ContactName], [u1].[ContactTitle], [u1].[Country], [u1].[Fax], [u1].[Phone], [u1].[PostalCode], [u1].[Region]
+    SELECT TOP(@p) [u1].[CustomerID], [u1].[Address], [u1].[City], [u1].[CompanyName], [u1].[ContactName], [u1].[ContactTitle], [u1].[Country], [u1].[Fax], [u1].[Phone], [u1].[PostalCode], [u1].[Region]
     FROM (
         SELECT [u0].[CustomerID], [u0].[Address], [u0].[City], [u0].[CompanyName], [u0].[ContactName], [u0].[ContactTitle], [u0].[Country], [u0].[Fax], [u0].[Phone], [u0].[PostalCode], [u0].[Region]
         FROM (
-            SELECT TOP(@__p_0) [u].[CustomerID], [u].[Address], [u].[City], [u].[CompanyName], [u].[ContactName], [u].[ContactTitle], [u].[Country], [u].[Fax], [u].[Phone], [u].[PostalCode], [u].[Region]
+            SELECT TOP(@p) [u].[CustomerID], [u].[Address], [u].[City], [u].[CompanyName], [u].[ContactName], [u].[ContactTitle], [u].[Country], [u].[Fax], [u].[Phone], [u].[PostalCode], [u].[Region]
             FROM (
                 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
                 FROM [Customers] AS [c]
@@ -333,8 +333,8 @@ ORDER BY [u].[CompanyName]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='10'
+@p='1'
+@p0='10'
 
 SELECT [u0].[Foo], [u0].[CustomerID], [u0].[Address], [u0].[City], [u0].[CompanyName], [u0].[ContactName], [u0].[ContactTitle], [u0].[Country], [u0].[Fax], [u0].[Phone], [u0].[PostalCode], [u0].[Region]
 FROM (
@@ -349,7 +349,7 @@ FROM (
         WHERE [c0].[City] = N'London'
     ) AS [u]
     ORDER BY [u].[Foo]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [u0]
 WHERE [u0].[Foo] = N'Berlin'
 ORDER BY [u0].[Foo]
@@ -1025,11 +1025,11 @@ FROM [Orders] AS [o1]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o1].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID]
+    SELECT TOP(@p) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderDate]
 ) AS [o1]
@@ -1059,14 +1059,14 @@ FROM [Orders] AS [o0]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 UNION
 SELECT [o1].[OrderID]
 FROM (
-    SELECT TOP(@__p_0) [o0].[OrderID]
+    SELECT TOP(@p) [o0].[OrderID]
     FROM [Orders] AS [o0]
     ORDER BY [o0].[OrderDate]
 ) AS [o1]
@@ -1093,18 +1093,18 @@ FROM [Orders] AS [o0]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
 ) AS [c1]
 UNION
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    SELECT TOP(@p) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     ORDER BY [c0].[ContactName]
 ) AS [c2]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -28,26 +28,26 @@ public class NorthwindSplitIncludeNoTrackingQuerySqlServerTest : NorthwindSplitI
         await base.Include_collection_skip_take_no_order_by(async);
 
         AssertSql(
-"""
-@__p_0='10'
-@__p_1='5'
+            """
+@p='10'
+@p0='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """,
-                //
-                """
-@__p_0='10'
-@__p_1='5'
+            //
+            """
+@p='10'
+@p0='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -59,24 +59,24 @@ ORDER BY [c0].[CustomerID]
         await base.Include_collection_skip_no_order_by(async);
 
         AssertSql(
-"""
-@__p_0='10'
+            """
+@p='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
-                //
-                """
-@__p_0='10'
+            //
+            """
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -159,8 +159,8 @@ END
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -168,23 +168,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -193,11 +193,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -268,11 +268,11 @@ ORDER BY [c].[PostalCode], [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -287,17 +287,17 @@ ORDER BY [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c0].[CustomerID]
 FROM (
@@ -305,14 +305,14 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o3] ON [c0].[CustomerID] = [o3].[CustomerID]
 ORDER BY [c0].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c0].[CustomerID], [o3].[OrderID]
 FROM (
@@ -320,7 +320,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o3] ON [c0].[CustomerID] = [o3].[CustomerID]
 INNER JOIN [Order Details] AS [o4] ON [o3].[OrderID] = [o4].[OrderID]
@@ -363,12 +363,12 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
-SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -382,14 +382,14 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[CustomerID], [s].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -406,14 +406,14 @@ ORDER BY [s].[CustomerID], [s].[CustomerID0]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [s0].[CustomerID], [s0].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -457,11 +457,11 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -546,9 +546,9 @@ ORDER BY [o].[OrderID], [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY CASE
@@ -561,11 +561,11 @@ END, [o].[OrderID], [c].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [s].[OrderID], [s].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+    SELECT TOP(@p) [o].[OrderID], [c].[CustomerID], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -593,8 +593,8 @@ ORDER BY [s].[c], [s].[c0], [s].[OrderID], [s].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -602,7 +602,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -1157,8 +1157,8 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1166,23 +1166,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1191,11 +1191,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1260,11 +1260,11 @@ ORDER BY [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
@@ -1273,13 +1273,13 @@ ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c1].[CustomerID]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -1291,13 +1291,13 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c1].[CustomerID], [o3].[OrderID]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -1316,11 +1316,11 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1366,11 +1366,11 @@ ORDER BY [p].[ProductID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1543,11 +1543,11 @@ ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1561,11 +1561,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1580,11 +1580,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1605,8 +1605,8 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1614,23 +1614,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1639,11 +1639,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1785,8 +1785,8 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1794,23 +1794,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1819,11 +1819,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1870,7 +1870,7 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [c0].[CustomerID]
 FROM (
@@ -1878,13 +1878,13 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [c0]
 ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c1].[CustomerID]
 FROM (
@@ -1894,7 +1894,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -1903,7 +1903,7 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c1].[CustomerID], [o3].[OrderID]
 FROM (
@@ -1913,7 +1913,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -1929,9 +1929,9 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY CASE
@@ -1944,11 +1944,11 @@ END, [o].[OrderID], [c].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [s].[OrderID], [s].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+    SELECT TOP(@p) [o].[OrderID], [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -2146,23 +2146,23 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName], [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__p_0='80'
+@p='80'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], [c].[ContactName]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName], [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -2175,19 +2175,19 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -2256,11 +2256,11 @@ LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -2273,11 +2273,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -2320,12 +2320,12 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
-SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -2339,14 +2339,14 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[CustomerID], [s].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -2459,19 +2459,19 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactTitle], [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactTitle]
+    SELECT TOP(@p) [c].[CustomerID], [c].[ContactTitle]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle], [c].[CustomerID]
 ) AS [c0]
@@ -2486,19 +2486,19 @@ ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName] DESC, [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactName]
+    SELECT TOP(@p) [c].[CustomerID], [c].[ContactName]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC, [c].[CustomerID]
 ) AS [c0]
@@ -2632,17 +2632,17 @@ ORDER BY [c0].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[ContactTitle], [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
@@ -2650,7 +2650,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle], [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -2690,19 +2690,19 @@ END, [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -126,24 +126,24 @@ ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]
         await base.Include_collection_skip_no_order_by(async);
 
         AssertSql(
-"""
-@__p_0='10'
+            """
+@p='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
-                //
-                """
-@__p_0='10'
+            //
+            """
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -156,19 +156,19 @@ ORDER BY [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -182,26 +182,26 @@ ORDER BY [c0].[CustomerID]
         await base.Include_collection_skip_take_no_order_by(async);
 
         AssertSql(
-"""
-@__p_0='10'
-@__p_1='5'
+            """
+@p='10'
+@p0='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 """,
-                //
-                """
-@__p_0='10'
-@__p_1='5'
+            //
+            """
+@p='10'
+@p0='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -482,19 +482,19 @@ ORDER BY [c].[PostalCode], [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactTitle], [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactTitle]
+    SELECT TOP(@p) [c].[CustomerID], [c].[ContactTitle]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle], [c].[CustomerID]
 ) AS [c0]
@@ -509,17 +509,17 @@ ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[ContactTitle], [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
@@ -527,7 +527,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle], [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -920,11 +920,11 @@ ORDER BY [c].[CustomerID], [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -937,11 +937,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -961,11 +961,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -979,11 +979,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -998,11 +998,11 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c1].[CustomerID], [c2].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1023,12 +1023,12 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
-SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1042,14 +1042,14 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[CustomerID], [s].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -1066,14 +1066,14 @@ ORDER BY [s].[CustomerID], [s].[CustomerID0]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [s0].[CustomerID], [s0].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -1152,11 +1152,11 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1171,8 +1171,8 @@ ORDER BY [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -1180,7 +1180,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -1193,12 +1193,12 @@ ORDER BY [o1].[OrderID], [o1].[ProductID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
-SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1212,14 +1212,14 @@ ORDER BY [c1].[CustomerID], [c2].[CustomerID]
 """,
             //
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[CustomerID], [s].[CustomerID0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c2].[CustomerID] AS [CustomerID0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -1269,11 +1269,11 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -1295,11 +1295,11 @@ ORDER BY [o1].[CustomerID], [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1320,11 +1320,11 @@ ORDER BY [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1463,19 +1463,19 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName] DESC, [c].[CustomerID]
 """,
             //
             """
-@__p_0='10'
+@p='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactName]
+    SELECT TOP(@p) [c].[CustomerID], [c].[ContactName]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC, [c].[CustomerID]
 ) AS [c0]
@@ -1490,23 +1490,23 @@ ORDER BY [c0].[ContactName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName], [c].[CustomerID]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__p_0='80'
+@p='80'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], [c].[ContactName]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName], [c].[CustomerID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -1519,9 +1519,9 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY CASE
@@ -1534,11 +1534,11 @@ END, [o].[OrderID], [c].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [s].[OrderID], [s].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+    SELECT TOP(@p) [o].[OrderID], [c].[CustomerID], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -2102,8 +2102,8 @@ ORDER BY [o].[OrderID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2111,23 +2111,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2136,11 +2136,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2153,8 +2153,8 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2162,23 +2162,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2187,11 +2187,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2204,8 +2204,8 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2213,23 +2213,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2238,11 +2238,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2255,8 +2255,8 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2264,23 +2264,23 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (
         SELECT [l].[value]
-        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
-OFFSET @__p_1 ROWS
+OFFSET @p ROWS
 """,
             //
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
     SELECT [c].[CustomerID], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -2289,11 +2289,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, [c].[CustomerID]
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 INNER JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2323,17 +2323,17 @@ ORDER BY [e].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c0].[CustomerID]
 FROM (
@@ -2341,14 +2341,14 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o3] ON [c0].[CustomerID] = [o3].[CustomerID]
 ORDER BY [c0].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c0].[CustomerID], [o3].[OrderID]
 FROM (
@@ -2356,7 +2356,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 INNER JOIN [Orders] AS [o3] ON [c0].[CustomerID] = [o3].[CustomerID]
 INNER JOIN [Order Details] AS [o4] ON [o3].[OrderID] = [o4].[OrderID]
@@ -2370,11 +2370,11 @@ ORDER BY [c0].[CustomerID], [o3].[OrderID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
@@ -2383,13 +2383,13 @@ ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c1].[CustomerID]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -2401,13 +2401,13 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c1].[CustomerID], [o3].[OrderID]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -2426,7 +2426,7 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [c0].[CustomerID]
 FROM (
@@ -2434,13 +2434,13 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [c0]
 ORDER BY [c0].[CustomerID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate], [c1].[CustomerID]
 FROM (
@@ -2450,7 +2450,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -2459,7 +2459,7 @@ ORDER BY [c1].[CustomerID], [o3].[OrderID]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice], [c1].[CustomerID], [o3].[OrderID]
 FROM (
@@ -2469,7 +2469,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -2736,19 +2736,19 @@ ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -3092,9 +3092,9 @@ ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
-SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY CASE
@@ -3107,11 +3107,11 @@ END, [o].[OrderID], [c].[CustomerID]
 """,
             //
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [s].[OrderID], [s].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+    SELECT TOP(@p) [o].[OrderID], [c].[CustomerID], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
@@ -146,15 +146,15 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -263,11 +263,11 @@ ORDER BY [c].[CustomerID], [c1].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -288,11 +288,11 @@ ORDER BY [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle]
 ) AS [c0]
@@ -328,11 +328,11 @@ ORDER BY [c0].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
@@ -383,14 +383,14 @@ ORDER BY [o].[OrderID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -413,11 +413,11 @@ ORDER BY [s].[CustomerID], [s].[CustomerID0]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -497,11 +497,11 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -615,15 +615,15 @@ ORDER BY [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -632,11 +632,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -681,11 +681,11 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[CustomerID], [o].[OrderID]
 ) AS [o1]
@@ -719,7 +719,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -727,7 +727,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[ContactTitle]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactTitle], [c0].[CustomerID]
@@ -755,13 +755,13 @@ ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
     SELECT TOP(1) [c0].[CustomerID]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID]
+        SELECT TOP(@p) [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
@@ -852,11 +852,11 @@ ORDER BY [c].[CustomerID], [o0].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -934,7 +934,7 @@ ORDER BY [o1].[OrderID], [s].[OrderID], [s].[ProductID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c1].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -944,7 +944,7 @@ FROM (
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'A%'
         ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
     ) AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [c1]
@@ -963,15 +963,15 @@ ORDER BY [c1].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -980,11 +980,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1101,11 +1101,11 @@ ORDER BY [c].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
         WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], CASE
@@ -1359,15 +1359,15 @@ ORDER BY [s].[OrderID], [s1].[OrderID], [s1].[OrderID0], [s1].[ProductID], [o3].
 
         AssertSql(
             """
-@__list_0='["ALFKI"]' (Size = 4000)
-@__p_1='1'
+@list='["ALFKI"]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1376,11 +1376,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -1393,7 +1393,7 @@ ORDER BY [c0].[c], [c0].[CustomerID]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [c0].[CustomerID], [s].[OrderID], [s].[CustomerID], [s].[EmployeeID], [s].[OrderDate], [s].[OrderID0], [s].[ProductID], [s].[Discount], [s].[Quantity], [s].[UnitPrice]
 FROM (
@@ -1401,7 +1401,7 @@ FROM (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'A%'
     ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 ) AS [c0]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
@@ -1418,11 +1418,11 @@ ORDER BY [c0].[CustomerID], [s].[OrderID], [s].[OrderID0]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region], [c1].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID]
+    SELECT TOP(@p) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c1]
@@ -1486,14 +1486,14 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_1='1'
-@__p_0='2'
+@p0='1'
+@p='2'
 
 SELECT [s].[CustomerID], [s].[Address], [s].[City], [s].[CompanyName], [s].[ContactName], [s].[ContactTitle], [s].[Country], [s].[Fax], [s].[Phone], [s].[PostalCode], [s].[Region], [s].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Address0], [s].[City0], [s].[CompanyName0], [s].[ContactName0], [s].[ContactTitle0], [s].[Country0], [s].[Fax0], [s].[Phone0], [s].[PostalCode0], [s].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_1) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
+    SELECT TOP(@p0) [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region], [c2].[CustomerID] AS [CustomerID0], [c2].[Address] AS [Address0], [c2].[City] AS [City0], [c2].[CompanyName] AS [CompanyName0], [c2].[ContactName] AS [ContactName0], [c2].[ContactTitle] AS [ContactTitle0], [c2].[Country] AS [Country0], [c2].[Fax] AS [Fax0], [c2].[Phone] AS [Phone0], [c2].[PostalCode] AS [PostalCode0], [c2].[Region] AS [Region0]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         ORDER BY [c].[CustomerID]
     ) AS [c1]
@@ -1568,14 +1568,14 @@ FROM [Products] AS [p]
 
         AssertSql(
             """
-@__p_0='80'
+@p='80'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[ContactName], [c0].[CustomerID]
@@ -1644,11 +1644,11 @@ ORDER BY [o2].[OrderID], [o4].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
 ) AS [c0]
@@ -1721,11 +1721,11 @@ END
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@p) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [o1]
@@ -1838,15 +1838,15 @@ ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]
 
         AssertSql(
             """
-@__list_0='[]' (Size = 4000)
-@__p_1='1'
+@list='[]' (Size = 4000)
+@p='1'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
@@ -1855,11 +1855,11 @@ FROM (
     ORDER BY CASE
         WHEN [c].[CustomerID] NOT IN (
             SELECT [l].[value]
-            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            FROM OPENJSON(@list) WITH ([value] nchar(5) '$') AS [l]
         ) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
-    OFFSET @__p_1 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[c], [c0].[CustomerID]
@@ -2018,14 +2018,14 @@ WHERE [o].[OrderID] % 23 = 13
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
 ORDER BY [c0].[CustomerID]
@@ -2073,8 +2073,8 @@ ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o0].[CustomerID]
 FROM (
@@ -2082,7 +2082,7 @@ FROM (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] = CAST(10 AS smallint)
     ORDER BY [o].[OrderID], [o].[ProductID]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o1]
 INNER JOIN [Orders] AS [o0] ON [o1].[OrderID] = [o0].[OrderID]
 ORDER BY [o1].[OrderID], [o1].[ProductID]
@@ -2095,11 +2095,11 @@ ORDER BY [o1].[OrderID], [o1].[ProductID]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@p) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName] DESC
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -54,19 +54,22 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__city_0='London' (Size = 15)
+@city='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_0
+WHERE [c].[City] = @city
 """);
 
         Assert.Equal(
-            @"DECLARE @__city_0 nvarchar(15) = N'London';
+            """
+DECLARE @city nvarchar(15) = N'London';
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_0", queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+WHERE [c].[City] = @city
+""",
+            queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
 
         return null;
     }
@@ -77,11 +80,11 @@ WHERE [c].[City] = @__city_0", queryString, ignoreLineEndingDifferences: true, i
 
         AssertSql(
             """
-@__p_0='London' (Size = 15)
+@p='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__p_0
+WHERE [c].[City] = @p
 """);
     }
 
@@ -91,11 +94,11 @@ WHERE [c].[City] = @__p_0
 
         AssertSql(
             """
-@__get_Item_0='London' (Size = 15)
+@get_Item='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__get_Item_0
+WHERE [c].[City] = @get_Item
 """);
     }
 
@@ -105,11 +108,11 @@ WHERE [c].[City] = @__get_Item_0
 
         AssertSql(
             """
-@__predicateTuple_Item2_0='London' (Size = 15)
+@predicateTuple_Item2='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__predicateTuple_Item2_0
+WHERE [c].[City] = @predicateTuple_Item2
 """);
     }
 
@@ -119,11 +122,11 @@ WHERE [c].[City] = @__predicateTuple_Item2_0
 
         AssertSql(
             """
-@__predicateTuple_Item2_0='London' (Size = 15)
+@predicateTuple_Item2='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__predicateTuple_Item2_0
+WHERE [c].[City] = @predicateTuple_Item2
 """);
     }
 
@@ -133,11 +136,11 @@ WHERE [c].[City] = @__predicateTuple_Item2_0
 
         AssertSql(
             """
-@__predicate_0='True'
+@predicate='True'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__predicate_0 = CAST(1 AS bit)
+WHERE @predicate = CAST(1 AS bit)
 """);
     }
 
@@ -147,19 +150,19 @@ WHERE @__predicate_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__city_0='London' (Size = 15)
+@city='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_0
+WHERE [c].[City] = @city
 """,
             //
             """
-@__city_0='Seattle' (Size = 15)
+@city='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_0
+WHERE [c].[City] = @city
 """);
     }
 
@@ -169,19 +172,19 @@ WHERE [c].[City] = @__city_0
 
         AssertSql(
             """
-@__p_0='2' (Nullable = true)
+@p='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """,
             //
             """
-@__p_0='5' (Nullable = true)
+@p='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """);
     }
 
@@ -191,19 +194,19 @@ WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
 
         AssertSql(
             """
-@__p_0='1' (Nullable = true)
+@p='1' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[EmployeeID] AS bigint) > @__p_0
+WHERE CAST([e].[EmployeeID] AS bigint) > @p
 """,
             //
             """
-@__p_0='5' (Nullable = true)
+@p='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[EmployeeID] AS bigint) > @__p_0
+WHERE CAST([e].[EmployeeID] AS bigint) > @p
 """);
     }
 
@@ -213,19 +216,19 @@ WHERE CAST([e].[EmployeeID] AS bigint) > @__p_0
 
         AssertSql(
             """
-@__GetCity_0='London' (Size = 15)
+@GetCity='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__GetCity_0
+WHERE [c].[City] = @GetCity
 """,
             //
             """
-@__GetCity_0='Seattle' (Size = 15)
+@GetCity='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__GetCity_0
+WHERE [c].[City] = @GetCity
 """);
     }
 
@@ -235,19 +238,19 @@ WHERE [c].[City] = @__GetCity_0
 
         AssertSql(
             """
-@__city_InstanceFieldValue_0='London' (Size = 15)
+@city_InstanceFieldValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_InstanceFieldValue_0
+WHERE [c].[City] = @city_InstanceFieldValue
 """,
             //
             """
-@__city_InstanceFieldValue_0='Seattle' (Size = 15)
+@city_InstanceFieldValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_InstanceFieldValue_0
+WHERE [c].[City] = @city_InstanceFieldValue
 """);
     }
 
@@ -257,19 +260,19 @@ WHERE [c].[City] = @__city_InstanceFieldValue_0
 
         AssertSql(
             """
-@__city_InstancePropertyValue_0='London' (Size = 15)
+@city_InstancePropertyValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_InstancePropertyValue_0
+WHERE [c].[City] = @city_InstancePropertyValue
 """,
             //
             """
-@__city_InstancePropertyValue_0='Seattle' (Size = 15)
+@city_InstancePropertyValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_InstancePropertyValue_0
+WHERE [c].[City] = @city_InstancePropertyValue
 """);
     }
 
@@ -279,19 +282,19 @@ WHERE [c].[City] = @__city_InstancePropertyValue_0
 
         AssertSql(
             """
-@__StaticFieldValue_0='London' (Size = 15)
+@StaticFieldValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__StaticFieldValue_0
+WHERE [c].[City] = @StaticFieldValue
 """,
             //
             """
-@__StaticFieldValue_0='Seattle' (Size = 15)
+@StaticFieldValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__StaticFieldValue_0
+WHERE [c].[City] = @StaticFieldValue
 """);
     }
 
@@ -301,19 +304,19 @@ WHERE [c].[City] = @__StaticFieldValue_0
 
         AssertSql(
             """
-@__StaticPropertyValue_0='London' (Size = 15)
+@StaticPropertyValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__StaticPropertyValue_0
+WHERE [c].[City] = @StaticPropertyValue
 """,
             //
             """
-@__StaticPropertyValue_0='Seattle' (Size = 15)
+@StaticPropertyValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__StaticPropertyValue_0
+WHERE [c].[City] = @StaticPropertyValue
 """);
     }
 
@@ -323,19 +326,19 @@ WHERE [c].[City] = @__StaticPropertyValue_0
 
         AssertSql(
             """
-@__city_Nested_InstanceFieldValue_0='London' (Size = 15)
+@city_Nested_InstanceFieldValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0
+WHERE [c].[City] = @city_Nested_InstanceFieldValue
 """,
             //
             """
-@__city_Nested_InstanceFieldValue_0='Seattle' (Size = 15)
+@city_Nested_InstanceFieldValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0
+WHERE [c].[City] = @city_Nested_InstanceFieldValue
 """);
     }
 
@@ -345,19 +348,19 @@ WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0
 
         AssertSql(
             """
-@__city_Nested_InstancePropertyValue_0='London' (Size = 15)
+@city_Nested_InstancePropertyValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0
+WHERE [c].[City] = @city_Nested_InstancePropertyValue
 """,
             //
             """
-@__city_Nested_InstancePropertyValue_0='Seattle' (Size = 15)
+@city_Nested_InstancePropertyValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0
+WHERE [c].[City] = @city_Nested_InstancePropertyValue
 """);
     }
 
@@ -367,19 +370,19 @@ WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0
 
         AssertSql(
             """
-@__InstanceFieldValue_0='London' (Size = 15)
+@InstanceFieldValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__InstanceFieldValue_0
+WHERE [c].[City] = @InstanceFieldValue
 """,
             //
             """
-@__InstanceFieldValue_0='Seattle' (Size = 15)
+@InstanceFieldValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__InstanceFieldValue_0
+WHERE [c].[City] = @InstanceFieldValue
 """);
     }
 
@@ -389,19 +392,19 @@ WHERE [c].[City] = @__InstanceFieldValue_0
 
         AssertSql(
             """
-@__InstanceFieldValue_0='London' (Size = 15)
+@InstanceFieldValue='London' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__InstanceFieldValue_0
+WHERE [c].[City] = @InstanceFieldValue
 """,
             //
             """
-@__InstanceFieldValue_0='Seattle' (Size = 15)
+@InstanceFieldValue='Seattle' (Size = 15)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = @__InstanceFieldValue_0
+WHERE [c].[City] = @InstanceFieldValue
 """);
     }
 
@@ -411,19 +414,19 @@ WHERE [c].[City] = @__InstanceFieldValue_0
 
         AssertSql(
             """
-@__p_0='2' (Nullable = true)
+@p='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """,
             //
             """
-@__p_0='5' (Nullable = true)
+@p='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """,
             //
             """
@@ -445,19 +448,19 @@ WHERE [e].[ReportsTo] IS NULL
 """,
             //
             """
-@__p_0='5' (Nullable = true)
+@p='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """,
             //
             """
-@__p_0='2' (Nullable = true)
+@p='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
+WHERE CAST([e].[ReportsTo] AS bigint) = @p
 """);
     }
 
@@ -467,25 +470,25 @@ WHERE CAST([e].[ReportsTo] AS bigint) = @__p_0
 
         AssertSql(
             """
-@__customerID_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] = @__customerID_0 AND [o].[CustomerID] = [c].[CustomerID])
+    WHERE [o].[CustomerID] = @customerID AND [o].[CustomerID] = [c].[CustomerID])
 """,
             //
             """
-@__customerID_0='ANATR' (Size = 5) (DbType = StringFixedLength)
+@customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] = @__customerID_0 AND [o].[CustomerID] = [c].[CustomerID])
+    WHERE [o].[CustomerID] = @customerID AND [o].[CustomerID] = [c].[CustomerID])
 """);
     }
 
@@ -621,7 +624,7 @@ WHERE 0 = 1
 """);
 
         Assert.Contains(
-            "Possible unintended use of method 'Equals' for arguments 'e.EmployeeID' and '@__longPrm_0' of different types in a query. This comparison will always return false.",
+            "Possible unintended use of method 'Equals' for arguments 'e.EmployeeID' and '@longPrm' of different types in a query. This comparison will always return false.",
             Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
     }
 
@@ -631,11 +634,11 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[EmployeeID] = @__p_0
+WHERE [e].[EmployeeID] = @p
 """);
     }
 
@@ -657,10 +660,10 @@ WHERE 0 = 1
 """);
 
         Assert.Contains(
-            "Possible unintended use of method 'Equals' for arguments 'e.ReportsTo' and '@__longPrm_0' of different types in a query. This comparison will always return false.",
+            "Possible unintended use of method 'Equals' for arguments 'e.ReportsTo' and '@longPrm' of different types in a query. This comparison will always return false.",
             Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
         Assert.Contains(
-            "Possible unintended use of method 'Equals' for arguments '@__longPrm_0' and 'e.ReportsTo' of different types in a query. This comparison will always return false.",
+            "Possible unintended use of method 'Equals' for arguments '@longPrm' and 'e.ReportsTo' of different types in a query. This comparison will always return false.",
             Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
     }
 
@@ -682,10 +685,10 @@ WHERE 0 = 1
 """);
 
         Assert.Contains(
-            "Possible unintended use of method 'Equals' for arguments 'e.ReportsTo' and '@__nullableLongPrm_0' of different types in a query. This comparison will always return false.",
+            "Possible unintended use of method 'Equals' for arguments 'e.ReportsTo' and '@nullableLongPrm' of different types in a query. This comparison will always return false.",
             Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
         Assert.Contains(
-            "Possible unintended use of method 'Equals' for arguments '@__nullableLongPrm_0' and 'e.ReportsTo' of different types in a query. This comparison will always return false.",
+            "Possible unintended use of method 'Equals' for arguments '@nullableLongPrm' and 'e.ReportsTo' of different types in a query. This comparison will always return false.",
             Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
     }
 
@@ -695,19 +698,19 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__intPrm_0='2'
+@intPrm='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[ReportsTo] = @__intPrm_0
+WHERE [e].[ReportsTo] = @intPrm
 """,
             //
             """
-@__intPrm_0='2'
+@intPrm='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE @__intPrm_0 = [e].[ReportsTo]
+WHERE @intPrm = [e].[ReportsTo]
 """);
     }
 
@@ -717,19 +720,19 @@ WHERE @__intPrm_0 = [e].[ReportsTo]
 
         AssertSql(
             """
-@__nullableIntPrm_0='2' (Nullable = true)
+@nullableIntPrm='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE @__nullableIntPrm_0 = [e].[ReportsTo]
+WHERE @nullableIntPrm = [e].[ReportsTo]
 """,
             //
             """
-@__nullableIntPrm_0='2' (Nullable = true)
+@nullableIntPrm='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[ReportsTo] = @__nullableIntPrm_0
+WHERE [e].[ReportsTo] = @nullableIntPrm
 """);
     }
 
@@ -829,11 +832,11 @@ WHERE SUBSTRING([c].[City], 1 + 1, 2) = N'ea'
 
         AssertSql(
             """
-@__myDatetime_0='2015-04-10T00:00:00.0000000'
+@myDatetime='2015-04-10T00:00:00.0000000'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE GETDATE() <> @__myDatetime_0
+WHERE GETDATE() <> @myDatetime
 """);
     }
 
@@ -843,11 +846,11 @@ WHERE GETDATE() <> @__myDatetime_0
 
         AssertSql(
             """
-@__myDatetime_0='2015-04-10T00:00:00.0000000'
+@myDatetime='2015-04-10T00:00:00.0000000'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE GETUTCDATE() <> @__myDatetime_0
+WHERE GETUTCDATE() <> @myDatetime
 """);
     }
 
@@ -857,11 +860,11 @@ WHERE GETUTCDATE() <> @__myDatetime_0
 
         AssertSql(
             """
-@__myDatetimeOffset_0='2015-04-10T00:00:00.0000000-08:00'
+@myDatetimeOffset='2015-04-10T00:00:00.0000000-08:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CAST(SYSUTCDATETIME() AS datetimeoffset) <> @__myDatetimeOffset_0
+WHERE CAST(SYSUTCDATETIME() AS datetimeoffset) <> @myDatetimeOffset
 """);
     }
 
@@ -882,11 +885,11 @@ FROM [Employees] AS [e]
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE CONVERT(date, [o].[OrderDate]) = @__myDatetime_0
+WHERE CONVERT(date, [o].[OrderDate]) = @myDatetime
 """);
     }
 
@@ -1200,11 +1203,11 @@ WHERE [c].[City] = N'London' AND [c].[Country] = N'UK' AND [e].[City] = N'London
 
         AssertSql(
             """
-@__p_0='9'
+@p='9'
 
 SELECT [e0].[EmployeeID]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID]
+    SELECT TOP(@p) [e].[EmployeeID]
     FROM [Employees] AS [e]
 ) AS [e0]
 WHERE [e0].[EmployeeID] = 5
@@ -1360,11 +1363,11 @@ END
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE @__prm_0 = CAST(1 AS bit)
+WHERE @prm = CAST(1 AS bit)
 """);
     }
 
@@ -1374,14 +1377,14 @@ WHERE @__prm_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE CASE
     WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END <> @__prm_0
+END <> @prm
 """);
     }
 
@@ -1391,14 +1394,14 @@ END <> @__prm_0
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE [p].[Discontinued] = CASE
     WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END ^ @__prm_0
+END ^ @prm
 """);
     }
 
@@ -1540,11 +1543,11 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
         AssertSql(
             """
-@__i_0='10'
+@i='10'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] + CAST(@__i_0 AS nvarchar(max)) = [c].[CompanyName]
+WHERE [c].[CustomerID] + CAST(@i AS nvarchar(max)) = [c].[CompanyName]
 """);
     }
 
@@ -1554,11 +1557,11 @@ WHERE [c].[CustomerID] + CAST(@__i_0 AS nvarchar(max)) = [c].[CompanyName]
 
         AssertSql(
             """
-@__i_0='10'
+@i='10'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID] = [c].[CompanyName]
+WHERE CAST(@i AS nvarchar(max)) + [c].[CustomerID] = [c].[CompanyName]
 """);
     }
 
@@ -1568,12 +1571,12 @@ WHERE CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID] = [c].[CompanyName]
 
         AssertSql(
             """
-@__p_0='30'
-@__j_1='21'
+@p='30'
+@j='21'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE CAST(@__p_0 AS nvarchar(max)) + [c].[CustomerID] + CAST(@__j_1 AS nvarchar(max)) + CAST(42 AS nvarchar(max)) = [c].[CompanyName]
+WHERE CAST(@p AS nvarchar(max)) + [c].[CustomerID] + CAST(@j AS nvarchar(max)) + CAST(42 AS nvarchar(max)) = [c].[CompanyName]
 """);
     }
 
@@ -1595,11 +1598,11 @@ WHERE CAST([o].[OrderID] AS nvarchar(max)) + COALESCE([o].[CustomerID], N'') = [
 
         AssertSql(
             """
-@__i_0='A' (Size = 4000)
+@i='A' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__i_0 + [c].[CustomerID] = N'AALFKI'
+WHERE @i + [c].[CustomerID] = N'AALFKI'
 """);
     }
 
@@ -1609,11 +1612,11 @@ WHERE @__i_0 + [c].[CustomerID] = N'AALFKI'
 
         AssertSql(
             """
-@__i_0='A' (Size = 4000)
+@i='A' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__i_0 + [c].[CustomerID] = N'AAROUT'
+WHERE @i + [c].[CustomerID] = N'AAROUT'
 """);
     }
 
@@ -1623,12 +1626,12 @@ WHERE @__i_0 + [c].[CustomerID] = N'AAROUT'
 
         AssertSql(
             """
-@__i_0='A' (Size = 4000)
-@__j_1='B' (Size = 4000)
+@i='A' (Size = 4000)
+@j='B' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__i_0 + @__j_1 + [c].[CustomerID] = N'ABANATR'
+WHERE @i + @j + [c].[CustomerID] = N'ABANATR'
 """);
     }
 
@@ -1638,13 +1641,13 @@ WHERE @__i_0 + @__j_1 + [c].[CustomerID] = N'ABANATR'
 
         AssertSql(
             """
-@__i_0='A' (Size = 4000)
-@__j_1='B' (Size = 4000)
-@__k_2='C' (Size = 4000)
+@i='A' (Size = 4000)
+@j='B' (Size = 4000)
+@k='C' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__i_0 + @__j_1 + @__k_2 + [c].[CustomerID] = N'ABCANTON'
+WHERE @i + @j + @k + [c].[CustomerID] = N'ABCANTON'
 """);
     }
 
@@ -1678,11 +1681,11 @@ WHERE [p].[UnitsInStock] < CAST(20 AS smallint)
 
         AssertSql(
             """
-@__productId_0='15'
+@productId='15'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE [p].[ProductID] < @__productId_0 AND [p].[UnitsInStock] >= CAST(20 AS smallint)
+WHERE [p].[ProductID] < @productId AND [p].[UnitsInStock] >= CAST(20 AS smallint)
 """);
     }
 
@@ -1886,11 +1889,11 @@ WHERE [o0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__p_0
+WHERE [c].[CustomerID] = @p
 """);
     }
 
@@ -2001,11 +2004,11 @@ FROM [Orders] AS [o]
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -2027,19 +2030,19 @@ WHERE 0 = 1
 
         AssertSql(
             """
-@__SettableProperty_0='10274'
+@SettableProperty='10274'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__SettableProperty_0
+WHERE [o].[OrderID] = @SettableProperty
 """,
             //
             """
-@__SettableProperty_0='10275'
+@SettableProperty='10275'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__SettableProperty_0
+WHERE [o].[OrderID] = @SettableProperty
 """);
     }
 
@@ -2049,11 +2052,11 @@ WHERE [o].[OrderID] = @__SettableProperty_0
 
         AssertSql(
             """
-@__ReadOnlyProperty_0='10275'
+@ReadOnlyProperty='10275'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__ReadOnlyProperty_0
+WHERE [o].[OrderID] = @ReadOnlyProperty
 """);
     }
 
@@ -2075,13 +2078,13 @@ WHERE [o].[OrderID] = 10274
 
         AssertSql(
             """
-@__cities_0='["Seattle"]' (Size = 4000)
+@cities='["Seattle"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] nvarchar(15) '$') AS [c0]
 )
 """);
     }
@@ -2131,12 +2134,28 @@ WHERE CAST([o].[OrderID] AS nvarchar(max)) LIKE N'%20%'
         await base.Using_same_parameter_twice_in_query_generates_one_sql_parameter(async);
 
         AssertSql(
-"""
-@__i_0='10'
+            """
+@i='10'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID] + CAST(@__i_0 AS nvarchar(max)) = N'10ALFKI10'
+WHERE CAST(@i AS nvarchar(max)) + [c].[CustomerID] + CAST(@i AS nvarchar(max)) = N'10ALFKI10'
+""");
+    }
+
+    [ConditionalTheory]
+    public override async Task Two_parameters_with_same_name_get_uniquified(bool async)
+    {
+        await base.Two_parameters_with_same_name_get_uniquified(async);
+
+        AssertSql(
+            """
+@p='11'
+@p0='12'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] + CAST(@p AS nvarchar(max)) + [c].[CustomerID] + CAST(@p0 AS nvarchar(max)) = N'ALFKI11ALFKI12'
 """);
     }
 
@@ -2319,7 +2338,7 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__entity_equality_order_0_OrderID='10248' (Nullable = true)
+@entity_equality_order_OrderID='10248' (Nullable = true)
 
 SELECT [c].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
@@ -2327,7 +2346,7 @@ LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @__entity_equality_order_0_OrderID)
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_order_OrderID)
 ORDER BY [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -2355,7 +2374,7 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__entity_equality_order_0_OrderID='10248' (Nullable = true)
+@entity_equality_order_OrderID='10248' (Nullable = true)
 
 SELECT [c].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
@@ -2363,7 +2382,7 @@ LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @__entity_equality_order_0_OrderID)
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_order_OrderID)
 ORDER BY [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -2391,7 +2410,7 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__entity_equality_order_0_OrderID='10248' (Nullable = true)
+@entity_equality_order_OrderID='10248' (Nullable = true)
 
 SELECT [c].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
@@ -2399,7 +2418,7 @@ LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @__entity_equality_order_0_OrderID)
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_order_OrderID)
 ORDER BY [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -2444,13 +2463,13 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 
         AssertSql(
             """
-@__orderIds_0='[10248,10249]' (Size = 4000)
+@orderIds='[10248,10249]' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] IN (
     SELECT [o0].[value]
-    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
+    FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
 )
 """);
     }
@@ -2461,13 +2480,13 @@ WHERE [o].[OrderID] IN (
 
         AssertSql(
             """
-@__orderIds_0='[10248,10249]' (Size = 4000)
+@orderIds='[10248,10249]' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] IN (
     SELECT [o0].[value]
-    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
+    FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
 )
 """);
     }
@@ -2551,13 +2570,13 @@ WHERE [c].[CustomerID] NOT IN (N'ALFKI', N'ANATR', N'ANTON')
         // issue #21462
         AssertSql(
             """
-@__prm1_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__prm2_1='ANATR' (Size = 5) (DbType = StringFixedLength)
-@__prm3_2='ANTON' (Size = 5) (DbType = StringFixedLength)
+@prm1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@prm2='ANATR' (Size = 5) (DbType = StringFixedLength)
+@prm3='ANTON' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <> @__prm1_0 AND [c].[CustomerID] <> @__prm2_1 AND [c].[CustomerID] <> @__prm3_2
+WHERE [c].[CustomerID] <> @prm1 AND [c].[CustomerID] <> @prm2 AND [c].[CustomerID] <> @prm3
 """);
     }
 
@@ -2568,12 +2587,12 @@ WHERE [c].[CustomerID] <> @__prm1_0 AND [c].[CustomerID] <> @__prm2_1 AND [c].[C
         // issue #21462
         AssertSql(
             """
-@__prm1_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
-@__prm2_1='ANATR' (Size = 5) (DbType = StringFixedLength)
+@prm1='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@prm2='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (@__prm1_0, @__prm2_1, N'ANTON')
+WHERE [c].[CustomerID] IN (@prm1, @prm2, N'ANTON')
 """);
     }
 
@@ -2596,13 +2615,13 @@ WHERE [c].[Region] IN (N'WA', N'OR') OR [c].[Region] IS NULL OR [c].[Region] = N
 
         AssertSql(
             """
-@__array_0='["ALFKI","ANATR"]' (Size = 4000)
+@array='["ALFKI","ANATR"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__array_0) WITH ([value] nchar(5) '$') AS [a]
+    FROM OPENJSON(@array) WITH ([value] nchar(5) '$') AS [a]
 ) OR [c].[CustomerID] = N'ANTON'
 """);
     }
@@ -2613,16 +2632,16 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__prm1_0='ANTON' (Size = 5) (DbType = StringFixedLength)
-@__array_1='["ALFKI","ANATR"]' (Size = 4000)
-@__prm2_2='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@prm1='ANTON' (Size = 5) (DbType = StringFixedLength)
+@array='["ALFKI","ANATR"]' (Size = 4000)
+@prm2='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__prm1_0 OR [c].[CustomerID] IN (
+WHERE [c].[CustomerID] = @prm1 OR [c].[CustomerID] IN (
     SELECT [a].[value]
-    FROM OPENJSON(@__array_1) WITH ([value] nchar(5) '$') AS [a]
-) OR [c].[CustomerID] = @__prm2_2
+    FROM OPENJSON(@array) WITH ([value] nchar(5) '$') AS [a]
+) OR [c].[CustomerID] = @prm2
 """);
     }
 
@@ -2924,13 +2943,13 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__customerIds_0='["ALFKI","FISSA","WHITC"]' (Size = 4000)
+@customerIds='["ALFKI","FISSA","WHITC"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__customerIds_0) WITH ([value] nchar(5) '$') AS [c0]
+    FROM OPENJSON(@customerIds) WITH ([value] nchar(5) '$') AS [c0]
 ) AND [c].[City] = N'Seattle'
 """);
     }
@@ -2941,13 +2960,13 @@ WHERE [c].[CustomerID] IN (
 
         AssertSql(
             """
-@__customerIds_0='["ALFKI","FISSA"]' (Size = 4000)
+@customerIds='["ALFKI","FISSA"]' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__customerIds_0) WITH ([value] nchar(5) '$') AS [c0]
+    FROM OPENJSON(@customerIds) WITH ([value] nchar(5) '$') AS [c0]
 ) OR [c].[City] = N'Seattle'
 """);
     }
@@ -3043,19 +3062,19 @@ END = N'OR'
 
         AssertSql(
             """
-@__entity_equality_customer_0_CustomerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_customer_CustomerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__entity_equality_customer_0_CustomerID
+WHERE [c].[CustomerID] = @entity_equality_customer_CustomerID
 """,
             //
             """
-@__entity_equality_customer_0_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+@entity_equality_customer_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__entity_equality_customer_0_CustomerID
+WHERE [c].[CustomerID] = @entity_equality_customer_CustomerID
 """);
     }
 
@@ -3077,11 +3096,11 @@ WHERE [c].[Region] IS NULL
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e0]
@@ -3096,11 +3115,11 @@ ORDER BY [e0].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='9'
+@p='9'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e0]
 WHERE [e0].[EmployeeID] = 5
@@ -3154,11 +3173,11 @@ FROM [Customers] AS [c]
 
         AssertSql(
             """
-@__p_0='9'
+@p='9'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
 ) AS [e0]
 WHERE [e0].[EmployeeID] = 5
@@ -3308,11 +3327,11 @@ WHERE [c].[CustomerID] = N'ALF' + N'KI'
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__p_0
+WHERE [c].[CustomerID] = @p
 """);
     }
 
@@ -3322,11 +3341,11 @@ WHERE [c].[CustomerID] = @__p_0
 
         AssertSql(
             """
-@__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
+@p='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__p_0
+WHERE [c].[CustomerID] = @p
 """);
     }
 
@@ -3336,11 +3355,11 @@ WHERE [c].[CustomerID] = @__p_0
 
         AssertSql(
             """
-@__id_0='ALF' (Size = 5)
+@id='ALF' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__id_0 + N'KI'
+WHERE [c].[CustomerID] = @id + N'KI'
 """);
     }
 
@@ -3363,27 +3382,27 @@ WHERE [o].[CustomerID] = N'1337'
 """,
             //
             """
-@__prm_Value_0='1337' (Size = 5)
+@prm_Value='1337' (Size = 5)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] = @__prm_Value_0
+WHERE [o].[CustomerID] = @prm_Value
 """,
             //
             """
-@__ToString_0='1337' (Size = 5)
+@ToString='1337' (Size = 5)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] = @__ToString_0
+WHERE [o].[CustomerID] = @ToString
 """,
             //
             """
-@__p_0='1337' (Size = 5)
+@p='1337' (Size = 5)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] = @__p_0
+WHERE [o].[CustomerID] = @p
 """,
             //
             """
@@ -3399,11 +3418,11 @@ WHERE [o].[CustomerID] = N'1337'
 
         AssertSql(
             """
-@__id_0='10252'
+@id='10252'
 
 SELECT [o].[OrderID] AS [Id]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__id_0
+WHERE [o].[OrderID] = @id
 """,
             //
             """
@@ -3431,11 +3450,11 @@ WHERE [o].[OrderID] = 10252
 
         AssertSql(
             """
-@__p_0='10248'
+@p='10248'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] = @__p_0
+WHERE [o].[OrderID] = @p
 """);
     }
 
@@ -3447,11 +3466,11 @@ WHERE [o].[OrderID] = @__p_0
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    SELECT TOP(@p) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
 ) AS [e0]
@@ -3466,14 +3485,14 @@ ORDER BY [e0].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
 FROM (
     SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [e0]
 WHERE [e0].[EmployeeID] % 2 = 0
 ORDER BY [e0].[EmployeeID]
@@ -3486,11 +3505,11 @@ ORDER BY [e0].[EmployeeID]
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT DISTINCT [c0].[ContactTitle]
 FROM (
-    SELECT TOP(@__p_0) [c].[ContactTitle]
+    SELECT TOP(@p) [c].[ContactTitle]
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactTitle]
 ) AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1922,11 +1922,11 @@ WHERE [e].[NullableStringA] IS NULL
 
         AssertSql(
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] = @__prm_0
+WHERE [e].[NullableStringA] = @prm
 """);
     }
 
@@ -1960,13 +1960,13 @@ INNER JOIN [Entities2] AS [e0] ON [e].[NullableIntA] = [e0].[NullableIntB] OR ([
 
         AssertSql(
             """
-@__ids_0_without_nulls='["Foo"]' (Size = 4000)
+@ids_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids_without_nulls) AS [i]
 ) OR [e].[NullableStringA] IS NULL
 """);
     }
@@ -1977,13 +1977,13 @@ WHERE [e].[NullableStringA] IN (
 
         AssertSql(
             """
-@__ids_0_without_nulls='["Foo"]' (Size = 4000)
+@ids_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids_without_nulls) AS [i]
 ) AND [e].[NullableStringA] IS NOT NULL
 """);
     }
@@ -1994,13 +1994,13 @@ WHERE [e].[NullableStringA] NOT IN (
 
         AssertSql(
             """
-@__ids_0='["Foo"]' (Size = 4000)
+@ids='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] nvarchar(max) '$') AS [i]
 ) OR [e].[NullableStringA] IS NULL
 """);
     }
@@ -2011,13 +2011,13 @@ WHERE [e].[NullableStringA] NOT IN (
 
         AssertSql(
             """
-@__ids_0_without_nulls='["Foo"]' (Size = 4000)
+@ids_without_nulls='["Foo"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids_without_nulls) AS [i]
 ) OR [e].[NullableStringA] IS NULL
 """);
     }
@@ -2064,11 +2064,11 @@ WHERE [e].[NullableStringA] = N'Foo' OR [e].[NullableStringA] IS NULL
 
         AssertSql(
             """
-@__prm3_2='Blah' (Size = 4000)
+@prm3='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] <> N'Foo' OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringA] <> @__prm3_2
+WHERE ([e].[NullableStringA] <> N'Foo' OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringA] <> @prm3
 """);
     }
 
@@ -2078,11 +2078,11 @@ WHERE ([e].[NullableStringA] <> N'Foo' OR [e].[NullableStringA] IS NULL) AND [e]
 
         AssertSql(
             """
-@__prm3_2='Blah' (Size = 4000)
+@prm3='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringB] IS NOT NULL AND ([e].[NullableStringA] <> N'Foo' OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringA] <> @__prm3_2
+WHERE [e].[NullableStringB] IS NOT NULL AND ([e].[NullableStringA] <> N'Foo' OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringA] <> @prm3
 """);
     }
 
@@ -2319,13 +2319,13 @@ END
 
         AssertSql(
             """
-@__list_0='["Foo","Bar"]' (Size = 4000)
+@list='["Foo","Bar"]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[StringA] IN (
     SELECT [l].[value]
-    FROM OPENJSON(@__list_0) WITH ([value] nvarchar(max) '$') AS [l]
+    FROM OPENJSON(@list) WITH ([value] nvarchar(max) '$') AS [l]
 )
 """,
             //
@@ -2365,13 +2365,13 @@ WHERE [e].[NullableBoolA] = [e].[NullableBoolB]
 
         AssertSql(
             """
-@__names_0='["Foo","Bar"]' (Size = 4000)
+@names='["Foo","Bar"]' (Size = 4000)
 
 SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -2382,13 +2382,13 @@ WHERE [e].[NullableStringA] IN (
 
         AssertSql(
             """
-@__names_0='[]' (Size = 4000)
+@names='[]' (Size = 4000)
 
 SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -2399,13 +2399,13 @@ WHERE [e].[NullableStringA] IN (
 
         AssertSql(
             """
-@__names_0='[null]' (Size = 4000)
+@names='[null]' (Size = 4000)
 
 SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
+    FROM OPENJSON(@names) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -2512,19 +2512,19 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]
 
         AssertSql(
             """
-@__p_0='True'
+@p='True'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """,
             //
             """
-@__p_0='False'
+@p='False'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -2534,19 +2534,19 @@ WHERE @__p_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -2556,19 +2556,19 @@ WHERE @__p_0 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -2608,19 +2608,19 @@ WHERE [e].[NullableBoolA] = [e].[NullableBoolB]
 
         AssertSql(
             """
-@__p_0='True'
+@p='True'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """,
             //
             """
-@__p_0='False'
+@p='False'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -2873,46 +2873,46 @@ END = COALESCE([e0].[NullableBoolA], [e0].[BoolC])
 
         AssertSql(
             """
-@__ids_0='[1,2]' (Size = 4000)
+@ids='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='[1,2]' (Size = 4000)
+@ids='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 ) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0_without_nulls='[1,2]' (Size = 4000)
+@ids2_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids2_without_nulls) AS [i]
 ) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0_without_nulls='[1,2]' (Size = 4000)
+@ids2_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids2_without_nulls) AS [i]
 ) AND [e].[NullableIntA] IS NOT NULL
 """,
             //
@@ -2947,46 +2947,46 @@ WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 ) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0_without_nulls='[]' (Size = 4000)
+@ids2_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids2_without_nulls) AS [i]
 ) OR [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__ids2_0_without_nulls='[]' (Size = 4000)
+@ids2_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableIntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids2_without_nulls) AS [i]
 ) AND [e].[NullableIntA] IS NOT NULL
 """,
             //
@@ -3347,90 +3347,90 @@ WHERE ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR
 
         AssertSql(
             """
-@__ids_0='[1,2,null]' (Size = 4000)
+@ids='[1,2,null]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids_0_without_nulls='[1,2]' (Size = 4000)
+@ids_without_nulls='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids_without_nulls) AS [i]
 )
 """,
             //
             """
-@__ids2_0='[1,2]' (Size = 4000)
+@ids2='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids2) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids2_0='[1,2]' (Size = 4000)
+@ids2='[1,2]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids2) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids3_0='[]' (Size = 4000)
+@ids3='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids3_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids3) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids3_0='[]' (Size = 4000)
+@ids3='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids3_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids3) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids4_0='[null]' (Size = 4000)
+@ids4='[null]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids4_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids4) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ids4_0_without_nulls='[]' (Size = 4000)
+@ids4_without_nulls='[]' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids4_0_without_nulls) AS [i]
+    FROM OPENJSON(@ids4_without_nulls) AS [i]
 )
 """);
     }
@@ -3561,35 +3561,35 @@ WHERE COALESCE([e].[NullableIntA], 0) <> 0
 
         AssertSql(
             """
-@__i_0='1'
+@i='1'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[IntA] <= @__i_0
+WHERE [e].[IntA] <= @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[IntA] < @__i_0
+WHERE [e].[IntA] < @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[IntA] >= @__i_0
+WHERE [e].[IntA] >= @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[IntA] > @__i_0
+WHERE [e].[IntA] > @i
 """);
     }
 
@@ -3599,45 +3599,45 @@ WHERE [e].[IntA] > @__i_0
 
         AssertSql(
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableIntA] > @__i_0 THEN CAST(0 AS bit)
+    WHEN [e].[NullableIntA] > @i THEN CAST(0 AS bit)
     ELSE CAST(1 AS bit)
 END = CAST(1 AS bit)
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableIntA] >= @__i_0 THEN CAST(0 AS bit)
+    WHEN [e].[NullableIntA] >= @i THEN CAST(0 AS bit)
     ELSE CAST(1 AS bit)
 END = CAST(1 AS bit)
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableIntA] < @__i_0 THEN CAST(0 AS bit)
+    WHEN [e].[NullableIntA] < @i THEN CAST(0 AS bit)
     ELSE CAST(1 AS bit)
 END = CAST(1 AS bit)
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableIntA] <= @__i_0 THEN CAST(0 AS bit)
+    WHEN [e].[NullableIntA] <= @i THEN CAST(0 AS bit)
     ELSE CAST(1 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -4086,11 +4086,11 @@ WHERE [e].[NullableBoolA] IS NOT NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE @__prm_0 = CASE
+WHERE @prm = CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -4118,11 +4118,11 @@ WHERE [e].[NullableBoolA] IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE @__prm_0 = CASE
+WHERE @prm = CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -4141,11 +4141,11 @@ WHERE [e].[NullableBoolA] IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE @__prm_0 <> CASE
+WHERE @prm <> CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -4173,11 +4173,11 @@ WHERE [e].[NullableIntA] IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE @__prm_0 <> CASE
+WHERE @prm <> CASE
     WHEN [e].[NullableIntA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -4205,11 +4205,11 @@ WHERE [e].[NullableBoolA] IS NOT NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE @__prm_0 <> CASE
+WHERE @prm <> CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -210,12 +210,12 @@ WHERE [o].[Value] AT TIME ZONE 'UTC' = '2000-01-01T18:00:00.0000000+00:00'
 
         AssertSql(
             """
-@__timeZone_1='UTC' (Size = 8000) (DbType = AnsiString)
-@__dateTime_2='2000-01-01T18:00:00.0000000+00:00'
+@timeZone='UTC' (Size = 8000) (DbType = AnsiString)
+@dateTime='2000-01-01T18:00:00.0000000+00:00'
 
 SELECT [o].[Id]
 FROM [OperatorEntityDateTimeOffset] AS [o]
-WHERE [o].[Value] AT TIME ZONE @__timeZone_1 = @__dateTime_2
+WHERE [o].[Value] AT TIME ZONE @timeZone = @dateTime
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -597,11 +597,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__id_0='6c1ae3e5-30b9-4c77-8d98-f02075974a0a'
+@id='6c1ae3e5-30b9-4c77-8d98-f02075974a0a'
 
 SELECT TOP(1) [l].[Id]
 FROM [Location25680] AS [l]
-WHERE [l].[Id] = @__id_0
+WHERE [l].[Id] = @id
 ORDER BY [l].[Id]
 """);
     }
@@ -612,9 +612,9 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c0].[CompanyId], [c0].[AdditionalCustomerData], [c0].[Id], [s].[CompanyId], [s].[AdditionalSupplierData], [s].[Id]
+SELECT TOP(@p) [c].[Id], [c].[Name], [c0].[CompanyId], [c0].[AdditionalCustomerData], [c0].[Id], [s].[CompanyId], [s].[AdditionalSupplierData], [s].[Id]
 FROM [Companies] AS [c]
 LEFT JOIN [CustomerData] AS [c0] ON [c].[Id] = [c0].[CompanyId]
 LEFT JOIN [SupplierData] AS [s] ON [c].[Id] = [s].[CompanyId]
@@ -629,9 +629,9 @@ ORDER BY [c].[Id]
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
-SELECT TOP(@__p_0) [o].[Id], [o].[Name], [i].[OwnerId], [i].[Id], [i].[Name], [i0].[IntermediateOwnedEntityOwnerId], [i0].[AdditionalCustomerData], [i0].[Id], [i1].[IntermediateOwnedEntityOwnerId], [i1].[AdditionalSupplierData], [i1].[Id]
+SELECT TOP(@p) [o].[Id], [o].[Name], [i].[OwnerId], [i].[Id], [i].[Name], [i0].[IntermediateOwnedEntityOwnerId], [i0].[AdditionalCustomerData], [i0].[Id], [i1].[IntermediateOwnedEntityOwnerId], [i1].[AdditionalSupplierData], [i1].[Id]
 FROM [Owners] AS [o]
 LEFT JOIN [IntermediateOwnedEntity] AS [i] ON [o].[Id] = [i].[OwnerId]
 LEFT JOIN [IM_CustomerData] AS [i0] ON [i].[OwnerId] = [i0].[IntermediateOwnedEntityOwnerId]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -169,11 +169,11 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o3].[PersonAddress_AddressLine], [o3].[PersonAddress_PlaceType], [o3].[PersonAddress_ZipCode], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [o3].[BranchAddress_BranchName], [o3].[BranchAddress_PlaceType], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o3].[LeafBAddress_LeafBType], [o3].[LeafBAddress_PlaceType], [o3].[LeafBAddress_Country_Name], [o3].[LeafBAddress_Country_PlanetId], [o3].[LeafAAddress_LeafType], [o3].[LeafAAddress_PlaceType], [o3].[LeafAAddress_Country_Name], [o3].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] AS [o]
@@ -533,8 +533,8 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='100'
+@p='0'
+@p0='100'
 
 SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o3].[PersonAddress_AddressLine], [o3].[PersonAddress_PlaceType], [o3].[PersonAddress_ZipCode], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [o3].[BranchAddress_BranchName], [o3].[BranchAddress_PlaceType], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o3].[LeafBAddress_LeafBType], [o3].[LeafBAddress_PlaceType], [o3].[LeafBAddress_Country_Name], [o3].[LeafBAddress_Country_PlanetId], [o3].[LeafAAddress_LeafType], [o3].[LeafAAddress_PlaceType], [o3].[LeafAAddress_Country_Name], [o3].[LeafAAddress_Country_PlanetId], [o3].[c]
 FROM (
@@ -543,7 +543,7 @@ FROM (
         FROM [OwnedPerson] AS [o2]) AS [c]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o3]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail]
@@ -578,14 +578,14 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail]
@@ -602,11 +602,11 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
 ) AS [o2]
@@ -625,15 +625,15 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail]
@@ -650,14 +650,14 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail]
@@ -674,11 +674,11 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
 ) AS [o2]
@@ -697,15 +697,15 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail]
@@ -1120,9 +1120,9 @@ ORDER BY [o].[Id], [o1].[ClientId], [o1].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
+SELECT TOP(@p) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
@@ -1131,11 +1131,11 @@ ORDER BY [o0].[Id]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o2].[ClientId], [o2].[Id], [o2].[OrderDate], [o5].[Id]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id]
+    SELECT TOP(@p) [o0].[Id]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] AS [o]
@@ -1147,11 +1147,11 @@ ORDER BY [o5].[Id], [o2].[ClientId], [o2].[Id]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o4].[OrderClientId], [o4].[OrderId], [o4].[Id], [o4].[Detail], [o5].[Id], [o2].[ClientId], [o2].[Id]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id]
+    SELECT TOP(@p) [o0].[Id]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -22,11 +22,11 @@ public class PrecompiledQuerySqlServerTest(
 
         AssertSql(
             """
-@__id_0='3'
+@id='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] > @__id_0
+WHERE [b].[Id] > @id
 """);
     }
 
@@ -50,10 +50,10 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__yes_0='yes' (Size = 4000)
+@yes='yes' (Size = 4000)
 
 SELECT CASE
-    WHEN [b].[Id] = 2 THEN @__yes_0
+    WHEN [b].[Id] = 2 THEN @yes
     ELSE N'no'
 END
 FROM [Blogs] AS [b]
@@ -130,11 +130,11 @@ WHERE [b].[Name] IS NOT NULL AND LEFT([b].[Name], LEN([b].[Name])) = [b].[Name]
 
         AssertSql(
             """
-@__pattern_0_startswith='foo%' (Size = 4000)
+@pattern_startswith='foo%' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] LIKE @__pattern_0_startswith ESCAPE N'\'
+WHERE [b].[Name] LIKE @pattern_startswith ESCAPE N'\'
 """);
     }
 
@@ -208,9 +208,9 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__id_0='8'
+@id='8'
 
-SELECT @__id_0 AS [Id], [b].[Name]
+SELECT @id AS [Id], [b].[Name]
 FROM [Blogs] AS [b]
 """);
     }
@@ -243,9 +243,9 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__i_0='8'
+@i='8'
 
-SELECT [b].[Id], [b].[Id] + @__i_0
+SELECT [b].[Id], [b].[Id] + @i
 FROM [Blogs] AS [b]
 """);
     }
@@ -640,10 +640,10 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__p_0='8'
+@p='8'
 
 SELECT CASE
-    WHEN @__p_0 IN (
+    WHEN @p IN (
         SELECT [b].[Id]
         FROM [Blogs] AS [b]
     ) THEN CAST(1 AS bit)
@@ -652,10 +652,10 @@ END
 """,
             //
             """
-@__p_0='7'
+@p='7'
 
 SELECT CASE
-    WHEN @__p_0 IN (
+    WHEN @p IN (
         SELECT [b].[Id]
         FROM [Blogs] AS [b]
     ) THEN CAST(1 AS bit)
@@ -670,10 +670,10 @@ END
 
         AssertSql(
             """
-@__p_0='8'
+@p='8'
 
 SELECT CASE
-    WHEN @__p_0 IN (
+    WHEN @p IN (
         SELECT [b].[Id]
         FROM [Blogs] AS [b]
     ) THEN CAST(1 AS bit)
@@ -682,10 +682,10 @@ END
 """,
             //
             """
-@__p_0='7'
+@p='7'
 
 SELECT CASE
-    WHEN @__p_0 IN (
+    WHEN @p IN (
         SELECT [b].[Id]
         FROM [Blogs] AS [b]
     ) THEN CAST(1 AS bit)
@@ -734,21 +734,21 @@ WHERE [b].[Id] > 8
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='3'
+@p='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -758,21 +758,21 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='3'
+@p='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -782,21 +782,21 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='3'
+@p='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -806,21 +806,21 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """,
             //
             """
-@__p_0='3'
+@p='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Id]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -1378,10 +1378,10 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__suffix_0='Suffix' (Size = 4000)
+@suffix='Suffix' (Size = 4000)
 
 UPDATE [b]
-SET [b].[Name] = COALESCE([b].[Name], N'') + @__suffix_0
+SET [b].[Name] = COALESCE([b].[Name], N'') + @suffix
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > 8
 """,
@@ -1399,10 +1399,10 @@ WHERE [b].[Id] = 9 AND [b].[Name] = N'Blog2Suffix'
 
         AssertSql(
             """
-@__suffix_0='Suffix' (Size = 4000)
+@suffix='Suffix' (Size = 4000)
 
 UPDATE [b]
-SET [b].[Name] = COALESCE([b].[Name], N'') + @__suffix_0
+SET [b].[Name] = COALESCE([b].[Name], N'') + @suffix
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > 8
 """,
@@ -1599,13 +1599,13 @@ WHERE (
 
         AssertSql(
             """
-@__ids_0='[1,2,3]' (Size = 4000)
+@ids='[1,2,3]' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -1895,12 +1895,12 @@ ORDER BY [b].[Name]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
-OFFSET @__p_0 ROWS
+OFFSET @p ROWS
 """);
     }
 
@@ -1910,9 +1910,9 @@ OFFSET @__p_0 ROWS
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [b].[Id], [b].[Name], [b].[Json]
+SELECT TOP(@p) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 ORDER BY [b].[Name]
 """);
@@ -1935,12 +1935,12 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__yes_0='yes' (Size = 4000)
-@__no_1='no' (Size = 4000)
+@yes='yes' (Size = 4000)
+@no='no' (Size = 4000)
 
 SELECT CASE
-    WHEN [b].[Id] = 3 THEN @__yes_0
-    ELSE @__no_1
+    WHEN [b].[Id] = 3 THEN @yes
+    ELSE @no
 END
 FROM [Blogs] AS [b]
 """);
@@ -1952,12 +1952,12 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
-@__starts_0_startswith='Blog%' (Size = 4000)
-@__ends_1_endswith='%2' (Size = 4000)
+@starts_startswith='Blog%' (Size = 4000)
+@ends_endswith='%2' (Size = 4000)
 
 SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] LIKE @__starts_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__ends_1_endswith ESCAPE N'\'
+WHERE [b].[Name] LIKE @starts_startswith ESCAPE N'\' AND [b].[Name] LIKE @ends_endswith ESCAPE N'\'
 """);
     }
 
@@ -1967,12 +1967,12 @@ WHERE [b].[Name] LIKE @__starts_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__
 
         AssertSql(
             """
-@__foo_0_startswith='X%' (Size = 4000)
-@__foo_0_endswith='%X' (Size = 4000)
+@foo_startswith='X%' (Size = 4000)
+@foo_endswith='%X' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo_0_endswith ESCAPE N'\'
+WHERE [b].[Name] LIKE @foo_startswith ESCAPE N'\' AND [b].[Name] LIKE @foo_endswith ESCAPE N'\'
 """);
     }
 
@@ -1982,12 +1982,12 @@ WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo
 
         AssertSql(
             """
-@__foo_0_startswith='X%' (Size = 4000)
-@__foo_0_endswith='%X' (Size = 4000)
+@foo_startswith='X%' (Size = 4000)
+@foo_endswith='%X' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] LIKE @__foo_0_startswith ESCAPE N'\' AND [b].[Name] LIKE @__foo_0_endswith ESCAPE N'\'
+WHERE [b].[Name] LIKE @foo_startswith ESCAPE N'\' AND [b].[Name] LIKE @foo_endswith ESCAPE N'\'
 """);
     }
 
@@ -2042,20 +2042,20 @@ ORDER BY [b].[Name]
 
         AssertSql(
             """
-@__id1_0='8'
-@__id2_1='9'
+@id1='8'
+@id2='9'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
+WHERE [b].[Id] = @id1 OR [b].[Id] = @id2
 """,
             //
             """
-@__id1_0='8'
+@id1='8'
 
 SELECT TOP(2) [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] = @__id1_0
+WHERE [b].[Id] = @id1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
@@ -33,11 +33,11 @@ WHERE [b].[Name] = N'foo'
 
         AssertSql(
             """
-@__id_0='8'
+@id='8'
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] = @__id_0
+WHERE [b].[Id] = @id
 """);
     }
 
@@ -47,11 +47,11 @@ WHERE [b].[Id] = @__id_0
 
         AssertSql(
             """
-@__id_0='8' (Nullable = true)
+@id='8' (Nullable = true)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] = @__id_0
+WHERE [b].[Id] = @id
 """);
     }
 
@@ -61,11 +61,11 @@ WHERE [b].[Id] = @__id_0
 
         AssertSql(
             """
-@__name_0='bar' (Size = 4000)
+@name='bar' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name_0
+WHERE [b].[Name] = @name
 """);
     }
 
@@ -75,11 +75,11 @@ WHERE [b].[Name] = @__name_0
 
         AssertSql(
             """
-@__name_0='bar' (Nullable = false) (Size = 4000)
+@name='bar' (Nullable = false) (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name_0
+WHERE [b].[Name] = @name
 """);
     }
 
@@ -89,12 +89,12 @@ WHERE [b].[Name] = @__name_0
 
         AssertSql(
             """
-@__id1_0='8' (Nullable = true)
-@__id2_1='9'
+@id1='8' (Nullable = true)
+@id2='9'
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
+WHERE [b].[Id] = @id1 OR [b].[Id] = @id2
 """);
     }
 
@@ -104,12 +104,12 @@ WHERE [b].[Id] = @__id1_0 OR [b].[Id] = @__id2_1
 
         AssertSql(
             """
-@__name1_0='foo' (Size = 4000)
-@__name2_1='bar' (Size = 4000)
+@name1='foo' (Size = 4000)
+@name2='bar' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+WHERE [b].[Name] = @name1 OR [b].[Name] = @name2
 """);
     }
 
@@ -119,12 +119,12 @@ WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
 
         AssertSql(
             """
-@__name1_0='foo' (Nullable = false) (Size = 4000)
-@__name2_1='bar' (Nullable = false) (Size = 4000)
+@name1='foo' (Nullable = false) (Size = 4000)
+@name2='bar' (Nullable = false) (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+WHERE [b].[Name] = @name1 OR [b].[Name] = @name2
 """);
     }
 
@@ -134,12 +134,12 @@ WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
 
         AssertSql(
             """
-@__name1_0='foo' (Size = 4000)
-@__name2_1='bar' (Nullable = false) (Size = 4000)
+@name1='foo' (Size = 4000)
+@name2='bar' (Nullable = false) (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
+WHERE [b].[Name] = @name1 OR [b].[Name] = @name2
 """);
     }
 
@@ -149,14 +149,14 @@ WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1
 
         AssertSql(
             """
-@__name1_0='foo' (Size = 4000)
-@__name2_1='bar' (Size = 4000)
-@__name3_2='baz' (Size = 4000)
-@__name4_3='baq' (Size = 4000)
+@name1='foo' (Size = 4000)
+@name2='bar' (Size = 4000)
+@name3='baz' (Size = 4000)
+@name4='baq' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1 OR [b].[Name] = @__name3_2 OR [b].[Name] = @__name4_3
+WHERE [b].[Name] = @name1 OR [b].[Name] = @name2 OR [b].[Name] = @name3 OR [b].[Name] = @name4
 """);
     }
 
@@ -166,14 +166,14 @@ WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1 OR [b].[Name] = @__name
 
         AssertSql(
             """
-@__name1_0='foo' (Nullable = false) (Size = 4000)
-@__name2_1='bar' (Nullable = false) (Size = 4000)
-@__name3_2='baz' (Nullable = false) (Size = 4000)
-@__name4_3='baq' (Nullable = false) (Size = 4000)
+@name1='foo' (Nullable = false) (Size = 4000)
+@name2='bar' (Nullable = false) (Size = 4000)
+@name3='baz' (Nullable = false) (Size = 4000)
+@name4='baq' (Nullable = false) (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] = @__name1_0 OR [b].[Name] = @__name2_1 OR [b].[Name] = @__name3_2 OR [b].[Name] = @__name4_3
+WHERE [b].[Name] = @name1 OR [b].[Name] = @name2 OR [b].[Name] = @name3 OR [b].[Name] = @name4
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -167,12 +167,12 @@ WHERE [p].[Id] IN (2, 999, 1000)
 
         AssertSql(
             """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (@__i_0, @__j_1)
+WHERE [p].[Id] IN (@i, @j)
 """);
     }
 
@@ -182,11 +182,11 @@ WHERE [p].[Id] IN (@__i_0, @__j_1)
 
         AssertSql(
             """
-@__j_0='999'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (2, @__j_0)
+WHERE [p].[Id] IN (2, @j)
 """);
     }
 
@@ -196,11 +196,11 @@ WHERE [p].[Id] IN (2, @__j_0)
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -210,11 +210,11 @@ WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -304,13 +304,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -320,13 +320,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -336,13 +336,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -352,13 +352,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -368,13 +368,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25' (Nullable = true)
+@i='25' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -384,13 +384,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35' (Nullable = true)
+@i='35' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -428,11 +428,11 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] = @__i_0
+WHERE [p].[Id] = @i
 """);
     }
 
@@ -442,13 +442,13 @@ WHERE [p].[Id] = @__i_0
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@__i_0 AS int))) AS [v]([Value])
+    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }
@@ -926,11 +926,11 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[1,10]' (Size = 4000)
+@ints='[1,10]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Ints] = @__ints_0
+WHERE [p].[Ints] = @ints
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
@@ -156,12 +156,12 @@ WHERE [p].[Id] IN (2, 999, 1000)
 
         AssertSql(
             """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (@__i_0, @__j_1)
+WHERE [p].[Id] IN (@i, @j)
 """);
     }
 
@@ -171,11 +171,11 @@ WHERE [p].[Id] IN (@__i_0, @__j_1)
 
         AssertSql(
             """
-@__j_0='999'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (2, @__j_0)
+WHERE [p].[Id] IN (2, @j)
 """);
     }
 
@@ -185,11 +185,11 @@ WHERE [p].[Id] IN (2, @__j_0)
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -199,11 +199,11 @@ WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -285,11 +285,11 @@ WHERE GREATEST(30, [p].[Int]) = 30
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -299,11 +299,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -313,11 +313,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -327,11 +327,11 @@ WHERE GREATEST(30, [p].[Int], @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -341,11 +341,11 @@ WHERE GREATEST(30, [p].[Int], @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='25' (Nullable = true)
+@i='25' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -355,11 +355,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='35' (Nullable = true)
+@i='35' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -393,11 +393,11 @@ WHERE GREATEST(30, [p].[NullableInt], NULL) = 30
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] = @__i_0
+WHERE [p].[Id] = @i
 """);
     }
 
@@ -407,13 +407,13 @@ WHERE [p].[Id] = @__i_0
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@__i_0 AS int))) AS [v]([Value])
+    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }
@@ -424,13 +424,13 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 4000)
+@p='[2,999,1000]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Id] IN (
     SELECT [p0].[value]
-    FROM OPENJSON(@__p_0) WITH ([value] int '$') AS [p0]
+    FROM OPENJSON(@p) WITH ([value] int '$') AS [p0]
 )
 """);
     }
@@ -441,13 +441,13 @@ WHERE [p].[Id] IN (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 4000)
+@p='[2,999,1000]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__p_0) WITH ([value] int '$') AS [p0]
+    FROM OPENJSON(@p) WITH ([value] int '$') AS [p0]
     WHERE [p0].[value] > [p].[Id]) = 2
 """);
     }
@@ -458,13 +458,13 @@ WHERE (
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 4000)
+@ids='[2,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     WHERE [i].[value] > [p].[Id]) = 1
 """);
     }
@@ -475,24 +475,24 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -503,24 +503,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -531,24 +531,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 ) OR [p].[NullableInt] IS NULL
 """);
     }
@@ -559,24 +559,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """,
             //
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -587,24 +587,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) OR [p].[NullableInt] IS NULL
 """,
             //
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) AND [p].[NullableInt] IS NOT NULL
 """);
     }
@@ -615,24 +615,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -643,24 +643,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 ) OR [p].[NullableString] IS NULL
 """);
     }
@@ -671,24 +671,24 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10",null]' (Size = 4000)
+@strings='["10",null]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0_without_nulls='["10"]' (Size = 4000)
+@strings_without_nulls='["10"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 )
 """);
     }
@@ -699,24 +699,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) OR [p].[NullableString] IS NULL
 """,
             //
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) AND [p].[NullableString] IS NOT NULL
 """);
     }
@@ -727,13 +727,13 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
+@dateTimes='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[DateTime] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dateTimes) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -744,13 +744,13 @@ WHERE [p].[DateTime] IN (
 
         AssertSql(
             """
-@__bools_0='[true]' (Size = 4000)
+@bools='[true]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Bool] IN (
     SELECT [b].[value]
-    FROM OPENJSON(@__bools_0) WITH ([value] bit '$') AS [b]
+    FROM OPENJSON(@bools) WITH ([value] bit '$') AS [b]
 )
 """);
     }
@@ -761,13 +761,13 @@ WHERE [p].[Bool] IN (
 
         AssertSql(
             """
-@__enums_0='[0,3]' (Size = 4000)
+@enums='[0,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Enum] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__enums_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
 )
 """);
     }
@@ -1115,11 +1115,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[0,2,3]' (Size = 4000)
+@ints='[0,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
 """);
     }
 
@@ -1130,11 +1130,11 @@ WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') 
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
 """);
     }
 
@@ -1459,14 +1459,14 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
-    INNER JOIN OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
+    INNER JOIN OPENJSON(@ints) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
 """);
     }
 
@@ -1491,7 +1491,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1499,7 +1499,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT 1 AS empty
-        FROM OPENJSON(@__ints_0) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         UNION ALL
         SELECT 1 AS empty
         FROM OPENJSON([p].[Ints]) AS [i0]
@@ -1513,10 +1513,10 @@ WHERE (
 
         AssertSql(
             """
-@__values_0='["one","two"]' (Size = 4000)
+@values='["one","two"]' (Size = 4000)
 
 SELECT CASE
-    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@__values_0, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
+    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@values, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
     ELSE N'foo'
 END
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1529,7 +1529,7 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1540,7 +1540,7 @@ WHERE (
         FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 2
 """);
     }
@@ -1613,11 +1613,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[1,10]' (Size = 4000)
+@ints='[1,10]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Ints] = @__ints_0
+WHERE [p].[Ints] = @ints
 """);
     }
 
@@ -1660,7 +1660,7 @@ WHERE [p].[Ints] = N'[1,10]'
 
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1670,7 +1670,7 @@ WHERE (
         SELECT [i1].[value]
         FROM (
             SELECT CAST([i].[value] AS int) AS [value]
-            FROM OPENJSON(@__ints) AS [i]
+            FROM OPENJSON(@ints) AS [i]
             ORDER BY CAST([i].[key] AS int)
             OFFSET 1 ROWS
         ) AS [i1]
@@ -1687,7 +1687,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1695,7 +1695,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i].[value]
         FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
@@ -1709,7 +1709,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1717,7 +1717,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i2].[value]
         FROM (
@@ -1751,7 +1751,7 @@ WHERE (
         // TODO: the subquery projection contains extra columns which we should remove
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT COUNT(*)
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1759,7 +1759,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT CAST([i].[value] AS int) AS [value0]
-        FROM OPENJSON(@__ints) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         ORDER BY CAST([i].[key] AS int)
         OFFSET 1 ROWS
     ) AS [i0]
@@ -1780,7 +1780,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1796,7 +1796,7 @@ WHERE (
         ) AS [i1]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 3
 """);
     }
@@ -2038,20 +2038,20 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -2062,20 +2062,20 @@ END IN (
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
@@ -28,11 +28,11 @@ public class PrimitiveCollectionsQuerySqlServerJsonTypeTest : PrimitiveCollectio
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] = @__i_0
+WHERE [p].[Id] = @i
 """);
     }
 
@@ -42,13 +42,13 @@ WHERE [p].[Id] = @__i_0
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@__i_0 AS int))) AS [v]([Value])
+    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }
@@ -237,12 +237,12 @@ WHERE [p].[Id] IN (2, 999, 1000)
 
         AssertSql(
             """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (@__i_0, @__j_1)
+WHERE [p].[Id] IN (@i, @j)
 """);
     }
 
@@ -252,11 +252,11 @@ WHERE [p].[Id] IN (@__i_0, @__j_1)
 
         AssertSql(
             """
-@__j_0='999'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (2, @__j_0)
+WHERE [p].[Id] IN (2, @j)
 """);
     }
 
@@ -266,11 +266,11 @@ WHERE [p].[Id] IN (2, @__j_0)
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -280,11 +280,11 @@ WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -366,11 +366,11 @@ WHERE GREATEST(30, [p].[Int]) = 30
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -380,11 +380,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -394,11 +394,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -408,11 +408,11 @@ WHERE GREATEST(30, [p].[Int], @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -422,11 +422,11 @@ WHERE GREATEST(30, [p].[Int], @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='25' (Nullable = true)
+@i='25' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE LEAST(30, [p].[Int], @__i_0) = 25
+WHERE LEAST(30, [p].[Int], @i) = 25
 """);
     }
 
@@ -436,11 +436,11 @@ WHERE LEAST(30, [p].[Int], @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='35' (Nullable = true)
+@i='35' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+WHERE GREATEST(30, [p].[Int], @i) = 35
 """);
     }
 
@@ -474,13 +474,13 @@ WHERE GREATEST(30, [p].[NullableInt], NULL) = 30
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 4000)
+@ids='[2,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     WHERE [i].[value] > [p].[Id]) = 1
 """);
     }
@@ -491,24 +491,24 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -519,24 +519,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -547,24 +547,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 ) OR [p].[NullableInt] IS NULL
 """);
     }
@@ -575,24 +575,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """,
             //
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -603,24 +603,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) OR [p].[NullableInt] IS NULL
 """,
             //
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) AND [p].[NullableInt] IS NOT NULL
 """);
     }
@@ -631,24 +631,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -659,24 +659,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 ) OR [p].[NullableString] IS NULL
 """);
     }
@@ -687,24 +687,24 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10",null]' (Size = 4000)
+@strings='["10",null]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0_without_nulls='["10"]' (Size = 4000)
+@strings_without_nulls='["10"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 )
 """);
     }
@@ -715,24 +715,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) OR [p].[NullableString] IS NULL
 """,
             //
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) AND [p].[NullableString] IS NOT NULL
 """);
     }
@@ -743,13 +743,13 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
+@dateTimes='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[DateTime] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dateTimes) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -760,13 +760,13 @@ WHERE [p].[DateTime] IN (
 
         AssertSql(
             """
-@__bools_0='[true]' (Size = 4000)
+@bools='[true]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Bool] IN (
     SELECT [b].[value]
-    FROM OPENJSON(@__bools_0) WITH ([value] bit '$') AS [b]
+    FROM OPENJSON(@bools) WITH ([value] bit '$') AS [b]
 )
 """);
     }
@@ -777,13 +777,13 @@ WHERE [p].[Bool] IN (
 
         AssertSql(
             """
-@__enums_0='[0,3]' (Size = 4000)
+@enums='[0,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Enum] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__enums_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
 )
 """);
     }
@@ -1089,11 +1089,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[0,2,3]' (Size = 4000)
+@ints='[0,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
 """);
     }
 
@@ -1104,11 +1104,11 @@ WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') 
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
 """);
     }
 
@@ -1433,14 +1433,14 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM OPENJSON(CAST([p].[Ints] AS nvarchar(max))) WITH ([value] int '$') AS [i]
-    INNER JOIN OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
+    INNER JOIN OPENJSON(@ints) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
 """);
     }
 
@@ -1465,7 +1465,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1473,7 +1473,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT 1 AS empty
-        FROM OPENJSON(@__ints_0) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         UNION ALL
         SELECT 1 AS empty
         FROM OPENJSON(CAST([p].[Ints] AS nvarchar(max))) AS [i0]
@@ -1487,10 +1487,10 @@ WHERE (
 
         AssertSql(
             """
-@__values_0='["one","two"]' (Size = 4000)
+@values='["one","two"]' (Size = 4000)
 
 SELECT CASE
-    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@__values_0, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
+    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@values, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
     ELSE N'foo'
 END
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1503,7 +1503,7 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1514,7 +1514,7 @@ WHERE (
         FROM OPENJSON(CAST([p].[Ints] AS nvarchar(max))) WITH ([value] int '$') AS [i]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 2
 """);
     }
@@ -1590,11 +1590,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[1,10]' (Size = 8000)
+@ints='[1,10]' (Size = 8000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Ints] = @__ints_0
+WHERE [p].[Ints] = @ints
 """);
     }
 
@@ -1640,7 +1640,7 @@ WHERE [p].[Ints] = '[1,10]'
 
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1650,7 +1650,7 @@ WHERE (
         SELECT [i1].[value]
         FROM (
             SELECT CAST([i].[value] AS int) AS [value]
-            FROM OPENJSON(@__ints) AS [i]
+            FROM OPENJSON(@ints) AS [i]
             ORDER BY CAST([i].[key] AS int)
             OFFSET 1 ROWS
         ) AS [i1]
@@ -1667,7 +1667,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1675,7 +1675,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i].[value]
         FROM OPENJSON(CAST([p].[Ints] AS nvarchar(max))) WITH ([value] int '$') AS [i]
@@ -1689,7 +1689,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1697,7 +1697,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i2].[value]
         FROM (
@@ -1731,7 +1731,7 @@ WHERE (
         // TODO: the subquery projection contains extra columns which we should remove
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT COUNT(*)
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1739,7 +1739,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT CAST([i].[value] AS int) AS [value0]
-        FROM OPENJSON(@__ints) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         ORDER BY CAST([i].[key] AS int)
         OFFSET 1 ROWS
     ) AS [i0]
@@ -1760,7 +1760,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1776,7 +1776,7 @@ WHERE (
         ) AS [i1]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 3
 """);
     }
@@ -2018,20 +2018,20 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -2042,20 +2042,20 @@ END IN (
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -155,12 +155,12 @@ WHERE [p].[Id] IN (2, 999, 1000)
 
         AssertSql(
             """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (@__i_0, @__j_1)
+WHERE [p].[Id] IN (@i, @j)
 """);
     }
 
@@ -170,11 +170,11 @@ WHERE [p].[Id] IN (@__i_0, @__j_1)
 
         AssertSql(
             """
-@__j_0='999'
+@j='999'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] IN (2, @__j_0)
+WHERE [p].[Id] IN (2, @j)
 """);
     }
 
@@ -184,11 +184,11 @@ WHERE [p].[Id] IN (2, @__j_0)
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -198,11 +198,11 @@ WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Int] IN (999, @__i_0, [p].[Id], [p].[Id] + [p].[Int])
+WHERE [p].[Int] IN (999, @i, [p].[Id], [p].[Id] + [p].[Int])
 """);
     }
 
@@ -292,13 +292,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -308,13 +308,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -324,13 +324,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -340,13 +340,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -356,13 +356,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='25' (Nullable = true)
+@i='25' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MIN([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 25
 """);
     }
 
@@ -372,13 +372,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35' (Nullable = true)
+@i='35' (Nullable = true)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT MAX([v].[Value])
-    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@i)) AS [v]([Value])) = 35
 """);
     }
 
@@ -416,11 +416,11 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Id] = @__i_0
+WHERE [p].[Id] = @i
 """);
     }
 
@@ -430,13 +430,13 @@ WHERE [p].[Id] = @__i_0
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@__i_0 AS int))) AS [v]([Value])
+    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }
@@ -447,13 +447,13 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 4000)
+@p='[2,999,1000]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Id] IN (
     SELECT [p0].[value]
-    FROM OPENJSON(@__p_0) WITH ([value] int '$') AS [p0]
+    FROM OPENJSON(@p) WITH ([value] int '$') AS [p0]
 )
 """);
     }
@@ -464,13 +464,13 @@ WHERE [p].[Id] IN (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 4000)
+@p='[2,999,1000]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__p_0) WITH ([value] int '$') AS [p0]
+    FROM OPENJSON(@p) WITH ([value] int '$') AS [p0]
     WHERE [p0].[value] > [p].[Id]) = 2
 """);
     }
@@ -481,13 +481,13 @@ WHERE (
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 4000)
+@ids='[2,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     WHERE [i].[value] > [p].[Id]) = 1
 """);
     }
@@ -498,24 +498,24 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -526,24 +526,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -554,24 +554,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 4000)
+@ints='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+    FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
 ) OR [p].[NullableInt] IS NULL
 """);
     }
@@ -582,24 +582,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """,
             //
             """
-@__nullableInts_0='[10,999]' (Size = 4000)
+@nullableInts='[10,999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -610,24 +610,24 @@ WHERE [p].[Int] NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) OR [p].[NullableInt] IS NULL
 """,
             //
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 4000)
+@nullableInts_without_nulls='[999]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableInt] NOT IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__nullableInts_0_without_nulls) AS [n]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
 ) AND [p].[NullableInt] IS NOT NULL
 """);
     }
@@ -638,24 +638,24 @@ WHERE [p].[NullableInt] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -666,24 +666,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 4000)
+@strings='["10","999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 ) OR [p].[NullableString] IS NULL
 """);
     }
@@ -694,24 +694,24 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10",null]' (Size = 4000)
+@strings='["10",null]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """,
             //
             """
-@__strings_0_without_nulls='["10"]' (Size = 4000)
+@strings_without_nulls='["10"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[String] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 )
 """);
     }
@@ -722,24 +722,24 @@ WHERE [p].[String] NOT IN (
 
         AssertSql(
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) OR [p].[NullableString] IS NULL
 """,
             //
             """
-@__strings_0_without_nulls='["999"]' (Size = 4000)
+@strings_without_nulls='["999"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[NullableString] NOT IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_0_without_nulls) AS [s]
+    FROM OPENJSON(@strings_without_nulls) AS [s]
 ) AND [p].[NullableString] IS NOT NULL
 """);
     }
@@ -750,13 +750,13 @@ WHERE [p].[NullableString] NOT IN (
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
+@dateTimes='["2020-01-10T12:30:00Z","9999-01-01T00:00:00Z"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[DateTime] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
+    FROM OPENJSON(@dateTimes) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -767,13 +767,13 @@ WHERE [p].[DateTime] IN (
 
         AssertSql(
             """
-@__bools_0='[true]' (Size = 4000)
+@bools='[true]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Bool] IN (
     SELECT [b].[value]
-    FROM OPENJSON(@__bools_0) WITH ([value] bit '$') AS [b]
+    FROM OPENJSON(@bools) WITH ([value] bit '$') AS [b]
 )
 """);
     }
@@ -784,13 +784,13 @@ WHERE [p].[Bool] IN (
 
         AssertSql(
             """
-@__enums_0='[0,3]' (Size = 4000)
+@enums='[0,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Enum] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__enums_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
 )
 """);
     }
@@ -1138,11 +1138,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[0,2,3]' (Size = 4000)
+@ints='[0,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = [p].[Int]
 """);
     }
 
@@ -1153,11 +1153,11 @@ WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') 
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE CAST(JSON_VALUE(@__ints_0, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
+WHERE CAST(JSON_VALUE(@ints, '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
 """);
     }
 
@@ -1482,14 +1482,14 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
-    INNER JOIN OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
+    INNER JOIN OPENJSON(@ints) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
 """);
     }
 
@@ -1514,7 +1514,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1522,7 +1522,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT 1 AS empty
-        FROM OPENJSON(@__ints_0) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         UNION ALL
         SELECT 1 AS empty
         FROM OPENJSON([p].[Ints]) AS [i0]
@@ -1537,10 +1537,10 @@ WHERE (
 
         AssertSql(
             """
-@__values_0='["one","two"]' (Size = 4000)
+@values='["one","two"]' (Size = 4000)
 
 SELECT CASE
-    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@__values_0, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
+    WHEN [p].[Id] <> 0 THEN JSON_VALUE(@values, '$[' + CAST([p].[Int] % 2 AS nvarchar(max)) + ']')
     ELSE N'foo'
 END
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1553,7 +1553,7 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 4000)
+@ints='[11,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1564,7 +1564,7 @@ WHERE (
         FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 2
 """);
     }
@@ -1637,11 +1637,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[1,10]' (Size = 4000)
+@ints='[1,10]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
-WHERE [p].[Ints] = @__ints_0
+WHERE [p].[Ints] = @ints
 """);
     }
 
@@ -1684,7 +1684,7 @@ WHERE [p].[Ints] = N'[1,10]'
 
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1694,7 +1694,7 @@ WHERE (
         SELECT [i1].[value]
         FROM (
             SELECT CAST([i].[value] AS int) AS [value]
-            FROM OPENJSON(@__ints) AS [i]
+            FROM OPENJSON(@ints) AS [i]
             ORDER BY CAST([i].[key] AS int)
             OFFSET 1 ROWS
         ) AS [i1]
@@ -1711,7 +1711,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1719,7 +1719,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i].[value]
         FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
@@ -1733,7 +1733,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 4000)
+@Skip='[111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1741,7 +1741,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [s].[value]
-        FROM OPENJSON(@__Skip_0) WITH ([value] int '$') AS [s]
+        FROM OPENJSON(@Skip) WITH ([value] int '$') AS [s]
         UNION
         SELECT [i2].[value]
         FROM (
@@ -1775,7 +1775,7 @@ WHERE (
         // TODO: the subquery projection contains extra columns which we should remove
         AssertSql(
             """
-@__ints='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT COUNT(*)
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1783,7 +1783,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT CAST([i].[value] AS int) AS [value0]
-        FROM OPENJSON(@__ints) AS [i]
+        FROM OPENJSON(@ints) AS [i]
         ORDER BY CAST([i].[key] AS int)
         OFFSET 1 ROWS
     ) AS [i0]
@@ -1804,7 +1804,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,111]' (Size = 4000)
+@ints='[10,111]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
@@ -1820,7 +1820,7 @@ WHERE (
         ) AS [i1]
         UNION
         SELECT [i0].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i0]
     ) AS [u]) = 3
 """);
     }
@@ -2062,20 +2062,20 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }
@@ -2086,20 +2086,20 @@ END IN (
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 4000)
-@__strings_1='["one","two","three"]' (Size = 4000)
+@ints='[1,2,3]' (Size = 4000)
+@strings='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
     WHEN [p].[Int] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ints) WITH ([value] int '$') AS [i]
     ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]
-    FROM OPENJSON(@__strings_1) WITH ([value] nvarchar(max) '$') AS [s]
+    FROM OPENJSON(@strings) WITH ([value] nvarchar(max) '$') AS [s]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -23,12 +23,12 @@ public class QueryFilterFuncletizationSqlServerTest
 
         AssertSql(
             """
-@__ef_filter__Field_0='False'
-@__Field_0='False'
+@ef_filter__Field='False'
+@Field='False'
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE [f].[IsEnabled] = @__ef_filter__Field_0 AND [f].[IsEnabled] = @__Field_0
+WHERE [f].[IsEnabled] = @ef_filter__Field AND [f].[IsEnabled] = @Field
 """);
     }
 
@@ -38,19 +38,19 @@ WHERE [f].[IsEnabled] = @__ef_filter__Field_0 AND [f].[IsEnabled] = @__Field_0
 
         AssertSql(
             """
-@__ef_filter__Field_0='False'
+@ef_filter__Field='False'
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE [f].[IsEnabled] = @__ef_filter__Field_0
+WHERE [f].[IsEnabled] = @ef_filter__Field
 """,
             //
             """
-@__ef_filter__Field_0='True'
+@ef_filter__Field='True'
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE [f].[IsEnabled] = @__ef_filter__Field_0
+WHERE [f].[IsEnabled] = @ef_filter__Field
 """);
     }
 
@@ -60,19 +60,19 @@ WHERE [f].[IsEnabled] = @__ef_filter__Field_0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyFilter] AS [p]
-WHERE [p].[IsEnabled] = @__ef_filter__Property_0
+WHERE [p].[IsEnabled] = @ef_filter__Property
 """,
             //
             """
-@__ef_filter__Property_0='True'
+@ef_filter__Property='True'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyFilter] AS [p]
-WHERE [p].[IsEnabled] = @__ef_filter__Property_0
+WHERE [p].[IsEnabled] = @ef_filter__Property
 """);
     }
 
@@ -82,11 +82,11 @@ WHERE [p].[IsEnabled] = @__ef_filter__Property_0
 
         AssertSql(
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [m].[Id], [m].[Tenant]
 FROM [MethodCallFilter] AS [m]
-WHERE [m].[Tenant] = @__ef_filter__p_0
+WHERE [m].[Tenant] = @ef_filter__p
 """);
     }
 
@@ -105,35 +105,35 @@ WHERE [l].[Tenant] IN (
 """,
             //
             """
-@__ef_filter__TenantIds_0='[]' (Size = 4000)
+@ef_filter__TenantIds='[]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@ef_filter__TenantIds) WITH ([value] int '$') AS [e]
 )
 """,
             //
             """
-@__ef_filter__TenantIds_0='[1]' (Size = 4000)
+@ef_filter__TenantIds='[1]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@ef_filter__TenantIds) WITH ([value] int '$') AS [e]
 )
 """,
             //
             """
-@__ef_filter__TenantIds_0='[2,3]' (Size = 4000)
+@ef_filter__TenantIds='[2,3]' (Size = 4000)
 
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
     SELECT [e].[value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
+    FROM OPENJSON(@ef_filter__TenantIds) WITH ([value] int '$') AS [e]
 )
 """);
     }
@@ -144,19 +144,19 @@ WHERE [l].[Tenant] IN (
 
         AssertSql(
             """
-@__ef_filter__Enabled_0='False'
+@ef_filter__Enabled='False'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyChainFilter] AS [p]
-WHERE [p].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [p].[IsEnabled] = @ef_filter__Enabled
 """,
             //
             """
-@__ef_filter__Enabled_0='True'
+@ef_filter__Enabled='True'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyChainFilter] AS [p]
-WHERE [p].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [p].[IsEnabled] = @ef_filter__Enabled
 """);
     }
 
@@ -166,11 +166,11 @@ WHERE [p].[IsEnabled] = @__ef_filter__Enabled_0
 
         AssertSql(
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [p].[Id], [p].[Tenant]
 FROM [PropertyMethodCallFilter] AS [p]
-WHERE [p].[Tenant] = @__ef_filter__p_0
+WHERE [p].[Tenant] = @ef_filter__p
 """);
     }
 
@@ -180,11 +180,11 @@ WHERE [p].[Tenant] = @__ef_filter__p_0
 
         AssertSql(
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [m].[Id], [m].[Tenant]
 FROM [MethodCallChainFilter] AS [m]
-WHERE [m].[Tenant] = @__ef_filter__p_0
+WHERE [m].[Tenant] = @ef_filter__p
 """);
     }
 
@@ -194,30 +194,30 @@ WHERE [m].[Tenant] = @__ef_filter__p_0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
-@__ef_filter__p_1='True'
+@ef_filter__Property='False'
+@ef_filter__p0='True'
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE [c].[IsEnabled] = @__ef_filter__Property_0 AND @__ef_filter__p_1 = CAST(1 AS bit)
+WHERE [c].[IsEnabled] = @ef_filter__Property AND @ef_filter__p0 = CAST(1 AS bit)
 """,
             //
             """
-@__ef_filter__Property_0='True'
-@__ef_filter__p_1='True'
+@ef_filter__Property='True'
+@ef_filter__p0='True'
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE [c].[IsEnabled] = @__ef_filter__Property_0 AND @__ef_filter__p_1 = CAST(1 AS bit)
+WHERE [c].[IsEnabled] = @ef_filter__Property AND @ef_filter__p0 = CAST(1 AS bit)
 """,
             //
             """
-@__ef_filter__Property_0='True'
-@__ef_filter__p_1='False'
+@ef_filter__Property='True'
+@ef_filter__p0='False'
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE [c].[IsEnabled] = @__ef_filter__Property_0 AND @__ef_filter__p_1 = CAST(1 AS bit)
+WHERE [c].[IsEnabled] = @ef_filter__Property AND @ef_filter__p0 = CAST(1 AS bit)
 """);
     }
 
@@ -227,29 +227,29 @@ WHERE [c].[IsEnabled] = @__ef_filter__Property_0 AND @__ef_filter__p_1 = CAST(1 
 
         AssertSql(
             """
-@__ef_filter__p_1='False'
-@__ef_filter__IsModerated_0='True' (Nullable = true)
+@ef_filter__p0='False'
+@ef_filter__IsModerated='True' (Nullable = true)
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE [s].[IsDeleted] = CAST(0 AS bit) AND (@__ef_filter__p_1 = CAST(1 AS bit) OR @__ef_filter__IsModerated_0 = [s].[IsModerated])
+WHERE [s].[IsDeleted] = CAST(0 AS bit) AND (@ef_filter__p0 = CAST(1 AS bit) OR @ef_filter__IsModerated = [s].[IsModerated])
 """,
             //
             """
-@__ef_filter__p_1='False'
-@__ef_filter__IsModerated_0='False' (Nullable = true)
+@ef_filter__p0='False'
+@ef_filter__IsModerated='False' (Nullable = true)
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE [s].[IsDeleted] = CAST(0 AS bit) AND (@__ef_filter__p_1 = CAST(1 AS bit) OR @__ef_filter__IsModerated_0 = [s].[IsModerated])
+WHERE [s].[IsDeleted] = CAST(0 AS bit) AND (@ef_filter__p0 = CAST(1 AS bit) OR @ef_filter__IsModerated = [s].[IsModerated])
 """,
             //
             """
-@__ef_filter__p_1='True'
+@ef_filter__p0='True'
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE [s].[IsDeleted] = CAST(0 AS bit) AND @__ef_filter__p_1 = CAST(1 AS bit)
+WHERE [s].[IsDeleted] = CAST(0 AS bit) AND @ef_filter__p0 = CAST(1 AS bit)
 """);
     }
 
@@ -259,19 +259,19 @@ WHERE [s].[IsDeleted] = CAST(0 AS bit) AND @__ef_filter__p_1 = CAST(1 AS bit)
 
         AssertSql(
             """
-@__ef_filter__Field_0='False'
+@ef_filter__Field='False'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0
+WHERE [e].[IsEnabled] = @ef_filter__Field
 """,
             //
             """
-@__ef_filter__Field_0='True'
+@ef_filter__Field='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0
+WHERE [e].[IsEnabled] = @ef_filter__Field
 """);
     }
 
@@ -281,19 +281,19 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0
+WHERE [e].[IsEnabled] = @ef_filter__Property
 """,
             //
             """
-@__ef_filter__Property_0='True'
+@ef_filter__Property='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0
+WHERE [e].[IsEnabled] = @ef_filter__Property
 """);
     }
 
@@ -303,11 +303,11 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0
 
         AssertSql(
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [e].[Id], [e].[Tenant]
 FROM [EntityTypeConfigurationMethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0
+WHERE [e].[Tenant] = @ef_filter__p
 """);
     }
 
@@ -317,19 +317,19 @@ WHERE [e].[Tenant] = @__ef_filter__p_0
 
         AssertSql(
             """
-@__ef_filter__Enabled_0='False'
+@ef_filter__Enabled='False'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [e].[IsEnabled] = @ef_filter__Enabled
 """,
             //
             """
-@__ef_filter__Enabled_0='True'
+@ef_filter__Enabled='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [e].[IsEnabled] = @ef_filter__Enabled
 """);
     }
 
@@ -339,19 +339,19 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
 
         AssertSql(
             """
-@__ef_filter__Field_0='False'
+@ef_filter__Field='False'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodFilter] AS [l]
-WHERE [l].[IsEnabled] = @__ef_filter__Field_0
+WHERE [l].[IsEnabled] = @ef_filter__Field
 """,
             //
             """
-@__ef_filter__Field_0='True'
+@ef_filter__Field='True'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodFilter] AS [l]
-WHERE [l].[IsEnabled] = @__ef_filter__Field_0
+WHERE [l].[IsEnabled] = @ef_filter__Field
 """);
     }
 
@@ -361,19 +361,19 @@ WHERE [l].[IsEnabled] = @__ef_filter__Field_0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodParamsFilter] AS [l]
-WHERE [l].[IsEnabled] = @__ef_filter__Property_0
+WHERE [l].[IsEnabled] = @ef_filter__Property
 """,
             //
             """
-@__ef_filter__Property_0='True'
+@ef_filter__Property='True'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodParamsFilter] AS [l]
-WHERE [l].[IsEnabled] = @__ef_filter__Property_0
+WHERE [l].[IsEnabled] = @ef_filter__Property
 """);
     }
 
@@ -383,11 +383,11 @@ WHERE [l].[IsEnabled] = @__ef_filter__Property_0
 
         AssertSql(
             """
-@__ef_filter__p_0='2'
+@ef_filter__p='2'
 
 SELECT [r].[Id], [r].[Tenant]
 FROM [RemoteMethodParamsFilter] AS [r]
-WHERE [r].[Tenant] = @__ef_filter__p_0
+WHERE [r].[Tenant] = @ef_filter__p
 """);
     }
 
@@ -397,19 +397,19 @@ WHERE [r].[Tenant] = @__ef_filter__p_0
 
         AssertSql(
             """
-@__ef_filter__Field_0='False'
+@ef_filter__Field='False'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0
+WHERE [e].[IsEnabled] = @ef_filter__Field
 """,
             //
             """
-@__ef_filter__Field_0='True'
+@ef_filter__Field='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0
+WHERE [e].[IsEnabled] = @ef_filter__Field
 """);
     }
 
@@ -419,19 +419,19 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0
 
         AssertSql(
             """
-@__ef_filter__Enabled_0='False'
+@ef_filter__Enabled='False'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [e].[IsEnabled] = @ef_filter__Enabled
 """,
             //
             """
-@__ef_filter__Enabled_0='True'
+@ef_filter__Enabled='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
+WHERE [e].[IsEnabled] = @ef_filter__Enabled
 """);
     }
 
@@ -441,7 +441,7 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [p].[Id], [p].[Filler]
 FROM [PrincipalSetFilter] AS [p]
@@ -451,7 +451,7 @@ WHERE EXISTS (
     WHERE EXISTS (
         SELECT 1
         FROM [MultiContextFilter] AS [m]
-        WHERE [m].[IsEnabled] = @__ef_filter__Property_0 AND [m].[BossId] = 1 AND [m].[BossId] = [d].[PrincipalSetFilterId]) AND [d].[PrincipalSetFilterId] = [p].[Id])
+        WHERE [m].[IsEnabled] = @ef_filter__Property AND [m].[BossId] = 1 AND [m].[BossId] = [d].[PrincipalSetFilterId]) AND [d].[PrincipalSetFilterId] = [p].[Id])
 """);
     }
 
@@ -461,14 +461,14 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [d].[Id], [d].[PrincipalSetFilterId]
 FROM [Dependents] AS [d]
 WHERE EXISTS (
     SELECT 1
     FROM [MultiContextFilter] AS [m]
-    WHERE [m].[IsEnabled] = @__ef_filter__Property_0 AND [m].[BossId] = 1 AND [m].[BossId] = [d].[PrincipalSetFilterId])
+    WHERE [m].[IsEnabled] = @ef_filter__Property AND [m].[BossId] = 1 AND [m].[BossId] = [d].[PrincipalSetFilterId])
 """);
     }
 
@@ -526,19 +526,19 @@ WHERE [p].[Tenant] = 0
 
         AssertSql(
             """
-@__ef_filter__Property_0='False'
+@ef_filter__Property='False'
 
 SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
 FROM [MultiContextFilter] AS [m]
-WHERE [m].[IsEnabled] = @__ef_filter__Property_0 AND [m].[BossId] = 1
+WHERE [m].[IsEnabled] = @ef_filter__Property AND [m].[BossId] = 1
 """,
             //
             """
-@__ef_filter__Property_0='True'
+@ef_filter__Property='True'
 
 SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
 FROM [MultiContextFilter] AS [m]
-WHERE [m].[IsEnabled] = @__ef_filter__Property_0 AND [m].[BossId] = 1
+WHERE [m].[IsEnabled] = @ef_filter__Property AND [m].[BossId] = 1
 """);
     }
 
@@ -548,22 +548,23 @@ WHERE [m].[IsEnabled] = @__ef_filter__Property_0 AND [m].[BossId] = 1
 
         AssertSql(
             """
-@__ef_filter__Tenant_0='1'
-@__ef_filter__Tenant_0_1='1' (DbType = Int16)
+@ef_filter__Tenant='1'
+@ef_filter__Tenant0='1' (DbType = Int16)
+@ef_filter__Tenant1='1'
 
 SELECT [d].[Id], [d].[Tenant], [d2].[Id], [d2].[DeDupeFilter1Id], [d2].[TenantX], [d3].[Id], [d3].[DeDupeFilter1Id], [d3].[Tenant]
 FROM [DeDupeFilter1] AS [d]
 LEFT JOIN (
     SELECT [d0].[Id], [d0].[DeDupeFilter1Id], [d0].[TenantX]
     FROM [DeDupeFilter2] AS [d0]
-    WHERE [d0].[TenantX] = @__ef_filter__Tenant_0
+    WHERE [d0].[TenantX] = @ef_filter__Tenant
 ) AS [d2] ON [d].[Id] = [d2].[DeDupeFilter1Id]
 LEFT JOIN (
     SELECT [d1].[Id], [d1].[DeDupeFilter1Id], [d1].[Tenant]
     FROM [DeDupeFilter3] AS [d1]
-    WHERE [d1].[Tenant] = @__ef_filter__Tenant_0_1
+    WHERE [d1].[Tenant] = @ef_filter__Tenant0
 ) AS [d3] ON [d].[Id] = [d3].[DeDupeFilter1Id]
-WHERE [d].[Tenant] = @__ef_filter__Tenant_0
+WHERE [d].[Tenant] = @ef_filter__Tenant1
 ORDER BY [d].[Id], [d2].[Id]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -153,9 +153,9 @@ GROUP BY [p].[Group]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STContains(@__point_0) AS [Contains]
+SELECT [p].[Id], [p].[Polygon].STContains(@point) AS [Contains]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -246,9 +246,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STDifference(@__polygon_0) AS [Difference]
+SELECT [p].[Id], [p].[Polygon].STDifference(@polygon) AS [Difference]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -270,9 +270,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@point) AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -283,11 +283,11 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
     WHEN [p].[Polygon] IS NULL THEN NULL
-    ELSE [p].[Polygon].STDisjoint(@__point_0)
+    ELSE [p].[Polygon].STDisjoint(@point)
 END AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
@@ -299,9 +299,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Point].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -312,9 +312,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Point].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -325,9 +325,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Geometry].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Geometry].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -357,9 +357,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-SELECT [g].[Id], [g].[Location].STDistance(@__point_0) AS [Distance]
+SELECT [g].[Id], [g].[Location].STDistance(@point) AS [Distance]
 FROM [GeoPointEntity] AS [g]
 """);
     }
@@ -370,9 +370,9 @@ FROM [GeoPointEntity] AS [g]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-SELECT [g].[Id], @__point_0.STDistance([g].[Location]) AS [Distance]
+SELECT [g].[Id], @point.STDistance([g].[Location]) AS [Distance]
 FROM [GeoPointEntity] AS [g]
 """);
     }
@@ -406,9 +406,9 @@ FROM [LineStringEntity] AS [l]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
+@point='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STEquals(@__point_0) AS [EqualsTopologically]
+SELECT [p].[Id], [p].[Point].STEquals(@point) AS [EqualsTopologically]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -485,9 +485,9 @@ FROM [LineStringEntity] AS [l]
 
         AssertSql(
             """
-@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
+SELECT [p].[Id], [p].[Polygon].STIntersection(@polygon) AS [Intersection]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -498,9 +498,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__lineString_0='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Object)
+@lineString='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-SELECT [l].[Id], [l].[LineString].STIntersects(@__lineString_0) AS [Intersects]
+SELECT [l].[Id], [l].[LineString].STIntersects(@lineString) AS [Intersects]
 FROM [LineStringEntity] AS [l]
 """);
     }
@@ -563,10 +563,10 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+@point='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
-    WHEN [p].[Point].STDistance(@__point_0) <= 1.0E0 THEN CAST(1 AS bit)
+    WHEN [p].[Point].STDistance(@point) <= 1.0E0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsWithinDistance]
 FROM [PointEntity] AS [p]
@@ -672,9 +672,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
+SELECT [p].[Id], [p].[Polygon].STOverlaps(@polygon) AS [Overlaps]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -730,9 +730,9 @@ FROM [LineStringEntity] AS [l]
 
         AssertSql(
             """
-@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
+SELECT [p].[Id], [p].[Polygon].STSymDifference(@polygon) AS [SymmetricDifference]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -769,9 +769,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STUnion(@__polygon_0) AS [Union]
+SELECT [p].[Id], [p].[Polygon].STUnion(@polygon) AS [Union]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -799,9 +799,9 @@ GROUP BY [p].[Group]
 
         AssertSql(
             """
-@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
+@polygon='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STWithin(@__polygon_0) AS [Within]
+SELECT [p].[Id], [p].[Point].STWithin(@polygon) AS [Within]
 FROM [PointEntity] AS [p]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -171,9 +171,9 @@ GROUP BY [p].[Group]
 
         AssertSql(
             """
-@__point_0='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STContains(@__point_0) AS [Contains]
+SELECT [p].[Id], [p].[Polygon].STContains(@point) AS [Contains]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -238,9 +238,9 @@ FROM [LineStringEntity] AS [l]
 
         AssertSql(
             """
-@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
+@lineString='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-SELECT [l].[Id], [l].[LineString].STCrosses(@__lineString_0) AS [Crosses]
+SELECT [l].[Id], [l].[LineString].STCrosses(@lineString) AS [Crosses]
 FROM [LineStringEntity] AS [l]
 """);
     }
@@ -273,9 +273,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STDifference(@__polygon_0) AS [Difference]
+SELECT [p].[Id], [p].[Polygon].STDifference(@polygon) AS [Difference]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -286,9 +286,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+@point='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-SELECT [g].[Id], [g].[Location].STDistance(@__point_0) AS [Distance]
+SELECT [g].[Id], [g].[Location].STDistance(@point) AS [Distance]
 FROM [GeoPointEntity] AS [g]
 """);
     }
@@ -299,9 +299,9 @@ FROM [GeoPointEntity] AS [g]
 
         AssertSql(
             """
-@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+@point='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-SELECT [g].[Id], @__point_0.STDistance([g].[Location]) AS [Distance]
+SELECT [g].[Id], @point.STDistance([g].[Location]) AS [Distance]
 FROM [GeoPointEntity] AS [g]
 """);
     }
@@ -389,9 +389,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@point) AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -402,11 +402,11 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
     WHEN [p].[Polygon] IS NULL THEN NULL
-    ELSE [p].[Polygon].STDisjoint(@__point_0)
+    ELSE [p].[Polygon].STDisjoint(@point)
 END AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
@@ -418,9 +418,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Point].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -431,9 +431,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Point].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -444,9 +444,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Geometry].STDistance(@__point_0) AS [Distance]
+SELECT [p].[Id], [p].[Geometry].STDistance(@point) AS [Distance]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -479,9 +479,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
+@point='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STEquals(@__point_0) AS [EqualsTopologically]
+SELECT [p].[Id], [p].[Point].STEquals(@point) AS [EqualsTopologically]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -565,9 +565,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
+SELECT [p].[Id], [p].[Polygon].STIntersection(@polygon) AS [Intersection]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -578,9 +578,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
+@lineString='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-SELECT [l].[Id], [l].[LineString].STIntersects(@__lineString_0) AS [Intersects]
+SELECT [l].[Id], [l].[LineString].STIntersects(@lineString) AS [Intersects]
 FROM [LineStringEntity] AS [l]
 """);
     }
@@ -657,10 +657,10 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+@point='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
-    WHEN [p].[Point].STDistance(@__point_0) <= 1.0E0 THEN CAST(1 AS bit)
+    WHEN [p].[Point].STDistance(@point) <= 1.0E0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsWithinDistance]
 FROM [PointEntity] AS [p]
@@ -765,9 +765,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
+SELECT [p].[Id], [p].[Polygon].STOverlaps(@polygon) AS [Overlaps]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -789,9 +789,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STRelate(@__polygon_0, N'212111212') AS [Relate]
+SELECT [p].[Id], [p].[Polygon].STRelate(@polygon, N'212111212') AS [Relate]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -839,9 +839,9 @@ FROM [LineStringEntity] AS [l]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
+SELECT [p].[Id], [p].[Polygon].STSymDifference(@polygon) AS [SymmetricDifference]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -874,9 +874,9 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STTouches(@__polygon_0) AS [Touches]
+SELECT [p].[Id], [p].[Polygon].STTouches(@polygon) AS [Touches]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -887,9 +887,9 @@ FROM [PolygonEntity] AS [p]
 
         AssertSql(
             """
-@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+@polygon='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-SELECT [p].[Id], [p].[Polygon].STUnion(@__polygon_0) AS [Union]
+SELECT [p].[Id], [p].[Polygon].STUnion(@polygon) AS [Union]
 FROM [PolygonEntity] AS [p]
 """);
     }
@@ -917,9 +917,9 @@ GROUP BY [p].[Group]
 
         AssertSql(
             """
-@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
+@polygon='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
-SELECT [p].[Id], [p].[Point].STWithin(@__polygon_0) AS [Within]
+SELECT [p].[Id], [p].[Point].STWithin(@polygon) AS [Within]
 FROM [PointEntity] AS [p]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SqlQuerySqlServerTest.cs
@@ -363,13 +363,13 @@ SELECT * FROM "Employees" WHERE "ReportsTo" = @p0 OR ("ReportsTo" IS NULL AND @p
         AssertSql(
             """
 p0='London' (Size = 4000)
-@__contactTitle_1='Sales Representative' (Size = 30)
+@contactTitle='Sales Representative' (Size = 30)
 
 SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
 ) AS [m]
-WHERE [m].[ContactTitle] = @__contactTitle_1
+WHERE [m].[ContactTitle] = @contactTitle
 """);
 
         return null;
@@ -514,9 +514,9 @@ SELECT * FROM "Customers" WHERE "City" = @p0 AND "ContactTitle" = @title
             //
             """
 @city='London' (Nullable = false) (Size = 6)
-p1='Sales Representative' (Size = 4000)
+p0='Sales Representative' (Size = 4000)
 
-SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
+SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p0
 """);
     }
 
@@ -577,14 +577,14 @@ FROM (
 """,
             //
             """
-@__max_1='10400'
+@max='10400'
 p0='10300'
 
 SELECT [m].[OrderID]
 FROM (
     SELECT * FROM "Orders"
 ) AS [m]
-WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
+WHERE [m].[OrderID] <= @max AND [m].[OrderID] IN (
     SELECT [m0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
@@ -593,14 +593,14 @@ WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
 """,
             //
             """
-@__max_1='10400'
+@max='10400'
 p0='10300'
 
 SELECT [m].[OrderID]
 FROM (
     SELECT * FROM "Orders"
 ) AS [m]
-WHERE [m].[OrderID] <= @__max_1 AND [m].[OrderID] IN (
+WHERE [m].[OrderID] <= @max AND [m].[OrderID] IN (
     SELECT [m0].[OrderID]
     FROM (
         SELECT * FROM "Orders" WHERE "OrderID" >= @p0
@@ -740,7 +740,7 @@ WHERE [m].[CustomerID] IN (
             //
             """
 @city='London' (Nullable = false) (Size = 6)
-p1='Sales Representative' (Size = 4000)
+p0='Sales Representative' (Size = 4000)
 
 SELECT [m].[CustomerID], [m].[EmployeeID], [m].[Freight], [m].[OrderDate], [m].[OrderID], [m].[RequiredDate], [m].[ShipAddress], [m].[ShipCity], [m].[ShipCountry], [m].[ShipName], [m].[ShipPostalCode], [m].[ShipRegion], [m].[ShipVia], [m].[ShippedDate]
 FROM (
@@ -749,19 +749,20 @@ FROM (
 WHERE [m].[CustomerID] IN (
     SELECT [m0].[CustomerID]
     FROM (
-        SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p1
+        SELECT * FROM "Customers" WHERE "City" = @city AND "ContactTitle" = @p0
     ) AS [m0]
 )
 """);
     }
 
-    public override async Task Multiple_occurrences_of_SqlQuery_with_db_parameter_adds_parameter_only_once(bool async)
+    public override async Task Multiple_occurrences_of_SqlQuery_with_db_parameter_adds_two_parameters(bool async)
     {
-        await base.Multiple_occurrences_of_SqlQuery_with_db_parameter_adds_parameter_only_once(async);
+        await base.Multiple_occurrences_of_SqlQuery_with_db_parameter_adds_two_parameters(async);
 
         AssertSql(
             """
 city='Seattle' (Nullable = false) (Size = 7)
+city0='Seattle' (Nullable = false) (Size = 3)
 
 SELECT [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[CustomerID], [m].[Fax], [m].[Phone], [m].[Region], [m].[PostalCode]
 FROM (
@@ -770,7 +771,7 @@ FROM (
 INTERSECT
 SELECT [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[CustomerID], [m0].[Fax], [m0].[Phone], [m0].[Region], [m0].[PostalCode]
 FROM (
-    SELECT * FROM "Customers" WHERE "City" = @city
+    SELECT * FROM "Customers" WHERE "City" = @city0
 ) AS [m0]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
@@ -206,11 +206,11 @@ FROM [Eagle] AS [e]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group]
 FROM [Eagle] AS [e]
-WHERE [e].[Id] = @__p_0
+WHERE [e].[Id] = @p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -313,7 +313,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
@@ -326,7 +326,7 @@ FROM (
 LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -342,7 +342,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM (
@@ -356,7 +356,7 @@ INNER JOIN [Cities] AS [c] ON [u].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -372,7 +372,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -385,7 +385,7 @@ FROM (
 LEFT JOIN [Tags] AS [t] ON [u].[Nickname] = [t].[GearNickName] AND [u].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -565,11 +565,11 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """);
     }
 
@@ -579,11 +579,11 @@ WHERE [w].[AmmunitionType] = @__ammunitionType_0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -695,11 +695,11 @@ WHERE [w].[AmmunitionType] & NULL > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """);
     }
 
@@ -709,11 +709,11 @@ WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """,
             //
             """
@@ -1026,7 +1026,7 @@ WHERE [u].[Rank] & (
 
         AssertSql(
             """
-@__parameter_0='2'
+@parameter='2'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -1036,7 +1036,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [u].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -1046,7 +1046,7 @@ WHERE [u].[Rank] & @__parameter_0 = @__parameter_0
 
         AssertSql(
             """
-@__parameter_0='2' (Nullable = true)
+@parameter='2' (Nullable = true)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -1056,7 +1056,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [u].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -1149,14 +1149,14 @@ FROM [LocustHordes] AS [l]
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] = @__ammunitionType_0 AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [w].[AmmunitionType] = @ammunitionType AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -1175,9 +1175,9 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -1187,9 +1187,9 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__ammunitionType_0='2' (Nullable = true)
+@ammunitionType='2' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -2880,11 +2880,11 @@ WHERE 'Unknown' = [c].[Location]
 
         AssertSql(
             """
-@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
+@value='Unknown' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Location] = @__value_0
+WHERE [c].[Location] = @value
 """);
     }
 
@@ -2894,13 +2894,13 @@ WHERE [c].[Location] = @__value_0
 
         AssertSql(
             """
-@__cities_0='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
+@cities='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] varchar(100) '$') AS [c0]
 )
 """);
     }
@@ -3798,11 +3798,11 @@ WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)
 
         AssertSql(
             """
-@__Date_0='0001-01-01T00:00:00.0000000'
+@Date='0001-01-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) > @__Date_0
+WHERE CONVERT(date, [m].[Timeline]) > @Date
 """);
     }
 
@@ -4134,13 +4134,13 @@ END
 
         AssertSql(
             """
-@__ids_0='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
+@ids='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -4382,11 +4382,11 @@ ORDER BY [u].[FullName]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
+    SELECT TOP(@p) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
@@ -4407,7 +4407,7 @@ ORDER BY [u0].[Rank]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [u0].[FullName]
 FROM (
@@ -4421,7 +4421,7 @@ FROM (
     ) AS [u]
     WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [u].[FullName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [u0]
 ORDER BY [u0].[Rank]
 """);
@@ -4433,11 +4433,11 @@ ORDER BY [u0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
+    SELECT TOP(@p) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
@@ -4457,11 +4457,11 @@ ORDER BY [u0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
+    SELECT TOP(@p) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
@@ -4481,11 +4481,11 @@ ORDER BY [u0].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [u0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [u].[FullName], [u].[Rank]
+    SELECT TOP(@p) [u].[FullName], [u].[Rank]
     FROM (
         SELECT [g].[FullName], [g].[HasSoulPatch], [g].[Rank]
         FROM [Gears] AS [g]
@@ -4787,7 +4787,7 @@ ORDER BY [u].[Nickname], [u0].[Nickname]
 
         AssertSql(
             """
-@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
+@cities_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -4800,7 +4800,7 @@ FROM (
 LEFT JOIN [Cities] AS [c] ON [u].[AssignedCityName] = [c].[Name]
 WHERE [u].[SquadId] < 2 AND ([c].[Name] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+    FROM OPENJSON(@cities_without_nulls) AS [c0]
 ) OR [c].[Name] IS NULL)
 """);
     }
@@ -6857,11 +6857,11 @@ WHERE [l2].[Eradicated] = CAST(0 AS bit) OR [l2].[Eradicated] IS NULL
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Name], [s].[LocustHordeId], [s].[ThreatLevel], [s].[ThreatLevelByte], [s].[ThreatLevelNullableByte], [s].[DefeatedByNickname], [s].[DefeatedBySquadId], [s].[HighCommandId], [s].[Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator0] AS [Discriminator], [s].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator] AS [Discriminator0], [t].[Id], [t].[Note]
+    SELECT TOP(@p) [u].[Name], [u].[LocustHordeId], [u].[ThreatLevel], [u].[ThreatLevelByte], [u].[ThreatLevelNullableByte], [u].[DefeatedByNickname], [u].[DefeatedBySquadId], [u].[HighCommandId], [u].[Discriminator], [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator] AS [Discriminator0], [t].[Id], [t].[Note]
     FROM (
         SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], NULL AS [DefeatedByNickname], NULL AS [DefeatedBySquadId], NULL AS [HighCommandId], N'LocustLeader' AS [Discriminator]
         FROM [LocustLeaders] AS [l]
@@ -8110,7 +8110,7 @@ ORDER BY [c].[Name], [u].[Nickname] DESC
 
         AssertSql(
             """
-@__nicknames_0='[]' (Size = 4000)
+@nicknames='[]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [w].[Name], [w].[Id]
 FROM (
@@ -8124,7 +8124,7 @@ LEFT JOIN [Weapons] AS [w] ON [u].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN [u].[Nickname] IN (
         SELECT [n].[value]
-        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        FROM OPENJSON(@nicknames) WITH ([value] nvarchar(450) '$') AS [n]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [u].[Nickname], [u].[SquadId]
@@ -8936,11 +8936,11 @@ ORDER BY (
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [u].[FullName]
+    SELECT TOP(@p) [u].[FullName]
     FROM (
         SELECT [g].[FullName]
         FROM [Gears] AS [g]
@@ -8987,15 +8987,15 @@ WHERE (
 
         AssertSql(
             """
-@__start_0='1902-01-01T10:00:00.1234567+01:30'
-@__end_1='1902-01-03T10:00:00.1234567+01:30'
-@__dates_2='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
+@start='1902-01-01T10:00:00.1234567+01:30'
+@end='1902-01-03T10:00:00.1234567+01:30'
+@dates='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
+WHERE @start <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @end AND [m].[Timeline] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -9155,7 +9155,7 @@ ORDER BY [t].[Id], [u].[Nickname]
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -9171,7 +9171,7 @@ FROM (
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] = @__isAutomatic_0
+    WHERE [w].[IsAutomatic] = @isAutomatic
 ) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -9474,7 +9474,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__prm_Inner_Nickname_0='Marcus' (Size = 450)
+@prm_Inner_Nickname='Marcus' (Size = 450)
 
 SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
 FROM (
@@ -9486,7 +9486,7 @@ FROM (
         SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
         FROM [Officers] AS [o]
     ) AS [u]
-    WHERE [u].[Nickname] <> @__prm_Inner_Nickname_0
+    WHERE [u].[Nickname] <> @prm_Inner_Nickname
 ) AS [u0]
 ORDER BY [u0].[FullName]
 """);
@@ -9498,7 +9498,7 @@ ORDER BY [u0].[FullName]
 
         AssertSql(
             """
-@__squadId_0='1'
+@squadId='1'
 
 SELECT [u1].[Nickname], [u1].[SquadId], [u1].[AssignedCityName], [u1].[CityOfBirthName], [u1].[FullName], [u1].[HasSoulPatch], [u1].[LeaderNickname], [u1].[LeaderSquadId], [u1].[Rank], [u1].[Discriminator]
 FROM (
@@ -9514,7 +9514,7 @@ FROM (
     WHERE [s].[Id] IN (
         SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0
+        WHERE [s0].[Id] = @squadId
     )
     UNION ALL
     SELECT [u0].[Nickname], [u0].[SquadId], [u0].[AssignedCityName], [u0].[CityOfBirthName], [u0].[FullName], [u0].[HasSoulPatch], [u0].[LeaderNickname], [u0].[LeaderSquadId], [u0].[Rank], [u0].[Discriminator]
@@ -9529,7 +9529,7 @@ FROM (
     WHERE [s1].[Id] IN (
         SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0
+        WHERE [s2].[Id] = @squadId
     )
 ) AS [u1]
 ORDER BY [u1].[FullName]
@@ -9542,7 +9542,7 @@ ORDER BY [u1].[FullName]
 
         AssertSql(
             """
-@__gearId_0='1'
+@gearId='1'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
@@ -9555,7 +9555,7 @@ WHERE EXISTS (
         SELECT [o].[SquadId]
         FROM [Officers] AS [o]
     ) AS [u]
-    WHERE [s].[Id] = [u].[SquadId] AND [u].[SquadId] = @__gearId_0 AND [u].[SquadId] = @__gearId_0)
+    WHERE [s].[Id] = [u].[SquadId] AND [u].[SquadId] = @gearId AND [u].[SquadId] = @gearId)
 """);
     }
 
@@ -9565,7 +9565,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__entity_equality_prm_Inner_Squad_0_Id='1' (Nullable = true)
+@entity_equality_prm_Inner_Squad_Id='1' (Nullable = true)
 
 SELECT [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank], [s1].[Discriminator]
 FROM (
@@ -9578,10 +9578,10 @@ FROM (
         FROM [Officers] AS [o]
     ) AS [u]
     INNER JOIN [Squads] AS [s] ON [u].[SquadId] = [s].[Id]
-    WHERE [s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+    WHERE [s].[Id] = @entity_equality_prm_Inner_Squad_Id
 ) AS [s1]
 INNER JOIN [Squads] AS [s0] ON [s1].[SquadId] = [s0].[Id]
-WHERE [s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+WHERE [s0].[Id] = @entity_equality_prm_Inner_Squad_Id
 ORDER BY [s1].[FullName]
 """);
     }
@@ -9808,9 +9808,9 @@ FROM (
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
-SELECT @__p_0
+SELECT @p
 FROM (
     SELECT 1 AS empty
     FROM [Gears] AS [g]
@@ -9827,7 +9827,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -9837,7 +9837,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -9865,7 +9865,7 @@ ORDER BY [u].[Nickname]
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -9878,7 +9878,7 @@ FROM (
 ORDER BY CASE
     WHEN [u].[SquadId] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -9891,7 +9891,7 @@ END
 
         AssertSql(
             """
-@__rank_0='1' (Nullable = true)
+@rank='1' (Nullable = true)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -9901,7 +9901,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[Rank] & @__rank_0 = @__rank_0
+WHERE [u].[Rank] & @rank = @rank
 """,
             //
             """
@@ -9916,7 +9916,7 @@ FROM (
 """,
             //
             """
-@__rank_0='2' (Nullable = true)
+@rank='2' (Nullable = true)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -9926,7 +9926,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[Rank] | @__rank_0 <> @__rank_0
+WHERE [u].[Rank] | @rank <> @rank
 """,
             //
             """
@@ -9987,7 +9987,7 @@ WHERE [c].[Name] = (
 
         AssertSql(
             """
-@__ranks_0='134'
+@ranks='134'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -9997,13 +9997,13 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[Rank] & @__ranks_0 <> 0
+WHERE [u].[Rank] & @ranks <> 0
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([u].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([u].[Rank] | @ranks) ^ @ranks AS bit)
 FROM (
     SELECT [g].[Rank]
     FROM [Gears] AS [g]
@@ -10014,9 +10014,9 @@ FROM (
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([u].[Rank] | [u].[Rank] | @__ranks_0 | [u].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([u].[Rank] | [u].[Rank] | @ranks | [u].[Rank] | @ranks) ^ @ranks AS bit)
 FROM (
     SELECT [g].[Rank]
     FROM [Gears] AS [g]
@@ -10056,19 +10056,19 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__prm_0='2' (Nullable = true)
+@prm='2' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 <> 0 OR [w].[AmmunitionType] IS NULL
+WHERE [w].[AmmunitionType] & @prm <> 0 OR [w].[AmmunitionType] IS NULL
 """,
             //
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
+WHERE [w].[AmmunitionType] & @prm = @prm
 """);
     }
 
@@ -10078,7 +10078,7 @@ WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10088,11 +10088,11 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[HasSoulPatch] <> @__prm_0
+WHERE [u].[HasSoulPatch] <> @prm
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10102,7 +10102,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE [u].[HasSoulPatch] <> @__prm_0
+WHERE [u].[HasSoulPatch] <> @prm
 """);
     }
 
@@ -10172,11 +10172,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @p
 """);
     }
 
@@ -10186,11 +10186,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 8000)
+@byteArrayParam='0x2A80' (Size = 8000)
 
 SELECT COUNT(*)
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@byteArrayParam) AS int)
 """);
     }
 
@@ -10200,11 +10200,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam)
 
         AssertSql(
             """
-@__someByte_0='1' (Size = 1)
+@someByte='1' (Size = 1)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0
+WHERE CHARINDEX(CAST(@someByte AS varbinary(max)), [s].[Banner]) > 0
 """);
     }
 
@@ -10226,7 +10226,7 @@ WHERE DATALENGTH([s].[Banner5]) = 5
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10237,7 +10237,7 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [u]
 WHERE CASE
-    WHEN [u].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    WHEN [u].[HasSoulPatch] = @prm THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -10249,8 +10249,8 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-@__prm_0='True'
-@__prm2_1='Marcus' Lancer' (Size = 4000)
+@prm='True'
+@prm2='Marcus' Lancer' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10261,10 +10261,10 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [u]
 WHERE CASE
-    WHEN [u].[HasSoulPatch] = @__prm_0 AND (
+    WHEN [u].[HasSoulPatch] = @prm AND (
         SELECT TOP(1) [w].[Name]
         FROM [Weapons] AS [w]
-        WHERE [w].[Id] = [u].[SquadId]) = @__prm2_1 THEN CAST(1 AS bit)
+        WHERE [w].[Id] = [u].[SquadId]) = @prm2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -10289,11 +10289,11 @@ ORDER BY [w0].[IsAutomatic]
 
         AssertSql(
             """
-@__dateTimeOffset_Date_0='0002-03-01T00:00:00.0000000'
+@dateTimeOffset_Date='0002-03-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0
+WHERE CONVERT(date, [m].[Timeline]) >= @dateTimeOffset_Date
 """);
     }
 
@@ -10354,11 +10354,11 @@ FROM (
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE [s].[Banner5] = @__byteArrayParam_0
+WHERE [s].[Banner5] = @byteArrayParam
 """);
     }
 
@@ -10797,11 +10797,11 @@ CROSS APPLY (
 
         AssertSql(
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE @__prm_0 = [w].[AmmunitionType]
+WHERE @prm = [w].[AmmunitionType]
 """);
     }
 
@@ -10811,7 +10811,7 @@ WHERE @__prm_0 = [w].[AmmunitionType]
 
         AssertSql(
             """
-@__prm_0='133'
+@prm='133'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10821,7 +10821,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE @__prm_0 & [u].[Rank] = [u].[Rank]
+WHERE @prm & [u].[Rank] = [u].[Rank]
 """);
     }
 
@@ -10831,7 +10831,7 @@ WHERE @__prm_0 & [u].[Rank] = [u].[Rank]
 
         AssertSql(
             """
-@__prm_0='5'
+@prm='5'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -10841,7 +10841,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE @__prm_0 & CAST([u].[Rank] AS int) = CAST([u].[Rank] AS int)
+WHERE @prm & CAST([u].[Rank] AS int) = CAST([u].[Rank] AS int)
 """);
     }
 
@@ -10851,9 +10851,9 @@ WHERE @__prm_0 & CAST([u].[Rank] AS int) = CAST([u].[Rank] AS int)
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [u].[Rank] & 1
+SELECT TOP(@p) [u].[Rank] & 1
 FROM (
     SELECT [g].[Nickname], [g].[Rank]
     FROM [Gears] AS [g]
@@ -10871,14 +10871,14 @@ ORDER BY [u].[Nickname]
 
         AssertSql(
             """
-@__types_0_without_nulls='[1]' (Size = 4000)
+@types_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
     SELECT [t].[value]
-    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+    FROM OPENJSON(@types_without_nulls) AS [t]
 ) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
@@ -11868,7 +11868,7 @@ WHERE CAST([t].[IssueDate] AS time) = [m].[Time]
 
         AssertSql(
             """
-@__time_0='02:00' (DbType = Time)
+@time='02:00' (DbType = Time)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
@@ -11879,7 +11879,7 @@ LEFT JOIN (
     SELECT [o].[Nickname], [o].[SquadId]
     FROM [Officers] AS [o]
 ) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
-WHERE [u].[Nickname] IS NOT NULL AND [u].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([u].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @__time_0
+WHERE [u].[Nickname] IS NOT NULL AND [u].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([u].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @time
 """);
     }
 
@@ -11913,11 +11913,11 @@ WHERE CAST([m].[Duration] AS time) < [m].[Time]
 
         AssertSql(
             """
-@__time_0='01:02' (DbType = Time)
+@time='01:02' (DbType = Time)
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Duration] AS time) = @__time_0
+WHERE CAST([m].[Duration] AS time) = @time
 """);
     }
 
@@ -11952,11 +11952,11 @@ WHERE CAST([t].[IssueDate] AS date) > [m].[Date]
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
-WHERE CAST([t].[IssueDate] AS date) IN (@__prm_0, '0015-03-07')
+WHERE CAST([t].[IssueDate] AS date) IN (@prm, '0015-03-07')
 """);
     }
 
@@ -12030,8 +12030,8 @@ LEFT JOIN [LocustHighCommands] AS [l2] ON [u].[HighCommandId] = [l2].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator], [s].[HasSoulPatch0], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
@@ -12056,7 +12056,7 @@ FROM (
         GROUP BY [u0].[HasSoulPatch]
     ) AS [u1] ON CAST(LEN([u].[Nickname]) AS int) = [u1].[c]
     ORDER BY [u].[Nickname]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [s]
 LEFT JOIN [Weapons] AS [w] ON [s].[FullName] = [w].[OwnerFullName]
 ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
@@ -12069,7 +12069,7 @@ ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -12081,7 +12081,7 @@ FROM (
 ) AS [u]
 WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -12092,7 +12092,7 @@ WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -12104,7 +12104,7 @@ FROM (
 ) AS [u]
 WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -12115,11 +12115,11 @@ WHERE [u].[HasSoulPatch] = CAST(1 AS bit) AND [u].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__place_0='Ephyra's location' (Size = 4000), @__place_0_1='Ephyra's location' (Size = 100) (DbType = AnsiString)
+@place='Ephyra's location' (Size = 4000), @place0='Ephyra's location' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @place OR [c].[Location] = @place0 OR [c].[Location] = @place
 """);
     }
 
@@ -12129,10 +12129,10 @@ WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Locatio
 
         AssertSql(
             """
-@__p_0='1'
-@__value_1='1'
+@p='1'
+@value='1'
 
-SELECT TOP(@__p_0) [u].[Rank] & @__value_1
+SELECT TOP(@p) [u].[Rank] & @value
 FROM (
     SELECT [g].[Nickname], [g].[Rank]
     FROM [Gears] AS [g]
@@ -12150,7 +12150,7 @@ ORDER BY [u].[Nickname]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -12166,7 +12166,7 @@ FROM (
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[Id] > @__prm_0
+    WHERE [w].[Id] > @prm
 ) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -12280,7 +12280,7 @@ WHERE [w].[AmmunitionType] = 1
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [u].[Nickname], [u].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -12296,7 +12296,7 @@ FROM (
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] <> @__isAutomatic_0
+    WHERE [w].[IsAutomatic] <> @isAutomatic
 ) AS [w0] ON [u].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -13264,7 +13264,7 @@ ORDER BY [u].[Nickname], [u].[SquadId], [u0].[Nickname]
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13275,7 +13275,7 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [u]
 ORDER BY [u].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -13285,7 +13285,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13296,7 +13296,7 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [u]
 ORDER BY [u].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -13306,7 +13306,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13317,7 +13317,7 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [u]
 ORDER BY [u].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -13384,7 +13384,7 @@ FROM [Squads] AS [s]
 
         AssertSql(
             """
-@__unixEpochMilliseconds_0='0'
+@unixEpochMilliseconds='0'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM (
@@ -13400,7 +13400,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochMilliseconds_0 = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochMilliseconds = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -13411,7 +13411,7 @@ ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 
         AssertSql(
             """
-@__unixEpochSeconds_0='0'
+@unixEpochSeconds='0'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s1].[SquadId], [s1].[MissionId]
 FROM (
@@ -13427,7 +13427,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochSeconds_0 = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochSeconds = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [u].[Nickname], [u].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -13493,7 +13493,7 @@ GROUP BY [s].[Name]
 
         AssertSql(
             """
-@__numbers_0='[1,-1]' (Size = 4000)
+@numbers='[1,-1]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13511,7 +13511,7 @@ WHERE CASE
     ELSE 0
 END IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -13522,7 +13522,7 @@ END IN (
 
         AssertSql(
             """
-@__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
+@weapons='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13538,7 +13538,7 @@ WHERE (
     WHERE [u].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]) IN (
     SELECT [w].[value]
-    FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w]
+    FROM OPENJSON(@weapons) WITH ([value] nvarchar(max) '$') AS [w]
 )
 """);
     }
@@ -13549,7 +13549,7 @@ WHERE (
 
         AssertSql(
             """
-@__numbers_0='[0,1,2]' (Size = 4000)
+@numbers='[0,1,2]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
@@ -13567,7 +13567,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= COALESCE((
         SELECT [n].[value]
-        FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+        FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
         ORDER BY [n].[value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]
@@ -13820,9 +13820,9 @@ LEFT JOIN [LocustHighCommands] AS [l1] ON [u].[HighCommandId] = [l1].[Id]
 
         AssertSql(
             """
-@__ranks_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ranks='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -13835,31 +13835,31 @@ FROM (
 WHERE CASE
     WHEN [u].[Rank] IN (
         SELECT [r].[value]
-        FROM OPENJSON(@__ranks_0) WITH ([value] int '$') AS [r]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ranks) WITH ([value] int '$') AS [r]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """,
             //
             """
-@__ammoTypes_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ammoTypes='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 WHERE CASE
     WHEN [w].[AmmunitionType] IN (
         SELECT [a].[value]
-        FROM OPENJSON(@__ammoTypes_0) WITH ([value] int '$') AS [a]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ammoTypes) WITH ([value] int '$') AS [a]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTestBase.cs
@@ -484,11 +484,11 @@ ORDER BY [k].[Name]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [u0].[Id], [u0].[CountryId], [u0].[Name], [u0].[Species], [u0].[EagleId], [u0].[IsFlightless], [u0].[FoundOn], [u0].[Discriminator]
 FROM (
-    SELECT TOP(@__p_0) [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
+    SELECT TOP(@p) [u].[Id], [u].[CountryId], [u].[Name], [u].[Species], [u].[EagleId], [u].[IsFlightless], [u].[FoundOn], [u].[Discriminator]
     FROM (
         SELECT [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], NULL AS [FoundOn], N'Eagle' AS [Discriminator]
         FROM [Eagle] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
@@ -2001,7 +2001,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
@@ -2009,7 +2009,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @__entity_equality_two_0_Id)
+    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @entity_equality_two_Id)
 """);
     }
 
@@ -2727,7 +2727,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [u].[Id], [u].[Name]
 FROM [UnidirectionalEntityOnes] AS [u]
@@ -2735,7 +2735,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @__entity_equality_two_0_Id)
+    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @entity_equality_two_Id)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
@@ -2009,7 +2009,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
@@ -2017,7 +2017,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @__entity_equality_two_0_Id)
+    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @entity_equality_two_Id)
 """);
     }
 
@@ -2751,7 +2751,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [u].[Id], [u].[Name]
 FROM [UnidirectionalEntityOnes] AS [u]
@@ -2759,7 +2759,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @__entity_equality_two_0_Id)
+    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @entity_equality_two_Id)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPHFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPHFiltersInheritanceQuerySqlServerTest.cs
@@ -157,11 +157,11 @@ WHERE [a].[Discriminator] = N'Eagle'
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group]
 FROM [Animals] AS [a]
-WHERE [a].[Discriminator] = N'Eagle' AND [a].[Id] = @__p_0
+WHERE [a].[Discriminator] = N'Eagle' AND [a].[Id] = @p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPHInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPHInheritanceQuerySqlServerTest.cs
@@ -483,11 +483,11 @@ WHERE ([t].[FoundOn] = CAST(0 AS tinyint)) AND [t].[FoundOn] IS NOT NULL
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[FoundOn]
 FROM (
-    SELECT TOP(@__p_0) [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
+    SELECT TOP(@p) [a].[Id], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
     FROM [Animals] AS [a]
     ORDER BY [a].[Species]
 ) AS [a0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
@@ -205,13 +205,13 @@ INNER JOIN [Eagle] AS [e] ON [a].[Id] = [e].[Id]
 """,
             //
             """
-@__p_0='1'
+@p='1'
 
 SELECT TOP(1) [a].[Id], [a].[CountryId], [a].[Name], [a].[Species], [b].[EagleId], [b].[IsFlightless], [e].[Group]
 FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Eagle] AS [e] ON [a].[Id] = [e].[Id]
-WHERE [a].[Id] = @__p_0
+WHERE [a].[Id] = @p
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -297,7 +297,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -307,7 +307,7 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -323,7 +323,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -334,7 +334,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -350,7 +350,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
+@tags='["34c8d86e-a4ac-4be5-827f-584dda348a07","df36f493-463f-4123-83f9-6b135deeb7ba","a8ad98f9-e023-4e2a-9a70-c2728455bd34","70534e05-782c-4052-8720-c2c54481ce5f","a7be028a-0cf2-448f-ab55-ce8bc5d8cf69","b39a6fba-9026-4d69-828e-fd7068673e57"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -360,7 +360,7 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -547,11 +547,11 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """);
     }
 
@@ -561,11 +561,11 @@ WHERE [w].[AmmunitionType] = @__ammunitionType_0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -662,11 +662,11 @@ WHERE [w].[AmmunitionType] & NULL > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """);
     }
 
@@ -676,11 +676,11 @@ WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """,
             //
             """
@@ -876,14 +876,14 @@ WHERE [g].[Rank] & (
 
         AssertSql(
             """
-@__parameter_0='2'
+@parameter='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -893,14 +893,14 @@ WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
 
         AssertSql(
             """
-@__parameter_0='2' (Nullable = true)
+@parameter='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -982,14 +982,14 @@ INNER JOIN [LocustHordes] AS [l] ON [f].[Id] = [l].[Id]
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] = @__ammunitionType_0 AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [w].[AmmunitionType] = @ammunitionType AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -1008,9 +1008,9 @@ WHERE [w].[AmmunitionType] IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -1020,9 +1020,9 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__ammunitionType_0='2' (Nullable = true)
+@ammunitionType='2' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] AS [w]
 """,
             //
@@ -2402,11 +2402,11 @@ WHERE 'Unknown' = [c].[Location]
 
         AssertSql(
             """
-@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
+@value='Unknown' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Location] = @__value_0
+WHERE [c].[Location] = @value
 """);
     }
 
@@ -2416,13 +2416,13 @@ WHERE [c].[Location] = @__value_0
 
         AssertSql(
             """
-@__cities_0='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
+@cities='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] varchar(100) '$') AS [c0]
 )
 """);
     }
@@ -3203,11 +3203,11 @@ WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)
 
         AssertSql(
             """
-@__Date_0='0001-01-01T00:00:00.0000000'
+@Date='0001-01-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) > @__Date_0
+WHERE CONVERT(date, [m].[Timeline]) > @Date
 """);
     }
 
@@ -3503,13 +3503,13 @@ END
 
         AssertSql(
             """
-@__ids_0='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
+@ids='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -3685,11 +3685,11 @@ ORDER BY [g].[FullName]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
@@ -3704,7 +3704,7 @@ ORDER BY [s].[Rank]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [s].[FullName]
 FROM (
@@ -3712,7 +3712,7 @@ FROM (
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [s]
 ORDER BY [s].[Rank]
 """);
@@ -3724,11 +3724,11 @@ ORDER BY [s].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [s].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [s]
@@ -3742,11 +3742,11 @@ ORDER BY [s].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [s].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [s]
@@ -3760,11 +3760,11 @@ ORDER BY [s].[Rank]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [s].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [s]
@@ -4088,7 +4088,7 @@ ORDER BY [g].[Nickname], [s].[Nickname]
 
         AssertSql(
             """
-@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
+@cities_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -4098,7 +4098,7 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND ([c].[Name] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+    FROM OPENJSON(@cities_without_nulls) AS [c0]
 ) OR [c].[Name] IS NULL)
 """);
     }
@@ -5796,11 +5796,11 @@ WHERE [s].[Eradicated] = CAST(0 AS bit) OR [s].[Eradicated] IS NULL
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s0].[Name], [s0].[LocustHordeId], [s0].[ThreatLevel], [s0].[ThreatLevelByte], [s0].[ThreatLevelNullableByte], [s0].[DefeatedByNickname], [s0].[DefeatedBySquadId], [s0].[HighCommandId], [s0].[Discriminator], [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator0] AS [Discriminator], [s0].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], CASE
+    SELECT TOP(@p) [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], CASE
         WHEN [l0].[Name] IS NOT NULL THEN N'LocustCommander'
     END AS [Discriminator], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator] AS [Discriminator0], [t].[Id], [t].[Note]
     FROM [LocustLeaders] AS [l]
@@ -6795,7 +6795,7 @@ ORDER BY [c].[Name], [s].[Nickname] DESC
 
         AssertSql(
             """
-@__nicknames_0='[]' (Size = 4000)
+@nicknames='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] AS [g]
@@ -6803,7 +6803,7 @@ LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN [g].[Nickname] IN (
         SELECT [n].[value]
-        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        FROM OPENJSON(@nicknames) WITH ([value] nvarchar(450) '$') AS [n]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
@@ -7353,19 +7353,19 @@ WHERE [t].[Id] = 'df36f493-463f-4123-83f9-6b135deeb7ba'
 
         AssertSql(
             """
-@__p_0='df36f493-463f-4123-83f9-6b135deeb7bd'
+@p='df36f493-463f-4123-83f9-6b135deeb7bd'
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
 FROM [Tags] AS [t]
-WHERE [t].[Id] = @__p_0
+WHERE [t].[Id] = @p
 """,
             //
             """
-@__p_0='b39a6fba-9026-4d69-828e-fd7068673e57'
+@p='b39a6fba-9026-4d69-828e-fd7068673e57'
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
 FROM [Tags] AS [t]
-WHERE [t].[Id] = @__p_0
+WHERE [t].[Id] = @p
 """);
     }
 
@@ -7542,11 +7542,11 @@ ORDER BY (
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName]
+    SELECT TOP(@p) [g].[FullName]
     FROM [Gears] AS [g]
 ) AS [s]
 LEFT JOIN (
@@ -7581,15 +7581,15 @@ WHERE (
 
         AssertSql(
             """
-@__start_0='1902-01-01T10:00:00.1234567+01:30'
-@__end_1='1902-01-03T10:00:00.1234567+01:30'
-@__dates_2='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
+@start='1902-01-01T10:00:00.1234567+01:30'
+@end='1902-01-03T10:00:00.1234567+01:30'
+@dates='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
+WHERE @start <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @end AND [m].[Timeline] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -7740,7 +7740,7 @@ ORDER BY [t].[Id], [s].[Nickname]
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -7750,7 +7750,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] = @__isAutomatic_0
+    WHERE [w].[IsAutomatic] = @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -8083,7 +8083,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__prm_Inner_Nickname_0='Marcus' (Size = 450)
+@prm_Inner_Nickname='Marcus' (Size = 450)
 
 SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[Rank], [s].[Discriminator]
 FROM (
@@ -8092,7 +8092,7 @@ FROM (
     END AS [Discriminator]
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-    WHERE [g].[Nickname] <> @__prm_Inner_Nickname_0
+    WHERE [g].[Nickname] <> @prm_Inner_Nickname
 ) AS [s]
 ORDER BY [s].[FullName]
 """);
@@ -8104,7 +8104,7 @@ ORDER BY [s].[FullName]
 
         AssertSql(
             """
-@__squadId_0='1'
+@squadId='1'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[Rank], [u].[Discriminator]
 FROM (
@@ -8117,7 +8117,7 @@ FROM (
     WHERE [s].[Id] IN (
         SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0
+        WHERE [s0].[Id] = @squadId
     )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
@@ -8129,7 +8129,7 @@ FROM (
     WHERE [s1].[Id] IN (
         SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0
+        WHERE [s2].[Id] = @squadId
     )
 ) AS [u]
 ORDER BY [u].[FullName]
@@ -8142,14 +8142,14 @@ ORDER BY [u].[FullName]
 
         AssertSql(
             """
-@__gearId_0='1'
+@gearId='1'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE EXISTS (
     SELECT 1
     FROM [Gears] AS [g]
-    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @__gearId_0 AND [g].[SquadId] = @__gearId_0)
+    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @gearId AND [g].[SquadId] = @gearId)
 """);
     }
 
@@ -8159,7 +8159,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__entity_equality_prm_Inner_Squad_0_Id='1' (Nullable = true)
+@entity_equality_prm_Inner_Squad_Id='1' (Nullable = true)
 
 SELECT [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[Rank], [s1].[Discriminator]
 FROM (
@@ -8169,10 +8169,10 @@ FROM (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
     INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE [s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+    WHERE [s].[Id] = @entity_equality_prm_Inner_Squad_Id
 ) AS [s1]
 INNER JOIN [Squads] AS [s0] ON [s1].[SquadId] = [s0].[Id]
-WHERE [s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+WHERE [s0].[Id] = @entity_equality_prm_Inner_Squad_Id
 ORDER BY [s1].[FullName]
 """);
     }
@@ -8336,9 +8336,9 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
-SELECT @__p_0
+SELECT @p
 FROM [Gears] AS [g]
 """);
     }
@@ -8349,14 +8349,14 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -8381,7 +8381,7 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -8391,7 +8391,7 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -8404,14 +8404,14 @@ END
 
         AssertSql(
             """
-@__rank_0='1' (Nullable = true)
+@rank='1' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[Rank] & @__rank_0 = @__rank_0
+WHERE [g].[Rank] & @rank = @rank
 """,
             //
             """
@@ -8423,14 +8423,14 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 """,
             //
             """
-@__rank_0='2' (Nullable = true)
+@rank='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[Rank] | @__rank_0 <> @__rank_0
+WHERE [g].[Rank] | @rank <> @rank
 """,
             //
             """
@@ -8473,27 +8473,27 @@ WHERE [c].[Name] = (
 
         AssertSql(
             """
-@__ranks_0='134'
+@ranks='134'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[Rank] & @__ranks_0 <> 0
+WHERE [g].[Rank] & @ranks <> 0
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] AS [g]
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | [g].[Rank] | @__ranks_0 | [g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | [g].[Rank] | @ranks | [g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] AS [g]
 """);
     }
@@ -8527,19 +8527,19 @@ FROM [Weapons] AS [w]
 """,
             //
             """
-@__prm_0='2' (Nullable = true)
+@prm='2' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 <> 0 OR [w].[AmmunitionType] IS NULL
+WHERE [w].[AmmunitionType] & @prm <> 0 OR [w].[AmmunitionType] IS NULL
 """,
             //
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
+WHERE [w].[AmmunitionType] & @prm = @prm
 """);
     }
 
@@ -8549,25 +8549,25 @@ WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """);
     }
 
@@ -8638,11 +8638,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @p
 """);
     }
 
@@ -8652,11 +8652,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 8000)
+@byteArrayParam='0x2A80' (Size = 8000)
 
 SELECT COUNT(*)
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@byteArrayParam) AS int)
 """);
     }
 
@@ -8666,11 +8666,11 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam)
 
         AssertSql(
             """
-@__someByte_0='1' (Size = 1)
+@someByte='1' (Size = 1)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0
+WHERE CHARINDEX(CAST(@someByte AS varbinary(max)), [s].[Banner]) > 0
 """);
     }
 
@@ -8692,7 +8692,7 @@ WHERE DATALENGTH([s].[Banner5]) = 5
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -8700,7 +8700,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    WHEN [g].[HasSoulPatch] = @prm THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -8712,8 +8712,8 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-@__prm_0='True'
-@__prm2_1='Marcus' Lancer' (Size = 4000)
+@prm='True'
+@prm2='Marcus' Lancer' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -8721,10 +8721,10 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 AND (
+    WHEN [g].[HasSoulPatch] = @prm AND (
         SELECT TOP(1) [w].[Name]
         FROM [Weapons] AS [w]
-        WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1 THEN CAST(1 AS bit)
+        WHERE [w].[Id] = [g].[SquadId]) = @prm2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -8749,11 +8749,11 @@ ORDER BY [w0].[IsAutomatic]
 
         AssertSql(
             """
-@__dateTimeOffset_Date_0='0002-03-01T00:00:00.0000000'
+@dateTimeOffset_Date='0002-03-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0
+WHERE CONVERT(date, [m].[Timeline]) >= @dateTimeOffset_Date
 """);
     }
 
@@ -8796,11 +8796,11 @@ FROM [Gears] AS [g]
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE [s].[Banner5] = @__byteArrayParam_0
+WHERE [s].[Banner5] = @byteArrayParam
 """);
     }
 
@@ -9146,11 +9146,11 @@ CROSS APPLY (
 
         AssertSql(
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE @__prm_0 = [w].[AmmunitionType]
+WHERE @prm = [w].[AmmunitionType]
 """);
     }
 
@@ -9160,14 +9160,14 @@ WHERE @__prm_0 = [w].[AmmunitionType]
 
         AssertSql(
             """
-@__prm_0='133'
+@prm='133'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 
@@ -9177,14 +9177,14 @@ WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
 
         AssertSql(
             """
-@__prm_0='5'
+@prm='5'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE @__prm_0 & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
 """);
     }
 
@@ -9194,9 +9194,9 @@ WHERE @__prm_0 & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & 1
+SELECT TOP(@p) [g].[Rank] & 1
 FROM [Gears] AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -9208,14 +9208,14 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__types_0_without_nulls='[1]' (Size = 4000)
+@types_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
     SELECT [t].[value]
-    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+    FROM OPENJSON(@types_without_nulls) AS [t]
 ) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
@@ -10084,7 +10084,7 @@ WHERE CAST([t].[IssueDate] AS time) = [m].[Time]
 
         AssertSql(
             """
-@__time_0='02:00' (DbType = Time)
+@time='02:00' (DbType = Time)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
@@ -10092,7 +10092,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [s] ON [t].[GearNickName] = [s].[Nickname] AND [t].[GearSquadId] = [s].[SquadId]
-WHERE [s].[Nickname] IS NOT NULL AND [s].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([s].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @__time_0
+WHERE [s].[Nickname] IS NOT NULL AND [s].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([s].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @time
 """);
     }
 
@@ -10126,11 +10126,11 @@ WHERE CAST([m].[Duration] AS time) < [m].[Time]
 
         AssertSql(
             """
-@__time_0='01:02' (DbType = Time)
+@time='01:02' (DbType = Time)
 
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Duration] AS time) = @__time_0
+WHERE CAST([m].[Duration] AS time) = @time
 """);
     }
 
@@ -10165,11 +10165,11 @@ WHERE CAST([t].[IssueDate] AS date) > [m].[Date]
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
-WHERE CAST([t].[IssueDate] AS date) IN (@__prm_0, '0015-03-07')
+WHERE CAST([t].[IssueDate] AS date) IN (@prm, '0015-03-07')
 """);
     }
 
@@ -10241,8 +10241,8 @@ LEFT JOIN [LocustHighCommands] AS [l2] ON [l0].[HighCommandId] = [l2].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [s0].[Nickname], [s0].[SquadId], [s0].[AssignedCityName], [s0].[CityOfBirthName], [s0].[FullName], [s0].[HasSoulPatch], [s0].[LeaderNickname], [s0].[LeaderSquadId], [s0].[Rank], [s0].[Discriminator], [s0].[HasSoulPatch0], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
@@ -10258,7 +10258,7 @@ FROM (
         GROUP BY [g0].[HasSoulPatch]
     ) AS [s] ON CAST(LEN([g].[Nickname]) AS int) = [s].[c]
     ORDER BY [g].[Nickname]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [s0]
 LEFT JOIN [Weapons] AS [w] ON [s0].[FullName] = [w].[OwnerFullName]
 ORDER BY [s0].[Nickname], [s0].[SquadId], [s0].[HasSoulPatch0]
@@ -10271,7 +10271,7 @@ ORDER BY [s0].[Nickname], [s0].[SquadId], [s0].[HasSoulPatch0]
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -10280,7 +10280,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -10291,7 +10291,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -10300,7 +10300,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -10311,11 +10311,11 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
 
         AssertSql(
             """
-@__place_0='Ephyra's location' (Size = 4000), @__place_0_1='Ephyra's location' (Size = 100) (DbType = AnsiString)
+@place='Ephyra's location' (Size = 4000), @place0='Ephyra's location' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @place OR [c].[Location] = @place0 OR [c].[Location] = @place
 """);
     }
 
@@ -10325,10 +10325,10 @@ WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Locatio
 
         AssertSql(
             """
-@__p_0='1'
-@__value_1='1'
+@p='1'
+@value='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & @__value_1
+SELECT TOP(@p) [g].[Rank] & @value
 FROM [Gears] AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -10340,7 +10340,7 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -10350,7 +10350,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[Id] > @__prm_0
+    WHERE [w].[Id] > @prm
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -10449,7 +10449,7 @@ WHERE [w].[AmmunitionType] = 1
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -10459,7 +10459,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE [w].[IsAutomatic] <> @__isAutomatic_0
+    WHERE [w].[IsAutomatic] <> @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -11346,7 +11346,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [s].[Nickname]
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11354,7 +11354,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -11364,7 +11364,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11372,7 +11372,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -11382,7 +11382,7 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11390,7 +11390,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -11445,7 +11445,7 @@ FROM [Squads] AS [s]
 
         AssertSql(
             """
-@__unixEpochMilliseconds_0='0'
+@unixEpochMilliseconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11458,7 +11458,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochMilliseconds_0 = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochMilliseconds = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -11469,7 +11469,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 
         AssertSql(
             """
-@__unixEpochSeconds_0='0'
+@unixEpochSeconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11482,7 +11482,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] AS [s0]
     INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochSeconds_0 = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochSeconds = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -11524,7 +11524,7 @@ GROUP BY [s].[Name]
 
         AssertSql(
             """
-@__numbers_0='[1,-1]' (Size = 4000)
+@numbers='[1,-1]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11539,7 +11539,7 @@ WHERE CASE
     ELSE 0
 END IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -11550,7 +11550,7 @@ END IN (
 
         AssertSql(
             """
-@__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
+@weapons='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11563,7 +11563,7 @@ WHERE (
     WHERE [g].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]) IN (
     SELECT [w].[value]
-    FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w]
+    FROM OPENJSON(@weapons) WITH ([value] nvarchar(max) '$') AS [w]
 )
 """);
     }
@@ -11574,7 +11574,7 @@ WHERE (
 
         AssertSql(
             """
-@__numbers_0='[0,1,2]' (Size = 4000)
+@numbers='[0,1,2]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId]
 FROM [Gears] AS [g]
@@ -11586,7 +11586,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= COALESCE((
         SELECT [n].[value]
-        FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+        FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
         ORDER BY [n].[value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]
@@ -11811,9 +11811,9 @@ LEFT JOIN [LocustHighCommands] AS [l1] ON [l0].[HighCommandId] = [l1].[Id]
 
         AssertSql(
             """
-@__ranks_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ranks='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -11823,31 +11823,31 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 WHERE CASE
     WHEN [g].[Rank] IN (
         SELECT [r].[value]
-        FROM OPENJSON(@__ranks_0) WITH ([value] int '$') AS [r]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ranks) WITH ([value] int '$') AS [r]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """,
             //
             """
-@__ammoTypes_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ammoTypes='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 WHERE CASE
     WHEN [w].[AmmunitionType] IN (
         SELECT [a].[value]
-        FROM OPENJSON(@__ammoTypes_0) WITH ([value] int '$') AS [a]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ammoTypes) WITH ([value] int '$') AS [a]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
@@ -540,11 +540,11 @@ VALUES (@p0, @p1, @p2);
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT DISTINCT [s].[Id], [s].[CountryId], [s].[Name], [s].[Species], [s].[EagleId], [s].[IsFlightless], [s].[FoundOn], [s].[Discriminator]
 FROM (
-    SELECT TOP(@__p_0) [a].[Id], [a].[CountryId], [a].[Name], [a].[Species], [b].[EagleId], [b].[IsFlightless], [k].[FoundOn], CASE
+    SELECT TOP(@p) [a].[Id], [a].[CountryId], [a].[Name], [a].[Species], [b].[EagleId], [b].[IsFlightless], [k].[FoundOn], CASE
         WHEN [k].[Id] IS NOT NULL THEN N'Kiwi'
         WHEN [e].[Id] IS NOT NULL THEN N'Eagle'
     END AS [Discriminator]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -1925,7 +1925,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
@@ -1933,7 +1933,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @__entity_equality_two_0_Id)
+    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @entity_equality_two_Id)
 """);
     }
 
@@ -2658,7 +2658,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [u].[Id], [u].[Name]
 FROM [UnidirectionalEntityOnes] AS [u]
@@ -2666,7 +2666,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @__entity_equality_two_0_Id)
+    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @entity_equality_two_Id)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -1932,7 +1932,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
@@ -1940,7 +1940,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @__entity_equality_two_0_Id)
+    WHERE [e].[Id] = [j].[OneId] AND [e0].[Id] = @entity_equality_two_Id)
 """);
     }
 
@@ -2681,7 +2681,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__entity_equality_two_0_Id='1' (Nullable = true)
+@entity_equality_two_Id='1' (Nullable = true)
 
 SELECT [u].[Id], [u].[Name]
 FROM [UnidirectionalEntityOnes] AS [u]
@@ -2689,7 +2689,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @__entity_equality_two_0_Id)
+    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Id] = @entity_equality_two_Id)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -533,15 +533,15 @@ ORDER BY [l].[Id], [s].[Id], [s].[Name0]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [l3].[PeriodEnd], [l3].[PeriodStart], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id] DESC
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l1].[Id] AS [Id0], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], [l1].[PeriodEnd] AS [PeriodEnd0], [l1].[PeriodStart] AS [PeriodStart0]
@@ -604,15 +604,15 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l1].[PeriodEnd], [l1].[PeriodStart], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l0].[PeriodEnd], [l0].[PeriodStart], [l2].[Id], [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id], [l3].[PeriodEnd], [l3].[PeriodStart], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Optional_Self_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToMany_Required_Self_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l4].[OneToOne_Optional_Self3Id], [l4].[PeriodEnd], [l4].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l2] ON [l1].[Id] = [l2].[Level1_Required_Id]
@@ -856,7 +856,7 @@ ORDER BY [l].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Id2]
 
         AssertSql(
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l2].[PeriodEnd], [l2].[PeriodStart]
 FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
@@ -865,7 +865,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l0].[PeriodEnd], [l0].[PeriodStart], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-        WHERE [l0].[Name] <> @__prm_0 OR [l0].[Name] IS NULL
+        WHERE [l0].[Name] <> @prm OR [l0].[Name] IS NULL
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1054,11 +1054,11 @@ ORDER BY [l].[Id], [l0].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [s].[PeriodEnd], [s].[PeriodStart]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Name]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -1082,15 +1082,15 @@ ORDER BY [l3].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l1].[PeriodEnd], [l1].[PeriodStart], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l0].[PeriodEnd], [l0].[PeriodStart], [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id], [l3].[PeriodEnd], [l3].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0] ON [l1].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
@@ -1358,15 +1358,15 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l1].[PeriodEnd], [l1].[PeriodStart], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l0].[PeriodEnd], [l0].[PeriodStart], [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Optional_Self_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToMany_Required_Self_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [l2].[OneToOne_Optional_Self3Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l3].[Id], [l3].[Level3_Optional_Id], [l3].[Level3_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse4Id], [l3].[OneToMany_Optional_Self_Inverse4Id], [l3].[OneToMany_Required_Inverse4Id], [l3].[OneToMany_Required_Self_Inverse4Id], [l3].[OneToOne_Optional_PK_Inverse4Id], [l3].[OneToOne_Optional_Self4Id], [l3].[PeriodEnd], [l3].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0] ON [l1].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l2] ON [l0].[Id] = [l2].[Level2_Required_Id]
@@ -1555,11 +1555,11 @@ ORDER BY [l].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [l3].[PeriodEnd], [l3].[PeriodStart], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -1712,11 +1712,11 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l2].[Id], [l4].[Id], [l1].[Id], [l4].[c]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 ) AS [l2]
 LEFT JOIN (
@@ -1948,7 +1948,7 @@ FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id], [l2].[PeriodEnd], [l2].[PeriodStart]
 FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
@@ -1957,7 +1957,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l0].[PeriodEnd], [l0].[PeriodStart], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-        WHERE @__p_0 = CAST(1 AS bit)
+        WHERE @p = CAST(1 AS bit)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -1972,11 +1972,11 @@ ORDER BY [l].[Id], [l2].[OneToMany_Optional_Inverse2Id], [l2].[Id]
 
         AssertSql(
             """
-@__p_0='30'
+@p='30'
 
 SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id], [l3].[PeriodEnd], [l3].[PeriodStart], [s].[Id], [s].[Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Optional_Self_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToMany_Required_Self_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[OneToOne_Optional_Self2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Name0], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Optional_Self_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToMany_Required_Self_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[OneToOne_Optional_Self3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]
@@ -2303,7 +2303,7 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l1].[Date], [l2].[Id]
 FROM (
@@ -2311,7 +2311,7 @@ FROM (
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     WHERE [l].[Name] IN (
         SELECT [v].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
     )
     GROUP BY [l].[Date]
 ) AS [l1]
@@ -2320,7 +2320,7 @@ LEFT JOIN (
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
     WHERE [l0].[Name] IN (
         SELECT [v0].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v0]
     )
 ) AS [l2] ON [l1].[Date] = [l2].[Date]
 ORDER BY [l1].[Date]
@@ -2414,14 +2414,14 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[OneToMany_Optional_Self_Inverse1Id], [s].[OneToMany_Required_Self_Inverse1Id], [s].[OneToOne_Optional_Self1Id], [s].[PeriodEnd], [s].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[Name], [l2].[OneToMany_Required_Inverse2Id] AS [Level1Id], [l2].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], [l1].[PeriodEnd], [l1].[PeriodStart]
@@ -2620,7 +2620,7 @@ ORDER BY ABS([l].[Level1_Required_Id]) + 7, [l].[Name], [l].[Id]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT CASE
     WHEN [l0].[Id] IS NULL THEN 0
@@ -2631,7 +2631,7 @@ LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
 LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [l0].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -43,15 +43,15 @@ public class TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest :
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[PeriodEnd], [l1].[PeriodStart], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l5].[Id], [l5].[Level2_Optional_Id], [l5].[Level2_Required_Id], [l5].[Level3_Name], [l5].[OneToMany_Optional_Inverse3Id], [l5].[OneToMany_Required_Inverse3Id], [l5].[OneToOne_Optional_PK_Inverse3Id], [l5].[PeriodEnd], [l5].[PeriodStart], [l6].[Id], [l6].[Level2_Optional_Id], [l6].[Level2_Required_Id], [l6].[Level3_Name], [l6].[OneToMany_Optional_Inverse3Id], [l6].[OneToMany_Required_Inverse3Id], [l6].[OneToOne_Optional_PK_Inverse3Id], [l6].[PeriodEnd], [l6].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[PeriodEnd], [l0].[PeriodStart]
@@ -82,15 +82,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l2].[Id], [l5].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[PeriodEnd], [l1].[PeriodStart], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l4].[Id], [l7].[Id], [l7].[Level2_Optional_Id], [l7].[Level2_Required_Id], [l7].[Level3_Name], [l7].[OneToMany_Optional_Inverse3Id], [l7].[OneToMany_Required_Inverse3Id], [l7].[OneToOne_Optional_PK_Inverse3Id], [l7].[PeriodEnd], [l7].[PeriodStart], [l4].[OneToOne_Required_PK_Date], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Level2_Name], [l4].[OneToMany_Optional_Inverse2Id], [l4].[OneToMany_Required_Inverse2Id], [l4].[OneToOne_Optional_PK_Inverse2Id], [l4].[PeriodEnd], [l4].[PeriodStart], [l8].[Id], [l8].[Level2_Optional_Id], [l8].[Level2_Required_Id], [l8].[Level3_Name], [l8].[OneToMany_Optional_Inverse3Id], [l8].[OneToMany_Required_Inverse3Id], [l8].[OneToOne_Optional_PK_Inverse3Id], [l8].[PeriodEnd], [l8].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[PeriodEnd], [l0].[PeriodStart]
@@ -126,15 +126,15 @@ ORDER BY [l1].[Name], [l1].[Id], [l2].[Id], [l4].[Id], [l7].[Id]
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[PeriodEnd], [l1].[PeriodStart], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Level3_Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l4].[PeriodEnd], [l4].[PeriodStart], [l6].[Id], [l6].[Level3_Optional_Id], [l6].[Level3_Required_Id], [l6].[Level4_Name], [l6].[OneToMany_Optional_Inverse4Id], [l6].[OneToMany_Required_Inverse4Id], [l6].[OneToOne_Optional_PK_Inverse4Id], [l6].[PeriodEnd], [l6].[PeriodStart]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Name]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l1]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[PeriodEnd], [l0].[PeriodStart]
@@ -592,7 +592,7 @@ FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 """,
             //
             """
-@__p_0='True'
+@p='True'
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart]
 FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
@@ -605,7 +605,7 @@ LEFT JOIN (
             WHEN [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
         END AS [c]
         FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND @__p_0 = CAST(1 AS bit)
+        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND @p = CAST(1 AS bit)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -770,11 +770,11 @@ ORDER BY [l].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [l4].[PeriodEnd], [l4].[PeriodStart], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]
@@ -828,7 +828,7 @@ ORDER BY [l].[Id], [s].[Level2_Name], [s].[Id], [s].[Level3_Name] DESC
 
         AssertSql(
             """
-@__prm_0='Foo' (Size = 4000)
+@prm='Foo' (Size = 4000)
 
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart], [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart]
 FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
@@ -841,7 +841,7 @@ LEFT JOIN (
             WHEN [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
         END AS [c]
         FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level2_Name] <> @__prm_0 OR [l0].[Level2_Name] IS NULL)
+        WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level2_Name] <> @prm OR [l0].[Level2_Name] IS NULL)
     ) AS [l1]
     WHERE [l1].[row] <= 3
 ) AS [l2] ON [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -888,11 +888,11 @@ ORDER BY [l4].[Id], [s].[Id]
 
         AssertSql(
             """
-@__p_0='30'
+@p='30'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [l4].[PeriodEnd], [l4].[PeriodStart], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
+    SELECT TOP(@p) [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l4]
@@ -1050,15 +1050,15 @@ ORDER BY [l].[Id], [s].[c], [s].[Id], [s].[Id0]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='5'
+@p='1'
+@p0='5'
 
 SELECT [l4].[Id], [l4].[Date], [l4].[Name], [l4].[PeriodEnd], [l4].[PeriodStart], [s].[Id], [s].[OneToOne_Required_PK_Date], [s].[Level1_Optional_Id], [s].[Level1_Required_Id], [s].[Level2_Name], [s].[OneToMany_Optional_Inverse2Id], [s].[OneToMany_Required_Inverse2Id], [s].[OneToOne_Optional_PK_Inverse2Id], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id0], [s].[Level2_Optional_Id], [s].[Level2_Required_Id], [s].[Level3_Name], [s].[OneToMany_Optional_Inverse3Id], [s].[OneToMany_Required_Inverse3Id], [s].[OneToOne_Optional_PK_Inverse3Id], [s].[PeriodEnd0], [s].[PeriodStart0]
 FROM (
     SELECT [l].[Id], [l].[Date], [l].[Name], [l].[PeriodEnd], [l].[PeriodStart]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id] DESC
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [l4]
 OUTER APPLY (
     SELECT [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[PeriodEnd], [l2].[PeriodStart], [l3].[Id] AS [Id0], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Level3_Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[PeriodEnd] AS [PeriodEnd0], [l3].[PeriodStart] AS [PeriodStart0]
@@ -1844,7 +1844,7 @@ ORDER BY [l].[Id], [l1].[Id], [l3].[Id]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NULL OR [s].[Level1_Required_Id] IS NULL OR [s].[OneToMany_Required_Inverse2Id] IS NULL OR CASE
@@ -1880,7 +1880,7 @@ LEFT JOIN (
 END = [l4].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+    FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
 )
 ORDER BY [l].[Id], [s].[Id], [s].[Id0]
 """);
@@ -1892,11 +1892,11 @@ ORDER BY [l].[Id], [s].[Id], [s].[Id0]
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [l2].[Id], [l4].[Id0], [l5].[Id], [l5].[Id0], [l4].[Id], [l4].[c]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id]
+    SELECT TOP(@p) [l].[Id]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 ) AS [l2]
 LEFT JOIN (
@@ -3032,7 +3032,7 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 
         AssertSql(
             """
-@__validIds_0='["L1 01","L1 02"]' (Size = 4000)
+@validIds='["L1 01","L1 02"]' (Size = 4000)
 
 SELECT [l1].[Date], [l2].[Id]
 FROM (
@@ -3040,7 +3040,7 @@ FROM (
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     WHERE [l].[Name] IN (
         SELECT [v].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v]
     )
     GROUP BY [l].[Date]
 ) AS [l1]
@@ -3049,7 +3049,7 @@ LEFT JOIN (
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
     WHERE [l0].[Name] IN (
         SELECT [v0].[value]
-        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
+        FROM OPENJSON(@validIds) WITH ([value] nvarchar(max) '$') AS [v0]
     )
 ) AS [l2] ON [l1].[Date] = [l2].[Date]
 ORDER BY [l1].[Date]
@@ -3148,14 +3148,14 @@ ORDER BY [l4].[Date], [s].[Name], [s].[Id]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id1]
 FROM (
     SELECT [l].[Id], [l].[Name]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p ROWS ONLY
 ) AS [l3]
 OUTER APPLY (
     SELECT CASE
@@ -3253,11 +3253,11 @@ ORDER BY [l1].[Date], [l3].[Date], [l3].[Name] DESC
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [l3].[Id], [l3].[Name], [s].[Id], [s].[Name], [s].[Level1Id], [s].[Level2Id], [s].[Id0], [s].[Date], [s].[Name0], [s].[PeriodEnd], [s].[PeriodStart], [s].[Id1]
 FROM (
-    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    SELECT TOP(@p) [l].[Id], [l].[Name]
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     ORDER BY [l].[Id]
 ) AS [l3]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -72,14 +72,14 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='[]' (Size = 4000)
+@tags='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -96,7 +96,7 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='[]' (Size = 4000)
+@tags='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Gears] AS [g]
@@ -104,7 +104,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -121,14 +121,14 @@ FROM [Tags] AS [t]
 """,
             //
             """
-@__tags_0='[]' (Size = 4000)
+@tags='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
     SELECT [t0].[value]
-    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    FROM OPENJSON(@tags) WITH ([value] uniqueidentifier '$') AS [t0]
 )
 """);
     }
@@ -141,7 +141,7 @@ WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN (
 
         AssertSql(
             """
-@__squadId_0='1'
+@squadId='1'
 
 SELECT [u].[Nickname], [u].[SquadId], [u].[AssignedCityName], [u].[CityOfBirthName], [u].[Discriminator], [u].[FullName], [u].[HasSoulPatch], [u].[LeaderNickname], [u].[LeaderSquadId], [u].[PeriodEnd], [u].[PeriodStart], [u].[Rank]
 FROM (
@@ -151,7 +151,7 @@ FROM (
     WHERE [s].[Id] IN (
         SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0
+        WHERE [s0].[Id] = @squadId
     )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[PeriodEnd], [g0].[PeriodStart], [g0].[Rank]
@@ -160,7 +160,7 @@ FROM (
     WHERE [s1].[Id] IN (
         SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0
+        WHERE [s2].[Id] = @squadId
     )
 ) AS [u]
 ORDER BY [u].[FullName]
@@ -228,11 +228,11 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 8000)
+@byteArrayParam='0x2A80' (Size = 8000)
 
 SELECT COUNT(*)
 FROM [Squads] AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@byteArrayParam) AS int)
 """);
     }
 
@@ -450,12 +450,12 @@ WHERE CAST([t].[IssueDate] AS time) = [m].[Time]
 
         AssertSql(
             """
-@__time_0='02:00' (DbType = Time)
+@time='02:00' (DbType = Time)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([g].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @__time_0
+WHERE [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL AND CAST(DATEADD(hour, CAST(CAST([g].[SquadId] AS float) AS int), [t].[IssueDate]) AS time) = @time
 """);
     }
 
@@ -489,11 +489,11 @@ WHERE CAST([m].[Duration] AS time) < [m].[Time]
 
         AssertSql(
             """
-@__time_0='01:02' (DbType = Time)
+@time='01:02' (DbType = Time)
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[PeriodEnd], [m].[PeriodStart], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
-WHERE CAST([m].[Duration] AS time) = @__time_0
+WHERE CAST([m].[Duration] AS time) = @time
 """);
     }
 
@@ -528,11 +528,11 @@ WHERE CAST([t].[IssueDate] AS date) > [m].[Date]
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
-WHERE CAST([t].[IssueDate] AS date) IN (@__prm_0, '0015-03-07')
+WHERE CAST([t].[IssueDate] AS date) IN (@prm, '0015-03-07')
 """);
     }
 
@@ -626,11 +626,11 @@ END
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[PeriodEnd], [w1].[PeriodStart], [w1].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName]
+    SELECT TOP(@p) [g].[FullName]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ) AS [g0]
 LEFT JOIN (
@@ -780,11 +780,11 @@ ORDER BY COALESCE([w0].[Name], N'') + CAST(5 AS nvarchar(max))
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE @__p_0 = CAST(1 AS bit)
+WHERE @p = CAST(1 AS bit)
 """);
     }
 
@@ -1024,7 +1024,7 @@ WHERE CHARINDEX(0x01, [s].[Banner]) > 0
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -1034,7 +1034,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-    WHERE [w].[IsAutomatic] = @__isAutomatic_0
+    WHERE [w].[IsAutomatic] = @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -1119,11 +1119,11 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
@@ -1151,12 +1151,12 @@ INNER JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] O
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    WHEN [g].[HasSoulPatch] = @prm THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -1443,16 +1443,16 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__prm_0='True'
-@__prm2_1='Marcus' Lancer' (Size = 4000)
+@prm='True'
+@prm2='Marcus' Lancer' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE CASE
-    WHEN [g].[HasSoulPatch] = @__prm_0 AND (
+    WHEN [g].[HasSoulPatch] = @prm AND (
         SELECT TOP(1) [w].[Name]
         FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-        WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1 THEN CAST(1 AS bit)
+        WHERE [w].[Id] = [g].[SquadId]) = @prm2 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -1714,13 +1714,13 @@ ORDER BY [f].[Name]
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -1821,14 +1821,14 @@ WHERE [s].[Name] = N'Kilo'
 
         AssertSql(
             """
-@__cities_0_without_nulls='["Ephyra"]' (Size = 4000)
+@cities_without_nulls='["Ephyra"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND ([c].[Name] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0_without_nulls) AS [c0]
+    FROM OPENJSON(@cities_without_nulls) AS [c0]
 ) OR [c].[Name] IS NULL)
 """);
     }
@@ -1853,7 +1853,7 @@ ORDER BY [g].[FullName]
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -1863,7 +1863,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-    WHERE [w].[IsAutomatic] <> @__isAutomatic_0
+    WHERE [w].[IsAutomatic] <> @isAutomatic
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -2135,7 +2135,7 @@ GROUP BY [g].[Rank]
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT [g].[Nickname], [g].[FullName], CASE
     WHEN [w0].[Id] IS NOT NULL THEN CAST(1 AS bit)
@@ -2145,7 +2145,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-    WHERE [w].[Id] > @__prm_0
+    WHERE [w].[Id] > @prm
 ) AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 """);
     }
@@ -2420,19 +2420,19 @@ FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[HasSoulPatch] <> @__prm_0
+WHERE [g].[HasSoulPatch] <> @prm
 """);
     }
 
@@ -2602,11 +2602,11 @@ FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
 
         AssertSql(
             """
-@__rank_0='1' (Nullable = true)
+@rank='1' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[Rank] & @__rank_0 = @__rank_0
+WHERE [g].[Rank] & @rank = @rank
 """,
             //
             """
@@ -2615,11 +2615,11 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """,
             //
             """
-@__rank_0='2' (Nullable = true)
+@rank='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[Rank] | @__rank_0 <> @__rank_0
+WHERE [g].[Rank] | @rank <> @rank
 """,
             //
             """
@@ -2881,11 +2881,11 @@ GROUP BY [g].[Rank]
 
         AssertSql(
             """
-@__parameter_0='2'
+@parameter='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -2907,13 +2907,13 @@ WHERE DATEPART(second, [m].[Duration]) = 3
 
         AssertSql(
             """
-@__prm_Inner_Nickname_0='Marcus' (Size = 450)
+@prm_Inner_Nickname='Marcus' (Size = 450)
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[PeriodEnd], [g0].[PeriodStart], [g0].[Rank]
 FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-    WHERE [g].[Nickname] <> @__prm_Inner_Nickname_0
+    WHERE [g].[Nickname] <> @prm_Inner_Nickname
 ) AS [g0]
 ORDER BY [g0].[FullName]
 """);
@@ -3182,11 +3182,11 @@ LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON
 
         AssertSql(
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE @__prm_0 = [w].[AmmunitionType]
+WHERE @prm = [w].[AmmunitionType]
 """);
     }
 
@@ -3232,19 +3232,19 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 """,
             //
             """
-@__prm_0='2' (Nullable = true)
+@prm='2' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 <> 0 OR [w].[AmmunitionType] IS NULL
+WHERE [w].[AmmunitionType] & @prm <> 0 OR [w].[AmmunitionType] IS NULL
 """,
             //
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] & @__prm_0 = @__prm_0
+WHERE [w].[AmmunitionType] & @prm = @prm
 """);
     }
 
@@ -3366,11 +3366,11 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 
         AssertSql(
             """
-@__place_0='Ephyra's location' (Size = 4000), @__place_0_1='Ephyra's location' (Size = 100) (DbType = AnsiString)
+@place='Ephyra's location' (Size = 4000), @place0='Ephyra's location' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodStart]
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @place OR [c].[Location] = @place0 OR [c].[Location] = @place
 """);
     }
 
@@ -3447,11 +3447,11 @@ ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t]
 
         AssertSql(
             """
-@__someByte_0='1' (Size = 1)
+@someByte='1' (Size = 1)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart]
 FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
-WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0
+WHERE CHARINDEX(CAST(@someByte AS varbinary(max)), [s].[Banner]) > 0
 """);
     }
 
@@ -3485,14 +3485,14 @@ WHERE DATEPART(hour, [m].[Duration]) = 1
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] = @__ammunitionType_0 AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN [w].[AmmunitionType] = @ammunitionType AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -3538,10 +3538,10 @@ WHERE ([t].[Note] <> N'Foo' OR [t].[Note] IS NULL) AND [g].[Discriminator] = N'O
 
         AssertSql(
             """
-@__p_0='1'
-@__value_1='1'
+@p='1'
+@value='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & @__value_1
+SELECT TOP(@p) [g].[Rank] & @value
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -3643,24 +3643,24 @@ ORDER BY [g].[Nickname], [s].[Id] DESC, [g].[SquadId], [w0].[Id], [g1].[Nickname
 
         AssertSql(
             """
-@__ranks_0='134'
+@ranks='134'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[Rank] & @__ranks_0 <> 0
+WHERE [g].[Rank] & @ranks <> 0
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT ~CAST(([g].[Rank] | [g].[Rank] | @__ranks_0 | [g].[Rank] | @__ranks_0) ^ @__ranks_0 AS bit)
+SELECT ~CAST(([g].[Rank] | [g].[Rank] | @ranks | [g].[Rank] | @ranks) ^ @ranks AS bit)
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """);
     }
@@ -3766,9 +3766,9 @@ WHERE (
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 """,
             //
@@ -3778,9 +3778,9 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 """,
             //
             """
-@__ammunitionType_0='2' (Nullable = true)
+@ammunitionType='2' (Nullable = true)
 
-SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+SELECT [w].[Id], @ammunitionType AS [AmmoType]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 """,
             //
@@ -4619,11 +4619,11 @@ LEFT JOIN [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s] ON
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -4712,11 +4712,11 @@ FROM [Factions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [f]
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """);
     }
 
@@ -5116,9 +5116,9 @@ WHERE 2 & (
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
-SELECT @__p_0
+SELECT @p
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """);
     }
@@ -5472,7 +5472,7 @@ LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [g0].[FullName]
 FROM (
@@ -5480,7 +5480,7 @@ FROM (
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
     ORDER BY [g].[FullName]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [g0]
 ORDER BY [g0].[Rank]
 """);
@@ -5685,14 +5685,14 @@ WHERE COALESCE([c].[Location], N'') + N'Added' LIKE N'%Add%'
 
         AssertSql(
             """
-@__types_0_without_nulls='[1]' (Size = 4000)
+@types_without_nulls='[1]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
     SELECT [t].[value]
-    FROM OPENJSON(@__types_0_without_nulls) AS [t]
+    FROM OPENJSON(@types_without_nulls) AS [t]
 ) OR [w0].[AmmunitionType] IS NULL)
 """);
     }
@@ -5809,11 +5809,11 @@ LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart]
 FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
-WHERE [s].[Banner5] = @__byteArrayParam_0
+WHERE [s].[Banner5] = @byteArrayParam
 """);
     }
 
@@ -5884,11 +5884,11 @@ ORDER BY [g0].[FullName] DESC, [g0].[Nickname], [g0].[SquadId], [w].[Name]
 
         AssertSql(
             """
-@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
+@value='Unknown' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodStart]
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
-WHERE [c].[Location] = @__value_0
+WHERE [c].[Location] = @value
 """);
     }
 
@@ -5898,11 +5898,11 @@ WHERE [c].[Location] = @__value_0
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -6074,11 +6074,11 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 
         AssertSql(
             """
-@__prm_0='5'
+@prm='5'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE @__prm_0 & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
 """);
     }
 
@@ -6245,11 +6245,11 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__Date_0='0001-01-01T00:00:00.0000000'
+@Date='0001-01-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[PeriodEnd], [m].[PeriodStart], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
-WHERE CONVERT(date, [m].[Timeline]) > @__Date_0
+WHERE CONVERT(date, [m].[Timeline]) > @Date
 """);
     }
 
@@ -6259,14 +6259,14 @@ WHERE CONVERT(date, [m].[Timeline]) > @__Date_0
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 4000)
+@ids='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
         SELECT [i].[value]
-        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+        FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -6379,15 +6379,15 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
 
         AssertSql(
             """
-@__start_0='1902-01-01T10:00:00.1234567+01:30'
-@__end_1='1902-01-03T10:00:00.1234567+01:30'
-@__dates_2='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
+@start='1902-01-01T10:00:00.1234567+01:30'
+@end='1902-01-03T10:00:00.1234567+01:30'
+@dates='["1902-01-02T10:00:00.1234567+01:30"]' (Size = 4000)
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[PeriodEnd], [m].[PeriodStart], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
-WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
+WHERE @start <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @end AND [m].[Timeline] IN (
     SELECT [d].[value]
-    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
+    FROM OPENJSON(@dates) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -6506,17 +6506,17 @@ ORDER BY [g].[Nickname]
 
         AssertSql(
             """
-@__entity_equality_prm_Inner_Squad_0_Id='1' (Nullable = true)
+@entity_equality_prm_Inner_Squad_Id='1' (Nullable = true)
 
 SELECT [s1].[Nickname], [s1].[SquadId], [s1].[AssignedCityName], [s1].[CityOfBirthName], [s1].[Discriminator], [s1].[FullName], [s1].[HasSoulPatch], [s1].[LeaderNickname], [s1].[LeaderSquadId], [s1].[PeriodEnd], [s1].[PeriodStart], [s1].[Rank]
 FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     INNER JOIN [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE [s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+    WHERE [s].[Id] = @entity_equality_prm_Inner_Squad_Id
 ) AS [s1]
 INNER JOIN [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s0] ON [s1].[SquadId] = [s0].[Id]
-WHERE [s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
+WHERE [s0].[Id] = @entity_equality_prm_Inner_Squad_Id
 ORDER BY [s1].[FullName]
 """);
     }
@@ -6763,13 +6763,13 @@ WHERE [t].[Note] <> N'K.I.A.' OR [t].[Note] IS NULL
 
         AssertSql(
             """
-@__cities_0='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
+@cities='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 4000)
 
 SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodStart]
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
 WHERE [c].[Location] IN (
     SELECT [c0].[value]
-    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    FROM OPENJSON(@cities) WITH ([value] varchar(100) '$') AS [c0]
 )
 """);
     }
@@ -6780,11 +6780,11 @@ WHERE [c].[Location] IN (
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT [s].[Name], [s].[Discriminator], [s].[LocustHordeId], [s].[PeriodEnd], [s].[PeriodStart], [s].[ThreatLevel], [s].[ThreatLevelByte], [s].[ThreatLevelNullableByte], [s].[DefeatedByNickname], [s].[DefeatedBySquadId], [s].[HighCommandId], [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[Discriminator0], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[PeriodEnd0], [s].[PeriodStart0], [s].[Rank], [s].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[PeriodEnd], [l].[PeriodStart], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator] AS [Discriminator0], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd] AS [PeriodEnd0], [g].[PeriodStart] AS [PeriodStart0], [g].[Rank], [t].[Id], [t].[Note]
+    SELECT TOP(@p) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[PeriodEnd], [l].[PeriodStart], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator] AS [Discriminator0], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd] AS [PeriodEnd0], [g].[PeriodStart] AS [PeriodStart0], [g].[Rank], [t].[Id], [t].[Note]
     FROM [LocustLeaders] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON [l].[DefeatedByNickname] = [g].[Nickname] AND [l].[DefeatedBySquadId] = [g].[SquadId]
     LEFT JOIN [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t] ON ([g].[Nickname] = [t].[GearNickName] OR ([g].[Nickname] IS NULL AND [t].[GearNickName] IS NULL)) AND ([g].[SquadId] = [t].[GearSquadId] OR ([g].[SquadId] IS NULL AND [t].[GearSquadId] IS NULL))
@@ -6967,9 +6967,9 @@ ORDER BY [t].[Note], [g].[Nickname] DESC, [t].[Id], [g].[SquadId], [s].[Id], [s0
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
-SELECT TOP(@__p_0) [g].[Rank] & 1
+SELECT TOP(@p) [g].[Rank] & 1
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY [g].[Nickname]
 """);
@@ -7035,11 +7035,11 @@ FROM [Factions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [f]
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT [g0].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].[FullName], [g].[Rank]
+    SELECT TOP(@p) [g].[FullName], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [g0]
@@ -7491,8 +7491,8 @@ WHERE [l].[Discriminator] = N'LocustCommander'
 
         AssertSql(
             """
-@__p_0='0'
-@__p_1='10'
+@p='0'
+@p0='10'
 
 SELECT [s].[Nickname], [s].[SquadId], [s].[AssignedCityName], [s].[CityOfBirthName], [s].[Discriminator], [s].[FullName], [s].[HasSoulPatch], [s].[LeaderNickname], [s].[LeaderSquadId], [s].[PeriodEnd], [s].[PeriodStart], [s].[Rank], [s].[HasSoulPatch0], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM (
@@ -7505,7 +7505,7 @@ FROM (
         GROUP BY [g0].[HasSoulPatch]
     ) AS [g1] ON CAST(LEN([g].[Nickname]) AS int) = [g1].[c]
     ORDER BY [g].[Nickname]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [s]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w] ON [s].[FullName] = [w].[OwnerFullName]
 ORDER BY [s].[Nickname], [s].[SquadId], [s].[HasSoulPatch0]
@@ -7576,11 +7576,11 @@ WHERE [g].[Discriminator] = N'Officer'
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """,
             //
             """
@@ -8065,7 +8065,7 @@ WHERE [c].[Location] LIKE '%Jacinto%'
 
         AssertSql(
             """
-@__nicknames_0='[]' (Size = 4000)
+@nicknames='[]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -8073,7 +8073,7 @@ LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w] O
 ORDER BY CASE
     WHEN [g].[Nickname] IN (
         SELECT [n].[value]
-        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        FROM OPENJSON(@nicknames) WITH ([value] nvarchar(450) '$') AS [n]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
@@ -8178,11 +8178,11 @@ LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON 
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] = @__ammunitionType_0
+WHERE [w].[AmmunitionType] = @ammunitionType
 """);
     }
 
@@ -8400,13 +8400,13 @@ ORDER BY [g0].[Nickname], [g0].[SquadId]
 
         AssertSql(
             """
-@__ids_0='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
+@ids='["df36f493-463f-4123-83f9-6b135deeb7ba","23cbcf9b-ce14-45cf-aafa-2c2667ebfdd3","ab1b82d7-88db-42bd-a132-7eef9aa68af4"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 WHERE [t].[Id] IN (
     SELECT [i].[value]
-    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
+    FROM OPENJSON(@ids) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -8790,11 +8790,11 @@ ORDER BY [l0].[Id], [l].[Name]
 
         AssertSql(
             """
-@__parameter_0='2' (Nullable = true)
+@parameter='2' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE [g].[Rank] & @__parameter_0 = @__parameter_0
+WHERE [g].[Rank] & @parameter = @parameter
 """);
     }
 
@@ -9045,11 +9045,11 @@ ORDER BY [g0].[Nickname]
 
         AssertSql(
             """
-@__prm_0='133'
+@prm='133'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 
@@ -9059,13 +9059,13 @@ WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 4000)
+@values='[false,true]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
     SELECT [v].[value]
-    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
+    FROM OPENJSON(@values) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -9127,14 +9127,14 @@ WHERE [m].[CodeName] = N'Operation Foobar'
 
         AssertSql(
             """
-@__gearId_0='1'
+@gearId='1'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart]
 FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
 WHERE EXISTS (
     SELECT 1
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @__gearId_0 AND [g].[SquadId] = @__gearId_0)
+    WHERE [s].[Id] = [g].[SquadId] AND [g].[SquadId] = @gearId AND [g].[SquadId] = @gearId)
 """);
     }
 
@@ -9381,11 +9381,11 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart]
 FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
-WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @p
 """);
     }
 
@@ -9422,11 +9422,11 @@ ORDER BY [w0].[IsAutomatic], [w0].[Id]
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-WHERE [w].[AmmunitionType] & @__ammunitionType_0 > 0
+WHERE [w].[AmmunitionType] & @ammunitionType > 0
 """,
             //
             """
@@ -9513,11 +9513,11 @@ ORDER BY [g0].[FullName], [g0].[Nickname], [g0].[SquadId]
 
         AssertSql(
             """
-@__dateTimeOffset_Date_0='0002-03-01T00:00:00.0000000'
+@dateTimeOffset_Date='0002-03-01T00:00:00.0000000'
 
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Difficulty], [m].[Duration], [m].[PeriodEnd], [m].[PeriodStart], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
-WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0
+WHERE CONVERT(date, [m].[Timeline]) >= @dateTimeOffset_Date
 """);
     }
 
@@ -10004,12 +10004,12 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -10019,12 +10019,12 @@ OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY [g].[FullName]
-OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+OFFSET @p ROWS FETCH NEXT 1 ROWS ONLY
 """);
     }
 
@@ -10079,7 +10079,7 @@ FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
 
         AssertSql(
             """
-@__unixEpochMilliseconds_0='0'
+@unixEpochMilliseconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart], [s1].[SquadId], [s1].[MissionId], [s1].[PeriodEnd], [s1].[PeriodStart]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -10089,7 +10089,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s0]
     INNER JOIN [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochMilliseconds_0 = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochMilliseconds = DATEDIFF_BIG(millisecond, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -10100,7 +10100,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 
         AssertSql(
             """
-@__unixEpochSeconds_0='0'
+@unixEpochSeconds='0'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart], [s1].[SquadId], [s1].[MissionId], [s1].[PeriodEnd], [s1].[PeriodStart]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -10110,7 +10110,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [SquadMissions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s0]
     INNER JOIN [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m] ON [s0].[MissionId] = [m].[Id]
-    WHERE [s].[Id] = [s0].[SquadId] AND @__unixEpochSeconds_0 = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
+    WHERE [s].[Id] = [s0].[SquadId] AND @unixEpochSeconds = DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [m].[Timeline]))
 ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id], [s1].[SquadId]
 """);
     }
@@ -10152,7 +10152,7 @@ GROUP BY [s].[Name]
 
         AssertSql(
             """
-@__numbers_0='[1,-1]' (Size = 4000)
+@numbers='[1,-1]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -10164,7 +10164,7 @@ WHERE CASE
     ELSE 0
 END IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+    FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -10175,7 +10175,7 @@ END IN (
 
         AssertSql(
             """
-@__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
+@weapons='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -10185,7 +10185,7 @@ WHERE (
     WHERE [g].[FullName] = [w0].[OwnerFullName]
     ORDER BY [w0].[Id]) IN (
     SELECT [w].[value]
-    FROM OPENJSON(@__weapons_0) WITH ([value] nvarchar(max) '$') AS [w]
+    FROM OPENJSON(@weapons) WITH ([value] nvarchar(max) '$') AS [w]
 )
 """);
     }
@@ -10196,7 +10196,7 @@ WHERE (
 
         AssertSql(
             """
-@__numbers_0='[0,1,2]' (Size = 4000)
+@numbers='[0,1,2]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[PeriodEnd], [w1].[PeriodStart], [w1].[SynergyWithId]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
@@ -10208,7 +10208,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= COALESCE((
         SELECT [n].[value]
-        FROM OPENJSON(@__numbers_0) WITH ([value] int '$') AS [n]
+        FROM OPENJSON(@numbers) WITH ([value] int '$') AS [n]
         ORDER BY [n].[value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]
@@ -10372,40 +10372,40 @@ LEFT JOIN [LocustHighCommands] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.000000
 
         AssertSql(
             """
-@__ranks_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ranks='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE CASE
     WHEN [g].[Rank] IN (
         SELECT [r].[value]
-        FROM OPENJSON(@__ranks_0) WITH ([value] int '$') AS [r]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ranks) WITH ([value] int '$') AS [r]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """,
             //
             """
-@__ammoTypes_0='[1]' (Size = 4000)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
+@ammoTypes='[1]' (Size = 4000)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 WHERE CASE
     WHEN [w].[AmmunitionType] IN (
         SELECT [a].[value]
-        FROM OPENJSON(@__ammoTypes_0) WITH ([value] int '$') AS [a]
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM OPENJSON(@ammoTypes) WITH ([value] int '$') AS [a]
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT [k].[value]
-    FROM OPENJSON(@__keys_2) WITH ([value] uniqueidentifier '$') AS [k]
+    FROM OPENJSON(@keys) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -210,11 +210,11 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name], [o3].[PeriodEnd], [o3].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o3].[PersonAddress_AddressLine], [o3].[PeriodEnd0], [o3].[PeriodStart0], [o3].[PersonAddress_PlaceType], [o3].[PersonAddress_ZipCode], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [o3].[BranchAddress_BranchName], [o3].[BranchAddress_PlaceType], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o3].[LeafBAddress_LeafBType], [o3].[LeafBAddress_PlaceType], [o3].[LeafBAddress_Country_Name], [o3].[LeafBAddress_Country_PlanetId], [o3].[LeafAAddress_LeafType], [o3].[LeafAAddress_PlaceType], [o3].[LeafAAddress_Country_Name], [o3].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[PersonAddress_AddressLine], [o0].[PeriodEnd0], [o0].[PeriodStart0], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[PersonAddress_AddressLine], [o0].[PeriodEnd0], [o0].[PeriodStart0], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
@@ -556,14 +556,14 @@ ORDER BY [o].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o0].[PeriodEnd], [o0].[PeriodStart], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail], [o1].[PeriodEnd] AS [PeriodEnd0], [o1].[PeriodStart] AS [PeriodStart0]
@@ -580,11 +580,11 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
 ) AS [o2]
@@ -603,15 +603,15 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o0].[PeriodEnd], [o0].[PeriodStart], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail], [o1].[PeriodEnd] AS [PeriodEnd0], [o1].[PeriodStart] AS [PeriodStart0]
@@ -628,14 +628,14 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS
+    OFFSET @p ROWS
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o0].[PeriodEnd], [o0].[PeriodStart], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail], [o1].[PeriodEnd] AS [PeriodEnd0], [o1].[PeriodStart] AS [PeriodStart0]
@@ -652,11 +652,11 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
+    SELECT TOP(@p) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
 ) AS [o2]
@@ -675,15 +675,15 @@ ORDER BY [o2].[Id], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId]
 
         AssertSql(
             """
-@__p_0='1'
-@__p_1='2'
+@p='1'
+@p0='2'
 
 SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd0], [o2].[PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
     ORDER BY [o].[Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    OFFSET @p ROWS FETCH NEXT @p0 ROWS ONLY
 ) AS [o2]
 LEFT JOIN (
     SELECT [o0].[ClientId], [o0].[Id], [o0].[OrderDate], [o0].[PeriodEnd], [o0].[PeriodStart], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id] AS [Id0], [o1].[Detail], [o1].[PeriodEnd] AS [PeriodEnd0], [o1].[PeriodStart] AS [PeriodStart0]
@@ -1098,9 +1098,9 @@ ORDER BY [o].[Id], [o1].[ClientId], [o1].[Id]
 
         AssertSql(
             """
-@__p_0='5'
+@p='5'
 
-SELECT TOP(@__p_0) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[PersonAddress_AddressLine], [o0].[PeriodEnd0], [o0].[PeriodStart0], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
+SELECT TOP(@p) [o0].[Id], [o0].[Discriminator], [o0].[Name], [o0].[PeriodEnd], [o0].[PeriodStart], [o0].[PersonAddress_AddressLine], [o0].[PeriodEnd0], [o0].[PeriodStart0], [o0].[PersonAddress_PlaceType], [o0].[PersonAddress_ZipCode], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [o0].[BranchAddress_BranchName], [o0].[BranchAddress_PlaceType], [o0].[BranchAddress_Country_Name], [o0].[BranchAddress_Country_PlanetId], [o0].[LeafBAddress_LeafBType], [o0].[LeafBAddress_PlaceType], [o0].[LeafBAddress_Country_Name], [o0].[LeafBAddress_Country_PlanetId], [o0].[LeafAAddress_LeafType], [o0].[LeafAAddress_PlaceType], [o0].[LeafAAddress_Country_Name], [o0].[LeafAAddress_Country_PlanetId]
 FROM (
     SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
@@ -1109,11 +1109,11 @@ ORDER BY [o0].[Id]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o2].[ClientId], [o2].[Id], [o2].[OrderDate], [o2].[PeriodEnd], [o2].[PeriodStart], [o5].[Id]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id]
+    SELECT TOP(@p) [o0].[Id]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
@@ -1125,11 +1125,11 @@ ORDER BY [o5].[Id], [o2].[ClientId], [o2].[Id]
 """,
             //
             """
-@__p_0='5'
+@p='5'
 
 SELECT [o4].[OrderClientId], [o4].[OrderId], [o4].[Id], [o4].[Detail], [o4].[PeriodEnd], [o4].[PeriodStart], [o5].[Id], [o2].[ClientId], [o2].[Id]
 FROM (
-    SELECT TOP(@__p_0) [o0].[Id]
+    SELECT TOP(@p) [o0].[Id]
     FROM (
         SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PeriodEnd], [o].[PeriodStart], [o].[PersonAddress_AddressLine], [o].[PeriodEnd] AS [PeriodEnd0], [o].[PeriodStart] AS [PeriodStart0], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
@@ -151,9 +151,9 @@ LEFT JOIN [OwnedEntityDifferentTable] AS [o] ON [m].[Id] = [o].[MainEntityDiffer
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
-SELECT TOP(@__p_0) [m0].[Id], [m0].[Description], [m0].[EndTime], [m0].[StartTime], [m0].[MainEntityDifferentTableId], [m0].[Description0], [m0].[EndTime0], [m0].[StartTime0]
+SELECT TOP(@p) [m0].[Id], [m0].[Description], [m0].[EndTime], [m0].[StartTime], [m0].[MainEntityDifferentTableId], [m0].[Description0], [m0].[EndTime0], [m0].[StartTime0]
 FROM (
     SELECT DISTINCT [m].[Id], [m].[Description], [m].[EndTime], [m].[StartTime], [o].[MainEntityDifferentTableId], [o].[Description] AS [Description0], [o].[EndTime] AS [EndTime0], [o].[StartTime] AS [StartTime0]
     FROM [MainEntityDifferentTable] FOR SYSTEM_TIME AS OF '2000-01-01T00:00:00.0000000' AS [m]
@@ -182,11 +182,11 @@ ORDER BY [m0].[Id] DESC
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s0].[Id], [s0].[Description], [s0].[EndTime], [s0].[StartTime], [s0].[MainEntityDifferentTableId], [s0].[Description1], [s0].[EndTime1], [s0].[StartTime1], [s0].[Id0], [s0].[Description0], [s0].[EndTime0], [s0].[StartTime0], [s0].[MainEntityDifferentTableId0], [s0].[Description2], [s0].[EndTime2], [s0].[StartTime2], [m1].[Id], [m1].[Description], [m1].[EndTime], [m1].[StartTime], [o1].[MainEntityDifferentTableId], [o1].[Description], [o1].[EndTime], [o1].[StartTime]
 FROM (
-    SELECT TOP(@__p_0) [s].[Id], [s].[Description], [s].[EndTime], [s].[StartTime], [s].[Id0], [s].[Description0], [s].[EndTime0], [s].[StartTime0], [s].[MainEntityDifferentTableId], [s].[Description1], [s].[EndTime1], [s].[StartTime1], [s].[MainEntityDifferentTableId0], [s].[Description2], [s].[EndTime2], [s].[StartTime2]
+    SELECT TOP(@p) [s].[Id], [s].[Description], [s].[EndTime], [s].[StartTime], [s].[Id0], [s].[Description0], [s].[EndTime0], [s].[StartTime0], [s].[MainEntityDifferentTableId], [s].[Description1], [s].[EndTime1], [s].[StartTime1], [s].[MainEntityDifferentTableId0], [s].[Description2], [s].[EndTime2], [s].[StartTime2]
     FROM (
         SELECT DISTINCT [m].[Id], [m].[Description], [m].[EndTime], [m].[StartTime], [m0].[Id] AS [Id0], [m0].[Description] AS [Description0], [m0].[EndTime] AS [EndTime0], [m0].[StartTime] AS [StartTime0], [o].[MainEntityDifferentTableId], [o].[Description] AS [Description1], [o].[EndTime] AS [EndTime1], [o].[StartTime] AS [StartTime1], [o0].[MainEntityDifferentTableId] AS [MainEntityDifferentTableId0], [o0].[Description] AS [Description2], [o0].[EndTime] AS [EndTime2], [o0].[StartTime] AS [StartTime2]
         FROM [MainEntityDifferentTable] FOR SYSTEM_TIME AS OF '2000-01-01T00:00:00.0000000' AS [m]
@@ -221,11 +221,11 @@ ORDER BY [s0].[Id] DESC
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT [s0].[Id], [s0].[Description], [s0].[EndTime], [s0].[StartTime], [s0].[MainEntityDifferentTableId], [s0].[Description1], [s0].[EndTime1], [s0].[StartTime1], [s0].[Id0], [s0].[Description0], [s0].[EndTime0], [s0].[StartTime0], [s0].[MainEntityDifferentTableId0], [s0].[Description2], [s0].[EndTime2], [s0].[StartTime2], [m1].[Id], [m1].[Description], [m1].[EndTime], [m1].[StartTime], [o1].[MainEntityDifferentTableId], [o1].[Description], [o1].[EndTime], [o1].[StartTime]
 FROM (
-    SELECT TOP(@__p_0) [s].[Id], [s].[Description], [s].[EndTime], [s].[StartTime], [s].[Id0], [s].[Description0], [s].[EndTime0], [s].[StartTime0], [s].[MainEntityDifferentTableId], [s].[Description1], [s].[EndTime1], [s].[StartTime1], [s].[MainEntityDifferentTableId0], [s].[Description2], [s].[EndTime2], [s].[StartTime2]
+    SELECT TOP(@p) [s].[Id], [s].[Description], [s].[EndTime], [s].[StartTime], [s].[Id0], [s].[Description0], [s].[EndTime0], [s].[StartTime0], [s].[MainEntityDifferentTableId], [s].[Description1], [s].[EndTime1], [s].[StartTime1], [s].[MainEntityDifferentTableId0], [s].[Description2], [s].[EndTime2], [s].[StartTime2]
     FROM (
         SELECT DISTINCT [m].[Id], [m].[Description], [m].[EndTime], [m].[StartTime], [m0].[Id] AS [Id0], [m0].[Description] AS [Description0], [m0].[EndTime] AS [EndTime0], [m0].[StartTime] AS [StartTime0], [o].[MainEntityDifferentTableId], [o].[Description] AS [Description1], [o].[EndTime] AS [EndTime1], [o].[StartTime] AS [StartTime1], [o0].[MainEntityDifferentTableId] AS [MainEntityDifferentTableId0], [o0].[Description] AS [Description2], [o0].[EndTime] AS [EndTime2], [o0].[StartTime] AS [StartTime2]
         FROM [MainEntityDifferentTable] AS [m]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -38,11 +38,11 @@ WHERE IsDate([c].[FirstName]) = CAST(0 AS bit)
 
         AssertSql(
             """
-@__customerId_0='3'
+@customerId='3'
 
 SELECT TOP(2) len([c].[LastName])
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -52,9 +52,9 @@ WHERE [c].[Id] = @__customerId_0
 
         AssertSql(
             """
-@__customerId_0='1'
+@customerId='1'
 
-SELECT [dbo].[CustomerOrderCount](@__customerId_0)
+SELECT [dbo].[CustomerOrderCount](@customerId)
 FROM [Customers] AS [c]
 """);
     }
@@ -89,11 +89,11 @@ WHERE [c].[Id] = 1
 
         AssertSql(
             """
-@__customerId_0='1'
+@customerId='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@customerId) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -103,12 +103,12 @@ WHERE [c].[Id] = @__customerId_0
 
         AssertSql(
             """
-@__starCount_1='3'
-@__customerId_0='3'
+@starCount='3'
+@customerId='3'
 
-SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_0)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@starCount, [dbo].[CustomerOrderCount](@customerId)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -130,11 +130,11 @@ WHERE [dbo].[IsTopCustomer]([c].[Id]) = CAST(1 AS bit)
 
         AssertSql(
             """
-@__startDate_0='2000-04-01T00:00:00.0000000' (Nullable = true)
+@startDate='2000-04-01T00:00:00.0000000' (Nullable = true)
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_0) = [c].[Id]
+WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@startDate) = [c].[Id]
 """);
     }
 
@@ -144,11 +144,11 @@ WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_0) = [c].[Id]
 
         AssertSql(
             """
-@__period_0='0'
+@period='0'
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@__period_0))
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@period))
 """);
     }
 
@@ -194,11 +194,11 @@ WHERE [c].[Id] = 2
 
         AssertSql(
             """
-@__customerId_0='2'
+@customerId='2'
 
-SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@customerId) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -208,12 +208,12 @@ WHERE [c].[Id] = @__customerId_0
 
         AssertSql(
             """
-@__starCount_1='3'
-@__customerId_0='1'
+@starCount='3'
+@customerId='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_0)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@starCount, [dbo].[CustomerOrderCount](@customerId)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -378,11 +378,11 @@ WHERE IsDate([c].[FirstName]) = CAST(0 AS bit)
 
         AssertSql(
             """
-@__customerId_0='3'
+@customerId='3'
 
 SELECT TOP(2) len([c].[LastName])
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -392,9 +392,9 @@ WHERE [c].[Id] = @__customerId_0
 
         AssertSql(
             """
-@__customerId_1='1'
+@customerId='1'
 
-SELECT [dbo].[CustomerOrderCount](@__customerId_1)
+SELECT [dbo].[CustomerOrderCount](@customerId)
 FROM [Customers] AS [c]
 """);
     }
@@ -429,11 +429,11 @@ WHERE [c].[Id] = 1
 
         AssertSql(
             """
-@__customerId_0='1'
+@customerId='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@customerId) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -443,12 +443,12 @@ WHERE [c].[Id] = @__customerId_0
 
         AssertSql(
             """
-@__starCount_2='3'
-@__customerId_0='3'
+@starCount='3'
+@customerId='3'
 
-SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_2, [dbo].[CustomerOrderCount](@__customerId_0)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@starCount, [dbo].[CustomerOrderCount](@customerId)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_0
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -470,11 +470,11 @@ WHERE [dbo].[IsTopCustomer]([c].[Id]) = CAST(1 AS bit)
 
         AssertSql(
             """
-@__startDate_1='2000-04-01T00:00:00.0000000' (Nullable = true)
+@startDate='2000-04-01T00:00:00.0000000' (Nullable = true)
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_1) = [c].[Id]
+WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@startDate) = [c].[Id]
 """);
     }
 
@@ -484,11 +484,11 @@ WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_1) = [c].[Id]
 
         AssertSql(
             """
-@__period_1='0'
+@period='0'
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@__period_1))
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@period))
 """);
     }
 
@@ -534,11 +534,11 @@ WHERE [c].[Id] = 2
 
         AssertSql(
             """
-@__customerId_1='2'
+@customerId='2'
 
-SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_1) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@customerId) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_1
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -548,12 +548,12 @@ WHERE [c].[Id] = @__customerId_1
 
         AssertSql(
             """
-@__starCount_2='3'
-@__customerId_1='1'
+@starCount='3'
+@customerId='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_2, [dbo].[CustomerOrderCount](@__customerId_1)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@starCount, [dbo].[CustomerOrderCount](@customerId)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = @__customerId_1
+WHERE [c].[Id] = @customerId
 """);
     }
 
@@ -617,10 +617,10 @@ ORDER BY [g].[ProductId]
 
         AssertSql(
             """
-@__customerId_1='1'
+@customerId='1'
 
 SELECT [g].[Count], [g].[CustomerId], [g].[Year]
-FROM [dbo].[GetCustomerOrderCountByYear](@__customerId_1) AS [g]
+FROM [dbo].[GetCustomerOrderCountByYear](@customerId) AS [g]
 ORDER BY [g].[Count] DESC
 """);
     }
@@ -752,12 +752,12 @@ ORDER BY [g].[Count]
 
         AssertSql(
             """
-@__custId_1='2'
+@custId='2'
 
 SELECT [c].[Id], [c].[LastName], [g].[Year], [g].[Count]
 FROM [Customers] AS [c]
-CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@__custId_1) AS [g]
-WHERE [c].[Id] = @__custId_1
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@custId) AS [g]
+WHERE [c].[Id] = @custId
 ORDER BY [g].[Count]
 """);
     }
@@ -847,12 +847,12 @@ ORDER BY [c].[Id], [g].[Year]
 
         AssertSql(
             """
-@__custId_1='2'
+@custId='2'
 
 SELECT [c].[Id], [c].[LastName], [g].[Year], [g].[Count]
 FROM [Customers] AS [c]
 CROSS JOIN [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues](1, 1)) AS [g]
-WHERE [c].[Id] = @__custId_1
+WHERE [c].[Id] = @custId
 ORDER BY [g].[Year]
 """);
     }
@@ -863,12 +863,12 @@ ORDER BY [g].[Year]
 
         AssertSql(
             """
-@__custId_1='2'
+@custId='2'
 
 SELECT [c].[Id], [g].[Count], [g].[Year]
 FROM [Customers] AS [c]
 CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues]([c].[Id], 1)) AS [g]
-WHERE [c].[Id] = @__custId_1
+WHERE [c].[Id] = @custId
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPCTest.cs
@@ -49,11 +49,11 @@ FROM (
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """,
             //
             """
@@ -79,11 +79,11 @@ FROM (
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPTTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTPTTest.cs
@@ -46,11 +46,11 @@ LEFT JOIN [SpecialCategory] AS [s] ON [c].[Id] = [s].[Id]
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """,
             //
             """
@@ -73,11 +73,11 @@ LEFT JOIN [SpecialCategory] AS [s] ON [c].[Id] = [s].[Id]
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/UpdatesSqlServerTest.cs
@@ -42,11 +42,11 @@ FROM [Categories] AS [c]
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """,
             //
             """
@@ -66,11 +66,11 @@ FROM [Categories] AS [c]
 """,
             //
             """
-@__category_PrincipalId_0='778' (Nullable = true)
+@category_PrincipalId='778' (Nullable = true)
 
 SELECT [p].[Id], [p].[Discriminator], [p].[DependentId], [p].[IsPrimary], [p].[IsPrimaryNormalized], [p].[Name], [p].[Price]
 FROM [ProductBase] AS [p]
-WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_PrincipalId_0
+WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @category_PrincipalId
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/ValueConvertersEndToEndSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ValueConvertersEndToEndSqlServerTest.cs
@@ -205,11 +205,11 @@ WHERE CAST(DATALENGTH(CAST(N'' AS nvarchar(max))) AS int) = 1
 
         Assert.Equal(
             """
-@__guid_0='d854227f-7076-48c3-997c-4e72c1c713b9' (Nullable = false) (Size = 40)
+@guid='d854227f-7076-48c3-997c-4e72c1c713b9' (Nullable = false) (Size = 40)
 
 SELECT [s].[Id], [s].[GuidToDbTypeString], [s].[GuidToFixedLengthString]
 FROM [SqlServerConvertingEntity] AS [s]
-WHERE [s].[GuidToFixedLengthString] <> @__guid_0
+WHERE [s].[GuidToFixedLengthString] <> @guid
 """,
             Fixture.TestSqlLoggerFactory.SqlStatements[0],
             ignoreLineEndingDifferences: true);
@@ -238,11 +238,11 @@ WHERE [s].[GuidToFixedLengthString] <> @__guid_0
 
         Assert.Equal(
             """
-@__guid_0='d854227f-7076-48c3-997c-4e72c1c713b9' (Nullable = false) (Size = 40) (DbType = AnsiStringFixedLength)
+@guid='d854227f-7076-48c3-997c-4e72c1c713b9' (Nullable = false) (Size = 40) (DbType = AnsiStringFixedLength)
 
 SELECT [s].[Id], [s].[GuidToDbTypeString], [s].[GuidToFixedLengthString]
 FROM [SqlServerConvertingEntity] AS [s]
-WHERE [s].[GuidToDbTypeString] <> @__guid_0
+WHERE [s].[GuidToDbTypeString] <> @guid
 """,
             Fixture.TestSqlLoggerFactory.SqlStatements[0],
             ignoreLineEndingDifferences: true);

--- a/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
@@ -302,12 +302,12 @@ public class QueryTests : IDisposable
 
         Assert.Equal(
             """
-            @__isaac_0='?' (DbType = Object)
+@isaac='?' (DbType = Object)
 
-            SELECT [p].[Name]
-            FROM [Patriarchy] AS [p]
-            WHERE @__isaac_0.IsDescendantOf([p].[Id]) = CAST(1 AS bit)
-            """,
+SELECT [p].[Name]
+FROM [Patriarchy] AS [p]
+WHERE @isaac.IsDescendantOf([p].[Id]) = CAST(1 AS bit)
+""",
             _db.Sql,
             ignoreLineEndingDifferences: true);
 
@@ -366,13 +366,13 @@ public class QueryTests : IDisposable
 
         Assert.Equal(
             """
-@__ids_0='?' (Size = 4000)
+@ids='?' (Size = 4000)
 
 SELECT TOP(2) [p].[Name]
 FROM [Patriarchy] AS [p]
 WHERE [p].[Id] IN (
     SELECT CAST([i].[value] AS hierarchyid) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    FROM OPENJSON(@ids) AS [i]
 )
 """,
             _db.Sql,

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -32,14 +32,14 @@ DELETE FROM "Owner" AS "o"
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 DELETE FROM "Owner" AS "o"
 WHERE "o"."Id" IN (
     SELECT "o0"."Id"
     FROM "Owner" AS "o0"
     ORDER BY "o0"."Title"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -46,10 +46,10 @@ WHERE "o"."OrderID" < 10300
 
         AssertSql(
             """
-@__quantity_0='1' (Nullable = true) (DbType = Int16)
+@quantity='1' (Nullable = true) (DbType = Int16)
 
 DELETE FROM "Order Details" AS "o"
-WHERE "o"."Quantity" = @__quantity_0
+WHERE "o"."Quantity" = @quantity
 """,
             //
             """
@@ -78,7 +78,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -88,7 +88,7 @@ WHERE EXISTS (
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
         ORDER BY "o0"."OrderID"
-        LIMIT -1 OFFSET @__p_0
+        LIMIT -1 OFFSET @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -100,7 +100,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -110,7 +110,7 @@ WHERE EXISTS (
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
         ORDER BY "o0"."OrderID"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -122,7 +122,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -132,7 +132,7 @@ WHERE EXISTS (
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
         ORDER BY "o0"."OrderID"
-        LIMIT @__p_0 OFFSET @__p_0
+        LIMIT @p OFFSET @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -144,7 +144,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -153,7 +153,7 @@ WHERE EXISTS (
         SELECT "o0"."OrderID", "o0"."ProductID"
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
-        LIMIT -1 OFFSET @__p_0
+        LIMIT -1 OFFSET @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -165,7 +165,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -174,7 +174,7 @@ WHERE EXISTS (
         SELECT "o0"."OrderID", "o0"."ProductID"
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -186,7 +186,7 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
+@p='100'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -195,7 +195,7 @@ WHERE EXISTS (
         SELECT "o0"."OrderID", "o0"."ProductID"
         FROM "Order Details" AS "o0"
         WHERE "o0"."OrderID" < 10300
-        LIMIT @__p_0 OFFSET @__p_0
+        LIMIT @p OFFSET @p
     ) AS "o1"
     WHERE "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
 """);
@@ -265,9 +265,9 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_0='100'
-@__p_2='5'
-@__p_1='20'
+@p='100'
+@p2='5'
+@p1='20'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -278,9 +278,9 @@ WHERE EXISTS (
             SELECT "o1"."OrderID", "o1"."ProductID"
             FROM "Order Details" AS "o1"
             WHERE "o1"."OrderID" < 10300
-            LIMIT @__p_0 OFFSET @__p_0
+            LIMIT @p OFFSET @p
         ) AS "o0"
-        LIMIT @__p_2 OFFSET @__p_1
+        LIMIT @p2 OFFSET @p1
     ) AS "o2"
     WHERE "o2"."OrderID" = "o"."OrderID" AND "o2"."ProductID" = "o"."ProductID")
 """);
@@ -511,8 +511,8 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_1='100'
-@__p_0='0'
+@p0='100'
+@p='0'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -523,7 +523,7 @@ WHERE EXISTS (
         FROM "Orders" AS "o2"
         WHERE "o2"."OrderID" < 10300
         ORDER BY "o2"."OrderID"
-        LIMIT @__p_1 OFFSET @__p_0
+        LIMIT @p0 OFFSET @p
     ) AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
     WHERE "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
@@ -535,8 +535,8 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@__p_1='100'
-@__p_0='0'
+@p0='100'
+@p='0'
 
 DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
@@ -547,7 +547,7 @@ WHERE EXISTS (
         FROM "Orders" AS "o2"
         WHERE "o2"."OrderID" < 10300
         ORDER BY "o2"."OrderID"
-        LIMIT @__p_1 OFFSET @__p_0
+        LIMIT @p0 OFFSET @p
     ) AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
     WHERE "o0"."OrderID" < 10276 AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
@@ -616,19 +616,19 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__customer_0='ALFKI' (Size = 5)
+@customer='ALFKI' (Size = 5)
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" = @__customer_0
+WHERE "c"."CustomerID" = @customer
 """,
             //
             """
-@__customer_0='ALFKI' (Size = 5)
+@customer='ALFKI' (Size = 5)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."CustomerID" = @__customer_0
+WHERE "c"."CustomerID" = @customer
 """,
             //
             """
@@ -650,10 +650,10 @@ WHERE 0
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 3)
+@value='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = @__value_0
+SET "ContactName" = @value
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -664,10 +664,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__p_0='Abc' (Size = 3)
+@p='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = @__p_0
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -690,10 +690,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__container_Containee_Property_0='Abc' (Size = 3)
+@container_Containee_Property='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = @__container_Containee_Property_0
+SET "ContactName" = @container_Containee_Property
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -704,7 +704,7 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -712,7 +712,7 @@ FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -724,7 +724,7 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -732,7 +732,7 @@ FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -744,8 +744,8 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_1='4'
-@__p_0='2'
+@p0='4'
+@p='2'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -753,7 +753,7 @@ FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
-    LIMIT @__p_1 OFFSET @__p_0
+    LIMIT @p0 OFFSET @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -782,7 +782,7 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -791,7 +791,7 @@ FROM (
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
     ORDER BY "c"."City"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -803,7 +803,7 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_0='4'
+@p='4'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -812,7 +812,7 @@ FROM (
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
     ORDER BY "c"."City"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -824,8 +824,8 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_1='4'
-@__p_0='2'
+@p0='4'
+@p='2'
 
 UPDATE "Customers" AS "c0"
 SET "ContactName" = 'Updated'
@@ -834,7 +834,7 @@ FROM (
     FROM "Customers" AS "c"
     WHERE "c"."CustomerID" LIKE 'F%'
     ORDER BY "c"."City"
-    LIMIT @__p_1 OFFSET @__p_0
+    LIMIT @p0 OFFSET @p
 ) AS "c1"
 WHERE "c0"."CustomerID" = "c1"."CustomerID"
 """);
@@ -846,8 +846,8 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
-@__p_1='6'
-@__p_0='2'
+@p0='6'
+@p='2'
 
 UPDATE "Customers" AS "c1"
 SET "ContactName" = 'Updated'
@@ -858,10 +858,10 @@ FROM (
         FROM "Customers" AS "c"
         WHERE "c"."CustomerID" LIKE 'F%'
         ORDER BY "c"."City"
-        LIMIT @__p_1 OFFSET @__p_0
+        LIMIT @p0 OFFSET @p
     ) AS "c0"
     ORDER BY "c0"."City"
-    LIMIT @__p_0 OFFSET @__p_0
+    LIMIT @p OFFSET @p
 ) AS "c2"
 WHERE "c1"."CustomerID" = "c2"."CustomerID"
 """);
@@ -1014,10 +1014,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 3)
+@value='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = COALESCE("c"."ContactName", '') || @__value_0
+SET "ContactName" = COALESCE("c"."ContactName", '') || @value
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -1078,11 +1078,11 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@__value_0='Abc' (Size = 3)
+@value='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
 SET "City" = 'Seattle',
-    "ContactName" = @__value_0
+    "ContactName" = @value
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -32,8 +32,8 @@ WHERE "a"."CountryId" = 1 AND "a"."Name" = 'Great spotted kiwi'
 
         AssertSql(
             """
-@__p_1='3'
-@__p_0='0'
+@p0='3'
+@p='0'
 
 DELETE FROM "Animals" AS "a"
 WHERE "a"."Id" IN (
@@ -41,7 +41,7 @@ WHERE "a"."Id" IN (
     FROM "Animals" AS "a0"
     WHERE "a0"."CountryId" = 1 AND "a0"."Name" = 'Great spotted kiwi'
     ORDER BY "a0"."Name"
-    LIMIT @__p_1 OFFSET @__p_0
+    LIMIT @p0 OFFSET @p
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqliteTest.cs
@@ -31,8 +31,8 @@ WHERE "a"."Name" = 'Great spotted kiwi'
 
         AssertSql(
             """
-@__p_1='3'
-@__p_0='0'
+@p0='3'
+@p='0'
 
 DELETE FROM "Animals" AS "a"
 WHERE "a"."Id" IN (
@@ -40,7 +40,7 @@ WHERE "a"."Id" IN (
     FROM "Animals" AS "a0"
     WHERE "a0"."Name" = 'Great spotted kiwi'
     ORDER BY "a0"."Name"
-    LIMIT @__p_1 OFFSET @__p_0
+    LIMIT @p0 OFFSET @p
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -22,11 +22,11 @@ public class CustomConvertersSqliteTest : CustomConvertersTestBase<CustomConvert
 
         AssertSql(
             """
-@__blogId_0='1'
+@blogId='1'
 
 SELECT "b"."Url"
 FROM "Blog" AS "b"
-INNER JOIN "Post" AS "p" ON "b"."BlogId" = "p"."BlogId" AND "b"."IsVisible" = 'Y' AND "b"."BlogId" = @__blogId_0
+INNER JOIN "Post" AS "p" ON "b"."BlogId" = "p"."BlogId" AND "b"."IsVisible" = 'Y' AND "b"."BlogId" = @blogId
 WHERE "b"."IsVisible" = 'Y'
 """);
     }
@@ -38,11 +38,11 @@ WHERE "b"."IsVisible" = 'Y'
 
         AssertSql(
             """
-@__blogId_0='1'
+@blogId='1'
 
 SELECT "b"."Url"
 FROM "Blog" AS "b"
-LEFT JOIN "Post" AS "p" ON "b"."BlogId" = "p"."BlogId" AND "b"."IsVisible" = 'Y' AND "b"."BlogId" = @__blogId_0
+LEFT JOIN "Post" AS "p" ON "b"."BlogId" = "p"."BlogId" AND "b"."IsVisible" = 'Y' AND "b"."BlogId" = @blogId
 WHERE "b"."IsVisible" = 'Y'
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -47,14 +47,14 @@ WHERE "c"."ShippingAddress_Country_Code" = 'DE'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "c0"."Id", "c0"."Name", "c0"."BillingAddress_AddressLine1", "c0"."BillingAddress_AddressLine2", "c0"."BillingAddress_Tags", "c0"."BillingAddress_ZipCode", "c0"."BillingAddress_Country_Code", "c0"."BillingAddress_Country_FullName", "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_Tags", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
     FROM "Customer" AS "c"
     ORDER BY "c"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c0"
 WHERE "c0"."ShippingAddress_ZipCode" = 7728
 """);
@@ -66,14 +66,14 @@ WHERE "c0"."ShippingAddress_ZipCode" = 7728
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "c0"."Id", "c0"."Name", "c0"."BillingAddress_AddressLine1", "c0"."BillingAddress_AddressLine2", "c0"."BillingAddress_Tags", "c0"."BillingAddress_ZipCode", "c0"."BillingAddress_Country_Code", "c0"."BillingAddress_Country_FullName", "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_Tags", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
     FROM "Customer" AS "c"
     ORDER BY "c"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c0"
 WHERE "c0"."ShippingAddress_Country_Code" = 'DE'
 """);
@@ -135,14 +135,14 @@ INNER JOIN "Customer" AS "c0" ON "c"."RequiredCustomerId" = "c0"."Id"
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "c0"."Id", "c0"."Name", "c0"."BillingAddress_AddressLine1", "c0"."BillingAddress_AddressLine2", "c0"."BillingAddress_Tags", "c0"."BillingAddress_ZipCode", "c0"."BillingAddress_Country_Code", "c0"."BillingAddress_Country_FullName", "c0"."ShippingAddress_AddressLine1", "c0"."ShippingAddress_AddressLine2", "c0"."ShippingAddress_Tags", "c0"."ShippingAddress_ZipCode", "c0"."ShippingAddress_Country_Code", "c0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
     FROM "Customer" AS "c"
     ORDER BY "c"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c0"
 """);
     }
@@ -233,15 +233,15 @@ WHERE "c"."ShippingAddress_AddressLine1" = '804 S. Lakeshore Road' AND "c"."Ship
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
-@__entity_equality_address_0_Tags='["foo","bar"]' (Size = 13)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 2)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@entity_equality_address_Tags='["foo","bar"]' (Size = 13)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 2)
+@entity_equality_address_Country_FullName='United States' (Size = 13)
 
 SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
 FROM "Customer" AS "c"
-WHERE "c"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c"."ShippingAddress_AddressLine2" IS NULL AND "c"."ShippingAddress_Tags" = @__entity_equality_address_0_Tags AND "c"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "c"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName
+WHERE "c"."ShippingAddress_AddressLine1" = @entity_equality_address_AddressLine1 AND "c"."ShippingAddress_AddressLine2" IS NULL AND "c"."ShippingAddress_Tags" = @entity_equality_address_Tags AND "c"."ShippingAddress_ZipCode" = @entity_equality_address_ZipCode AND "c"."ShippingAddress_Country_Code" = @entity_equality_address_Country_Code AND "c"."ShippingAddress_Country_FullName" = @entity_equality_address_Country_FullName
 """);
     }
 
@@ -265,18 +265,18 @@ WHERE "c"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressL
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
-@__entity_equality_address_0_Tags='["foo","bar"]' (Size = 13)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 2)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@entity_equality_address_Tags='["foo","bar"]' (Size = 13)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 2)
+@entity_equality_address_Country_FullName='United States' (Size = 13)
 
 SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
 FROM "Customer" AS "c"
 WHERE EXISTS (
     SELECT 1
     FROM "Customer" AS "c0"
-    WHERE "c0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "c0"."ShippingAddress_AddressLine2" IS NULL AND "c0"."ShippingAddress_Tags" = @__entity_equality_address_0_Tags AND "c0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "c0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "c0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName)
+    WHERE "c0"."ShippingAddress_AddressLine1" = @entity_equality_address_AddressLine1 AND "c0"."ShippingAddress_AddressLine2" IS NULL AND "c0"."ShippingAddress_Tags" = @entity_equality_address_Tags AND "c0"."ShippingAddress_ZipCode" = @entity_equality_address_ZipCode AND "c0"."ShippingAddress_Country_Code" = @entity_equality_address_Country_Code AND "c0"."ShippingAddress_Country_FullName" = @entity_equality_address_Country_FullName)
 """);
     }
 
@@ -416,14 +416,14 @@ WHERE "v"."ShippingAddress_Country_Code" = 'DE'
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
     FROM "ValuedCustomer" AS "v"
     ORDER BY "v"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "v0"
 WHERE "v0"."ShippingAddress_ZipCode" = 7728
 """);
@@ -435,14 +435,14 @@ WHERE "v0"."ShippingAddress_ZipCode" = 7728
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
     FROM "ValuedCustomer" AS "v"
     ORDER BY "v"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "v0"
 WHERE "v0"."ShippingAddress_Country_Code" = 'DE'
 """);
@@ -505,14 +505,14 @@ INNER JOIN "ValuedCustomer" AS "v0" ON "v"."RequiredCustomerId" = "v0"."Id"
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT DISTINCT "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
 FROM (
     SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
     FROM "ValuedCustomer" AS "v"
     ORDER BY "v"."Id"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "v0"
 """);
     }
@@ -603,14 +603,14 @@ WHERE "v"."ShippingAddress_AddressLine1" = '804 S. Lakeshore Road' AND "v"."Ship
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 2)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 2)
+@entity_equality_address_Country_FullName='United States' (Size = 13)
 
 SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
 FROM "ValuedCustomer" AS "v"
-WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "v"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName
+WHERE "v"."ShippingAddress_AddressLine1" = @entity_equality_address_AddressLine1 AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = @entity_equality_address_ZipCode AND "v"."ShippingAddress_Country_Code" = @entity_equality_address_Country_Code AND "v"."ShippingAddress_Country_FullName" = @entity_equality_address_Country_FullName
 """);
     }
 
@@ -627,17 +627,17 @@ WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressL
 
         AssertSql(
             """
-@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
-@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
-@__entity_equality_address_0_Country_Code='US' (Size = 2)
-@__entity_equality_address_0_Country_FullName='United States' (Size = 13)
+@entity_equality_address_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@entity_equality_address_ZipCode='38654' (Nullable = true)
+@entity_equality_address_Country_Code='US' (Size = 2)
+@entity_equality_address_Country_FullName='United States' (Size = 13)
 
 SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
 FROM "ValuedCustomer" AS "v"
 WHERE EXISTS (
     SELECT 1
     FROM "ValuedCustomer" AS "v0"
-    WHERE "v0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v0"."ShippingAddress_AddressLine2" IS NULL AND "v0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Country_Code AND "v0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_Country_FullName)
+    WHERE "v0"."ShippingAddress_AddressLine1" = @entity_equality_address_AddressLine1 AND "v0"."ShippingAddress_AddressLine2" IS NULL AND "v0"."ShippingAddress_ZipCode" = @entity_equality_address_ZipCode AND "v0"."ShippingAddress_Country_Code" = @entity_equality_address_Country_Code AND "v0"."ShippingAddress_Country_FullName" = @entity_equality_address_Country_FullName)
 """);
     }
 
@@ -783,7 +783,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "s0"."Id", "s0"."Name", "s0"."BillingAddress_AddressLine1", "s0"."BillingAddress_AddressLine2", "s0"."BillingAddress_Tags", "s0"."BillingAddress_ZipCode", "s0"."BillingAddress_Country_Code", "s0"."BillingAddress_Country_FullName", "s0"."ShippingAddress_AddressLine1", "s0"."ShippingAddress_AddressLine2", "s0"."ShippingAddress_Tags", "s0"."ShippingAddress_ZipCode", "s0"."ShippingAddress_Country_Code", "s0"."ShippingAddress_Country_FullName", "s0"."Id0", "s0"."Name0", "s0"."BillingAddress_AddressLine10", "s0"."BillingAddress_AddressLine20", "s0"."BillingAddress_Tags0", "s0"."BillingAddress_ZipCode0", "s0"."BillingAddress_Country_Code0", "s0"."BillingAddress_Country_FullName0", "s0"."ShippingAddress_AddressLine10", "s0"."ShippingAddress_AddressLine20", "s0"."ShippingAddress_Tags0", "s0"."ShippingAddress_ZipCode0", "s0"."ShippingAddress_Country_Code0", "s0"."ShippingAddress_Country_FullName0"
 FROM (
@@ -793,7 +793,7 @@ FROM (
         FROM "Customer" AS "c"
         CROSS JOIN "Customer" AS "c0"
         ORDER BY "c"."Id", "c0"."Id"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "s"
 ) AS "s0"
 """);
@@ -805,7 +805,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "s0"."BillingAddress_AddressLine1", "s0"."BillingAddress_AddressLine2", "s0"."BillingAddress_Tags", "s0"."BillingAddress_ZipCode", "s0"."BillingAddress_Country_Code", "s0"."BillingAddress_Country_FullName", "s0"."BillingAddress_AddressLine10", "s0"."BillingAddress_AddressLine20", "s0"."BillingAddress_Tags0", "s0"."BillingAddress_ZipCode0", "s0"."BillingAddress_Country_Code0", "s0"."BillingAddress_Country_FullName0"
 FROM (
@@ -815,7 +815,7 @@ FROM (
         FROM "Customer" AS "c"
         CROSS JOIN "Customer" AS "c0"
         ORDER BY "c"."Id", "c0"."Id"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "s"
 ) AS "s0"
 """);
@@ -857,7 +857,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "s0"."Id", "s0"."Name", "s0"."BillingAddress_AddressLine1", "s0"."BillingAddress_AddressLine2", "s0"."BillingAddress_ZipCode", "s0"."BillingAddress_Country_Code", "s0"."BillingAddress_Country_FullName", "s0"."ShippingAddress_AddressLine1", "s0"."ShippingAddress_AddressLine2", "s0"."ShippingAddress_ZipCode", "s0"."ShippingAddress_Country_Code", "s0"."ShippingAddress_Country_FullName", "s0"."Id0", "s0"."Name0", "s0"."BillingAddress_AddressLine10", "s0"."BillingAddress_AddressLine20", "s0"."BillingAddress_ZipCode0", "s0"."BillingAddress_Country_Code0", "s0"."BillingAddress_Country_FullName0", "s0"."ShippingAddress_AddressLine10", "s0"."ShippingAddress_AddressLine20", "s0"."ShippingAddress_ZipCode0", "s0"."ShippingAddress_Country_Code0", "s0"."ShippingAddress_Country_FullName0"
 FROM (
@@ -867,7 +867,7 @@ FROM (
         FROM "ValuedCustomer" AS "v"
         CROSS JOIN "ValuedCustomer" AS "v0"
         ORDER BY "v"."Id", "v0"."Id"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "s"
 ) AS "s0"
 """);
@@ -879,7 +879,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "s0"."BillingAddress_AddressLine1", "s0"."BillingAddress_AddressLine2", "s0"."BillingAddress_ZipCode", "s0"."BillingAddress_Country_Code", "s0"."BillingAddress_Country_FullName", "s0"."BillingAddress_AddressLine10", "s0"."BillingAddress_AddressLine20", "s0"."BillingAddress_ZipCode0", "s0"."BillingAddress_Country_Code0", "s0"."BillingAddress_Country_FullName0"
 FROM (
@@ -889,7 +889,7 @@ FROM (
         FROM "ValuedCustomer" AS "v"
         CROSS JOIN "ValuedCustomer" AS "v0"
         ORDER BY "v"."Id", "v0"."Id"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "s"
 ) AS "s0"
 """);
@@ -901,7 +901,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "u"."Id", "u"."Name", "u"."BillingAddress_AddressLine1", "u"."BillingAddress_AddressLine2", "u"."BillingAddress_Tags", "u"."BillingAddress_ZipCode", "u"."BillingAddress_Country_Code", "u"."BillingAddress_Country_FullName", "u"."ShippingAddress_AddressLine1", "u"."ShippingAddress_AddressLine2", "u"."ShippingAddress_Tags", "u"."ShippingAddress_ZipCode", "u"."ShippingAddress_Country_Code", "u"."ShippingAddress_Country_FullName", "u"."Id0", "u"."Name0", "u"."BillingAddress_AddressLine10", "u"."BillingAddress_AddressLine20", "u"."BillingAddress_Tags0", "u"."BillingAddress_ZipCode0", "u"."BillingAddress_Country_Code0", "u"."BillingAddress_Country_FullName0", "u"."ShippingAddress_AddressLine10", "u"."ShippingAddress_AddressLine20", "u"."ShippingAddress_Tags0", "u"."ShippingAddress_ZipCode0", "u"."ShippingAddress_Country_Code0", "u"."ShippingAddress_Country_FullName0"
 FROM (
@@ -914,7 +914,7 @@ FROM (
     CROSS JOIN "Customer" AS "c2"
 ) AS "u"
 ORDER BY "u"."Id", "u"."Id0"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -924,7 +924,7 @@ LIMIT @__p_0
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "u1"."Id", "u1"."Name", "u1"."BillingAddress_AddressLine1", "u1"."BillingAddress_AddressLine2", "u1"."BillingAddress_Tags", "u1"."BillingAddress_ZipCode", "u1"."BillingAddress_Country_Code", "u1"."BillingAddress_Country_FullName", "u1"."ShippingAddress_AddressLine1", "u1"."ShippingAddress_AddressLine2", "u1"."ShippingAddress_Tags", "u1"."ShippingAddress_ZipCode", "u1"."ShippingAddress_Country_Code", "u1"."ShippingAddress_Country_FullName", "u1"."Id0", "u1"."Name0", "u1"."BillingAddress_AddressLine10", "u1"."BillingAddress_AddressLine20", "u1"."BillingAddress_Tags0", "u1"."BillingAddress_ZipCode0", "u1"."BillingAddress_Country_Code0", "u1"."BillingAddress_Country_FullName0", "u1"."ShippingAddress_AddressLine10", "u1"."ShippingAddress_AddressLine20", "u1"."ShippingAddress_Tags0", "u1"."ShippingAddress_ZipCode0", "u1"."ShippingAddress_Country_Code0", "u1"."ShippingAddress_Country_FullName0"
 FROM (
@@ -941,11 +941,11 @@ FROM (
             CROSS JOIN "Customer" AS "c2"
         ) AS "u"
         ORDER BY "u"."Id", "u"."Id0"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "u0"
 ) AS "u1"
 ORDER BY "u1"."Id", "u1"."Id0"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -955,7 +955,7 @@ LIMIT @__p_0
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "u"."BillingAddress_AddressLine1", "u"."BillingAddress_AddressLine2", "u"."BillingAddress_Tags", "u"."BillingAddress_ZipCode", "u"."BillingAddress_Country_Code", "u"."BillingAddress_Country_FullName", "u"."BillingAddress_AddressLine10", "u"."BillingAddress_AddressLine20", "u"."BillingAddress_Tags0", "u"."BillingAddress_ZipCode0", "u"."BillingAddress_Country_Code0", "u"."BillingAddress_Country_FullName0"
 FROM (
@@ -968,7 +968,7 @@ FROM (
     CROSS JOIN "Customer" AS "c2"
 ) AS "u"
 ORDER BY "u"."BillingAddress_ZipCode", "u"."BillingAddress_ZipCode0"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -978,7 +978,7 @@ LIMIT @__p_0
 
         AssertSql(
             """
-@__p_0='50'
+@p='50'
 
 SELECT "u1"."BillingAddress_AddressLine1", "u1"."BillingAddress_AddressLine2", "u1"."BillingAddress_Tags", "u1"."BillingAddress_ZipCode", "u1"."BillingAddress_Country_Code", "u1"."BillingAddress_Country_FullName", "u1"."BillingAddress_AddressLine10", "u1"."BillingAddress_AddressLine20", "u1"."BillingAddress_Tags0", "u1"."BillingAddress_ZipCode0", "u1"."BillingAddress_Country_Code0", "u1"."BillingAddress_Country_FullName0"
 FROM (
@@ -995,11 +995,11 @@ FROM (
             CROSS JOIN "Customer" AS "c2"
         ) AS "u"
         ORDER BY "u"."BillingAddress_ZipCode", "u"."BillingAddress_ZipCode0"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "u0"
 ) AS "u1"
 ORDER BY "u1"."BillingAddress_ZipCode", "u1"."BillingAddress_ZipCode0"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -1100,7 +1100,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__p_0='20'
+@p='20'
 
 SELECT "s0"."ShippingAddress_ZipCode"
 FROM (
@@ -1110,7 +1110,7 @@ FROM (
         FROM "CustomerGroup" AS "c"
         LEFT JOIN "Customer" AS "c0" ON "c"."OptionalCustomerId" = "c0"."Id"
         ORDER BY "c0"."ShippingAddress_ZipCode"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "s"
 ) AS "s0"
 """);
@@ -1122,8 +1122,8 @@ FROM (
 
         AssertSql(
             """
-@__p_0='20'
-@__p_1='30'
+@p='20'
+@p0='30'
 
 SELECT "c3"."BillingAddress_ZipCode" AS "Zip1", "c4"."ShippingAddress_ZipCode" AS "Zip2"
 FROM (
@@ -1132,7 +1132,7 @@ FROM (
         SELECT "c"."Id", "c"."Name", "c"."BillingAddress_AddressLine1", "c"."BillingAddress_AddressLine2", "c"."BillingAddress_Tags", "c"."BillingAddress_ZipCode", "c"."BillingAddress_Country_Code", "c"."BillingAddress_Country_FullName", "c"."ShippingAddress_AddressLine1", "c"."ShippingAddress_AddressLine2", "c"."ShippingAddress_Tags", "c"."ShippingAddress_ZipCode", "c"."ShippingAddress_Country_Code", "c"."ShippingAddress_Country_FullName"
         FROM "Customer" AS "c"
         ORDER BY "c"."Id"
-        LIMIT @__p_0
+        LIMIT @p
     ) AS "c0"
 ) AS "c3"
 LEFT JOIN (
@@ -1141,7 +1141,7 @@ LEFT JOIN (
         SELECT "c1"."Id", "c1"."Name", "c1"."BillingAddress_AddressLine1", "c1"."BillingAddress_AddressLine2", "c1"."BillingAddress_Tags", "c1"."BillingAddress_ZipCode", "c1"."BillingAddress_Country_Code", "c1"."BillingAddress_Country_FullName", "c1"."ShippingAddress_AddressLine1", "c1"."ShippingAddress_AddressLine2", "c1"."ShippingAddress_Tags", "c1"."ShippingAddress_ZipCode", "c1"."ShippingAddress_Country_Code", "c1"."ShippingAddress_Country_FullName"
         FROM "Customer" AS "c1"
         ORDER BY "c1"."Id" DESC
-        LIMIT @__p_1
+        LIMIT @p0
     ) AS "c2"
 ) AS "c4" ON "c3"."Id" = "c4"."Id"
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -32,13 +32,13 @@ WHERE instr("m"."ContactName", 'z') > 0
         Assert.Equal(
             """
 .param set p0 'London'
-.param set @__contactTitle_1 'Sales Representative'
+.param set @contactTitle 'Sales Representative'
 
 SELECT "m"."CustomerID", "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."Fax", "m"."Phone", "m"."PostalCode", "m"."Region"
 FROM (
     SELECT * FROM "Customers" WHERE "City" = @p0
 ) AS "m"
-WHERE "m"."ContactTitle" = @__contactTitle_1
+WHERE "m"."ContactTitle" = @contactTitle
 """, queryString, ignoreLineEndingDifferences: true);
 
         return queryString;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteTest.cs
@@ -20,12 +20,12 @@ public class FunkyDataQuerySqliteTest : FunkyDataQueryTestBase<FunkyDataQuerySql
 
         AssertSql(
             """
-@__s_0='B' (Size = 1)
-@__s_0_startswith='B%' (Size = 2)
+@s='B' (Size = 1)
+@s_startswith='B%' (Size = 2)
 
 SELECT "f"."Id", "f"."FirstName", "f"."LastName", "f"."NullableBool"
 FROM "FunkyCustomers" AS "f"
-WHERE instr("f"."FirstName", @__s_0) > 0 OR "f"."LastName" LIKE @__s_0_startswith ESCAPE '\'
+WHERE instr("f"."FirstName", @s) > 0 OR "f"."LastName" LIKE @s_startswith ESCAPE '\'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -388,11 +388,11 @@ WHERE instr("s"."Banner", X'01') > 0
 
         AssertSql(
             """
-@__someByte_0='1'
+@someByte='1'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE instr("s"."Banner", char(@__someByte_0)) > 0
+WHERE instr("s"."Banner", char(@someByte)) > 0
 """);
     }
 
@@ -414,11 +414,11 @@ WHERE length("s"."Banner") = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = @__p_0
+WHERE length("s"."Banner") = @p
 """);
     }
 
@@ -428,11 +428,11 @@ WHERE length("s"."Banner") = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 2)
+@byteArrayParam='0x2A80' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = length(@__byteArrayParam)
+WHERE length("s"."Banner") = length(@byteArrayParam)
 """);
     }
 
@@ -442,11 +442,11 @@ WHERE length("s"."Banner") = length(@__byteArrayParam)
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE "s"."Banner5" = @__byteArrayParam_0
+WHERE "s"."Banner5" = @byteArrayParam
 """);
     }
 
@@ -765,11 +765,11 @@ WHERE date("t"."IssueDate") > "m"."Date"
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
-WHERE date("t"."IssueDate") IN (@__prm_0, '0015-03-07')
+WHERE date("t"."IssueDate") IN (@prm, '0015-03-07')
 """);
     }
 
@@ -821,19 +821,19 @@ FROM "Missions" AS "m"
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."HasSoulPatch" <> @__prm_0
+WHERE "g"."HasSoulPatch" <> @prm
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."HasSoulPatch" <> @__prm_0
+WHERE "g"."HasSoulPatch" <> @prm
 """);
     }
 
@@ -892,7 +892,7 @@ FROM "Tags" AS "t"
 """,
             //
             """
-@__tags_0='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
+@tags='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank", "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Gears" AS "g"
@@ -900,7 +900,7 @@ INNER JOIN "Cities" AS "c" ON "g"."CityOfBirthName" = "c"."Name"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
 WHERE "c"."Location" IS NOT NULL AND "t"."Id" IN (
     SELECT "t0"."value"
-    FROM json_each(@__tags_0) AS "t0"
+    FROM json_each(@tags) AS "t0"
 )
 """);
     }
@@ -1191,8 +1191,8 @@ WHERE "g"."HasSoulPatch"
 
         AssertSql(
             """
-@__p_1='10'
-@__p_0='0'
+@p0='10'
+@p='0'
 
 SELECT "s"."Nickname", "s"."SquadId", "s"."AssignedCityName", "s"."CityOfBirthName", "s"."Discriminator", "s"."FullName", "s"."HasSoulPatch", "s"."LeaderNickname", "s"."LeaderSquadId", "s"."Rank", "s"."HasSoulPatch0", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM (
@@ -1205,7 +1205,7 @@ FROM (
         GROUP BY "g0"."HasSoulPatch"
     ) AS "g1" ON length("g"."Nickname") = "g1"."c"
     ORDER BY "g"."Nickname"
-    LIMIT @__p_1 OFFSET @__p_0
+    LIMIT @p0 OFFSET @p
 ) AS "s"
 LEFT JOIN "Weapons" AS "w" ON "s"."FullName" = "w"."OwnerFullName"
 ORDER BY "s"."Nickname", "s"."SquadId", "s"."HasSoulPatch0"
@@ -1258,13 +1258,13 @@ FROM "Weapons" AS "w"
 
         AssertSql(
             """
-@__cities_0='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 62)
+@cities='["Unknown","Jacinto\u0027s location","Ephyra\u0027s location"]' (Size = 62)
 
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
 WHERE "c"."Location" IN (
     SELECT "c0"."value"
-    FROM json_each(@__cities_0) AS "c0"
+    FROM json_each(@cities) AS "c0"
 )
 """);
     }
@@ -1301,13 +1301,13 @@ INNER JOIN "Cities" AS "c" ON "g"."CityOfBirthName" = "c"."Name"
 
         AssertSql(
             """
-@__p_0='25'
+@p='25'
 
 SELECT "w1"."Id", "w1"."AmmunitionType", "w1"."IsAutomatic", "w1"."Name", "w1"."OwnerFullName", "w1"."SynergyWithId"
 FROM (
     SELECT "g"."FullName"
     FROM "Gears" AS "g"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "g0"
 LEFT JOIN (
     SELECT "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
@@ -1443,11 +1443,11 @@ ORDER BY "l"."Name"
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" & @__ammunitionType_0 > 0
+WHERE "w"."AmmunitionType" & @ammunitionType > 0
 """,
             //
             """
@@ -1735,11 +1735,11 @@ WHERE 0
 
         AssertSql(
             """
-@__rank_0='1' (Nullable = true)
+@rank='1' (Nullable = true)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."Rank" & @__rank_0 = @__rank_0
+WHERE "g"."Rank" & @rank = @rank
 """,
             //
             """
@@ -1748,11 +1748,11 @@ FROM "Gears" AS "g"
 """,
             //
             """
-@__rank_0='2' (Nullable = true)
+@rank='2' (Nullable = true)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."Rank" | @__rank_0 <> @__rank_0
+WHERE "g"."Rank" | @rank <> @rank
 """,
             //
             """
@@ -1965,11 +1965,11 @@ WHERE "g"."Rank" = 4
 
         AssertSql(
             """
-@__parameter_0='2' (Nullable = true)
+@parameter='2' (Nullable = true)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
+WHERE "g"."Rank" & @parameter = @parameter
 """);
     }
 
@@ -1979,14 +1979,14 @@ WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
 
         AssertSql(
             """
-@__nicknames_0='[]' (Size = 2)
+@nicknames='[]' (Size = 2)
 
 SELECT "g"."Nickname", "g"."SquadId", "w"."Name", "w"."Id"
 FROM "Gears" AS "g"
 LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName"
 ORDER BY "g"."Nickname" IN (
     SELECT "n"."value"
-    FROM json_each(@__nicknames_0) AS "n"
+    FROM json_each(@nicknames) AS "n"
 ) DESC, "g"."Nickname", "g"."SquadId"
 """);
     }
@@ -2028,7 +2028,7 @@ ORDER BY "g"."Rank"
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT "g0"."FullName"
 FROM (
@@ -2036,7 +2036,7 @@ FROM (
     FROM "Gears" AS "g"
     WHERE NOT ("g"."HasSoulPatch")
     ORDER BY "g"."FullName"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "g0"
 ORDER BY "g0"."Rank"
 """);
@@ -2244,13 +2244,13 @@ ORDER BY "f"."Id", "l0"."Name", "f0"."Id"
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 12)
+@values='[false,true]' (Size = 12)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch" AND "g"."HasSoulPatch" IN (
     SELECT "v"."value"
-    FROM json_each(@__values_0) AS "v"
+    FROM json_each(@values) AS "v"
 )
 """);
     }
@@ -2445,11 +2445,11 @@ GROUP BY "g0"."Key"
 
         AssertSql(
             """
-@__value_0='Unknown' (Size = 7)
+@value='Unknown' (Size = 7)
 
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE "c"."Location" = @__value_0
+WHERE "c"."Location" = @value
 """);
     }
 
@@ -2810,14 +2810,14 @@ ORDER BY (
 
         AssertSql(
             """
-@__cities_0_without_nulls='["Ephyra"]' (Size = 10)
+@cities_without_nulls='["Ephyra"]' (Size = 10)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 LEFT JOIN "Cities" AS "c" ON "g"."AssignedCityName" = "c"."Name"
 WHERE "g"."SquadId" < 2 AND ("c"."Name" IN (
     SELECT "c0"."value"
-    FROM json_each(@__cities_0_without_nulls) AS "c0"
+    FROM json_each(@cities_without_nulls) AS "c0"
 ) OR "c"."Name" IS NULL)
 """);
     }
@@ -2949,11 +2949,11 @@ WHERE "m"."Timeline" = '1902-01-02 10:00:00.1234567+01:30'
 
         AssertSql(
             """
-@__place_0='Ephyra's location' (Size = 17)
+@place='Ephyra's location' (Size = 17)
 
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE "c"."Nation" = @__place_0 OR "c"."Location" = @__place_0 OR "c"."Location" = @__place_0
+WHERE "c"."Nation" = @place OR "c"."Location" = @place OR "c"."Location" = @place
 """);
     }
 
@@ -3094,14 +3094,14 @@ WHERE "w"."Id" = 0
 
         AssertSql(
             """
-@__types_0_without_nulls='[1]' (Size = 3)
+@types_without_nulls='[1]' (Size = 3)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
 LEFT JOIN "Weapons" AS "w0" ON "w"."SynergyWithId" = "w0"."Id"
 WHERE "w0"."Id" IS NOT NULL AND ("w0"."AmmunitionType" IN (
     SELECT "t"."value"
-    FROM json_each(@__types_0_without_nulls) AS "t"
+    FROM json_each(@types_without_nulls) AS "t"
 ) OR "w0"."AmmunitionType" IS NULL)
 """);
     }
@@ -3666,7 +3666,7 @@ HAVING 0
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT "g0"."FullName"
 FROM (
@@ -3674,7 +3674,7 @@ FROM (
     FROM "Gears" AS "g"
     WHERE NOT ("g"."HasSoulPatch")
     ORDER BY "g"."FullName"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "g0"
 ORDER BY "g0"."Rank"
 """);
@@ -3750,11 +3750,11 @@ FROM "Squads" AS "s"
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE @__p_0
+WHERE @p
 """);
     }
 
@@ -3783,14 +3783,14 @@ FROM "Tags" AS "t"
 """,
             //
             """
-@__tags_0='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
+@tags='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
 WHERE "t"."Id" IS NOT NULL AND "t"."Id" IN (
     SELECT "t0"."value"
-    FROM json_each(@__tags_0) AS "t0"
+    FROM json_each(@tags) AS "t0"
 )
 """);
     }
@@ -3839,13 +3839,13 @@ FROM "Gears" AS "g"
 
         AssertSql(
             """
-@__prm_Inner_Nickname_0='Marcus' (Size = 6)
+@prm_Inner_Nickname='Marcus' (Size = 6)
 
 SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
 FROM (
     SELECT DISTINCT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
     FROM "Gears" AS "g"
-    WHERE "g"."Nickname" <> @__prm_Inner_Nickname_0
+    WHERE "g"."Nickname" <> @prm_Inner_Nickname
 ) AS "g0"
 ORDER BY "g0"."FullName"
 """);
@@ -4212,11 +4212,11 @@ ORDER BY "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" = @__ammunitionType_0
+WHERE "w"."AmmunitionType" = @ammunitionType
 """,
             //
             """
@@ -4394,17 +4394,17 @@ WHERE "c"."Location" = 'Unknown'
 
         AssertSql(
             """
-@__entity_equality_prm_Inner_Squad_0_Id='1' (Nullable = true)
+@entity_equality_prm_Inner_Squad_Id='1' (Nullable = true)
 
 SELECT "s1"."Nickname", "s1"."SquadId", "s1"."AssignedCityName", "s1"."CityOfBirthName", "s1"."Discriminator", "s1"."FullName", "s1"."HasSoulPatch", "s1"."LeaderNickname", "s1"."LeaderSquadId", "s1"."Rank"
 FROM (
     SELECT DISTINCT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
     FROM "Gears" AS "g"
     INNER JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
-    WHERE "s"."Id" = @__entity_equality_prm_Inner_Squad_0_Id
+    WHERE "s"."Id" = @entity_equality_prm_Inner_Squad_Id
 ) AS "s1"
 INNER JOIN "Squads" AS "s0" ON "s1"."SquadId" = "s0"."Id"
-WHERE "s0"."Id" = @__entity_equality_prm_Inner_Squad_0_Id
+WHERE "s0"."Id" = @entity_equality_prm_Inner_Squad_Id
 ORDER BY "s1"."FullName"
 """);
     }
@@ -4618,13 +4618,13 @@ FROM "Missions" AS "m"
 
         AssertSql(
             """
-@__values_0='[false,true]' (Size = 12)
+@values='[false,true]' (Size = 12)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch" AND "g"."HasSoulPatch" IN (
     SELECT "v"."value"
-    FROM json_each(@__values_0) AS "v"
+    FROM json_each(@values) AS "v"
 )
 """);
     }
@@ -4821,9 +4821,9 @@ GROUP BY "g"."Rank"
 
         AssertSql(
             """
-@__p_0='False'
+@p='False'
 
-SELECT @__p_0
+SELECT @p
 FROM "Gears" AS "g"
 """);
     }
@@ -4948,14 +4948,14 @@ FROM "Tags" AS "t"
 """,
             //
             """
-@__tags_0='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
+@tags='["34C8D86E-A4AC-4BE5-827F-584DDA348A07","70534E05-782C-4052-8720-C2C54481CE5F","A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69","A8AD98F9-E023-4E2A-9A70-C2728455BD34","B39A6FBA-9026-4D69-828E-FD7068673E57","DF36F493-463F-4123-83F9-6B135DEEB7BA"]' (Size = 235)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank", "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Gears" AS "g"
 LEFT JOIN "Tags" AS "t" ON "g"."Nickname" = "t"."GearNickName" AND "g"."SquadId" = "t"."GearSquadId"
 WHERE "t"."Id" IS NOT NULL AND "t"."Id" IN (
     SELECT "t0"."value"
-    FROM json_each(@__tags_0) AS "t0"
+    FROM json_each(@tags) AS "t0"
 )
 """);
     }
@@ -5026,14 +5026,14 @@ ORDER BY "w"."Name" = 'Marcus'' Lancer' AND "w"."Name" IS NOT NULL, "w"."Id"
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT "g0"."FullName"
 FROM (
     SELECT "g"."FullName", "g"."Rank"
     FROM "Gears" AS "g"
     WHERE NOT ("g"."HasSoulPatch")
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "g0"
 ORDER BY "g0"."FullName", "g0"."Rank"
 """);
@@ -5062,11 +5062,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-@__parameter_0='2'
+@parameter='2'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
+WHERE "g"."Rank" & @parameter = @parameter
 """);
     }
 
@@ -5091,14 +5091,14 @@ LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSqu
 
         AssertSql(
             """
-@__gearId_0='1'
+@gearId='1'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
 WHERE EXISTS (
     SELECT 1
     FROM "Gears" AS "g"
-    WHERE "s"."Id" = "g"."SquadId" AND "g"."SquadId" = @__gearId_0 AND "g"."SquadId" = @__gearId_0)
+    WHERE "s"."Id" = "g"."SquadId" AND "g"."SquadId" = @gearId AND "g"."SquadId" = @gearId)
 """);
     }
 
@@ -5703,13 +5703,13 @@ ORDER BY "t"."Id", "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 
         AssertSql(
             """
-@__ids_0='[]' (Size = 2)
+@ids='[]' (Size = 2)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 ORDER BY "g"."SquadId" IN (
     SELECT "i"."value"
-    FROM json_each(@__ids_0) AS "i"
+    FROM json_each(@ids) AS "i"
 )
 """);
     }
@@ -5924,11 +5924,11 @@ FROM "Missions" AS "m"
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" & @__ammunitionType_0 > 0
+WHERE "w"."AmmunitionType" & @ammunitionType > 0
 """);
     }
 
@@ -6232,14 +6232,14 @@ LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSqu
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT "g0"."FullName"
 FROM (
     SELECT "g"."FullName", "g"."Rank"
     FROM "Gears" AS "g"
     WHERE NOT ("g"."HasSoulPatch")
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "g0"
 ORDER BY "g0"."Rank"
 """);
@@ -6324,24 +6324,24 @@ FROM "Gears" AS "g"
 
         AssertSql(
             """
-@__ranks_0='134'
+@ranks='134'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE "g"."Rank" & @__ranks_0 <> 0
+WHERE "g"."Rank" & @ranks <> 0
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT "g"."Rank" | @__ranks_0 = @__ranks_0
+SELECT "g"."Rank" | @ranks = @ranks
 FROM "Gears" AS "g"
 """,
             //
             """
-@__ranks_0='134'
+@ranks='134'
 
-SELECT "g"."Rank" | "g"."Rank" | @__ranks_0 | "g"."Rank" | @__ranks_0 = @__ranks_0
+SELECT "g"."Rank" | "g"."Rank" | @ranks | "g"."Rank" | @ranks = @ranks
 FROM "Gears" AS "g"
 """);
     }
@@ -6363,12 +6363,12 @@ FROM "Missions" AS "m"
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT "g"."Rank" & 1
 FROM "Gears" AS "g"
 ORDER BY "g"."Nickname"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -6437,14 +6437,14 @@ WHERE "t"."Id" = 'DF36F493-463F-4123-83F9-6B135DEEB7BA'
 
         AssertSql(
             """
-@__prm_0='1'
+@prm='1'
 
 SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
 LEFT JOIN (
     SELECT "w"."Id", "w"."OwnerFullName"
     FROM "Weapons" AS "w"
-    WHERE "w"."Id" > @__prm_0
+    WHERE "w"."Id" > @prm
 ) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
 """);
     }
@@ -6593,11 +6593,11 @@ WHERE "l"."Discriminator" = 'LocustCommander' AND "g"."Nickname" IS NOT NULL AND
 
         AssertSql(
             """
-@__ammunitionType_0='1'
+@ammunitionType='1'
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" = @__ammunitionType_0
+WHERE "w"."AmmunitionType" = @ammunitionType
 """);
     }
 
@@ -6607,14 +6607,14 @@ WHERE "w"."AmmunitionType" = @__ammunitionType_0
 
         AssertSql(
             """
-@__p_0='999'
+@p='999'
 
 SELECT "g0"."FullName"
 FROM (
     SELECT "g"."FullName", "g"."Rank"
     FROM "Gears" AS "g"
     WHERE NOT ("g"."HasSoulPatch")
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "g0"
 ORDER BY "g0"."Rank"
 """);
@@ -6756,17 +6756,17 @@ LEFT JOIN "Weapons" AS "w" ON "w"."SynergyWithId" IS NOT NULL
 
         AssertSql(
             """
-@__prm_0='True'
-@__prm2_1='Marcus' Lancer' (Size = 14)
+@prm='True'
+@prm2='Marcus' Lancer' (Size = 14)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 WHERE CASE
-    WHEN "g"."HasSoulPatch" = @__prm_0 THEN (
+    WHEN "g"."HasSoulPatch" = @prm THEN (
         SELECT "w"."Name"
         FROM "Weapons" AS "w"
         WHERE "w"."Id" = "g"."SquadId"
-        LIMIT 1) = @__prm2_1
+        LIMIT 1) = @prm2
     ELSE 0
 END
 """);
@@ -7055,19 +7055,19 @@ FROM "Weapons" AS "w"
 """,
             //
             """
-@__prm_0='2' (Nullable = true)
+@prm='2' (Nullable = true)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" & @__prm_0 <> 0 OR "w"."AmmunitionType" IS NULL
+WHERE "w"."AmmunitionType" & @prm <> 0 OR "w"."AmmunitionType" IS NULL
 """,
             //
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" & @__prm_0 = @__prm_0
+WHERE "w"."AmmunitionType" & @prm = @prm
 """);
     }
 
@@ -7118,7 +7118,7 @@ ORDER BY "s"."Id", "g"."Nickname"
 
         AssertSql(
             """
-@__p_0='10'
+@p='10'
 
 SELECT "s"."Name", "s"."Discriminator", "s"."LocustHordeId", "s"."ThreatLevel", "s"."ThreatLevelByte", "s"."ThreatLevelNullableByte", "s"."DefeatedByNickname", "s"."DefeatedBySquadId", "s"."HighCommandId", "s"."Nickname", "s"."SquadId", "s"."AssignedCityName", "s"."CityOfBirthName", "s"."Discriminator0", "s"."FullName", "s"."HasSoulPatch", "s"."LeaderNickname", "s"."LeaderSquadId", "s"."Rank", "s"."Id", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM (
@@ -7127,7 +7127,7 @@ FROM (
     LEFT JOIN "Gears" AS "g" ON "l"."DefeatedByNickname" = "g"."Nickname" AND "l"."DefeatedBySquadId" = "g"."SquadId"
     LEFT JOIN "Tags" AS "t" ON ("g"."Nickname" = "t"."GearNickName" OR ("g"."Nickname" IS NULL AND "t"."GearNickName" IS NULL)) AND ("g"."SquadId" = "t"."GearSquadId" OR ("g"."SquadId" IS NULL AND "t"."GearSquadId" IS NULL))
     ORDER BY "t"."Note"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "s"
 LEFT JOIN "Weapons" AS "w" ON "s"."FullName" = "w"."OwnerFullName"
 ORDER BY "s"."Note", "s"."Name", "s"."Nickname", "s"."SquadId", "s"."Id"
@@ -7196,7 +7196,7 @@ WHERE "s"."Name" = 'Kilo'
 
         AssertSql(
             """
-@__squadId_0='1'
+@squadId='1'
 
 SELECT "u"."Nickname", "u"."SquadId", "u"."AssignedCityName", "u"."CityOfBirthName", "u"."Discriminator", "u"."FullName", "u"."HasSoulPatch", "u"."LeaderNickname", "u"."LeaderSquadId", "u"."Rank"
 FROM (
@@ -7206,7 +7206,7 @@ FROM (
     WHERE "s"."Id" IN (
         SELECT "s0"."Id"
         FROM "Squads" AS "s0"
-        WHERE "s0"."Id" = @__squadId_0
+        WHERE "s0"."Id" = @squadId
     )
     UNION ALL
     SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
@@ -7215,7 +7215,7 @@ FROM (
     WHERE "s1"."Id" IN (
         SELECT "s2"."Id"
         FROM "Squads" AS "s2"
-        WHERE "s2"."Id" = @__squadId_0
+        WHERE "s2"."Id" = @squadId
     )
 ) AS "u"
 ORDER BY "u"."FullName"
@@ -7407,11 +7407,11 @@ FROM "Gears" AS "g"
 
         AssertSql(
             """
-@__prm_0='5'
+@prm='5'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE @__prm_0 & CAST("g"."Rank" AS INTEGER) = CAST("g"."Rank" AS INTEGER)
+WHERE @prm & CAST("g"."Rank" AS INTEGER) = CAST("g"."Rank" AS INTEGER)
 """);
     }
 
@@ -7434,11 +7434,11 @@ ORDER BY "g"."Nickname"
 
         AssertSql(
             """
-@__prm_0='1' (Nullable = true)
+@prm='1' (Nullable = true)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
-WHERE @__prm_0 = "w"."AmmunitionType"
+WHERE @prm = "w"."AmmunitionType"
 """);
     }
 
@@ -7910,14 +7910,14 @@ FROM "Cities" AS "c"
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
 LEFT JOIN (
     SELECT "w"."Id", "w"."OwnerFullName"
     FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" = @__isAutomatic_0
+    WHERE "w"."IsAutomatic" = @isAutomatic
 ) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
 """);
     }
@@ -7983,14 +7983,14 @@ INNER JOIN "Weapons" AS "w" ON "w"."SynergyWithId" IS NOT NULL
 
         AssertSql(
             """
-@__isAutomatic_0='True'
+@isAutomatic='True'
 
 SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
 LEFT JOIN (
     SELECT "w"."Id", "w"."OwnerFullName"
     FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" <> @__isAutomatic_0
+    WHERE "w"."IsAutomatic" <> @isAutomatic
 ) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
 """);
     }
@@ -8040,13 +8040,13 @@ WHERE (
 
         AssertSql(
             """
-@__value_1='1'
-@__p_0='1'
+@value='1'
+@p='1'
 
-SELECT "g"."Rank" & @__value_1
+SELECT "g"."Rank" & @value
 FROM "Gears" AS "g"
 ORDER BY "g"."Nickname"
-LIMIT @__p_0
+LIMIT @p
 """);
     }
 
@@ -8102,13 +8102,13 @@ ORDER BY "g"."FullName"
 
         AssertSql(
             """
-@__ids_0='["DF36F493-463F-4123-83F9-6B135DEEB7BA","23CBCF9B-CE14-45CF-AAFA-2C2667EBFDD3","AB1B82D7-88DB-42BD-A132-7EEF9AA68AF4"]' (Size = 118)
+@ids='["DF36F493-463F-4123-83F9-6B135DEEB7BA","23CBCF9B-CE14-45CF-AAFA-2C2667EBFDD3","AB1B82D7-88DB-42BD-A132-7EEF9AA68AF4"]' (Size = 118)
 
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
 WHERE "t"."Id" IN (
     SELECT "i"."value"
-    FROM json_each(@__ids_0) AS "i"
+    FROM json_each(@ids) AS "i"
 )
 """);
     }
@@ -8181,12 +8181,12 @@ WHERE "g"."HasSoulPatch"
 
         AssertSql(
             """
-@__prm_0='True'
+@prm='True'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 WHERE CASE
-    WHEN "g"."HasSoulPatch" = @__prm_0 THEN 1
+    WHEN "g"."HasSoulPatch" = @prm THEN 1
     ELSE 0
 END
 """);
@@ -8214,11 +8214,11 @@ END IS NOT NULL
 
         AssertSql(
             """
-@__prm_0='133'
+@prm='133'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE @__prm_0 & "g"."Rank" = "g"."Rank"
+WHERE @prm & "g"."Rank" = "g"."Rank"
 """);
     }
 
@@ -8254,11 +8254,11 @@ FROM "Gears" AS "g"
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT "w"."Id", "w"."AmmunitionType" = @__ammunitionType_0 AND "w"."AmmunitionType" IS NOT NULL AS "Cartridge"
+SELECT "w"."Id", "w"."AmmunitionType" = @ammunitionType AND "w"."AmmunitionType" IS NOT NULL AS "Cartridge"
 FROM "Weapons" AS "w"
-WHERE "w"."AmmunitionType" = @__ammunitionType_0
+WHERE "w"."AmmunitionType" = @ammunitionType
 """,
             //
             """
@@ -8946,9 +8946,9 @@ WHERE "t"."Note" <> 'Foo' OR "t"."Note" IS NULL
 
         AssertSql(
             """
-@__ammunitionType_0='1' (Nullable = true)
+@ammunitionType='1' (Nullable = true)
 
-SELECT "w"."Id", @__ammunitionType_0 AS "AmmoType"
+SELECT "w"."Id", @ammunitionType AS "AmmoType"
 FROM "Weapons" AS "w"
 """,
             //
@@ -8958,9 +8958,9 @@ FROM "Weapons" AS "w"
 """,
             //
             """
-@__ammunitionType_0='2' (Nullable = true)
+@ammunitionType='2' (Nullable = true)
 
-SELECT "w"."Id", @__ammunitionType_0 AS "AmmoType"
+SELECT "w"."Id", @ammunitionType AS "AmmoType"
 FROM "Weapons" AS "w"
 """,
             //
@@ -9515,12 +9515,12 @@ ORDER BY "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 
         AssertSql(
             """
-@__p_0='0'
+@p='0'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 ORDER BY "g"."FullName"
-LIMIT 1 OFFSET @__p_0
+LIMIT 1 OFFSET @p
 """);
     }
 
@@ -9530,12 +9530,12 @@ LIMIT 1 OFFSET @__p_0
 
         AssertSql(
             """
-@__p_0='1'
+@p='1'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 ORDER BY "g"."FullName"
-LIMIT 1 OFFSET @__p_0
+LIMIT 1 OFFSET @p
 """);
     }
 
@@ -9545,12 +9545,12 @@ LIMIT 1 OFFSET @__p_0
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 ORDER BY "g"."FullName"
-LIMIT 1 OFFSET @__p_0
+LIMIT 1 OFFSET @p
 """);
     }
 
@@ -9639,7 +9639,7 @@ GROUP BY "s"."Name"
 
         AssertSql(
             """
-@__numbers_0='[1,-1]' (Size = 6)
+@numbers='[1,-1]' (Size = 6)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
@@ -9651,7 +9651,7 @@ WHERE CASE
     ELSE 0
 END IN (
     SELECT "n"."value"
-    FROM json_each(@__numbers_0) AS "n"
+    FROM json_each(@numbers) AS "n"
 )
 """);
     }
@@ -9662,7 +9662,7 @@ END IN (
 
         AssertSql(
             """
-@__weapons_0='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 44)
+@weapons='["Marcus\u0027 Lancer","Dom\u0027s Gnasher"]' (Size = 44)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
@@ -9673,7 +9673,7 @@ WHERE (
     ORDER BY "w0"."Id"
     LIMIT 1) IN (
     SELECT "w"."value"
-    FROM json_each(@__weapons_0) AS "w"
+    FROM json_each(@weapons) AS "w"
 )
 """);
     }
@@ -9684,7 +9684,7 @@ WHERE (
 
         AssertSql(
             """
-@__numbers_0='[0,1,2]' (Size = 7)
+@numbers='[0,1,2]' (Size = 7)
 
 SELECT "g"."Nickname", "g"."SquadId", "w1"."Id", "w1"."AmmunitionType", "w1"."IsAutomatic", "w1"."Name", "w1"."OwnerFullName", "w1"."SynergyWithId"
 FROM "Gears" AS "g"
@@ -9696,7 +9696,7 @@ LEFT JOIN (
     ) AS "w0"
     WHERE "w0"."row" <= COALESCE((
         SELECT "n"."value"
-        FROM json_each(@__numbers_0) AS "n"
+        FROM json_each(@numbers) AS "n"
         ORDER BY "n"."value"
         LIMIT 1 OFFSET 1), 0)
 ) AS "w1" ON "g"."FullName" = "w1"."OwnerFullName"
@@ -9854,40 +9854,40 @@ LEFT JOIN "LocustHighCommands" AS "l0" ON "l"."HighCommandId" = "l0"."Id"
 
         AssertSql(
             """
-@__ranks_0='[1]' (Size = 3)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0A47BCB7-A1CB-4345-8944-C58F82D6AAC7","5F221FB9-66F4-442A-92C9-D97ED5989CC7"]' (Size = 79)
+@ranks='[1]' (Size = 3)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0A47BCB7-A1CB-4345-8944-C58F82D6AAC7","5F221FB9-66F4-442A-92C9-D97ED5989CC7"]' (Size = 79)
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
 WHERE CASE
     WHEN "g"."Rank" IN (
         SELECT "r"."value"
-        FROM json_each(@__ranks_0) AS "r"
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM json_each(@ranks) AS "r"
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT "k"."value"
-    FROM json_each(@__keys_2) AS "k"
+    FROM json_each(@keys) AS "k"
 )
 """,
             //
             """
-@__ammoTypes_0='[1]' (Size = 3)
-@__key_1='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
-@__keys_2='["0A47BCB7-A1CB-4345-8944-C58F82D6AAC7","5F221FB9-66F4-442A-92C9-D97ED5989CC7"]' (Size = 79)
+@ammoTypes='[1]' (Size = 3)
+@key='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
+@keys='["0A47BCB7-A1CB-4345-8944-C58F82D6AAC7","5F221FB9-66F4-442A-92C9-D97ED5989CC7"]' (Size = 79)
 
 SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Weapons" AS "w"
 WHERE CASE
     WHEN "w"."AmmunitionType" IN (
         SELECT "a"."value"
-        FROM json_each(@__ammoTypes_0) AS "a"
-    ) THEN @__key_1
-    ELSE @__key_1
+        FROM json_each(@ammoTypes) AS "a"
+    ) THEN @key
+    ELSE @key
 END IN (
     SELECT "k"."value"
-    FROM json_each(@__keys_2) AS "k"
+    FROM json_each(@keys) AS "k"
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -215,11 +215,11 @@ FROM (
 
         AssertSql(
             """
-@__prm_0='0'
+@prm='0'
 
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
-WHERE "j"."OwnedCollectionRoot" ->> '$[1].OwnedCollectionBranch' ->> @__prm_0 ->> 'OwnedCollectionLeaf' ->> ("j"."Id" - 1) ->> 'SomethingSomething' = 'e1_c2_c1_c1'
+WHERE "j"."OwnedCollectionRoot" ->> '$[1].OwnedCollectionBranch' ->> @prm ->> 'OwnedCollectionLeaf' ->> ("j"."Id" - 1) ->> 'SomethingSomething' = 'e1_c2_c1_c1'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
@@ -369,13 +369,13 @@ WHERE "t"."Id" IN (2, 999)
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 7)
+@ids='[2,999]' (Size = 7)
 
 SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE (
     SELECT COUNT(*)
-    FROM json_each(@__ids_0) AS "i"
+    FROM json_each(@ids) AS "i"
     WHERE "i"."value" > "t"."Id") = 1
 """);
     }
@@ -386,13 +386,13 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[2,999]' (Size = 7)
+@ints='[2,999]' (Size = 7)
 
 SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE "t"."Id" IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """);
     }
@@ -403,13 +403,13 @@ WHERE "t"."Id" IN (
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 7)
+@ids='[2,999]' (Size = 7)
 
 SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE (
     SELECT COUNT(*)
-    FROM json_each(@__ids_0) AS "i"
+    FROM json_each(@ids) AS "i"
     WHERE "i"."value" > "t"."Id") = 1
 """);
     }
@@ -420,13 +420,13 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[2,999]' (Size = 7)
+@ints='[2,999]' (Size = 7)
 
 SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE "t"."Id" IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -69,7 +69,7 @@ FROM "Order Details" AS "o"
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT ef_avg(CAST((
     SELECT AVG(CAST(5 + (
@@ -82,7 +82,7 @@ FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     ORDER BY "c"."CustomerID"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c0"
 """);
     }
@@ -93,7 +93,7 @@ FROM (
 
         AssertSql(
             """
-@__p_0='3'
+@p='3'
 
 SELECT ef_avg(CAST((
     SELECT AVG(5.0 + (
@@ -106,7 +106,7 @@ FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     ORDER BY "c"."CustomerID"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c0"
 """);
     }
@@ -129,12 +129,12 @@ FROM (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT COUNT(CASE
     WHEN "c"."City" IN (
         SELECT "c0"."value"
-        FROM json_each(@__cities_0) AS "c0"
+        FROM json_each(@cities) AS "c0"
     ) THEN 1
 END)
 FROM "Customers" AS "c"
@@ -148,12 +148,12 @@ GROUP BY "c"."Country"
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT AVG(CASE
     WHEN "c"."City" IN (
         SELECT "c0"."value"
-        FROM json_each(@__cities_0) AS "c0"
+        FROM json_each(@cities) AS "c0"
     ) THEN 1.0
     ELSE 0.0
 END)
@@ -167,12 +167,12 @@ FROM "Customers" AS "c"
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT COALESCE(SUM(CASE
     WHEN "c"."City" IN (
         SELECT "c0"."value"
-        FROM json_each(@__cities_0) AS "c0"
+        FROM json_each(@cities) AS "c0"
     ) THEN 1
     ELSE 0
 END), 0)
@@ -186,13 +186,13 @@ FROM "Customers" AS "c"
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
 WHERE "c"."City" IN (
     SELECT "c0"."value"
-    FROM json_each(@__cities_0) AS "c0"
+    FROM json_each(@cities) AS "c0"
 )
 """);
     }
@@ -203,13 +203,13 @@ WHERE "c"."City" IN (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
 WHERE "c"."City" IN (
     SELECT "c0"."value"
-    FROM json_each(@__cities_0) AS "c0"
+    FROM json_each(@cities) AS "c0"
 )
 """);
     }
@@ -220,12 +220,12 @@ WHERE "c"."City" IN (
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT MAX(CASE
     WHEN "c"."City" IN (
         SELECT "c0"."value"
-        FROM json_each(@__cities_0) AS "c0"
+        FROM json_each(@cities) AS "c0"
     ) THEN 1
     ELSE 0
 END)
@@ -239,12 +239,12 @@ FROM "Customers" AS "c"
 
         AssertSql(
             """
-@__cities_0='["London","Berlin"]' (Size = 19)
+@cities='["London","Berlin"]' (Size = 19)
 
 SELECT MIN(CASE
     WHEN "c"."City" IN (
         SELECT "c0"."value"
-        FROM json_each(@__cities_0) AS "c0"
+        FROM json_each(@cities) AS "c0"
     ) THEN 1
     ELSE 0
 END)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -714,11 +714,11 @@ WHERE "c"."ContactName" LIKE 'M%'
 
         AssertSql(
             """
-@__pattern_0_startswith='M%' (Size = 2)
+@pattern_startswith='M%' (Size = 2)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" LIKE @__pattern_0_startswith ESCAPE '\'
+WHERE "c"."ContactName" LIKE @pattern_startswith ESCAPE '\'
 """);
     }
 
@@ -776,11 +776,11 @@ WHERE "c"."ContactName" LIKE '%b'
 
         AssertSql(
             """
-@__pattern_0_endswith='%b' (Size = 2)
+@pattern_endswith='%b' (Size = 2)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" LIKE @__pattern_0_endswith ESCAPE '\'
+WHERE "c"."ContactName" LIKE @pattern_endswith ESCAPE '\'
 """);
     }
 
@@ -1046,11 +1046,11 @@ WHERE instr("c"."ContactName", 'a') - 1 = 1
 
         AssertSql(
             """
-@__pattern_0='a' (Size = 1)
+@pattern='a' (Size = 1)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE instr("c"."ContactName", @__pattern_0) - 1 = 1
+WHERE instr("c"."ContactName", @pattern) - 1 = 1
 """);
     }
 
@@ -1114,11 +1114,11 @@ WHERE substr("c"."CustomerID", 1 + 1) = 'LFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
 SELECT "c"."ContactName"
 FROM "Customers" AS "c"
-WHERE substr("c"."CustomerID", @__start_0 + 1) = 'FKI'
+WHERE substr("c"."CustomerID", @start + 1) = 'FKI'
 """);
     }
 
@@ -1152,9 +1152,9 @@ WHERE "c"."CustomerID" = 'ALFKI'
 
         AssertSql(
             """
-@__start_0='2'
+@start='2'
 
-SELECT substr("c"."ContactName", @__start_0 + 1, 3)
+SELECT substr("c"."ContactName", @start + 1, 3)
 FROM "Customers" AS "c"
 WHERE "c"."CustomerID" = 'ALFKI'
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -38,18 +38,18 @@ WHERE "o"."OrderDate" IS NOT NULL AND instr(COALESCE(CAST("o"."EmployeeID" AS TE
 
         AssertSql(
             """
-@__p_0='10'
-@__p_1='5'
+@p='10'
+@p0='5'
 
 SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
 FROM (
     SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
     FROM "Customers" AS "c"
     ORDER BY "c"."ContactName"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c0"
 ORDER BY "c0"."ContactName"
-LIMIT -1 OFFSET @__p_1
+LIMIT -1 OFFSET @p0
 """);
     }
 
@@ -212,9 +212,9 @@ WHERE "o"."OrderDate" IS NOT NULL
 
         AssertSql(
             """
-@__millisecondsPerDay_0='86400000'
+@millisecondsPerDay='86400000'
 
-SELECT rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "o"."OrderDate", COALESCE(CAST(CAST(CAST((CAST(strftime('%f', "o"."OrderDate") AS REAL) * 1000.0) % 1000.0 AS INTEGER) / @__millisecondsPerDay_0 AS REAL) AS TEXT), '') || ' days', COALESCE(CAST(CAST(CAST((CAST(strftime('%f', "o"."OrderDate") AS REAL) * 1000.0) % 1000.0 AS INTEGER) % @__millisecondsPerDay_0 AS REAL) / 1000.0 AS TEXT), '') || ' seconds'), '0'), '.') AS "OrderDate"
+SELECT rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "o"."OrderDate", COALESCE(CAST(CAST(CAST((CAST(strftime('%f', "o"."OrderDate") AS REAL) * 1000.0) % 1000.0 AS INTEGER) / @millisecondsPerDay AS REAL) AS TEXT), '') || ' days', COALESCE(CAST(CAST(CAST((CAST(strftime('%f', "o"."OrderDate") AS REAL) * 1000.0) % 1000.0 AS INTEGER) % @millisecondsPerDay AS REAL) / 1000.0 AS TEXT), '') || ' seconds'), '0'), '.') AS "OrderDate"
 FROM "Orders" AS "o"
 WHERE "o"."OrderDate" IS NOT NULL
 """);
@@ -253,14 +253,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1
     FROM "Customers" AS "c"
     ORDER BY "c"."Country"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c0"
 """);
     }
@@ -271,14 +271,14 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1
     FROM "Customers" AS "c"
     ORDER BY "c"."Country"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c0"
 """);
     }
@@ -289,13 +289,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1
     FROM "Customers" AS "c"
-    LIMIT -1 OFFSET @__p_0
+    LIMIT -1 OFFSET @p
 ) AS "c0"
 """);
     }
@@ -306,13 +306,13 @@ FROM (
 
         AssertSql(
             """
-@__p_0='7'
+@p='7'
 
 SELECT COUNT(*)
 FROM (
     SELECT 1
     FROM "Customers" AS "c"
-    LIMIT @__p_0
+    LIMIT @p
 ) AS "c0"
 """);
     }
@@ -356,9 +356,9 @@ FROM "Orders" AS "o"
 
         AssertSql(
             """
-@__parameter_0='-' (Size = 1)
+@parameter='-' (Size = 1)
 
-SELECT @__parameter_0 || CAST("o"."OrderID" AS TEXT)
+SELECT @parameter || CAST("o"."OrderID" AS TEXT)
 FROM "Orders" AS "o"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
@@ -23,11 +23,11 @@ public class NorthwindQueryFiltersQuerySqliteTest : NorthwindQueryFiltersQueryTe
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 2)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE "c"."CompanyName" LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE '\'
+WHERE "c"."CompanyName" LIKE @ef_filter__TenantPrefix_startswith ESCAPE '\'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
@@ -44,19 +44,22 @@ END
 
         AssertSql(
             """
-@__city_0='London' (Size = 6)
+@city='London' (Size = 6)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."City" = @__city_0
+WHERE "c"."City" = @city
 """);
 
         Assert.Equal(
-            @".param set @__city_0 'London'
+            """
+.param set @city 'London'
 
-SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE ""c"".""City"" = @__city_0", queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+FROM "Customers" AS "c"
+WHERE "c"."City" = @city
+""",
+            queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
 
         return null;
     }
@@ -67,11 +70,11 @@ WHERE ""c"".""City"" = @__city_0", queryString, ignoreLineEndingDifferences: tru
 
         AssertSql(
             """
-@__myDatetime_0='2015-04-10T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='2015-04-10T00:00:00.0000000' (DbType = DateTime)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @myDatetime
 """);
     }
 
@@ -81,11 +84,11 @@ WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') 
 
         AssertSql(
             """
-@__myDatetime_0='2015-04-10T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='2015-04-10T00:00:00.0000000' (DbType = DateTime)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @myDatetime
 """);
     }
 
@@ -106,11 +109,11 @@ FROM "Employees" AS "e"
 
         AssertSql(
             """
-@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+@myDatetime='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
 SELECT "o"."OrderID", "o"."CustomerID", "o"."EmployeeID", "o"."OrderDate"
 FROM "Orders" AS "o"
-WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "o"."OrderDate", 'start of day'), '0'), '.') = @__myDatetime_0
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "o"."OrderDate", 'start of day'), '0'), '.') = @myDatetime
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -1212,11 +1212,11 @@ WHERE "e"."NullableBoolA" IS NOT NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
 FROM "Entities1" AS "e"
-WHERE @__prm_0 = ("e"."NullableBoolA" IS NOT NULL)
+WHERE @prm = ("e"."NullableBoolA" IS NOT NULL)
 """,
             //
             """
@@ -1238,11 +1238,11 @@ WHERE "e"."NullableBoolA" IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
 FROM "Entities1" AS "e"
-WHERE @__prm_0 = ("e"."NullableBoolA" IS NOT NULL)
+WHERE @prm = ("e"."NullableBoolA" IS NOT NULL)
 """);
     }
 
@@ -1258,11 +1258,11 @@ WHERE "e"."NullableBoolA" IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
 FROM "Entities1" AS "e"
-WHERE @__prm_0 <> ("e"."NullableBoolA" IS NOT NULL)
+WHERE @prm <> ("e"."NullableBoolA" IS NOT NULL)
 """,
             //
             """
@@ -1284,11 +1284,11 @@ WHERE "e"."NullableIntA" IS NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
 FROM "Entities1" AS "e"
-WHERE @__prm_0 <> ("e"."NullableIntA" IS NOT NULL)
+WHERE @prm <> ("e"."NullableIntA" IS NOT NULL)
 """,
             //
             """
@@ -1310,11 +1310,11 @@ WHERE "e"."NullableBoolA" IS NOT NULL
 """,
             //
             """
-@__prm_0='False'
+@prm='False'
 
 SELECT "e"."Id", "e"."BoolA", "e"."BoolB", "e"."BoolC", "e"."IntA", "e"."IntB", "e"."IntC", "e"."NullableBoolA", "e"."NullableBoolB", "e"."NullableBoolC", "e"."NullableIntA", "e"."NullableIntB", "e"."NullableIntC", "e"."NullableStringA", "e"."NullableStringB", "e"."NullableStringC", "e"."StringA", "e"."StringB", "e"."StringC"
 FROM "Entities1" AS "e"
-WHERE @__prm_0 <> ("e"."NullableBoolA" IS NOT NULL)
+WHERE @prm <> ("e"."NullableBoolA" IS NOT NULL)
 """);
     }
 
@@ -1347,35 +1347,35 @@ WHERE "e"."BoolB" OR "e"."NullableBoolA" IS NOT NULL
 
         AssertSql(
             """
-@__i_0='1'
+@i='1'
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE "e"."IntA" <= @__i_0
+WHERE "e"."IntA" <= @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE "e"."IntA" < @__i_0
+WHERE "e"."IntA" < @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE "e"."IntA" >= @__i_0
+WHERE "e"."IntA" >= @i
 """,
             //
             """
-@__i_0='1'
+@i='1'
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
-WHERE "e"."IntA" > @__i_0
+WHERE "e"."IntA" > @i
 """);
     }
 
@@ -1385,45 +1385,45 @@ WHERE "e"."IntA" > @__i_0
 
         AssertSql(
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
 WHERE CASE
-    WHEN "e"."NullableIntA" > @__i_0 THEN 0
+    WHEN "e"."NullableIntA" > @i THEN 0
     ELSE 1
 END
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
 WHERE CASE
-    WHEN "e"."NullableIntA" >= @__i_0 THEN 0
+    WHEN "e"."NullableIntA" >= @i THEN 0
     ELSE 1
 END
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
 WHERE CASE
-    WHEN "e"."NullableIntA" < @__i_0 THEN 0
+    WHEN "e"."NullableIntA" < @i THEN 0
     ELSE 1
 END
 """,
             //
             """
-@__i_0='1' (Nullable = true)
+@i='1' (Nullable = true)
 
 SELECT "e"."Id"
 FROM "Entities1" AS "e"
 WHERE CASE
-    WHEN "e"."NullableIntA" <= @__i_0 THEN 0
+    WHEN "e"."NullableIntA" <= @i THEN 0
     ELSE 1
 END
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -161,12 +161,12 @@ WHERE "p"."Id" IN (2, 999, 1000)
 
         AssertSql(
             """
-@__i_0='2'
-@__j_1='999'
+@i='2'
+@j='999'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Id" IN (@__i_0, @__j_1)
+WHERE "p"."Id" IN (@i, @j)
 """);
     }
 
@@ -176,11 +176,11 @@ WHERE "p"."Id" IN (@__i_0, @__j_1)
 
         AssertSql(
             """
-@__j_0='999'
+@j='999'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Id" IN (2, @__j_0)
+WHERE "p"."Id" IN (2, @j)
 """);
     }
 
@@ -190,11 +190,11 @@ WHERE "p"."Id" IN (2, @__j_0)
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Int" IN (999, @__i_0, "p"."Id", "p"."Id" + "p"."Int")
+WHERE "p"."Int" IN (999, @i, "p"."Id", "p"."Id" + "p"."Int")
 """);
     }
 
@@ -204,11 +204,11 @@ WHERE "p"."Int" IN (999, @__i_0, "p"."Id", "p"."Id" + "p"."Int")
 
         AssertSql(
             """
-@__i_0='11'
+@i='11'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Int" IN (999, @__i_0, "p"."Id", "p"."Id" + "p"."Int")
+WHERE "p"."Int" IN (999, @i, "p"."Id", "p"."Id" + "p"."Int")
 """);
     }
 
@@ -290,11 +290,11 @@ WHERE max(30, "p"."Int") = 30
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE min(30, "p"."Int", @__i_0) = 25
+WHERE min(30, "p"."Int", @i) = 25
 """);
     }
 
@@ -304,11 +304,11 @@ WHERE min(30, "p"."Int", @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='25'
+@i='25'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE min(30, "p"."Int", @__i_0) = 25
+WHERE min(30, "p"."Int", @i) = 25
 """);
     }
 
@@ -318,11 +318,11 @@ WHERE min(30, "p"."Int", @__i_0) = 25
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE max(30, "p"."Int", @__i_0) = 35
+WHERE max(30, "p"."Int", @i) = 35
 """);
     }
 
@@ -332,11 +332,11 @@ WHERE max(30, "p"."Int", @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='35'
+@i='35'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE max(30, "p"."Int", @__i_0) = 35
+WHERE max(30, "p"."Int", @i) = 35
 """);
     }
 
@@ -346,13 +346,13 @@ WHERE max(30, "p"."Int", @__i_0) = 35
 
         AssertSql(
             """
-@__i_0='25' (Nullable = true)
+@i='25' (Nullable = true)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT MIN("v"."Value")
-    FROM (SELECT CAST(30 AS INTEGER) AS "Value" UNION ALL VALUES ("p"."Int"), (@__i_0)) AS "v") = 25
+    FROM (SELECT CAST(30 AS INTEGER) AS "Value" UNION ALL VALUES ("p"."Int"), (@i)) AS "v") = 25
 """);
     }
 
@@ -362,13 +362,13 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='35' (Nullable = true)
+@i='35' (Nullable = true)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT MAX("v"."Value")
-    FROM (SELECT CAST(30 AS INTEGER) AS "Value" UNION ALL VALUES ("p"."Int"), (@__i_0)) AS "v") = 35
+    FROM (SELECT CAST(30 AS INTEGER) AS "Value" UNION ALL VALUES ("p"."Int"), (@i)) AS "v") = 35
 """);
     }
 
@@ -406,11 +406,11 @@ WHERE (
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Id" = @__i_0
+WHERE "p"."Id" = @i
 """);
     }
 
@@ -420,13 +420,13 @@ WHERE "p"."Id" = @__i_0
 
         AssertSql(
             """
-@__i_0='2'
+@i='2'
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
-    FROM (SELECT CAST(@__i_0 AS INTEGER) AS "Value") AS "v"
+    FROM (SELECT CAST(@i AS INTEGER) AS "Value") AS "v"
     WHERE "v"."Value" > "p"."Id") = 1
 """);
     }
@@ -437,13 +437,13 @@ WHERE (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 12)
+@p='[2,999,1000]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Id" IN (
     SELECT "p0"."value"
-    FROM json_each(@__p_0) AS "p0"
+    FROM json_each(@p) AS "p0"
 )
 """);
     }
@@ -454,13 +454,13 @@ WHERE "p"."Id" IN (
 
         AssertSql(
             """
-@__p_0='[2,999,1000]' (Size = 12)
+@p='[2,999,1000]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
-    FROM json_each(@__p_0) AS "p0"
+    FROM json_each(@p) AS "p0"
     WHERE "p0"."value" > "p"."Id") = 2
 """);
     }
@@ -471,13 +471,13 @@ WHERE (
 
         AssertSql(
             """
-@__ids_0='[2,999]' (Size = 7)
+@ids='[2,999]' (Size = 7)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
-    FROM json_each(@__ids_0) AS "i"
+    FROM json_each(@ids) AS "i"
     WHERE "i"."value" > "p"."Id") = 1
 """);
     }
@@ -488,24 +488,24 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" NOT IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """);
     }
@@ -516,24 +516,24 @@ WHERE "p"."Int" NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" NOT IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """);
     }
@@ -544,24 +544,24 @@ WHERE "p"."Int" NOT IN (
 
         AssertSql(
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableInt" IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 )
 """,
             //
             """
-@__ints_0='[10,999]' (Size = 8)
+@ints='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableInt" NOT IN (
     SELECT "i"."value"
-    FROM json_each(@__ints_0) AS "i"
+    FROM json_each(@ints) AS "i"
 ) OR "p"."NullableInt" IS NULL
 """);
     }
@@ -572,24 +572,24 @@ WHERE "p"."NullableInt" NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0='[10,999]' (Size = 8)
+@nullableInts='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" IN (
     SELECT "n"."value"
-    FROM json_each(@__nullableInts_0) AS "n"
+    FROM json_each(@nullableInts) AS "n"
 )
 """,
             //
             """
-@__nullableInts_0='[10,999]' (Size = 8)
+@nullableInts='[10,999]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Int" NOT IN (
     SELECT "n"."value"
-    FROM json_each(@__nullableInts_0) AS "n"
+    FROM json_each(@nullableInts) AS "n"
 )
 """);
     }
@@ -600,24 +600,24 @@ WHERE "p"."Int" NOT IN (
 
         AssertSql(
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 5)
+@nullableInts_without_nulls='[999]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableInt" IN (
     SELECT "n"."value"
-    FROM json_each(@__nullableInts_0_without_nulls) AS "n"
+    FROM json_each(@nullableInts_without_nulls) AS "n"
 ) OR "p"."NullableInt" IS NULL
 """,
             //
             """
-@__nullableInts_0_without_nulls='[999]' (Size = 5)
+@nullableInts_without_nulls='[999]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableInt" NOT IN (
     SELECT "n"."value"
-    FROM json_each(@__nullableInts_0_without_nulls) AS "n"
+    FROM json_each(@nullableInts_without_nulls) AS "n"
 ) AND "p"."NullableInt" IS NOT NULL
 """);
     }
@@ -628,24 +628,24 @@ WHERE "p"."NullableInt" NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 12)
+@strings='["10","999"]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."String" IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 12)
+@strings='["10","999"]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."String" NOT IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """);
     }
@@ -656,24 +656,24 @@ WHERE "p"."String" NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10","999"]' (Size = 12)
+@strings='["10","999"]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableString" IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """,
             //
             """
-@__strings_0='["10","999"]' (Size = 12)
+@strings='["10","999"]' (Size = 12)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableString" NOT IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0) AS "s"
+    FROM json_each(@strings) AS "s"
 ) OR "p"."NullableString" IS NULL
 """);
     }
@@ -684,24 +684,24 @@ WHERE "p"."NullableString" NOT IN (
 
         AssertSql(
             """
-@__strings_0='["10",null]' (Size = 11)
+@strings='["10",null]' (Size = 11)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."String" IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """,
             //
             """
-@__strings_0_without_nulls='["10"]' (Size = 6)
+@strings_without_nulls='["10"]' (Size = 6)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."String" NOT IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0_without_nulls) AS "s"
+    FROM json_each(@strings_without_nulls) AS "s"
 )
 """);
     }
@@ -712,24 +712,24 @@ WHERE "p"."String" NOT IN (
 
         AssertSql(
             """
-@__strings_0_without_nulls='["999"]' (Size = 7)
+@strings_without_nulls='["999"]' (Size = 7)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableString" IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0_without_nulls) AS "s"
+    FROM json_each(@strings_without_nulls) AS "s"
 ) OR "p"."NullableString" IS NULL
 """,
             //
             """
-@__strings_0_without_nulls='["999"]' (Size = 7)
+@strings_without_nulls='["999"]' (Size = 7)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."NullableString" NOT IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_0_without_nulls) AS "s"
+    FROM json_each(@strings_without_nulls) AS "s"
 ) AND "p"."NullableString" IS NOT NULL
 """);
     }
@@ -740,13 +740,13 @@ WHERE "p"."NullableString" NOT IN (
 
         AssertSql(
             """
-@__dateTimes_0='["2020-01-10 12:30:00","9999-01-01 00:00:00"]' (Size = 45)
+@dateTimes='["2020-01-10 12:30:00","9999-01-01 00:00:00"]' (Size = 45)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."DateTime" IN (
     SELECT "d"."value"
-    FROM json_each(@__dateTimes_0) AS "d"
+    FROM json_each(@dateTimes) AS "d"
 )
 """);
     }
@@ -757,13 +757,13 @@ WHERE "p"."DateTime" IN (
 
         AssertSql(
             """
-@__bools_0='[true]' (Size = 6)
+@bools='[true]' (Size = 6)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Bool" IN (
     SELECT "b"."value"
-    FROM json_each(@__bools_0) AS "b"
+    FROM json_each(@bools) AS "b"
 )
 """);
     }
@@ -774,13 +774,13 @@ WHERE "p"."Bool" IN (
 
         AssertSql(
             """
-@__enums_0='[0,3]' (Size = 5)
+@enums='[0,3]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."Enum" IN (
     SELECT "e"."value"
-    FROM json_each(@__enums_0) AS "e"
+    FROM json_each(@enums) AS "e"
 )
 """);
     }
@@ -1113,11 +1113,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[0,2,3]' (Size = 7)
+@ints='[0,2,3]' (Size = 7)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE @__ints_0 ->> "p"."Int" = "p"."Int"
+WHERE @ints ->> "p"."Int" = "p"."Int"
 """);
     }
 
@@ -1127,11 +1127,11 @@ WHERE @__ints_0 ->> "p"."Int" = "p"."Int"
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 7)
+@ints='[1,2,3]' (Size = 7)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE @__ints_0 ->> "p"."Int" = 1
+WHERE @ints ->> "p"."Int" = 1
 """);
     }
 
@@ -1438,14 +1438,14 @@ ORDER BY "p"."Id"
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 8)
+@ints='[11,111]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
     FROM json_each("p"."Ints") AS "i"
-    INNER JOIN json_each(@__ints_0) AS "i0" ON "i"."value" = "i0"."value") = 2
+    INNER JOIN json_each(@ints) AS "i0" ON "i"."value" = "i0"."value") = 2
 """);
     }
 
@@ -1473,7 +1473,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 8)
+@ints='[11,111]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1481,7 +1481,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT 1
-        FROM json_each(@__ints_0) AS "i"
+        FROM json_each(@ints) AS "i"
         UNION ALL
         SELECT 1
         FROM json_each("p"."Ints") AS "i0"
@@ -1495,10 +1495,10 @@ WHERE (
 
         AssertSql(
             """
-@__values_0='["one","two"]' (Size = 13)
+@values='["one","two"]' (Size = 13)
 
 SELECT CASE
-    WHEN "p"."Id" <> 0 THEN @__values_0 ->> ("p"."Int" % 2)
+    WHEN "p"."Id" <> 0 THEN @values ->> ("p"."Int" % 2)
     ELSE 'foo'
 END
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1511,7 +1511,7 @@ FROM "PrimitiveCollectionsEntity" AS "p"
 
         AssertSql(
             """
-@__ints_0='[11,111]' (Size = 8)
+@ints='[11,111]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1522,7 +1522,7 @@ WHERE (
         FROM json_each("p"."Ints") AS "i"
         UNION
         SELECT "i0"."value"
-        FROM json_each(@__ints_0) AS "i0"
+        FROM json_each(@ints) AS "i0"
     ) AS "u") = 2
 """);
     }
@@ -1592,11 +1592,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[1,10]' (Size = 6)
+@ints='[1,10]' (Size = 6)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE "p"."Ints" = @__ints_0
+WHERE "p"."Ints" = @ints
 """);
     }
 
@@ -1639,7 +1639,7 @@ WHERE "p"."Ints" = '[1,10]'
 
         AssertSql(
             """
-@__ints='[10,111]' (Size = 8)
+@ints='[10,111]' (Size = 8)
 
 SELECT COUNT(*)
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1647,7 +1647,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT "i"."value" AS "value0"
-        FROM json_each(@__ints) AS "i"
+        FROM json_each(@ints) AS "i"
         ORDER BY "i"."key"
         LIMIT -1 OFFSET 1
     ) AS "i0"
@@ -1668,7 +1668,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints='[10,111]' (Size = 8)
+@ints='[10,111]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1678,7 +1678,7 @@ WHERE (
         SELECT "i1"."value"
         FROM (
             SELECT "i"."value"
-            FROM json_each(@__ints) AS "i"
+            FROM json_each(@ints) AS "i"
             ORDER BY "i"."key"
             LIMIT -1 OFFSET 1
         ) AS "i1"
@@ -1695,7 +1695,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 5)
+@Skip='[111]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1703,7 +1703,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT "s"."value"
-        FROM json_each(@__Skip_0) AS "s"
+        FROM json_each(@Skip) AS "s"
         UNION
         SELECT "i"."value"
         FROM json_each("p"."Ints") AS "i"
@@ -1717,7 +1717,7 @@ WHERE (
 
         AssertSql(
             """
-@__Skip_0='[111]' (Size = 5)
+@Skip='[111]' (Size = 5)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1725,7 +1725,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT "s"."value"
-        FROM json_each(@__Skip_0) AS "s"
+        FROM json_each(@Skip) AS "s"
         UNION
         SELECT "i2"."value"
         FROM (
@@ -1759,7 +1759,7 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0='[10,111]' (Size = 8)
+@ints='[10,111]' (Size = 8)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
@@ -1775,7 +1775,7 @@ WHERE (
         ) AS "i1"
         UNION
         SELECT "i0"."value"
-        FROM json_each(@__ints_0) AS "i0"
+        FROM json_each(@ints) AS "i0"
     ) AS "u") = 3
 """);
     }
@@ -1895,20 +1895,20 @@ FROM "PrimitiveCollectionsEntity" AS "p"
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 7)
-@__strings_1='["one","two","three"]' (Size = 21)
+@ints='[1,2,3]' (Size = 7)
+@strings='["one","two","three"]' (Size = 21)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE CASE
     WHEN "p"."Int" IN (
         SELECT "i"."value"
-        FROM json_each(@__ints_0) AS "i"
+        FROM json_each(@ints) AS "i"
     ) THEN 'one'
     ELSE 'two'
 END IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_1) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """);
     }
@@ -1919,20 +1919,20 @@ END IN (
 
         AssertSql(
             """
-@__ints_0='[1,2,3]' (Size = 7)
-@__strings_1='["one","two","three"]' (Size = 21)
+@ints='[1,2,3]' (Size = 7)
+@strings='["one","two","three"]' (Size = 21)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE CASE
     WHEN "p"."Int" IN (
         SELECT "i"."value"
-        FROM json_each(@__ints_0) AS "i"
+        FROM json_each(@ints) AS "i"
     ) THEN 'one'
     ELSE 'two'
 END IN (
     SELECT "s"."value"
-    FROM json_each(@__strings_1) AS "s"
+    FROM json_each(@strings) AS "s"
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -23,21 +23,21 @@ public class QueryFilterFuncletizationSqliteTest : QueryFilterFuncletizationTest
 
         AssertSql(
             """
-@__ef_filter__Tenant_0='1'
+@ef_filter__Tenant='1'
 
 SELECT "d"."Id", "d"."Tenant", "d2"."Id", "d2"."DeDupeFilter1Id", "d2"."TenantX", "d3"."Id", "d3"."DeDupeFilter1Id", "d3"."Tenant"
 FROM "DeDupeFilter1" AS "d"
 LEFT JOIN (
     SELECT "d0"."Id", "d0"."DeDupeFilter1Id", "d0"."TenantX"
     FROM "DeDupeFilter2" AS "d0"
-    WHERE "d0"."TenantX" = @__ef_filter__Tenant_0
+    WHERE "d0"."TenantX" = @ef_filter__Tenant
 ) AS "d2" ON "d"."Id" = "d2"."DeDupeFilter1Id"
 LEFT JOIN (
     SELECT "d1"."Id", "d1"."DeDupeFilter1Id", "d1"."Tenant"
     FROM "DeDupeFilter3" AS "d1"
-    WHERE "d1"."Tenant" = @__ef_filter__Tenant_0
+    WHERE "d1"."Tenant" = @ef_filter__Tenant
 ) AS "d3" ON "d"."Id" = "d3"."DeDupeFilter1Id"
-WHERE "d"."Tenant" = @__ef_filter__Tenant_0
+WHERE "d"."Tenant" = @ef_filter__Tenant
 ORDER BY "d"."Id", "d2"."Id"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -47,9 +47,9 @@ FROM "MultiLineStringEntity" AS "m"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Nullable = false) (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Nullable = false) (Size = 60) (DbType = String)
 
-SELECT "g"."Id", Distance("g"."Location", @__point_0) AS "Distance"
+SELECT "g"."Id", Distance("g"."Location", @point) AS "Distance"
 FROM "GeoPointEntity" AS "g"
 """);
     }
@@ -60,9 +60,9 @@ FROM "GeoPointEntity" AS "g"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Nullable = false) (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Nullable = false) (Size = 60) (DbType = String)
 
-SELECT "g"."Id", Distance(@__point_0, "g"."Location") AS "Distance"
+SELECT "g"."Id", Distance(@point, "g"."Location") AS "Distance"
 FROM "GeoPointEntity" AS "g"
 """);
     }
@@ -223,10 +223,10 @@ GROUP BY "p"."Group"
 
         AssertSql(
             """
-@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
+@point='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Contains("p"."Polygon", @__point_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Contains("p"."Polygon", @point)
 END AS "Contains"
 FROM "PolygonEntity" AS "p"
 """);
@@ -284,10 +284,10 @@ FROM "LineStringEntity" AS "l"
 
         AssertSql(
             """
-@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
+@polygon='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Point" IS NOT NULL THEN CoveredBy("p"."Point", @__polygon_0)
+    WHEN "p"."Point" IS NOT NULL THEN CoveredBy("p"."Point", @polygon)
 END AS "CoveredBy"
 FROM "PointEntity" AS "p"
 """);
@@ -299,10 +299,10 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
+@point='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Covers("p"."Polygon", @__point_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Covers("p"."Polygon", @point)
 END AS "Covers"
 FROM "PolygonEntity" AS "p"
 """);
@@ -314,10 +314,10 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id", CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Crosses("l"."LineString", @__lineString_0)
+    WHEN "l"."LineString" IS NOT NULL THEN Crosses("l"."LineString", @lineString)
 END AS "Crosses"
 FROM "LineStringEntity" AS "l"
 """);
@@ -329,9 +329,9 @@ FROM "LineStringEntity" AS "l"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-SELECT "p"."Id", Difference("p"."Polygon", @__polygon_0) AS "Difference"
+SELECT "p"."Id", Difference("p"."Polygon", @polygon) AS "Difference"
 FROM "PolygonEntity" AS "p"
 """);
     }
@@ -353,10 +353,10 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
+@point='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Disjoint("p"."Polygon", @__point_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Disjoint("p"."Polygon", @point)
 END AS "Disjoint"
 FROM "PolygonEntity" AS "p"
 """);
@@ -368,11 +368,11 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
+@point='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
     WHEN "p"."Polygon" IS NULL THEN NULL
-    WHEN "p"."Polygon" IS NOT NULL THEN Disjoint("p"."Polygon", @__point_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Disjoint("p"."Polygon", @point)
 END AS "Disjoint"
 FROM "PolygonEntity" AS "p"
 """);
@@ -384,9 +384,9 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-SELECT "p"."Id", Distance("p"."Point", @__point_0) AS "Distance"
+SELECT "p"."Id", Distance("p"."Point", @point) AS "Distance"
 FROM "PointEntity" AS "p"
 """);
     }
@@ -397,9 +397,9 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-SELECT "p"."Id", Distance("p"."Point", @__point_0) AS "Distance"
+SELECT "p"."Id", Distance("p"."Point", @point) AS "Distance"
 FROM "PointEntity" AS "p"
 """);
     }
@@ -410,9 +410,9 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-SELECT "p"."Id", Distance("p"."Geometry", @__point_0) AS "Distance"
+SELECT "p"."Id", Distance("p"."Geometry", @point) AS "Distance"
 FROM "PointEntity" AS "p"
 """);
     }
@@ -478,10 +478,10 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000000000000000000000000000...' (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000000000000000000000000000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Point" IS NOT NULL THEN Equals("p"."Point", @__point_0)
+    WHEN "p"."Point" IS NOT NULL THEN Equals("p"."Point", @point)
 END AS "EqualsTopologically"
 FROM "PointEntity" AS "p"
 """);
@@ -584,9 +584,9 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-SELECT "p"."Id", Intersection("p"."Polygon", @__polygon_0) AS "Intersection"
+SELECT "p"."Id", Intersection("p"."Polygon", @polygon) AS "Intersection"
 FROM "PolygonEntity" AS "p"
 """);
     }
@@ -597,10 +597,10 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id", CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @__lineString_0)
+    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @lineString)
 END AS "Intersects"
 FROM "LineStringEntity" AS "l"
 """);
@@ -690,10 +690,10 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+@point='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN Distance("p"."Point", @__point_0) <= 1.0 THEN 1
+    WHEN Distance("p"."Point", @point) <= 1.0 THEN 1
     ELSE 0
 END AS "IsWithinDistance"
 FROM "PointEntity" AS "p"
@@ -795,10 +795,10 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Overlaps("p"."Polygon", @__polygon_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Overlaps("p"."Polygon", @polygon)
 END AS "Overlaps"
 FROM "PolygonEntity" AS "p"
 """);
@@ -821,10 +821,10 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Relate("p"."Polygon", @__polygon_0, '212111212')
+    WHEN "p"."Polygon" IS NOT NULL THEN Relate("p"."Polygon", @polygon, '212111212')
 END AS "Relate"
 FROM "PolygonEntity" AS "p"
 """);
@@ -880,9 +880,9 @@ FROM "LineStringEntity" AS "l"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-SELECT "p"."Id", SymDifference("p"."Polygon", @__polygon_0) AS "SymmetricDifference"
+SELECT "p"."Id", SymDifference("p"."Polygon", @polygon) AS "SymmetricDifference"
 FROM "PolygonEntity" AS "p"
 """);
     }
@@ -915,10 +915,10 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Polygon" IS NOT NULL THEN Touches("p"."Polygon", @__polygon_0)
+    WHEN "p"."Polygon" IS NOT NULL THEN Touches("p"."Polygon", @polygon)
 END AS "Touches"
 FROM "PolygonEntity" AS "p"
 """);
@@ -930,9 +930,9 @@ FROM "PolygonEntity" AS "p"
 
         AssertSql(
             """
-@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+@polygon='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-SELECT "p"."Id", GUnion("p"."Polygon", @__polygon_0) AS "Union"
+SELECT "p"."Id", GUnion("p"."Polygon", @polygon) AS "Union"
 FROM "PolygonEntity" AS "p"
 """);
     }
@@ -967,10 +967,10 @@ FROM "MultiLineStringEntity" AS "m"
 
         AssertSql(
             """
-@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
+@polygon='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
 
 SELECT "p"."Id", CASE
-    WHEN "p"."Point" IS NOT NULL THEN Within("p"."Point", @__polygon_0)
+    WHEN "p"."Point" IS NOT NULL THEN Within("p"."Point", @polygon)
 END AS "Within"
 FROM "PointEntity" AS "p"
 """);
@@ -1043,22 +1043,22 @@ END IS NOT NULL
 
         AssertSql(
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id"
 FROM "LineStringEntity" AS "l"
 WHERE CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @__lineString_0)
+    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @lineString)
 END IS NULL
 """,
             //
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id"
 FROM "LineStringEntity" AS "l"
 WHERE CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Intersects(@__lineString_0, "l"."LineString")
+    WHEN "l"."LineString" IS NOT NULL THEN Intersects(@lineString, "l"."LineString")
 END IS NULL
 """);
     }
@@ -1069,22 +1069,22 @@ END IS NULL
 
         AssertSql(
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id"
 FROM "LineStringEntity" AS "l"
 WHERE CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @__lineString_0)
+    WHEN "l"."LineString" IS NOT NULL THEN Intersects("l"."LineString", @lineString)
 END IS NOT NULL
 """,
             //
             """
-@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+@lineString='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
 SELECT "l"."Id"
 FROM "LineStringEntity" AS "l"
 WHERE CASE
-    WHEN "l"."LineString" IS NOT NULL THEN Intersects(@__lineString_0, "l"."LineString")
+    WHEN "l"."LineString" IS NOT NULL THEN Intersects(@lineString, "l"."LineString")
 END IS NOT NULL
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
@@ -32,14 +32,17 @@ WHERE instr("m"."ContactName", 'z') > 0
         var queryString = await base.SqlQueryRaw_queryable_with_parameters_and_closure(async);
 
         Assert.Equal(
-            @".param set p0 'London'
-.param set @__contactTitle_1 'Sales Representative'
+            """
+.param set p0 'London'
+.param set @contactTitle 'Sales Representative'
 
-SELECT ""m"".""Address"", ""m"".""City"", ""m"".""CompanyName"", ""m"".""ContactName"", ""m"".""ContactTitle"", ""m"".""Country"", ""m"".""CustomerID"", ""m"".""Fax"", ""m"".""Phone"", ""m"".""Region"", ""m"".""PostalCode""
+SELECT "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."ContactTitle", "m"."Country", "m"."CustomerID", "m"."Fax", "m"."Phone", "m"."Region", "m"."PostalCode"
 FROM (
-    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
-) AS ""m""
-WHERE ""m"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEndingDifferences: true);
+    SELECT * FROM "Customers" WHERE "City" = @p0
+) AS "m"
+WHERE "m"."ContactTitle" = @contactTitle
+""",
+            queryString, ignoreLineEndingDifferences: true);
 
         return queryString;
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPCGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPCGearsOfWarQuerySqliteTest.cs
@@ -239,11 +239,11 @@ WHERE instr("s"."Banner", X'01') > 0
 
         AssertSql(
             """
-@__someByte_0='1'
+@someByte='1'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE instr("s"."Banner", char(@__someByte_0)) > 0
+WHERE instr("s"."Banner", char(@someByte)) > 0
 """);
     }
 
@@ -265,11 +265,11 @@ WHERE length("s"."Banner") = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = @__p_0
+WHERE length("s"."Banner") = @p
 """);
     }
 
@@ -279,11 +279,11 @@ WHERE length("s"."Banner") = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 2)
+@byteArrayParam='0x2A80' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = length(@__byteArrayParam)
+WHERE length("s"."Banner") = length(@byteArrayParam)
 """);
     }
 
@@ -293,11 +293,11 @@ WHERE length("s"."Banner") = length(@__byteArrayParam)
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE "s"."Banner5" = @__byteArrayParam_0
+WHERE "s"."Banner5" = @byteArrayParam
 """);
     }
 
@@ -428,11 +428,11 @@ WHERE date("t"."IssueDate") > "m"."Date"
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
-WHERE date("t"."IssueDate") IN (@__prm_0, '0015-03-07')
+WHERE date("t"."IssueDate") IN (@prm, '0015-03-07')
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
@@ -239,11 +239,11 @@ WHERE instr("s"."Banner", X'01') > 0
 
         AssertSql(
             """
-@__someByte_0='1'
+@someByte='1'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE instr("s"."Banner", char(@__someByte_0)) > 0
+WHERE instr("s"."Banner", char(@someByte)) > 0
 """);
     }
 
@@ -265,11 +265,11 @@ WHERE length("s"."Banner") = 2
 
         AssertSql(
             """
-@__p_0='2'
+@p='2'
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = @__p_0
+WHERE length("s"."Banner") = @p
 """);
     }
 
@@ -279,11 +279,11 @@ WHERE length("s"."Banner") = @__p_0
 
         AssertSql(
             """
-@__byteArrayParam='0x2A80' (Size = 2)
+@byteArrayParam='0x2A80' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Squads" AS "s"
-WHERE length("s"."Banner") = length(@__byteArrayParam)
+WHERE length("s"."Banner") = length(@byteArrayParam)
 """);
     }
 
@@ -293,11 +293,11 @@ WHERE length("s"."Banner") = length(@__byteArrayParam)
 
         AssertSql(
             """
-@__byteArrayParam_0='0x0405060708' (Size = 5)
+@byteArrayParam='0x0405060708' (Size = 5)
 
 SELECT "s"."Id", "s"."Banner", "s"."Banner5", "s"."InternalNumber", "s"."Name"
 FROM "Squads" AS "s"
-WHERE "s"."Banner5" = @__byteArrayParam_0
+WHERE "s"."Banner5" = @byteArrayParam
 """);
     }
 
@@ -428,11 +428,11 @@ WHERE date("t"."IssueDate") > "m"."Date"
 
         AssertSql(
             """
-@__prm_0='10/11/0002' (DbType = Date)
+@prm='10/11/0002' (DbType = Date)
 
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
-WHERE date("t"."IssueDate") IN (@__prm_0, '0015-03-07')
+WHERE date("t"."IssueDate") IN (@prm, '0015-03-07')
 """);
     }
 

--- a/test/EFCore.VisualBasic.FunctionalTests/NorthwindQueryVisualBasicTest.vb
+++ b/test/EFCore.VisualBasic.FunctionalTests/NorthwindQueryVisualBasicTest.vb
@@ -89,11 +89,11 @@ WHERE [p].[UnitsInStock] * CAST(1 AS smallint) = CAST(101 AS smallint)")
             Function(ss) ss.Set(Of Product).Where(Function(p) p.UnitsInStock = units))
 
         AssertSql(
-            "@__units_0='101'
+            "@units='101'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE [p].[UnitsInStock] = @__units_0")
+WHERE [p].[UnitsInStock] = @units")
     End Sub
 
     Protected Overrides Function CreateQueryAsserter(fixture As NorthwindVBQuerySqlServerFixture(Of NoopModelCustomizer)) As QueryAsserter


### PR DESCRIPTION
* Remove our query parameter prefix (`__`), and implement proper uniquification in the funcletizer - only as needed -  rather than always adding on a running number. This causes our basic parameter name to change from `@__city_0` to `@city`.
* While the above - in the funcletizer - takes care of uniquification across regular parameters, it does not do so for FromSql parameters, which may have the same name and therefore conflict. Allowing the funcletizer to know about DbParameters would mean making it provider-specific (it's currently universal and internal).
* To implement the uniquification, Worked logic into FromSqlParameterExpandingExpressionVisitor, which was previously purely about "expanding" FromSql parameters; it now also performs uniquification across all parameters (DbParameter and regular). Renamed the visitor to RelationalParameterProcessor (it's internal).
* As long as we're at it, also moved the logic that sends two distinct parameters when the same parameter is used twice in the query, with different type mappings; this used to be in QuerySqlGenerator.VisitSqlParameter, moved it into the new RelationalParameterProcessor as well (this way all parameter handling is concentrated in a single visitor, and QuerySqlGenerator is kept as a very thin SQL generator, with minimal logic).
* Since we may need to change the SqlParameterExpression name as part of uniquification in this phase (i.e. a DbParameter exists earlier in the tree with the same name), added InvariantName to SqlParameter (InvariantName references the parameter value via QueryContext.ParameterValues, Name is the name that the ADO.NET DbParameter gets; only the latter needs to be modified for uniquification).

Closes #35113
Fixes #35196
