### PR TITLE
Don't escape separator characters in single key values

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinition.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinition.cs
@@ -89,7 +89,7 @@ public class JsonIdDefinition : IJsonIdDefinition
 
         if (_discriminatorProperty != null)
         {
-            AppendValue(_discriminatorProperty!, _discriminatorValue!, false);
+            AppendValue(_discriminatorProperty!, _discriminatorValue!, singleValue: false);
         }
 
         var i = 0;
@@ -160,17 +160,15 @@ public class JsonIdDefinition : IJsonIdDefinition
         var startingIndex = builder.Length;
         builder = builder.Append(stringValue);
 
-        if (!singleValue)
-        {
-            // We need this to avoid collisions with the value separator, but only when the key has multiple values.
-            builder = builder.Replace("|", "^|", startingIndex, builder.Length - startingIndex);
-        }
-
-        return builder
-            // These are invalid characters, see https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.resource.id
-            .Replace("/", "^2F", startingIndex, builder.Length - startingIndex)
-            .Replace("\\", "^5C", startingIndex, builder.Length - startingIndex)
-            .Replace("?", "^3F", startingIndex, builder.Length - startingIndex)
-            .Replace("#", "^23", startingIndex, builder.Length - startingIndex);
+        return singleValue
+            ? builder
+            : builder
+                // We need this to avoid collisions with the value separator, but only when the key has multiple values.
+                .Replace("|", "^|", startingIndex, builder.Length - startingIndex)
+                // These are invalid characters, see https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.resource.id
+                .Replace("/", "^2F", startingIndex, builder.Length - startingIndex)
+                .Replace("\\", "^5C", startingIndex, builder.Length - startingIndex)
+                .Replace("?", "^3F", startingIndex, builder.Length - startingIndex)
+                .Replace("#", "^23", startingIndex, builder.Length - startingIndex);
     }
 }

--- a/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinition.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/JsonIdDefinition.cs
@@ -89,23 +89,24 @@ public class JsonIdDefinition : IJsonIdDefinition
 
         if (_discriminatorProperty != null)
         {
-            AppendValue(_discriminatorProperty!, _discriminatorValue!);
+            AppendValue(_discriminatorProperty!, _discriminatorValue!, false);
         }
 
         var i = 0;
+        var multipleValues = _discriminatorProperty != null || values.Skip(1).Any();
         foreach (var value in values)
         {
-            AppendValue(Properties[i++], value);
+            AppendValue(Properties[i++], value, !multipleValues);
         }
 
         builder.Remove(builder.Length - 1, 1);
 
         return builder.ToString();
 
-        void AppendValue(IProperty property, object? value)
+        void AppendValue(IProperty property, object? value, bool singleValue)
         {
             var converter = property.GetTypeMapping().Converter;
-            AppendString(builder, converter == null ? value : converter.ConvertToProvider(value));
+            AppendString(builder, converter == null ? value : converter.ConvertToProvider(value), singleValue);
             builder.Append('|');
         }
     }
