### PR TITLE
[release/9.0] Add missing Converts when simplifying in funcletizer (#35122)

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -3306,6 +3306,18 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = 10252))
 """);
             });
 
+    public override Task Simplifiable_coalesce_over_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Simplifiable_coalesce_over_nullable(a);
+
+                AssertSql(
+                    """
+ReadItem(None, Order|10248)
+""");
+            });
+
     #region Evaluation order of predicates
 
     public override Task Take_and_Where_evaluation_order(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -2536,7 +2536,18 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
             elementAsserter: (e, a) => AssertEqual(e.Id, a.Id));
     }
 
-    #region Evaluation order of predicates
+    [ConditionalTheory] // #35095
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Simplifiable_coalesce_over_nullable(bool async)
+    {
+        int? orderId = 10248;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.OrderID == (orderId ?? 0)));
+    }
+
+    #region Evaluation order of operators
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -2559,5 +2570,5 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
             async,
             ss => ss.Set<Customer>().Select(c => c.ContactTitle).OrderBy(t => t).Take(3).Distinct());
 
-    #endregion Evaluation order of predicates
+    #endregion Evaluation order of operators
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -3425,7 +3425,21 @@ WHERE [o].[OrderID] = 10252
 """);
     }
 
-    #region Evaluation order of predicates
+    public override async Task Simplifiable_coalesce_over_nullable(bool async)
+    {
+        await base.Simplifiable_coalesce_over_nullable(async);
+
+        AssertSql(
+            """
+@__p_0='10248'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = @__p_0
+""");
+    }
+
+    #region Evaluation order of operators
 
     public override async Task Take_and_Where_evaluation_order(bool async)
     {
@@ -3483,7 +3497,7 @@ FROM (
 """);
     }
 
-    #endregion Evaluation order of predicates
+    #endregion Evaluation order of operators
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
Fixes #35095
Port of #35122

**Description**
In 9.0, EF's funcletizer was rewritten for performance and NativeAOT support; this is the very first component that processes the incoming expression tree, extracting parameters and performing other important tasks. For certain query scenarios, e.g. Coalesce operations which can be optimized away, a missing conversion node can cause an exception.

**Customer impact**

LINQ queries such as the following, where a nullable value type parameter is coalesced in the query, but can be optimized away (since the parameter is known to be non-null), fail to translate in 9.0:

```c#
int? test = 1;
var blog = context.Blogs.Where(b => b.Id == (test ?? 0)).ToList();
```

As this querying scenario seems somewhat common, and the fix is very low-risk (add missing Convert node), it seems like this is a good candidate for servicing.

**How found**
Customer reported on 9.0.0

**Regression**
Yes, from 8.0.

**Testing**
Test added.

**Risk**
Low, quirk added.