### PR TITLE
[release/9.0] Return null when the type is nullable for Cosmos Max/Min/Average

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -444,25 +444,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateAverage(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-    {
-        var selectExpression = (SelectExpression)source.QueryExpression;
-        if (selectExpression.IsDistinct
-            || selectExpression.Limit != null
-            || selectExpression.Offset != null)
-        {
-            return null;
-        }
-
-        if (selector != null)
-        {
-            source = TranslateSelect(source, selector);
-        }
-
-        var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
-        projection = _sqlExpressionFactory.Function("AVG", new[] { projection }, projection.Type, projection.TypeMapping);
-
-        return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
-    }
+        => TranslateAggregate(source, selector, resultType, "AVG");
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -842,26 +824,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateMax(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-    {
-        var selectExpression = (SelectExpression)source.QueryExpression;
-        if (selectExpression.IsDistinct
-            || selectExpression.Limit != null
-            || selectExpression.Offset != null)
-        {
-            return null;
-        }
-
-        if (selector != null)
-        {
-            source = TranslateSelect(source, selector);
-        }
-
-        var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
-
-        projection = _sqlExpressionFactory.Function("MAX", new[] { projection }, resultType, projection.TypeMapping);
-
-        return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
-    }
+        => TranslateAggregate(source, selector, resultType, "MAX");
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -870,26 +833,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override ShapedQueryExpression? TranslateMin(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-    {
-        var selectExpression = (SelectExpression)source.QueryExpression;
-        if (selectExpression.IsDistinct
-            || selectExpression.Limit != null
-            || selectExpression.Offset != null)
-        {
-            return null;
-        }
-
-        if (selector != null)
-        {
-            source = TranslateSelect(source, selector);
-        }
-
-        var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
-
-        projection = _sqlExpressionFactory.Function("MIN", new[] { projection }, resultType, projection.TypeMapping);
-
-        return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
-    }
+    => TranslateAggregate(source, selector, resultType, "MIN");
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1242,7 +1186,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
         projection = _sqlExpressionFactory.Function("SUM", new[] { projection }, serverOutputType, projection.TypeMapping);
 
-        return AggregateResultShaper(source, projection, throwOnNullResult: false, resultType);
+        return AggregateResultShaper(source, projection, resultType);
     }
 
     /// <summary>
@@ -1520,6 +1464,35 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
 
     #endregion Queryable collection support
 
+    private ShapedQueryExpression? TranslateAggregate(ShapedQueryExpression source, LambdaExpression? selector, Type resultType, string functionName)
+    {
+        var selectExpression = (SelectExpression)source.QueryExpression;
+        if (selectExpression.IsDistinct
+            || selectExpression.Limit != null
+            || selectExpression.Offset != null)
+        {
+            return null;
+        }
+
+        if (selector != null)
+        {
+            source = TranslateSelect(source, selector);
+        }
+
+        if (!_subquery && resultType.IsNullableType())
+        {
+            // For nullable types, we want to return null from Max, Min, and Average, rather than throwing. See Issue #35094.
+            // Note that relational databases typically return null, which propagates. Cosmos will instead return no elements,
+            // and hence for Cosmos only we need to change no elements into null.
+            source = source.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
+        }
+
+        var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
+        projection = _sqlExpressionFactory.Function(functionName, [projection], resultType, _typeMappingSource.FindMapping(resultType));
+
+        return AggregateResultShaper(source, projection, resultType);
+    }
+
     private bool TryApplyPredicate(ShapedQueryExpression source, LambdaExpression predicate)
     {
         var select = (SelectExpression)source.QueryExpression;
@@ -1700,7 +1673,6 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
     private static ShapedQueryExpression AggregateResultShaper(
         ShapedQueryExpression source,
         Expression projection,
-        bool throwOnNullResult,
         Type resultType)
     {
         var selectExpression = (SelectExpression)source.QueryExpression;
@@ -1711,29 +1683,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         var nullableResultType = resultType.MakeNullable();
         Expression shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), nullableResultType);
 
-        if (throwOnNullResult)
-        {
-            var resultVariable = Expression.Variable(nullableResultType, "result");
-            var returnValueForNull = resultType.IsNullableType()
-                ? (Expression)Expression.Constant(null, resultType)
-                : Expression.Throw(
-                    Expression.New(
-                        typeof(InvalidOperationException).GetConstructors()
-                            .Single(ci => ci.GetParameters().Length == 1),
-                        Expression.Constant(CoreStrings.SequenceContainsNoElements)),
-                    resultType);
-
-            shaper = Expression.Block(
-                new[] { resultVariable },
-                Expression.Assign(resultVariable, shaper),
-                Expression.Condition(
-                    Expression.Equal(resultVariable, Expression.Default(nullableResultType)),
-                    returnValueForNull,
-                    resultType != resultVariable.Type
-                        ? Expression.Convert(resultVariable, resultType)
-                        : resultVariable));
-        }
-        else if (resultType != shaper.Type)
+        if (resultType != shaper.Type)
         {
             shaper = Expression.Convert(shaper, resultType);
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -1565,7 +1565,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
         var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
         projection = _sqlExpressionFactory.Function(functionName, [projection], resultType, _typeMappingSource.FindMapping(resultType));
 
-        return AggregateResultShaper(source, projection, throwOnNullResult: false, resultType);
+        return AggregateResultShaper(source, projection, throwOnNullResult: true, resultType);
     }
 
     private bool TryApplyPredicate(ShapedQueryExpression source, LambdaExpression predicate)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -518,7 +518,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         ShapedQueryExpression source,
         LambdaExpression? selector,
         Type resultType)
-        => TranslateAggregateWithSelector(source, selector, QueryableMethods.GetAverageWithoutSelector, resultType);
+        => TranslateAggregateWithSelector(source, selector, QueryableMethods.GetAverageWithoutSelector, throwWhenEmpty: true, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression TranslateCast(ShapedQueryExpression source, Type resultType)
@@ -968,7 +968,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         }
 
         return TranslateAggregateWithSelector(
-            source, selector, t => QueryableMethods.MaxWithoutSelector.MakeGenericMethod(t), resultType);
+            source, selector, t => QueryableMethods.MaxWithoutSelector.MakeGenericMethod(t), throwWhenEmpty: true, resultType);
     }
 
     /// <inheritdoc />
