### PR TITLE
Fix to #35208 - Query/Perf: don't compile liftable constant resolvers in interpretation mode

### DIFF
--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -36,7 +36,8 @@ public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
         if (liftableConstant.ResolverExpression is Expression<Func<RelationalMaterializerLiftableConstantContext, object>>
             resolverExpression)
         {
-            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            // TODO: deep dive into this - see issue #35210
+            var resolver = resolverExpression.Compile(preferInterpretation: false);
             var value = resolver(_relationalMaterializerLiftableConstantContext);
             return Expression.Constant(value, liftableConstant.Type);
         }

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -198,7 +198,8 @@ public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantPro
             // Make sure there aren't any problematic un-lifted constants within the resolver expression.
             _unsupportedConstantChecker.Check(resolverExpression);
 
-            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            // TODO: deep dive into this - see issue #35210
+            var resolver = resolverExpression.Compile(preferInterpretation: false);
             var value = resolver(_materializerLiftableConstantContext);
 
             return Expression.Constant(value, liftableConstant.Type);


### PR DESCRIPTION
In EF9 we changed the way we generate shapers in preparation for AOT scenarios. We no longer can embed arbitrary objects into the shaper, instead we need to provide a way to construct that object in code (using LiftableConstant mechanism), or simulate the functionality it used to provide. At the end of our processing, we find all liftable constants and for the non-AOT case we compile their resolver lambdas and invoke the result with liftable context object to produce the resulting constant object we initially wanted. (in AOT case we generate code from the resolver lambda). Problem is that we are compiling the resolver lambda in the interpretation mode - if the final product is itself a delegate, that delegate will itself be in the interpreter mode and therefore less efficient.

Fix is to scan the resolver expression and look for nested lambdas inside - if we find some, compile the resolver in the regular mode instead.

Fixes #35208

This is part of a fix for a larger perf issue: #35053