### PR TITLE
[release/9.0] Correct VisitUnary operand evaluation in funcletizer (#35172)

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -5284,6 +5284,17 @@ WHERE (c["id"] = "ALFKI")
         AssertSql();
     }
 
+    public override async Task Cast_to_object_over_parameter_directly_in_lambda(bool async)
+    {
+        // Sync always throws before getting to exception being tested.
+        if (async)
+        {
+            // Cosmos doesn't support ORDER BY over parameter/constant:
+            // Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path.
+            await Assert.ThrowsAsync<CosmosException>(() => base.Cast_to_object_over_parameter_directly_in_lambda(async: true));
+        }
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5856,4 +5856,15 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Where(o => c.CustomerID == "ALFKI").Any()));
+
+    [ConditionalTheory] // #35152
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Cast_to_object_over_parameter_directly_in_lambda(bool async)
+    {
+        var i = 8;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Order>().OrderBy(o => (object)i).Select(o => o));
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -7476,6 +7476,17 @@ WHERE EXISTS (
 """);
     }
 
+    public override async Task Cast_to_object_over_parameter_directly_in_lambda(bool async)
+    {
+        await base.Cast_to_object_over_parameter_directly_in_lambda(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #35152
Port of #35172

**Description**
In 9.0, EF's funcletizer was rewritten for performance and NativeAOT support; this is the very first component that processes the incoming expression tree, extracting parameters and performing other important tasks. In the new implementation, processing of unary expression nodes was faulty, not setting the expression visitor's state properly.

**Customer impact**
For various query types involving unary expression nodes (e.g. Convert), the query fails to translate. For example, in the following query type, the cast to `object` is a mishandled unary node:

```c#
var v = 1;
var q = await context.Set<Blog>().OrderBy(x => (object)v).ToListAsync();
```

As this querying scenario seems somewhat common, and the fix is very low-risk (add missing Convert node), it seems like this is a good candidate for servicing.

**How found**
Customer reported on 9.0.0

**Regression**
Yes, from 8.0.

**Testing**
Test added.

**Risk**
Low, quirk added.