### PR TITLE
[release/9.0] Add more specific messages when pending model changes are detected

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -81,6 +81,7 @@ public static class RelationalEventId
         NonTransactionalMigrationOperationWarning,
         AcquiringMigrationLock,
         MigrationsUserTransactionWarning,
+        ModelSnapshotNotFound,
 
         // Query events
         QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
@@ -777,6 +778,19 @@ public static class RelationalEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId MigrationsUserTransactionWarning = MakeMigrationsId(Id.MigrationsUserTransactionWarning);
+
+    /// <summary>
+    ///     Model snapshot was not found.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="MigrationAssemblyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId ModelSnapshotNotFound = MakeMigrationsId(Id.ModelSnapshotNotFound);
 
     private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
 

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -2344,6 +2344,77 @@ public static class RelationalLoggerExtensions
     }
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.PendingModelChangesWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="contextType">The <see cref="DbContext" /> type being used.</param>
+    public static void NonDeterministicModel(
+        this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+        Type contextType)
+    {
+        var definition = RelationalResources.LogNonDeterministicModel(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, contextType.ShortDisplayName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new DbContextTypeEventData(
+                definition,
+                NonDeterministicModel,
+                contextType);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string NonDeterministicModel(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string>)definition;
+        var p = (DbContextTypeEventData)payload;
+        return d.GenerateMessage(p.ContextType.ShortDisplayName());
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.MigrationsNotFound" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="migrator">The migrator.</param>
+    /// <param name="migrationsAssembly">The assembly in which migrations are stored.</param>
+    public static void ModelSnapshotNotFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+        IMigrator migrator,
+        IMigrationsAssembly migrationsAssembly)
+    {
+        var definition = RelationalResources.LogNoModelSnapshotFound(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, migrationsAssembly.Assembly.GetName().Name!);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MigrationAssemblyEventData(
+                definition,
+                ModelSnapshotNotFound,
+                migrator,
+                migrationsAssembly);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string ModelSnapshotNotFound(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string>)definition;
+        var p = (MigrationAssemblyEventData)payload;
+        return d.GenerateMessage(p.MigrationsAssembly.Assembly.GetName().Name!);
+    }
+
+    /// <summary>
     ///     Logs for the <see cref="RelationalEventId.NonTransactionalMigrationOperationWarning" /> event.
     /// </summary>
     /// <param name="diagnostics">The diagnostics logger to use.</param>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -374,7 +374,7 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public EventDefinitionBase? LogMigrationsUserTransactionWarning;
+    public EventDefinitionBase? LogMigrationsUserTransaction;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -672,6 +672,24 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     /// </summary>
     [EntityFrameworkInternal]
     public EventDefinitionBase? LogPendingModelChanges;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogNonDeterministicModel;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogNoModelSnapshotFound;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -3429,11 +3429,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         /// </summary>
         public static EventDefinition LogMigrationsUserTransaction(IDiagnosticsLogger logger)
         {
-            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransactionWarning;
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransaction;
             if (definition == null)
             {
                 definition = NonCapturingLazyInitializer.EnsureInitialized(
-                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransactionWarning,
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationsUserTransaction,
                     logger,
                     static logger => new EventDefinition(
                         logger.Options,
@@ -3572,7 +3572,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     No migrations were found in assembly '{migrationsAssembly}'.
+        ///     No migrations were found in assembly '{migrationsAssembly}'. A migration needs to be added before the database can be updated.
         /// </summary>
         public static EventDefinition<string> LogNoMigrationsFound(IDiagnosticsLogger logger)
         {
@@ -3585,12 +3585,62 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationsNotFound,
-                        LogLevel.Debug,
+                        LogLevel.Information,
                         "RelationalEventId.MigrationsNotFound",
                         level => LoggerMessage.Define<string>(
                             level,
                             RelationalEventId.MigrationsNotFound,
                             _resourceManager.GetString("LogNoMigrationsFound")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     Model snapshot was not found in assembly '{migrationsAssembly}'. Skipping pending model changes check.
+        /// </summary>
+        public static EventDefinition<string> LogNoModelSnapshotFound(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNoModelSnapshotFound;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogNoModelSnapshotFound,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        RelationalEventId.ModelSnapshotNotFound,
+                        LogLevel.Information,
+                        "RelationalEventId.ModelSnapshotNotFound",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            RelationalEventId.ModelSnapshotNotFound,
+                            _resourceManager.GetString("LogNoModelSnapshotFound")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     The model for context '{contextType}' changes each time it is built. This is usually caused by dynamic values used in a 'HasData' call (e.g. `new DateTime()`, `Guid.NewGuid()`). Add a new migration and examine its contents to locate the cause, and replace the dynamic call with a static, hardcoded value. See https://aka.ms/efcore-docs-pending-changes.
+        /// </summary>
+        public static EventDefinition<string> LogNonDeterministicModel(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNonDeterministicModel;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogNonDeterministicModel,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        RelationalEventId.PendingModelChangesWarning,
+                        LogLevel.Error,
+                        "RelationalEventId.PendingModelChangesWarning",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            RelationalEventId.PendingModelChangesWarning,
+                            _resourceManager.GetString("LogNonDeterministicModel")!)));
             }
 
             return (EventDefinition<string>)definition;
@@ -3610,7 +3660,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.NonTransactionalMigrationOperationWarning,
-                        LogLevel.Error,
+                        LogLevel.Warning,
                         "RelationalEventId.NonTransactionalMigrationOperationWarning",
                         level => LoggerMessage.Define<string, string>(
                             level,
@@ -3747,7 +3797,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The model for context '{contextType}' has pending changes. Add a new migration before updating the database.
+        ///     The model for context '{contextType}' has pending changes. Add a new migration before updating the database. See https://aka.ms/efcore-docs-pending-changes.
         /// </summary>
         public static EventDefinition<string> LogPendingModelChanges(IDiagnosticsLogger logger)
         {

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -811,12 +811,20 @@
     <comment>Information RelationalEventId.MigrationsNotApplied</comment>
   </data>
   <data name="LogNoMigrationsFound" xml:space="preserve">
-    <value>No migrations were found in assembly '{migrationsAssembly}'.</value>
-    <comment>Debug RelationalEventId.MigrationsNotFound string</comment>
+    <value>No migrations were found in assembly '{migrationsAssembly}'. A migration needs to be added before the database can be updated.</value>
+    <comment>Information RelationalEventId.MigrationsNotFound string</comment>
+  </data>
+  <data name="LogNoModelSnapshotFound" xml:space="preserve">
+    <value>Model snapshot was not found in assembly '{migrationsAssembly}'. Skipping pending model changes check.</value>
+    <comment>Information RelationalEventId.ModelSnapshotNotFound string</comment>
+  </data>
+  <data name="LogNonDeterministicModel" xml:space="preserve">
+    <value>The model for context '{contextType}' changes each time it is built. This is usually caused by dynamic values used in a 'HasData' call (e.g. `new DateTime()`, `Guid.NewGuid()`). Add a new migration and examine its contents to locate the cause, and replace the dynamic call with a static, hardcoded value. See https://aka.ms/efcore-docs-pending-changes.</value>
+    <comment>Error RelationalEventId.PendingModelChangesWarning string</comment>
   </data>
   <data name="LogNonTransactionalMigrationOperationWarning" xml:space="preserve">
     <value>The migration operation '{operation}' from migration '{migration}' cannot be executed in a transaction. If the app is terminated or an unrecoverable error occurs while this operation is being executed then the migration will be left in a partially applied state and would need to be reverted manually before it can be applied again. Create a separate migration that contains just this operation.</value>
-    <comment>Error RelationalEventId.NonTransactionalMigrationOperationWarning string string</comment>
+    <comment>Warning RelationalEventId.NonTransactionalMigrationOperationWarning string string</comment>
   </data>
   <data name="LogOpenedConnection" xml:space="preserve">
     <value>Opened connection to database '{database}' on server '{server}'.</value>
@@ -839,7 +847,7 @@
     <comment>Warning RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning string</comment>
   </data>
   <data name="LogPendingModelChanges" xml:space="preserve">
-    <value>The model for context '{contextType}' has pending changes. Add a new migration before updating the database.</value>
+    <value>The model for context '{contextType}' has pending changes. Add a new migration before updating the database. See https://aka.ms/efcore-docs-pending-changes.</value>
     <comment>Error RelationalEventId.PendingModelChangesWarning string</comment>
   </data>
   <data name="LogPossibleUnintendedUseOfEquals" xml:space="preserve">

--- a/src/EFCore/Infrastructure/ModelSource.cs
+++ b/src/EFCore/Infrastructure/ModelSource.cs
@@ -65,11 +65,7 @@ public class ModelSource : IModelSource
             {
                 if (!cache.TryGetValue(cacheKey, out model))
                 {
-                    model = CreateModel(
-                        context, modelCreationDependencies.ConventionSetBuilder, modelCreationDependencies.ModelDependencies);
-
-                    var designTimeModel = modelCreationDependencies.ModelRuntimeInitializer.Initialize(
-                        model, designTime: true, modelCreationDependencies.ValidationLogger);
+                    var designTimeModel = CreateModel(context, modelCreationDependencies, designTime: true);
 
                     var runtimeModel = (IModel)designTimeModel.FindRuntimeAnnotationValue(CoreAnnotationNames.ReadOnlyModel)!;
 
@@ -86,6 +82,23 @@ public class ModelSource : IModelSource
         }
 
         return model!;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual IModel CreateModel(
+        DbContext context,
+        ModelCreationDependencies modelCreationDependencies,
+        bool designTime)
+    {
+        var model = CreateModel(context, modelCreationDependencies.ConventionSetBuilder, modelCreationDependencies.ModelDependencies);
+        return modelCreationDependencies.ModelRuntimeInitializer.Initialize(
+            model, designTime, modelCreationDependencies.ValidationLogger);
     }
 
     /// <summary>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -8570,10 +8570,7 @@ namespace RootNamespace
         var sqlServerTypeMappingSource = new SqlServerTypeMappingSource(
             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
             new RelationalTypeMappingSourceDependencies(
-                new IRelationalTypeMappingSourcePlugin[]
-                {
-                    new SqlServerNetTopologySuiteTypeMappingSourcePlugin(NtsGeometryServices.Instance)
-                }));
+                [new SqlServerNetTopologySuiteTypeMappingSourcePlugin(NtsGeometryServices.Instance)]));
 
         var codeHelper = new CSharpHelper(sqlServerTypeMappingSource);
 

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -154,8 +154,8 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
             x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
 
         Assert.Equal(
-            LogLevel.Error,
-            Fixture.TestSqlLoggerFactory.Log.Single(l => l.Id == RelationalEventId.PendingModelChangesWarning).Level);
+            LogLevel.Information,
+            Fixture.TestSqlLoggerFactory.Log.Single(l => l.Id == RelationalEventId.ModelSnapshotNotFound).Level);
     }
 
     [ConditionalFact]
@@ -291,6 +291,10 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         using var db = Fixture.CreateEmptyContext();
         var migrator = db.GetService<IMigrator>();
 
+        await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
         await SetAndExecuteSqlAsync(migrator.GenerateScript());
     }
 
@@ -299,6 +303,10 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
     {
         using var db = Fixture.CreateContext();
         var migrator = db.GetService<IMigrator>();
+
+        await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await SetAndExecuteSqlAsync(migrator.GenerateScript(fromMigration: Migration.InitialDatabase, toMigration: Migration.InitialDatabase));
     }
@@ -310,6 +318,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await SetAndExecuteSqlAsync(migrator.GenerateScript());
@@ -327,6 +336,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await SetAndExecuteSqlAsync(migrator.GenerateScript(options: MigrationsSqlGenerationOptions.NoTransactions));
@@ -345,6 +355,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await ExecuteSqlAsync(migrator.GenerateScript(
@@ -367,6 +378,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await ExecuteSqlAsync(migrator.GenerateScript(
@@ -389,6 +401,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await SetAndExecuteSqlAsync(migrator.GenerateScript(
@@ -409,6 +422,7 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
         var migrator = db.GetService<IMigrator>();
 
         await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
         await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
 
         await SetAndExecuteSqlAsync(migrator.GenerateScript(

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
+using static Microsoft.EntityFrameworkCore.Migrations.MigrationsInfrastructureFixtureBase;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Migrations
@@ -651,11 +652,135 @@ GO
         }
 
         [ConditionalFact]
+        public void Throws_when_no_migrations()
+        {
+            using var context = new DbContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)
+                        .ConfigureWarnings(e => e.Throw(RelationalEventId.MigrationsNotFound))).Options);
+
+            context.Database.EnsureDeleted();
+            GiveMeSomeTime(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.MigrationsNotFound.ToString(),
+                    RelationalResources.LogNoMigrationsFound(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(typeof(DbContext).Assembly.GetName().Name),
+                    "RelationalEventId.MigrationsNotFound"),
+                (Assert.Throws<InvalidOperationException>(context.Database.Migrate)).Message);
+        }
+
+        [ConditionalFact]
+        public async Task Throws_when_no_migrations_async()
+        {
+            using var context = new DbContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)
+                        .ConfigureWarnings(e => e.Throw(RelationalEventId.MigrationsNotFound))).Options);
+
+            await context.Database.EnsureDeletedAsync();
+            await GiveMeSomeTimeAsync(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.MigrationsNotFound.ToString(),
+                    RelationalResources.LogNoMigrationsFound(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(typeof(DbContext).Assembly.GetName().Name),
+                    "RelationalEventId.MigrationsNotFound"),
+                (await Assert.ThrowsAsync<InvalidOperationException>(() => context.Database.MigrateAsync())).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_when_no_snapshot()
+        {
+            using var context = new MigrationsContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)
+                        .ConfigureWarnings(e => e.Throw(RelationalEventId.ModelSnapshotNotFound))).Options);
+
+            context.Database.EnsureDeleted();
+            GiveMeSomeTime(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.ModelSnapshotNotFound.ToString(),
+                    RelationalResources.LogNoModelSnapshotFound(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(typeof(MigrationsContext).Assembly.GetName().Name),
+                    "RelationalEventId.ModelSnapshotNotFound"),
+                (Assert.Throws<InvalidOperationException>(context.Database.Migrate)).Message);
+        }
+
+        [ConditionalFact]
+        public async Task Throws_when_no_snapshot_async()
+        {
+            using var context = new MigrationsContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)
+                        .ConfigureWarnings(e => e.Throw(RelationalEventId.ModelSnapshotNotFound))).Options);
+
+            await context.Database.EnsureDeletedAsync();
+            await GiveMeSomeTimeAsync(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.ModelSnapshotNotFound.ToString(),
+                    RelationalResources.LogNoModelSnapshotFound(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(typeof(MigrationsContext).Assembly.GetName().Name),
+                    "RelationalEventId.ModelSnapshotNotFound"),
+                (await Assert.ThrowsAsync<InvalidOperationException>(() => context.Database.MigrateAsync())).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_for_nondeterministic_HasData()
+        {
+            using var context = new BloggingContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options,
+                randomData: true);
+
+            context.Database.EnsureDeleted();
+            GiveMeSomeTime(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.PendingModelChangesWarning.ToString(),
+                    RelationalResources.LogNonDeterministicModel(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(nameof(BloggingContext)),
+                    "RelationalEventId.PendingModelChangesWarning"),
+                (Assert.Throws<InvalidOperationException>(context.Database.Migrate)).Message);
+        }
+
+        [ConditionalFact]
+        public async Task Throws_for_nondeterministic_HasData_async()
+        {
+            using var context = new BloggingContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options,
+                randomData: true);
+
+            await context.Database.EnsureDeletedAsync();
+            await GiveMeSomeTimeAsync(context);
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    RelationalEventId.PendingModelChangesWarning.ToString(),
+                    RelationalResources.LogNonDeterministicModel(new TestLogger<TestRelationalLoggingDefinitions>())
+                        .GenerateMessage(nameof(BloggingContext)),
+                    "RelationalEventId.PendingModelChangesWarning"),
+                (await Assert.ThrowsAsync<InvalidOperationException>(() => context.Database.MigrateAsync())).Message);
+        }
+
+        [ConditionalFact]
         public void Throws_for_pending_model_changes()
         {
             using var context = new BloggingContext(
                 Fixture.TestStore.AddProviderOptions(
-                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options);
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options,
+                randomData: false);
+
+            context.Database.EnsureDeleted();
+            GiveMeSomeTime(context);
 
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
@@ -671,7 +796,11 @@ GO
         {
             using var context = new BloggingContext(
                 Fixture.TestStore.AddProviderOptions(
-                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options);
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options,
+                randomData: false);
+
+            await context.Database.EnsureDeletedAsync();
+            await GiveMeSomeTimeAsync(context);
 
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
@@ -925,7 +1054,7 @@ SELECT @result
                 ignoreLineEndingDifferences: true);
         }
 