@@ -116,23 +117,23 @@ public class JsonIdDefinition : IJsonIdDefinition
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected virtual void AppendString(StringBuilder builder, object? propertyValue)
+    protected virtual void AppendString(StringBuilder builder, object? propertyValue, bool singleValue)
     {
         switch (propertyValue)
         {
             case string stringValue:
-                AppendEscape(builder, stringValue);
+                AppendEscape(builder, stringValue, singleValue);
                 return;
             case IEnumerable enumerable:
                 foreach (var item in enumerable)
                 {
-                    AppendEscape(builder, item.ToString()!);
+                    AppendEscape(builder, item.ToString()!, singleValue);
                     builder.Append('|');
                 }
 
                 return;
             case DateTime dateTime:
-                AppendEscape(builder, dateTime.ToString("O"));
+                AppendEscape(builder, dateTime.ToString("O"), singleValue);
                 return;
             default:
                 if (propertyValue == null)
@@ -141,7 +142,7 @@ public class JsonIdDefinition : IJsonIdDefinition
                 }
                 else
                 {
-                    AppendEscape(builder, propertyValue.ToString()!);
+                    AppendEscape(builder, propertyValue.ToString()!, singleValue);
                 }
 
                 return;
@@ -154,12 +155,18 @@ public class JsonIdDefinition : IJsonIdDefinition
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected virtual StringBuilder AppendEscape(StringBuilder builder, string stringValue)
+    protected virtual StringBuilder AppendEscape(StringBuilder builder, string stringValue, bool singleValue)
     {
         var startingIndex = builder.Length;
-        return builder.Append(stringValue)
-            // We need this to avoid collisions with the value separator
-            .Replace("|", "^|", startingIndex, builder.Length - startingIndex)
+        builder = builder.Append(stringValue);
+
+        if (!singleValue)
+        {
+            // We need this to avoid collisions with the value separator, but only when the key has multiple values.
+            builder = builder.Replace("|", "^|", startingIndex, builder.Length - startingIndex);
+        }
+
+        return builder
             // These are invalid characters, see https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.resource.id
             .Replace("/", "^2F", startingIndex, builder.Length - startingIndex)
             .Replace("\\", "^5C", startingIndex, builder.Length - startingIndex)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
@@ -17,6 +17,34 @@ public class ReadItemPartitionKeyQueryDiscriminatorInIdTest
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Key_with_special_characters_1()
+    {
+        await base.Key_with_special_characters_1();
+
+        AssertSql("""ReadItem(["Cat|1"], Cat35224|Cat^|1)""");
+    }
+
+    public override async Task Key_with_special_characters_2()
+    {
+        await base.Key_with_special_characters_2();
+
+        AssertSql("""ReadItem(["Cat2||"], Cat35224|Cat2^|^|)""");
+    }
+
+    public override async Task Key_with_special_characters_3()
+    {
+        await base.Key_with_special_characters_3();
+
+        AssertSql("""ReadItem(["Cat|3|$|5"], Cat35224|Cat^|3^|$^|5)""");
+    }
+
+    public override async Task Key_with_special_characters_4()
+    {
+        await base.Key_with_special_characters_4();
+
+        AssertSql("""ReadItem(["|Cat|"], Cat35224|^|Cat^|)""");
+    }
+
     public override async Task Predicate_with_hierarchical_partition_key()
     {
         await base.Predicate_with_hierarchical_partition_key();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryDiscriminatorInIdTest.cs
@@ -21,28 +21,28 @@ public class ReadItemPartitionKeyQueryDiscriminatorInIdTest
     {
         await base.Key_with_special_characters_1();
 
-        AssertSql("""ReadItem(["Cat|1"], Cat35224|Cat^|1)""");
+        AssertSql("""ReadItem(["Cat|1"], FancyDiscriminatorEntity|Cat^|1)""");
     }
 
     public override async Task Key_with_special_characters_2()
     {
         await base.Key_with_special_characters_2();
 
-        AssertSql("""ReadItem(["Cat2||"], Cat35224|Cat2^|^|)""");
+        AssertSql("""ReadItem(["Cat2||"], FancyDiscriminatorEntity|Cat2^|^|)""");
     }
 
     public override async Task Key_with_special_characters_3()
     {
         await base.Key_with_special_characters_3();
 
-        AssertSql("""ReadItem(["Cat|3|$|5"], Cat35224|Cat^|3^|$^|5)""");
+        AssertSql("""ReadItem(["Cat|3|$|5"], FancyDiscriminatorEntity|Cat^|3^|$^|5)""");
     }
 
     public override async Task Key_with_special_characters_4()
     {
         await base.Key_with_special_characters_4();
 
-        AssertSql("""ReadItem(["|Cat|"], Cat35224|^|Cat^|)""");
+        AssertSql("""ReadItem(["|Cat|"], FancyDiscriminatorEntity|^|Cat^|)""");
     }
 
     public override async Task Predicate_with_hierarchical_partition_key()

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
@@ -65,6 +65,11 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
             .HasKey(e => new { e.Id, e.PartitionKey });
 
         modelBuilder.Entity<SharedContainerEntity2Child>();
+
+        modelBuilder.Entity<Cat35224>()
+            .ToContainer(nameof(Cat35224))
+            .HasPartitionKey(e => e.Id)
+            .HasDiscriminator<string>("Discriminator");
     }
 
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
@@ -90,6 +95,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
         context.AddRange(data.SharedContainerEntities1);
         context.AddRange(data.SharedContainerEntities2);
         context.AddRange(data.SharedContainerEntities2Children);
+        context.AddRange(data.Cat35224Entities);
 
         return context.SaveChangesAsync();
     }
@@ -102,6 +108,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
         { typeof(HierarchicalPartitionKeyEntity), e => ((HierarchicalPartitionKeyEntity?)e)?.Id },
         { typeof(OnlyHierarchicalPartitionKeyEntity), e => ((OnlyHierarchicalPartitionKeyEntity?)e)?.Payload },
         { typeof(SinglePartitionKeyEntity), e => ((SinglePartitionKeyEntity?)e)?.Id },
+        { typeof(Cat35224), e => ((Cat35224?)e)?.Id },
         { typeof(OnlySinglePartitionKeyEntity), e => ((OnlySinglePartitionKeyEntity?)e)?.Payload },
         { typeof(NoPartitionKeyEntity), e => ((NoPartitionKeyEntity?)e)?.Id },
         { typeof(SharedContainerEntity1), e => ((SharedContainerEntity1?)e)?.Id },
@@ -239,6 +246,22 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                     Assert.Equal(ee.ChildPayload, aa.ChildPayload);
                 }
             }