@@ -984,7 +984,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         }
 
         return TranslateAggregateWithSelector(
-            source, selector, t => QueryableMethods.MinWithoutSelector.MakeGenericMethod(t), resultType);
+            source, selector, t => QueryableMethods.MinWithoutSelector.MakeGenericMethod(t), throwWhenEmpty: true, resultType);
     }
 
     /// <inheritdoc />
@@ -1235,7 +1235,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateSum(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-        => TranslateAggregateWithSelector(source, selector, QueryableMethods.GetSumWithoutSelector, resultType);
+        => TranslateAggregateWithSelector(source, selector, QueryableMethods.GetSumWithoutSelector, throwWhenEmpty: false, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateTake(ShapedQueryExpression source, Expression count)
@@ -1958,6 +1958,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         ShapedQueryExpression source,
         LambdaExpression? selectorLambda,
         Func<Type, MethodInfo> methodGenerator,
+        bool throwWhenEmpty,
         Type resultType)
     {
         var selectExpression = (SelectExpression)source.QueryExpression;
@@ -2003,13 +2004,48 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), translation } });
 
         selectExpression.ClearOrdering();
+        Expression shaper;
 
-        // Sum case. Projection is always non-null. We read nullable value.
-        Expression shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), translation.Type.MakeNullable());
-
-        if (resultType != shaper.Type)
+        if (throwWhenEmpty)
         {
-            shaper = Expression.Convert(shaper, resultType);
+            // Avg/Max/Min case.
+            // We always read nullable value
+            // If resultType is nullable then we always return null. Only non-null result shows throwing behavior.
+            // otherwise, if projection.Type is nullable then server result is passed through DefaultIfEmpty, hence we return default
+            // otherwise, server would return null only if it is empty, and we throw
+            var nullableResultType = resultType.MakeNullable();
+            shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), nullableResultType);
+            var resultVariable = Expression.Variable(nullableResultType, "result");
+            var returnValueForNull = resultType.IsNullableType()
+                ? (Expression)Expression.Default(resultType)
+                : translation.Type.IsNullableType()
+                    ? Expression.Default(resultType)
+                    : Expression.Throw(
+                        Expression.New(
+                            typeof(InvalidOperationException).GetConstructors()
+                                .Single(ci => ci.GetParameters().Length == 1),
+                            Expression.Constant(CoreStrings.SequenceContainsNoElements)),
+                        resultType);
+
+            shaper = Expression.Block(
+                new[] { resultVariable },
+                Expression.Assign(resultVariable, shaper),
+                Expression.Condition(
+                    Expression.Equal(resultVariable, Expression.Default(nullableResultType)),
+                    returnValueForNull,
+                    resultType != resultVariable.Type
+                        ? Expression.Convert(resultVariable, resultType)
+                        : resultVariable));
+        }
+        else
+        {
+            // Sum case. Projection is always non-null. We read nullable value.
+            shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), translation.Type.MakeNullable());
+
+            if (resultType != shaper.Type)
+            {
+                shaper = Expression.Convert(shaper, resultType);
+            }
         }
 
         return source.UpdateShaperExpression(shaper);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
