### PR TITLE
[release/9.0] Set environment variables to "Development" when creating DbContext using IDesignTimeDbContextFactory

### DIFF
--- a/src/EFCore.Design/Design/Internal/AppServiceProviderFactory.cs
+++ b/src/EFCore.Design/Design/Internal/AppServiceProviderFactory.cs
@@ -55,23 +55,6 @@ public class AppServiceProviderFactory
             return null;
         }
 
-        var aspnetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
-        var environment = aspnetCoreEnvironment
-            ?? dotnetEnvironment
-            ?? "Development";
-        if (aspnetCoreEnvironment == null)
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
-        }
-
-        if (dotnetEnvironment == null)
-        {
-            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", environment);
-        }
-
-        _reporter.WriteVerbose(DesignStrings.UsingEnvironment(environment));
-
         try
         {
             var services = serviceProviderFactory(args);

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -503,6 +503,23 @@ public class DbContextOperations
     {
         _reporter.WriteVerbose(DesignStrings.FindingContexts);
 
+        var aspnetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var environment = aspnetCoreEnvironment
+            ?? dotnetEnvironment
+            ?? "Development";
+        if (aspnetCoreEnvironment == null)
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+        }
+
+        if (dotnetEnvironment == null)
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", environment);
+        }
+
+        _reporter.WriteVerbose(DesignStrings.UsingEnvironment(environment));
+
         var contexts = new Dictionary<Type, Func<DbContext>?>();
 
         try

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AppServiceProviderFactoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AppServiceProviderFactoryTest.cs
@@ -21,8 +21,6 @@ public class AppServiceProviderFactoryTest
         var factory = new TestAppServiceProviderFactory(
             MockAssembly.Create(programType));
 
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
-        Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
         var services = factory.Create(["arg1"]);
 
         Assert.NotNull(services.GetRequiredService<TestService>());
@@ -66,8 +64,6 @@ public class AppServiceProviderFactoryTest
                 [typeof(ProgramWithNoHostBuilder)],
                 new MockMethodInfo(typeof(ProgramWithNoHostBuilder), InjectHostIntoDiagnostics)));
 
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
-        Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
         var services = factory.Create(["arg1"]);
 
         Assert.NotNull(services.GetRequiredService<TestService>());
@@ -75,8 +71,6 @@ public class AppServiceProviderFactoryTest
 
     private static void InjectHostIntoDiagnostics(object[] args)
     {
-        Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("Development", Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"));
         Assert.Single(args);
         Assert.Equal((string[])args[0], new[] { "arg1", "--applicationName", "MockAssembly" });
 
@@ -91,8 +85,6 @@ public class AppServiceProviderFactoryTest
 
     private static void ValidateEnvironmentAndArgs(string[] args)
     {
-        Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("Development", Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"));
         Assert.Equal(args, new[] { "arg1" });
     }
 

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -414,6 +414,8 @@ public class DbContextOperationsTest
         public TestContext(DbContextOptions<TestContext> options)
             : base(options)
         {
+            Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+            Assert.Equal("Development", Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"));
         }
     }
 
@@ -425,6 +427,8 @@ public class DbContextOperationsTest
         public TestContextFromFactory(DbContextOptions<TestContextFromFactory> options)
             : base(options)
         {
+            Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+            Assert.Equal("Development", Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"));
         }
     }
 


### PR DESCRIPTION
Fixes #35174

### Description

In EF 9.0 we added a short-circuit that avoids creating an `AppHost` when creating a `DbContext` using `IDesignTimeDbContextFactory`. But this had an unintended side effect of no longer setting the environment variables `ASPNETCORE_ENVIRONMENT` and `DOTNET_ENVIRONMENT` to `Development`

### Customer impact

Code that relied on a specific environment is broken. A workaround is to set the environment variables manually.

### How found

Customer reported on 9.

### Regression

Yes, from 8.

### Testing

Tests fixed.

### Risk

Low.