### PR TITLE
[release/9.0-staging] Fix to #35208 - Query/Perf: don't compile liftable constant resolvers in interpretation mode

### DIFF
--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -36,7 +36,7 @@ public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
         if (liftableConstant.ResolverExpression is Expression<Func<RelationalMaterializerLiftableConstantContext, object>>
             resolverExpression)
         {
-            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var resolver = resolverExpression.Compile(preferInterpretation: UseOldBehavior35208);
             var value = resolver(_relationalMaterializerLiftableConstantContext);
             return Expression.Constant(value, liftableConstant.Type);
         }

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -31,6 +31,9 @@ public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantPro
     private readonly LiftedConstantOptimizer _liftedConstantOptimizer = new();
     private ParameterExpression? _contextParameter;
 
+    protected static readonly bool UseOldBehavior35208 =
+           AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35208", out var enabled35208) && enabled35208;
+
     /// <summary>
     ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
     /// </summary>
@@ -198,7 +201,7 @@ public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantPro
             // Make sure there aren't any problematic un-lifted constants within the resolver expression.
             _unsupportedConstantChecker.Check(resolverExpression);
 
-            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var resolver = resolverExpression.Compile(preferInterpretation: UseOldBehavior35208);
             var value = resolver(_materializerLiftableConstantContext);
 
             return Expression.Constant(value, liftableConstant.Type);


### PR DESCRIPTION
Fixes #35208
Port of #35209

**Description**
In EF9 we changed the way we generate shapers in preparation for AOT scenarios. We no longer can embed arbitrary objects into the shaper, instead we need to provide a way to construct that object in code (using LiftableConstant mechanism), or simulate the functionality it used to provide. At the end of our processing, we find all liftable constants and for the non-AOT case we compile their resolver lambdas and invoke the result with liftable context object to produce the resulting constant object we initially wanted. (in AOT case we generate code from the resolver lambda). Problem is that we are compiling the resolver lambda in the interpretation mode - if the final product is itself a delegate, that delegate will itself be in the interpreter mode and therefore less efficient when invoked multiple times when the query runs. Fix is to use regular compilation rather than interpretation.

**Customer impact**
Queries using collection navigation with significant amount of data suffer large performance degradation when compared with EF8. No good workaround.

**How found**
Multiple customer reports on 9.0.0

**Regression**
Yes, from 8.0.

**Testing**
Ad-hoc perf testing with BenchmarkDotNet. Functional change already covered by numerous tests.

**Risk**
Low, quirk added.

**Benchmarks**

before this change

|      Method | Async |     Mean |   Error |  StdDev |  Op/s |       Gen0 |       Gen1 | Allocated |
|------------ |------ |---------:|--------:|--------:|------:|-----------:|-----------:|----------:|
| MultiInclue | False | 487.1 ms | 0.99 ms | 0.88 ms | 2.053 | 17000.0000 | 11000.0000 | 103.29 MB |
| MultiInclue |  True | 487.4 ms | 3.63 ms | 3.22 ms | 2.052 | 17000.0000 | 11000.0000 | 103.29 MB |

after this change

|      Method | Async |     Mean |   Error |   StdDev |  Op/s |       Gen0 |      Gen1 | Allocated |
|------------ |------ |---------:|--------:|---------:|------:|-----------:|----------:|----------:|
| MultiInclue | False | 455.1 ms | 8.94 ms | 10.29 ms | 2.197 | 11000.0000 | 6000.0000 |  67.92 MB |
| MultiInclue |  True | 435.4 ms | 1.77 ms |  1.66 ms | 2.297 | 11000.0000 | 6000.0000 |  67.92 MB |