### PR TITLE
[release/9.0] Fix TPC equality check inside subquery predicate (#35120)

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -51,6 +52,9 @@ public sealed partial class SelectExpression : TableExpressionBase
     private List<(ColumnExpression Column, ValueComparer Comparer)>? _preGroupByIdentifier;
 
     private static ConstructorInfo? _quotingConstructor;
+
+    private static readonly bool UseOldBehavior35118 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35118", out var enabled35118) && enabled35118;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1550,7 +1554,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                         Left: ColumnExpression leftColumn,
                         Right: SqlConstantExpression { Value: string s1 }
                     }
-                    when GetTable(leftColumn) is TpcTablesExpression
+                    when (UseOldBehavior35118 ? GetTable(leftColumn) : TryGetTable(leftColumn, out var table, out _) ? table : null)
+                    is TpcTablesExpression
                     {
                         DiscriminatorColumn: var discriminatorColumn,
                         DiscriminatorValues: var discriminatorValues
@@ -1573,7 +1578,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                         Left: SqlConstantExpression { Value: string s2 },
                         Right: ColumnExpression rightColumn
                     }
-                    when GetTable(rightColumn) is TpcTablesExpression
+                    when (UseOldBehavior35118 ? GetTable(rightColumn) : TryGetTable(rightColumn, out var table, out _) ? table : null)
+                    is TpcTablesExpression
                     {
                         DiscriminatorColumn: var discriminatorColumn,
                         DiscriminatorValues: var discriminatorValues
@@ -1597,7 +1603,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                         Item: ColumnExpression itemColumn,
                         Values: IReadOnlyList<SqlExpression> valueExpressions
                     }
-                    when GetTable(itemColumn) is TpcTablesExpression
+                    when (UseOldBehavior35118 ? GetTable(itemColumn) : TryGetTable(itemColumn, out var table, out _) ? table : null)
+                    is TpcTablesExpression
                     {
                         DiscriminatorColumn: var discriminatorColumn,
                         DiscriminatorValues: var discriminatorValues
@@ -2721,6 +2728,24 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
         }
 
+        return false;
+    }
+
+    private bool TryGetTable(ColumnExpression column, [NotNullWhen(true)] out TableExpressionBase? table, out int tableIndex)
+    {
+        for (var i = 0; i < _tables.Count; i++)
+        {
+            var t = _tables[i];
+            if (t.UnwrapJoin().Alias == column.TableAlias)
+            {
+                table = t;
+                tableIndex = i;
+                return true;
+            }
+        }
+
+        table = null;
+        tableIndex = 0;
         return false;
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -5276,6 +5276,14 @@ WHERE (c["id"] = "ALFKI")
 
     #endregion ToPageAsync
 
+    public override async Task Column_access_inside_subquery_predicate(bool async)
+    {
+        // Uncorrelated subquery, not supported by Cosmos
+        await AssertTranslationFailed(() => base.Column_access_inside_subquery_predicate(async));
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5849,4 +5849,11 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     private static string StaticProperty
         => "ALF";
+
+    [ConditionalTheory] // #35118
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_access_inside_subquery_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Where(o => c.CustomerID == "ALFKI").Any()));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -7461,6 +7461,21 @@ WHERE (
 """);
     }
 
+    public override async Task Column_access_inside_subquery_predicate(bool async)
+    {
+        await base.Column_access_inside_subquery_predicate(async);
+
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = N'ALFKI')
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #35118
Port of #35120

**Description**
The deep query pipeline re-architecting in 9.0 included turning our SQL expression tree into a real tree rather than a graph, i.e. removing cycles where a SQL table was referenced both from its containing SelectExpression, and from any referencing columns. As a result, a changed predicate check for TPC inheritance was broken and did not correctly access the column's table when the column was nested in a subquery and referenced an outer table.

**Customer impact**
LINQ queries including a minimal equality predicate where a column references an outer table are now broken. For example:

```c#
var results = await context.As
    .Where(a => context.As.Where(g => a.Name == "A").Any())
    .ToListAsync();
```

These queries are sufficiently common, and the fix sufficiently simple, that servicing seems justified.

**How found**
Customer reported on 9.0.0

**Regression**
Yes, from 8.0.

**Testing**
Test added.

**Risk**
Low, quirk added.