+        },
+        {
+            typeof(Cat35224), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Cat35224)e!;
+                    var aa = (Cat35224)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Discriminator, aa.Discriminator);
+                }
+            }
         }
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
@@ -255,6 +278,8 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
         public List<SharedContainerEntity1> SharedContainerEntities1 { get; } = CreateSharedContainerEntities1();
         public List<SharedContainerEntity2> SharedContainerEntities2 { get; } = CreateSharedContainerEntities2();
         public List<SharedContainerEntity2Child> SharedContainerEntities2Children { get; } = CreateSharedContainerEntities2Children();
+
+        public List<Cat35224> Cat35224Entities { get; } = CreateCat35224Entities();
 
         public virtual IQueryable<TEntity> Set<TEntity>()
             where TEntity : class
@@ -297,6 +322,11 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
             if (typeof(TEntity) == typeof(SharedContainerEntity2Child))
             {
                 return (IQueryable<TEntity>)SharedContainerEntities2Children.AsQueryable();
+            }
+
+            if (typeof(TEntity) == typeof(Cat35224))
+            {
+                return (IQueryable<TEntity>)Cat35224Entities.AsQueryable();
             }
 
             throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
@@ -480,6 +510,32 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                     ChildPayload = "Child2"
                 }
             };
+
+        private static List<Cat35224> CreateCat35224Entities()
+            => new()
+            {
+                new Cat35224
+                {
+                    Id = "Cat|1",
+                    Name = "Smokey"
+                },
+                new Cat35224
+                {
+                    Id = "Cat2||",
+                    Name = "Clippy"
+                },
+                new Cat35224
+                {
+                    Id = "Cat|3|$|5",
+                    Name = "Sid"
+                },
+                new Cat35224
+                {
+                    Id = "|Cat|",
+                    Name = "Killes"
+                }
+            };
+
     }
 }
 
@@ -501,6 +557,13 @@ public class SinglePartitionKeyEntity
     public required string PartitionKey { get; set; }
 
     public required string Payload { get; set; }