-        private class BloggingContext(DbContextOptions options) : DbContext(options)
+        private class BloggingContext(DbContextOptions options, bool? randomData = null) : DbContext(options)
         {
             // ReSharper disable once UnusedMember.Local
             public DbSet<Blog> Blogs { get; set; }
@@ -938,6 +1067,46 @@ SELECT @result
 
                 public string Name { get; set; }
                 // ReSharper restore UnusedMember.Local
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                if (randomData != null)
+                {
+                    modelBuilder.Entity<Blog>().HasData(
+                        new Blog { Id = randomData.Value ? (int)new Random().NextInt64(int.MaxValue) : 1, Name = "HalfADonkey" });
+                }
+            }
+        }
+
+        [DbContext(typeof(BloggingContext))]
+        partial class BloggingContextSnapshot : ModelSnapshot
+        {
+            protected override void BuildModel(ModelBuilder modelBuilder)
+            {
+#pragma warning disable 612, 618
+                modelBuilder
+                    .HasAnnotation("ProductVersion", "9.0.0")
+                    .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+                SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+                modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.MigrationsInfrastructureSqlServerTest+BloggingContext+Blog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Blogs");
+                });
+#pragma warning restore 612, 618
             }
         }
 


### PR DESCRIPTION
Fixes #35133
Addresses comments in #34431, #35080 and #35181

### Description

EF offers a way of updating the database schema to match the current model via incremental *migrations*. The common scenario is to add a new migration, then update the database to the latest migration. But it is easy to forget adding a new migration after the model was changed. So, in 9.0 we added a runtime warning that would throw by default when updating the database if there are any changes detected in the model that aren't reflected in the latest migration.

However, there are several reasons why the migrations could be out-of-date and the exception message was not helpful for some of the users. This PR adds more specific messages and makes the warning to be logged instead of throwing for some cases:

1. There are no migrations at all. This is common when the database is updated through other means. The exception will not be thrown.
2. There are some migrations, but the model snapshot is missing. This is common for migrations added manually. The exception will not be thrown.
3. The model wasn't modified by the developer, but it's built in a non-deterministic way causing EF to detect it as modified. This is common when `new DateTime()` or `Guid.NewGuid()` are used in seed data. The exception will still be thrown.
4. For other cases the exception will still be thrown.

We will also add documentation explaining the above.

### Customer impact

After the upgrade some applications that were working correctly started crashing on startup. This was by-design, but the required action from the developer wasn't clear. The workaround is to ignore the warning using options.

### How found

Multiple customer reports on 9.

### Regression

Yes, from 8.

### Testing

Tests added.

### Risk

Low.