@@ -49,6 +51,115 @@ public class AdHocMiscellaneousQueryCosmosTest : NonSharedModelTestBase
     }
 
     #endregion 34911
+
+    #region 35094
+
+    // TODO: Move these tests to a better location. They require nullable properties with nulls in the database.
+
+    [ConditionalFact]
+    public virtual async Task Min_over_value_type_containing_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().MinAsync(p => p.NullableVal));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Min_over_value_type_containing_all_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.NullableVal == null).MinAsync(p => p.NullableVal));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Min_over_reference_type_containing_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().MinAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Min_over_reference_type_containing_all_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.NullableRef == null).MinAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Min_over_reference_type_containing_no_data()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.Id < 0).MinAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Max_over_value_type_containing_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Equal(3.14, await context.Set<Context35094.Product>().MaxAsync(p => p.NullableVal));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Max_over_value_type_containing_all_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.NullableVal == null).MaxAsync(p => p.NullableVal));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Max_over_reference_type_containing_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Equal("Value", await context.Set<Context35094.Product>().MaxAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Max_over_reference_type_containing_all_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.NullableRef == null).MaxAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Max_over_reference_type_containing_no_data()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.Id < 0).MaxAsync(p => p.NullableRef));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Average_over_value_type_containing_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().AverageAsync(p => p.NullableVal));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Average_over_value_type_containing_all_nulls()
+    {
+        await using var context = (await InitializeAsync<Context35094>()).CreateContext();
+        Assert.Null(await context.Set<Context35094.Product>().Where(e => e.NullableVal == null).AverageAsync(p => p.NullableVal));
+    }
+
+    protected class Context35094(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Product> Products { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Product>().HasData(
+                new Product { Id = 1, NullableRef = "Value", NullableVal = 3.14 },
+                new Product { Id = 2, NullableVal = 3.14 },
+                new Product { Id = 3, NullableRef = "Value" });
+
+        public class Product
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+            public double? NullableVal { get; set; }
+            public string NullableRef { get; set; }
+        }
+    }
+
+    #endregion 35094
 
     protected override string StoreName
         => "AdHocMiscellaneousQueryTests";

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -667,22 +667,19 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
         AssertSql();
     }
 
