### PR TITLE
[release/9.0] Fix query filters with context accessors

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -106,6 +106,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     private static readonly bool UseOldBehavior35152 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35152", out var enabled35152) && enabled35152;
 
+    private static readonly bool UseOldBehavior35111 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35111", out var enabled35111) && enabled35111;
+
     private static readonly MethodInfo ReadOnlyCollectionIndexerGetter = typeof(ReadOnlyCollection<Expression>).GetProperties()
         .Single(p => p.GetIndexParameters() is { Length: 1 } indexParameters && indexParameters[0].ParameterType == typeof(int)).GetMethod!;
 
@@ -554,7 +557,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
             case StateType.ContainsEvaluatable:
                 if (testState.IsEvaluatable)
                 {
-                    test = ProcessEvaluatableRoot(test, ref testState);
+                    test = UseOldBehavior35111 ? test : ProcessEvaluatableRoot(test, ref testState);
                 }
 
                 if (ifTrueState.IsEvaluatable)

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -552,7 +552,11 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 goto case StateType.ContainsEvaluatable;
 
             case StateType.ContainsEvaluatable:
-                // The case where the test is evaluatable has been handled above
+                if (testState.IsEvaluatable)
+                {
+                    test = ProcessEvaluatableRoot(test, ref testState);
+                }
+
                 if (ifTrueState.IsEvaluatable)
                 {
                     ifTrue = ProcessEvaluatableRoot(ifTrue, ref ifTrueState);

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -730,4 +730,42 @@ public abstract class AdHocQueryFiltersQueryTestBase : NonSharedModelTestBase
     }
 
     #endregion
+
+    #region 35111
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Query_filter_with_context_accessor_with_constant(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context35111>();
+        using var context = contextFactory.CreateContext();
+
+        var data = async
+           ? await context.Set<FooBar35111>().ToListAsync()
+           : context.Set<FooBar35111>().ToList();
+    }
+
+    protected class Context35111(DbContextOptions options) : DbContext(options)
+    {
+        public int Foo { get; set; }
+        public long? Bar { get; set; }
+        public List<long> Baz { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<FooBar35111>()
+                .HasQueryFilter(e =>
+                    Foo == 1
+                        ? Baz.Contains(e.Bar)
+                        : e.Bar == Bar);
+        }
+    }
+
+    public class FooBar35111
+    {
+        public long Id { get; set; }
+        public long Bar { get; set; }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Fixes #35111
Backport of #35237

### Description

In EF Core 9 as part of our work on NativeAOT support we reworked piece of query pipeline. This work missed processing of specific node - created when using _Query Filters_ - in expression tree. This results in query shape that we can't translate later.

### Customer impact

Customers using _Query Filters_ with this shape experience an exception when running their application.

### How found

Customer reported on 9.

### Regression

Yes, from 8.

### Testing

Tests added.

### Risk

Low.