+}
+
+public class Cat35224
+{
+    public string Id { get; set; } = null!;
+    public string? Name { get; set; }
+    public string Discriminator { get; set; } = null!;
 }
 
 // This type is configured with all partition key properties, and nothing else, in the primary key.

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryFixtureBase.cs
@@ -66,8 +66,8 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
 
         modelBuilder.Entity<SharedContainerEntity2Child>();
 
-        modelBuilder.Entity<Cat35224>()
-            .ToContainer(nameof(Cat35224))
+        modelBuilder.Entity<FancyDiscriminatorEntity>()
+            .ToContainer("Cat35224")
             .HasPartitionKey(e => e.Id)
             .HasDiscriminator<string>("Discriminator");
     }
@@ -108,7 +108,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
         { typeof(HierarchicalPartitionKeyEntity), e => ((HierarchicalPartitionKeyEntity?)e)?.Id },
         { typeof(OnlyHierarchicalPartitionKeyEntity), e => ((OnlyHierarchicalPartitionKeyEntity?)e)?.Payload },
         { typeof(SinglePartitionKeyEntity), e => ((SinglePartitionKeyEntity?)e)?.Id },
-        { typeof(Cat35224), e => ((Cat35224?)e)?.Id },
+        { typeof(FancyDiscriminatorEntity), e => ((FancyDiscriminatorEntity?)e)?.Id },
         { typeof(OnlySinglePartitionKeyEntity), e => ((OnlySinglePartitionKeyEntity?)e)?.Payload },
         { typeof(NoPartitionKeyEntity), e => ((NoPartitionKeyEntity?)e)?.Id },
         { typeof(SharedContainerEntity1), e => ((SharedContainerEntity1?)e)?.Id },