-    public override async Task Average_with_no_arg(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_no_arg(async));
+    public override Task Average_with_no_arg(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_with_no_arg(a);
 
-            AssertSql(
-                """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["$type"] = "Order")
 """);
-        }
-    }
+            });
 
     public override Task Average_with_binary_expression(bool async)
         => Fixture.NoSyncTest(
@@ -698,22 +695,19 @@ WHERE (c["$type"] = "Order")
 """);
             });
 
-    public override async Task Average_with_arg(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Average truncates. Issue #26378.
-            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_arg(async));
+    public override Task Average_with_arg(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_with_arg(a);
 
-            AssertSql(
-                """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE (c["$type"] = "Order")
 """);
-        }
-    }
+            });
 
     public override Task Average_with_arg_expression(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -555,49 +555,33 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
         }
     }
 
-    public override async Task Average_no_data_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Average_no_data_nullable(a))).Message);
+    public override Task Average_no_data_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_no_data_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["SupplierID"])
 FROM root c
 WHERE ((c["$type"] = "Product") AND (c["SupplierID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
-    public override async Task Average_no_data_cast_to_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Average_no_data_cast_to_nullable(a))).Message);
+    public override Task Average_no_data_cast_to_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Average_no_data_cast_to_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE AVG(c["OrderID"])
 FROM root c
 WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
     public override async Task Min_no_data(bool async)
     {
@@ -647,49 +631,33 @@ WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
         AssertSql();
     }
 
-    public override async Task Max_no_data_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_no_data_nullable(a))).Message);
+    public override Task Max_no_data_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Max_no_data_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE MAX(c["SupplierID"])
 FROM root c
 WHERE ((c["$type"] = "Product") AND (c["SupplierID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
-    public override async Task Max_no_data_cast_to_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_no_data_cast_to_nullable(a))).Message);
+    public override Task Max_no_data_cast_to_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Max_no_data_cast_to_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE MAX(c["OrderID"])
 FROM root c
 WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
     public override async Task Min_no_data_subquery(bool async)
     {
@@ -874,49 +842,33 @@ WHERE (c["$type"] = "Order")
 """);
             });
 
-    public override async Task Min_no_data_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Min_no_data_nullable(a))).Message);
+    public override  Task Min_no_data_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Min_no_data_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE MIN(c["SupplierID"])
 FROM root c
 WHERE ((c["$type"] = "Product") AND (c["SupplierID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
-    public override async Task Min_no_data_cast_to_nullable(bool async)
-    {
-        // Sync always throws before getting to exception being tested.
-        if (async)
-        {
-            await Fixture.NoSyncTest(
-                async, async a =>
-                {
-                    Assert.Equal(
-                        CoreStrings.SequenceContainsNoElements,
-                        (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Min_no_data_cast_to_nullable(a))).Message);
+    public override Task Min_no_data_cast_to_nullable(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Min_no_data_cast_to_nullable(a);
 
-                    AssertSql(
-                        """
+                AssertSql(
+                    """
 SELECT VALUE MIN(c["OrderID"])
 FROM root c
 WHERE ((c["$type"] = "Order") AND (c["OrderID"] = -1))
 """);
-                });
-        }
-    }
+            });
 
     public override Task Min_with_coalesce(bool async)
         => Fixture.NoSyncTest(


### PR DESCRIPTION
Ports #35173
Fixes #35094

### Description

Updates to the Cosmos query architecture regressed translation for aggregate functions where the return type is nullable.

### Customer impact

Cosmos queries that use `Min`, `Max`, or `Average` and return a nullable type throw in EF8 if the set is empty. This is the correct behavior for non-nullable returns, but if possible we instead return null, which is a more useful behavior, aligns with relational, and is the behavior we had in EF8.

### How found

Customer reported on 9.

### Regression

Yes, from 8.

### Testing

Existing tests fixes and new tests added.

### Risk

Low and quirked.
