### PR TITLE
[release/9.0] Avoid using `^` and `~` when invalid because of value converters

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -8047,6 +8047,13 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Faction>().Where(f => f.ServerAddress == IPAddress.Loopback));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_equality_with_value_converted_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Mission>().Select(m => m.Difficulty == MissionDifficulty.Unknown));
+
     private static readonly IEnumerable<AmmunitionType?> _weaponTypes = new AmmunitionType?[] { AmmunitionType.Cartridge };
 
     [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -9380,6 +9380,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task Contains_on_readonly_enumerable(bool async)
     {
         await base.Contains_on_readonly_enumerable(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -12341,6 +12341,20 @@ WHERE [l].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(bool async)
     {
         await base.FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -10507,6 +10507,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] AS [m]
+""");
+    }
+
     public override async Task FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(bool async)
     {
         await base.FirstOrDefault_on_empty_collection_of_DateTime_in_subquery(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -6999,6 +6999,20 @@ WHERE [f].[ServerAddress] = CAST(N'127.0.0.1' AS nvarchar(45))
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [m].[Difficulty] = N'Unknown' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
+""");
+    }
+
     public override async Task Navigation_access_on_derived_materialized_entity_using_cast(bool async)
     {
         await base.Navigation_access_on_derived_materialized_entity_using_cast(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -3076,6 +3076,17 @@ WHERE "f"."ServerAddress" = CAST('127.0.0.1' AS TEXT)
 """);
     }
 
+    public override async Task Project_equality_with_value_converted_property(bool async)
+    {
+        await base.Project_equality_with_value_converted_property(async);
+
+        AssertSql(
+            """
+SELECT "m"."Difficulty" = 'Unknown'
+FROM "Missions" AS "m"
+""");
+    }
+
     public override async Task GetValueOrDefault_in_filter_non_nullable_column(bool async)
     {
         await base.GetValueOrDefault_in_filter_non_nullable_column(async);


### PR DESCRIPTION
Fixes #35093
Backports #35124

### Description

EF 9 brings many improvements to SQL generation ([list](https://github.com/dotnet/efcore/issues/34151)). [One of these](https://github.com/dotnet/efcore/pull/34124), which also improves query performance, applies bit arithmetic (XOR) to implement equality in contexts where SQL Server requires a BIT value (as opposed to a search condition, so projected SELECT values rather than WHERE predicates).

Unfortunately, the SQL optimization was implemented too widely, applying also on value-converted values, which is incorrect.

### Customer impact

Queries on SQL Server which involve equality with a value-converted value sometimes generate invalid SQL and fail. For example:

```c#
_ = await context.Orders
    .Select(order => new { Paid = order.State == OrderState.Paid })
    // The following is OK (non-value-converted string)
    // .Select(order => new { IsNameFoo = order.Name == "Foo" })
    .ToListAsync();
```

This scenario is particularly common with value-converted enums, and so has the potential to affect many users. The fix is trivial and low-risk.

### How found

Customer reported on 9.

### Regression

Yes, from 8.

### Testing

Tests added.

### Risk

Low and quirked.

/cc @ranma42