@@ -248,14 +248,14 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
             }
         },
         {
-            typeof(Cat35224), (e, a) =>
+            typeof(FancyDiscriminatorEntity), (e, a) =>
             {
                 Assert.Equal(e == null, a == null);
 
                 if (a != null)
                 {
-                    var ee = (Cat35224)e!;
-                    var aa = (Cat35224)a;
+                    var ee = (FancyDiscriminatorEntity)e!;
+                    var aa = (FancyDiscriminatorEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
                     Assert.Equal(ee.Name, aa.Name);
@@ -279,7 +279,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
         public List<SharedContainerEntity2> SharedContainerEntities2 { get; } = CreateSharedContainerEntities2();
         public List<SharedContainerEntity2Child> SharedContainerEntities2Children { get; } = CreateSharedContainerEntities2Children();
 
-        public List<Cat35224> Cat35224Entities { get; } = CreateCat35224Entities();
+        public List<FancyDiscriminatorEntity> Cat35224Entities { get; } = CreateCat35224Entities();
 
         public virtual IQueryable<TEntity> Set<TEntity>()
             where TEntity : class
@@ -324,7 +324,7 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                 return (IQueryable<TEntity>)SharedContainerEntities2Children.AsQueryable();
             }
 
-            if (typeof(TEntity) == typeof(Cat35224))
+            if (typeof(TEntity) == typeof(FancyDiscriminatorEntity))
             {
                 return (IQueryable<TEntity>)Cat35224Entities.AsQueryable();
             }
@@ -511,25 +511,25 @@ public class ReadItemPartitionKeyQueryFixtureBase : SharedStoreFixtureBase<DbCon
                 }
             };
 
-        private static List<Cat35224> CreateCat35224Entities()
+        private static List<FancyDiscriminatorEntity> CreateCat35224Entities()
             => new()
             {
-                new Cat35224
+                new FancyDiscriminatorEntity
                 {
                     Id = "Cat|1",
                     Name = "Smokey"
                 },
-                new Cat35224
+                new FancyDiscriminatorEntity
                 {
                     Id = "Cat2||",
                     Name = "Clippy"
                 },
-                new Cat35224
+                new FancyDiscriminatorEntity
                 {
                     Id = "Cat|3|$|5",
                     Name = "Sid"
                 },
-                new Cat35224
+                new FancyDiscriminatorEntity
                 {
                     Id = "|Cat|",
                     Name = "Killes"
@@ -559,7 +559,7 @@ public class SinglePartitionKeyEntity
     public required string Payload { get; set; }
 }
 
-public class Cat35224
+public class FancyDiscriminatorEntity
 {
     public string Id { get; set; } = null!;
     public string? Name { get; set; }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryNoDiscriminatorInIdTest.cs
@@ -17,6 +17,43 @@ public class ReadItemPartitionKeyQueryNoDiscriminatorInIdTest
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Key_with_special_characters_1()
+    {
+        await base.Key_with_special_characters_1();
+
+        AssertSql("""ReadItem(["Cat|1"], Cat|1)""");
+    }
+
+    public override async Task Key_with_special_characters_2()
+    {
+        await base.Key_with_special_characters_2();
+
+        AssertSql(
+            """
+ReadItem(["Cat2||"], Cat2||)
+""");
+    }
+
+    public override async Task Key_with_special_characters_3()
+    {
+        await base.Key_with_special_characters_3();
+
+        AssertSql(
+            """
+ReadItem(["Cat|3|$|5"], Cat|3|$|5)
+""");
+    }
+
+    public override async Task Key_with_special_characters_4()
+    {
+        await base.Key_with_special_characters_4();
+
+        AssertSql(
+            """
+ReadItem(["|Cat|"], |Cat|)
+""");
+    }
+
     public override async Task Predicate_with_hierarchical_partition_key()
     {
         await base.Predicate_with_hierarchical_partition_key();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
@@ -17,6 +17,34 @@ public class ReadItemPartitionKeyQueryRootDiscriminatorInIdTest
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Key_with_special_characters_1()
+    {
+        await base.Key_with_special_characters_1();
+
+        AssertSql("""ReadItem(["Cat|1"], Cat35224|Cat^|1)""");
+    }
+
+    public override async Task Key_with_special_characters_2()
+    {
+        await base.Key_with_special_characters_2();
+
+        AssertSql("""ReadItem(["Cat2||"], Cat35224|Cat2^|^|)""");
+    }
+
+    public override async Task Key_with_special_characters_3()
+    {
+        await base.Key_with_special_characters_3();
+
+        AssertSql("""ReadItem(["Cat|3|$|5"], Cat35224|Cat^|3^|$^|5)""");
+    }
+
+    public override async Task Key_with_special_characters_4()
+    {
+        await base.Key_with_special_characters_4();
+
+        AssertSql("""ReadItem(["|Cat|"], Cat35224|^|Cat^|)""");
+    }
+
     public override async Task Predicate_with_hierarchical_partition_key()
     {
         await base.Predicate_with_hierarchical_partition_key();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryRootDiscriminatorInIdTest.cs
@@ -21,28 +21,28 @@ public class ReadItemPartitionKeyQueryRootDiscriminatorInIdTest
     {
         await base.Key_with_special_characters_1();
 
-        AssertSql("""ReadItem(["Cat|1"], Cat35224|Cat^|1)""");
+        AssertSql("""ReadItem(["Cat|1"], FancyDiscriminatorEntity|Cat^|1)""");
     }
 
     public override async Task Key_with_special_characters_2()
     {
         await base.Key_with_special_characters_2();
 
-        AssertSql("""ReadItem(["Cat2||"], Cat35224|Cat2^|^|)""");
+        AssertSql("""ReadItem(["Cat2||"], FancyDiscriminatorEntity|Cat2^|^|)""");
     }
 
     public override async Task Key_with_special_characters_3()
     {
         await base.Key_with_special_characters_3();
 
-        AssertSql("""ReadItem(["Cat|3|$|5"], Cat35224|Cat^|3^|$^|5)""");
+        AssertSql("""ReadItem(["Cat|3|$|5"], FancyDiscriminatorEntity|Cat^|3^|$^|5)""");
     }
 
     public override async Task Key_with_special_characters_4()
     {
         await base.Key_with_special_characters_4();
 
-        AssertSql("""ReadItem(["|Cat|"], Cat35224|^|Cat^|)""");
+        AssertSql("""ReadItem(["|Cat|"], FancyDiscriminatorEntity|^|Cat^|)""");
     }
 
     public override async Task Predicate_with_hierarchical_partition_key()

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTest.cs
@@ -17,6 +17,37 @@ public class ReadItemPartitionKeyQueryTest : ReadItemPartitionKeyQueryTestBase<
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Key_with_special_characters_1()
+    {
+        await base.Key_with_special_characters_1();
+
+        AssertSql("""ReadItem(["Cat|1"], Cat|1)""");
+    }
+
+    public override async Task Key_with_special_characters_2()
+    {
+        await base.Key_with_special_characters_2();
+
+        AssertSql("""ReadItem(["Cat2||"], Cat2||)""");
+    }
+
+    public override async Task Key_with_special_characters_3()
+    {
+        await base.Key_with_special_characters_3();
+
+        AssertSql("""ReadItem(["Cat|3|$|5"], Cat|3|$|5)""");
+    }
+
+    public override async Task Key_with_special_characters_4()
+    {
+        await base.Key_with_special_characters_4();
+
+        AssertSql(
+            """
+ReadItem(["|Cat|"], |Cat|)
+""");
+    }
+
     public override async Task Predicate_with_hierarchical_partition_key()
     {
         await base.Predicate_with_hierarchical_partition_key();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
@@ -15,6 +15,30 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact] // Issue #35224
+    public virtual Task Key_with_special_characters_1()
+        => AssertQuery(
+            async: true,
+            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat|1"));
+
+    [ConditionalFact]
+    public virtual Task Key_with_special_characters_2()
+        => AssertQuery(
+            async: true,
+            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat2||"));
+
+    [ConditionalFact]
+    public virtual Task Key_with_special_characters_3()
+        => AssertQuery(
+            async: true,
+            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat|3|$|5"));
+
+    [ConditionalFact]
+    public virtual Task Key_with_special_characters_4()
+        => AssertQuery(
+            async: true,
+            ss => ss.Set<Cat35224>().Where(c => c.Id == "|Cat|"));
+
     [ConditionalFact]
     public virtual Task Predicate_with_hierarchical_partition_key()
         => AssertQuery(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/ReadItemPartitionKeyQueryTestBase.cs
@@ -19,25 +19,25 @@ public abstract class ReadItemPartitionKeyQueryTestBase<TFixture> : QueryTestBas
     public virtual Task Key_with_special_characters_1()
         => AssertQuery(
             async: true,
-            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat|1"));
+            ss => ss.Set<FancyDiscriminatorEntity>().Where(c => c.Id == "Cat|1"));
 
     [ConditionalFact]
     public virtual Task Key_with_special_characters_2()
         => AssertQuery(
             async: true,
-            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat2||"));
+            ss => ss.Set<FancyDiscriminatorEntity>().Where(c => c.Id == "Cat2||"));
 
     [ConditionalFact]
     public virtual Task Key_with_special_characters_3()
         => AssertQuery(
             async: true,
-            ss => ss.Set<Cat35224>().Where(c => c.Id == "Cat|3|$|5"));
+            ss => ss.Set<FancyDiscriminatorEntity>().Where(c => c.Id == "Cat|3|$|5"));
 
     [ConditionalFact]
     public virtual Task Key_with_special_characters_4()
         => AssertQuery(
             async: true,
-            ss => ss.Set<Cat35224>().Where(c => c.Id == "|Cat|"));
+            ss => ss.Set<FancyDiscriminatorEntity>().Where(c => c.Id == "|Cat|"));
 
     [ConditionalFact]
     public virtual Task Predicate_with_hierarchical_partition_key()


### PR DESCRIPTION
Fixes #35224

When we generate a key containing multiple values, then we escape the separator character if it is found in any of the values. However, we should not do this if the key is made up of a single value and so will have no separators.
