### PR TITLE
Change ExecuteUpdate to accept non-expression lambda

### DIFF
--- a/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
@@ -1245,10 +1245,10 @@ public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>
         public bool IsNonNullableReferenceType { get; } = isNonNullableReferenceType;
 
         public override object[] GetCustomAttributes(bool inherit)
-            => Array.Empty<object>();
+            => [];
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
-            => Array.Empty<object>();
+            => [];
 
         public override bool IsDefined(Type attributeType, bool inherit)
             => false;
@@ -1289,10 +1289,10 @@ public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>
     private sealed class FakeConstructorInfo(Type type, ParameterInfo[] parameters) : ConstructorInfo
     {
         public override object[] GetCustomAttributes(bool inherit)
-            => Array.Empty<object>();
+            => [];
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
-            => Array.Empty<object>();
+            => [];
 
         public override bool IsDefined(Type attributeType, bool inherit)
             => false;

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -734,18 +734,52 @@ namespace System.Runtime.CompilerServices
 
                     for (var i = 1; i < parameters.Length; i++)
                     {
-                        var parameter = parameters[i];
+                        var (parameterName, parameterType) = (parameters[i].Name!, parameters[i].ParameterType);
 
-                        if (parameter.ParameterType == typeof(CancellationToken))
+                        if (parameterType == typeof(CancellationToken))
                         {
                             continue;
                         }
 
-                        if (_funcletizer.CalculatePathsToEvaluatableRoots(operatorMethodCall, i) is not ExpressionTreeFuncletizer.PathNode
-                            evaluatableRootPaths)
+                        ExpressionTreeFuncletizer.PathNode? evaluatableRootPaths;
+
+                        // ExecuteUpdate requires really special handling: the function accepts a Func<SetPropertyCalls...> argument, but
+                        // we need to run funcletization on the setter lambdas added via that Func<>.
+                        if (operatorMethodCall.Method is
+                            {
+                                Name: nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate)
+                                or nameof(EntityFrameworkQueryableExtensions.ExecuteUpdateAsync),
+                                IsGenericMethod: true
+                            }
+                            && operatorMethodCall.Method.DeclaringType == typeof(EntityFrameworkQueryableExtensions))
                         {
-                            // There are no captured variables in this lambda argument - skip the argument
-                            continue;
+                            // First, statically convert the Func<SetPropertyCalls...> to a NewArrayExpression which represents all the
+                            // setters; since that's an expression, we can run the funcletizer on it.
+                            var settersExpression = ProcessExecuteUpdate(operatorMethodCall);
+                            evaluatableRootPaths = _funcletizer.CalculatePathsToEvaluatableRoots(settersExpression);
+
+                            if (evaluatableRootPaths is null)
+                            {
+                                // There are no captured variables in this lambda argument - skip the argument
+                                continue;
+                            }
+
+                            // If there were captured variables, generate code to evaluate and build the same NewArrayExpression at runtime,
+                            // and then fall through to the normal logic, generating variable extractors against that NewArrayExpression
+                            // (local var) instead of against the method argument.
+                            code.AppendLine(
+                                $"var setters = {parameterName}(new SetPropertyCalls<{sourceElementTypeName}>()).BuildSettersExpression();");
+                            parameterName = "setters";
+                            parameterType = typeof(NewArrayExpression);
+                        }
+                        else
+                        {
+                            evaluatableRootPaths = _funcletizer.CalculatePathsToEvaluatableRoots(operatorMethodCall, i);
+                            if (evaluatableRootPaths is null)
+                            {
+                                // There are no captured variables in this lambda argument - skip the argument
+                                continue;
+                            }
                         }
 
                         // We have a lambda argument with captured variables. Use the information returned by the funcletizer to generate code
@@ -756,11 +790,11 @@ namespace System.Runtime.CompilerServices
                             declaredQueryContextVariable = true;
                         }
 
-                        if (!parameter.ParameterType.IsSubclassOf(typeof(Expression)))
+                        if (!parameterType.IsSubclassOf(typeof(Expression)))
                         {
                             // Special case: this is a non-lambda argument (Skip/Take/FromSql).
                             // Simply add the argument directly as a parameter
-                            code.AppendLine($"""queryContext.AddParameter("{evaluatableRootPaths.ParameterName}", {parameter.Name});""");
+                            code.AppendLine($"""queryContext.AddParameter("{evaluatableRootPaths.ParameterName}", {parameterName});""");
                             continue;
                         }
 
@@ -769,7 +803,7 @@ namespace System.Runtime.CompilerServices
                         // Lambda argument. Recurse through evaluatable path trees.
                         foreach (var child in evaluatableRootPaths.Children!)
                         {
-                            GenerateCapturedVariableExtractors(parameter.Name!, parameter.ParameterType, child);
+                            GenerateCapturedVariableExtractors(parameterName, parameterType, child);
 
                             void GenerateCapturedVariableExtractors(
                                 string currentIdentifier,
@@ -786,12 +820,13 @@ namespace System.Runtime.CompilerServices
 
                                 var variableName = capturedVariablesPathTree.ExpressionType.Name;
                                 variableName = char.ToLower(variableName[0]) + variableName[1..^"Expression".Length] + ++variableCounter;
-                                code.AppendLine(
-                                    $"var {variableName} = ({capturedVariablesPathTree.ExpressionType.Name}){roslynPathSegment};");
 
                                 if (capturedVariablesPathTree.Children?.Count > 0)
                                 {
                                     // This is an intermediate node which has captured variables in the children. Continue recursing down.
+                                    code.AppendLine(
+                                        $"var {variableName} = ({capturedVariablesPathTree.ExpressionType.Name}){roslynPathSegment};");
+
                                     foreach (var child in capturedVariablesPathTree.Children)
                                     {
                                         GenerateCapturedVariableExtractors(variableName, capturedVariablesPathTree.ExpressionType, child);
@@ -816,7 +851,7 @@ namespace System.Runtime.CompilerServices
                                 {
                                     code
                                         .Append('"').Append(capturedVariablesPathTree.ParameterName!).AppendLine("\",")
-                                        .AppendLine($"Expression.Lambda<Func<object?>>(Expression.Convert({variableName}, typeof(object)))")
+                                        .AppendLine($"Expression.Lambda<Func<object?>>(Expression.Convert({roslynPathSegment}, typeof(object)))")
                                         .AppendLine(".Compile(preferInterpretation: true)")
                                         .AppendLine(".Invoke());");
                                 }
@@ -1073,15 +1108,23 @@ namespace System.Runtime.CompilerServices
                     QueryableMethods.GetSumWithSelector(
                         method.GetParameters()[1].ParameterType.GenericTypeArguments[0].GenericTypeArguments[1])),
 
-            // ExecuteDelete/Update behave just like other scalar-returning operators
+            // ExecuteDelete behaves just like other scalar-returning operators
             nameof(EntityFrameworkQueryableExtensions.ExecuteDeleteAsync) when method.DeclaringType
                 == typeof(EntityFrameworkQueryableExtensions)
                 => RewriteToSync(
                     typeof(EntityFrameworkQueryableExtensions).GetMethod(nameof(EntityFrameworkQueryableExtensions.ExecuteDelete))),
-            nameof(EntityFrameworkQueryableExtensions.ExecuteUpdateAsync) when method.DeclaringType
-                == typeof(EntityFrameworkQueryableExtensions)
-                => RewriteToSync(
-                    typeof(EntityFrameworkQueryableExtensions).GetMethod(nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate))),
+
+            // ExecuteUpdate is special; it accepts a non-expression-tree argument (Func<SetPropertyCalls, SetPropertyCalls>),
+            // evaluates it immediately, and injects a different MethodCall node into the expression tree with the resulting setter
+            // expressions.
+            // When statically analyzing ExecuteUpdate, we have to manually perform the same thing.
+            nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate) or nameof(EntityFrameworkQueryableExtensions.ExecuteUpdateAsync)
+                when method.DeclaringType == typeof(EntityFrameworkQueryableExtensions)
+                => Expression.Call(
+                    EntityFrameworkQueryableExtensions.ExecuteUpdateMethodInfo.MakeGenericMethod(
+                        terminatingOperator.Arguments[0].Type.GetSequenceType()),
+                    penultimateOperator,
+                    ProcessExecuteUpdate(terminatingOperator)),
 
             // In the regular case (sync terminating operator which needs to stay in the query tree), simply compose the terminating
             // operator over the penultimate and return that.
@@ -1114,6 +1157,56 @@ namespace System.Runtime.CompilerServices
 
             return Expression.Call(terminatingOperator.Object, syncMethod, syncArguments);
         }
+    }
+
+    // Accepts an expression tree representing a series of SetProperty() calls, parses them and passes them through the SetPropertyCalls
+    // builder; returns the resulting NewArrayExpression representing all the setters.
+    private static NewArrayExpression ProcessExecuteUpdate(MethodCallExpression executeUpdateCall)
+    {
+        var setPropertyCalls = Activator.CreateInstance<SetPropertyCalls>();
+        var settersLambda = (LambdaExpression)executeUpdateCall.Arguments[1];
+        var settersParameter = settersLambda.Parameters.Single();
+        var expression = settersLambda.Body;
+
+        while (expression != settersParameter)
+        {
+            if (expression is MethodCallExpression
+                {
+                    Method:
+                    {
+                        IsGenericMethod: true,
+                        Name: nameof(SetPropertyCalls<int>.SetProperty),
+                        DeclaringType.IsGenericType: true,
+                    },
+                    Arguments:
+                    [
+                        UnaryExpression { NodeType: ExpressionType.Quote, Operand: LambdaExpression propertySelector },
+                        Expression valueSelector
+                    ]
+                } methodCallExpression
+                && methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(SetPropertyCalls<>))
+            {
+                if (valueSelector is UnaryExpression
+                    {
+                        NodeType: ExpressionType.Quote,
+                        Operand: LambdaExpression unwrappedValueSelector
+                    })
+                {
+                    setPropertyCalls.SetProperty(propertySelector, unwrappedValueSelector);
+                }
+                else
+                {
+                    setPropertyCalls.SetProperty(propertySelector, valueSelector);
+                }
+
+                expression = methodCallExpression.Object;
+                continue;
+            }
+
+            throw new InvalidOperationException(RelationalStrings.InvalidArgumentToExecuteUpdate);
+        }
+
+        return setPropertyCalls.BuildSettersExpression();
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -16,22 +16,19 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         typeof(RelationalSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ParameterValueExtractor))!;
 
     /// <inheritdoc />
-    protected override UpdateExpression? TranslateExecuteUpdate(ShapedQueryExpression source, LambdaExpression setPropertyCalls)
+    protected override UpdateExpression? TranslateExecuteUpdate(ShapedQueryExpression source, IReadOnlyList<ExecuteUpdateSetter> setters)
     {
+        if (setters.Count == 0)
+        {
+            throw new UnreachableException("Empty setters list");
+        }
+
         // Our source may have IncludeExpressions because of owned entities or auto-include; unwrap these, as they're meaningless for
         // ExecuteUpdate's lambdas. Note that we don't currently support updates across tables.
         source = source.UpdateShaperExpression(new IncludePruner().Visit(source.ShaperExpression));
 
-        var setters = new List<(LambdaExpression PropertySelector, Expression ValueExpression)>();
-        PopulateSetPropertyCalls(setPropertyCalls.Body, setters, setPropertyCalls.Parameters[0]);
         if (TranslationErrorDetails != null)
         {
-            return null;
-        }
-
-        if (setters.Count == 0)
-        {
-            AddTranslationErrorDetails(RelationalStrings.NoSetPropertyInvocation);
             return null;
         }
 
@@ -67,42 +64,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
         return PushdownWithPkInnerJoinPredicate();
 
-        void PopulateSetPropertyCalls(
-            Expression expression,
-            List<(LambdaExpression, Expression)> list,
-            ParameterExpression parameter)
-        {
-            switch (expression)
-            {
-                case ParameterExpression p
-                    when parameter == p:
-                    break;
-
-                case MethodCallExpression
-                    {
-                        Method:
-                        {
-                            IsGenericMethod: true,
-                            Name: nameof(SetPropertyCalls<int>.SetProperty),
-                            DeclaringType.IsGenericType: true
-                        }
-                    } methodCallExpression
-                    when methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(SetPropertyCalls<>):
-                    list.Add(((LambdaExpression)methodCallExpression.Arguments[0], methodCallExpression.Arguments[1]));
-
-                    PopulateSetPropertyCalls(methodCallExpression.Object!, list, parameter);
-
-                    break;
-
-                default:
-                    AddTranslationErrorDetails(RelationalStrings.InvalidArgumentToExecuteUpdate);
-                    break;
-            }
-        }
-
         bool TranslateSetters(
             ShapedQueryExpression source,
-            List<(LambdaExpression PropertySelector, Expression ValueExpression)> setters,
+            IReadOnlyList<ExecuteUpdateSetter> setters,
             [NotNullWhen(true)] out List<ColumnValueSetter>? translatedSetters,
             [NotNullWhen(true)] out TableExpressionBase? targetTable)
         {
@@ -464,7 +428,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             var inner = source;
             var outerParameter = Expression.Parameter(entityType.ClrType);
             var outerKeySelector = Expression.Lambda(outerParameter.CreateKeyValuesExpression(pk.Properties), outerParameter);
-            var firstPropertyLambdaExpression = setters[0].Item1;
+            var firstPropertyLambdaExpression = setters[0].PropertySelector;
             var entitySource = GetEntitySource(RelationalDependencies.Model, firstPropertyLambdaExpression.Body);
             var innerKeySelector = Expression.Lambda(
                 entitySource.CreateKeyValuesExpression(pk.Properties), firstPropertyLambdaExpression.Parameters);
@@ -481,6 +445,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
             var propertyReplacement = AccessField(transparentIdentifierType, transparentIdentifierParameter, "Outer");
             var valueReplacement = AccessField(transparentIdentifierType, transparentIdentifierParameter, "Inner");
+            var rewrittenSetters = new ExecuteUpdateSetter[setters.Count];
             for (var i = 0; i < setters.Count; i++)
             {
                 var (propertyExpression, valueExpression) = setters[i];
@@ -499,14 +464,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                         transparentIdentifierParameter)
                     : valueExpression;
 
-                setters[i] = (propertyExpression, valueExpression);
+                rewrittenSetters[i] = new(propertyExpression, valueExpression);
             }
 
             tableExpression = (TableExpression)outerSelectExpression.Tables[0];
 
             // Re-translate the property selectors to get column expressions pointing to the new outer select expression (the original one
             // has been pushed down into a subquery).
-            if (!TranslateSetters(outer, setters, out var translatedSetters, out _))
+            if (!TranslateSetters(outer, rewrittenSetters, out var translatedSetters, out _))
             {
                 return null;
             }

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -1316,7 +1316,12 @@ public class SqlNullabilityProcessor : ExpressionVisitor
         bool allowOptimizedExpansion,
         out bool nullable)
     {
-        var parameterValue = ParameterValues[sqlParameterExpression.Name];
+        if (!ParameterValues.TryGetValue(sqlParameterExpression.Name, out var parameterValue))
+        {
+            throw new UnreachableException(
+                $"Encountered SqlParameter with name '{sqlParameterExpression.Name}', but such a parameter does not exist.");
+        }
+
         nullable = parameterValue == null;
 
         if (nullable)

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -3337,9 +3337,12 @@ public static class EntityFrameworkQueryableExtensions
     /// <returns>The total number of rows updated in the database.</returns>
     public static int ExecuteUpdate<TSource>(
         this IQueryable<TSource> source,
-        Expression<Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>>> setPropertyCalls)
+        Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>> setPropertyCalls)
         => source.Provider.Execute<int>(
-            Expression.Call(ExecuteUpdateMethodInfo.MakeGenericMethod(typeof(TSource)), source.Expression, setPropertyCalls));
+            Expression.Call(
+                ExecuteUpdateMethodInfo.MakeGenericMethod(typeof(TSource)),
+                source.Expression,
+                setPropertyCalls(new SetPropertyCalls<TSource>()).BuildSettersExpression()));
 
     /// <summary>
     ///     Asynchronously updates database rows for the entity instances which match the LINQ query from the database.
@@ -3360,18 +3363,35 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="setPropertyCalls">A collection of set property statements specifying properties to update.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>The total number of rows updated in the database.</returns>
+    [DynamicDependency("ExecuteUpdate``1(System.Linq.IQueryable{``1},System.Collections.Generic.IReadOnlyList{ITuple})", typeof(EntityFrameworkQueryableExtensions))]
     public static Task<int> ExecuteUpdateAsync<TSource>(
         this IQueryable<TSource> source,
-        Expression<Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>>> setPropertyCalls,
+        Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>> setPropertyCalls,
         CancellationToken cancellationToken = default)
         => source.Provider is IAsyncQueryProvider provider
             ? provider.ExecuteAsync<Task<int>>(
                 Expression.Call(
-                    ExecuteUpdateMethodInfo.MakeGenericMethod(typeof(TSource)), source.Expression, setPropertyCalls), cancellationToken)
+                    ExecuteUpdateMethodInfo.MakeGenericMethod(typeof(TSource)),
+                    source.Expression,
+                    setPropertyCalls(new SetPropertyCalls<TSource>()).BuildSettersExpression()),
+                cancellationToken)
             : throw new InvalidOperationException(CoreStrings.IQueryableProviderNotAsync);
 
-    internal static readonly MethodInfo ExecuteUpdateMethodInfo
-        = typeof(EntityFrameworkQueryableExtensions).GetTypeInfo().GetDeclaredMethod(nameof(ExecuteUpdate))!;
+    private static int ExecuteUpdate<TSource>(this IQueryable<TSource> source, [NotParameterized] IReadOnlyList<ITuple> setters)
+        => throw new UnreachableException("Can't call this overload directly");
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static readonly MethodInfo ExecuteUpdateMethodInfo
+        = typeof(EntityFrameworkQueryableExtensions)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(
+                m => m.Name == nameof(ExecuteUpdate) && m.GetParameters()[1].ParameterType == typeof(IReadOnlyList<ITuple>));
 
     #endregion
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property, expectedType, actualType);
 
         /// <summary>
-        ///     The methods '{methodName}' and '{asyncMethodName}' are not supported by the current database provider. Please contact the publisher of the database provider for more information. 
+        ///     The methods '{methodName}' and '{asyncMethodName}' are not supported by the current database provider. Please contact the publisher of the database provider for more information.
         /// </summary>
         public static string ExecuteQueriesNotSupported(object? methodName, object? asyncMethodName)
             => string.Format(
@@ -2242,6 +2242,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 service);
 
         /// <summary>
+        ///     An 'ExecuteUpdate' call must specify at least one 'SetProperty' invocation, to indicate the properties to be updated.
+        /// </summary>
+        public static string NoSetPropertyInvocation
+            => GetString("NoSetPropertyInvocation");
+
+        /// <summary>
         ///     The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{propertyAccessMode}'.
         /// </summary>
         public static string NoSetter(object? property, object? entityType, object? propertyAccessMode)
@@ -2948,12 +2954,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string SetOperationWithDifferentIncludesInOperands
             => GetString("SetOperationWithDifferentIncludesInOperands");
-
-        /// <summary>
-        ///     The SetProperty&lt;TProperty&gt; method can only be used within 'ExecuteUpdate' method.
-        /// </summary>
-        public static string SetPropertyMethodInvoked
-            => GetString("SetPropertyMethodInvoked");
 
         /// <summary>
         ///     The shared-type entity type '{entityType}' cannot have a base type.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1301,6 +1301,9 @@
   <data name="NoProviderConfiguredFailedToResolveService" xml:space="preserve">
     <value>Unable to resolve service for type '{service}'. This is often because no database provider has been configured for this DbContext. A provider can be configured by overriding the 'DbContext.OnConfiguring' method or by using 'AddDbContext' on the application service provider. If 'AddDbContext' is used, then also ensure that your DbContext type accepts a DbContextOptions&lt;TContext&gt; object in its constructor and passes it to the base constructor for DbContext.</value>
   </data>
+  <data name="NoSetPropertyInvocation" xml:space="preserve">
+    <value>An 'ExecuteUpdate' call must specify at least one 'SetProperty' invocation, to indicate the properties to be updated.</value>
+  </data>
   <data name="NoSetter" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{propertyAccessMode}'.</value>
   </data>
@@ -1579,9 +1582,6 @@
   </data>
   <data name="SetOperationWithDifferentIncludesInOperands" xml:space="preserve">
     <value>Unable to translate set operation since both operands have different 'Include' operations. Consider having same 'Include' applied on both sides.</value>
-  </data>
-  <data name="SetPropertyMethodInvoked" xml:space="preserve">
-    <value>The SetProperty&lt;TProperty&gt; method can only be used within 'ExecuteUpdate' method.</value>
   </data>
   <data name="SharedTypeDerivedType" xml:space="preserve">
     <value>The shared-type entity type '{entityType}' cannot have a base type.</value>

--- a/src/EFCore/Query/SetPropertyCalls`.cs
+++ b/src/EFCore/Query/SetPropertyCalls`.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <inheritdoc />
+public sealed class SetPropertyCalls<TSource> : SetPropertyCalls
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SetPropertyCalls()
+    {
+    }
+
+    /// <summary>
+    ///     Specifies a property and corresponding value it should be updated to in ExecuteUpdate method.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of property.</typeparam>
+    /// <param name="propertyExpression">A property access expression.</param>
+    /// <param name="valueExpression">A value expression.</param>
+    /// <returns>
+    ///     The same instance so that multiple calls to
+    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, Expression{Func{TSource, TProperty}})" />
+    ///     can be chained.
+    /// </returns>
+    public SetPropertyCalls<TSource> SetProperty<TProperty>(
+        Expression<Func<TSource, TProperty>> propertyExpression,
+        Expression<Func<TSource, TProperty>> valueExpression)
+    {
+        SetProperty((LambdaExpression)propertyExpression, valueExpression);
+        return this;
+    }
+
+    /// <summary>
+    ///     Specifies a property and corresponding value it should be updated to in ExecuteUpdate method.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of property.</typeparam>
+    /// <param name="propertyExpression">A property access expression.</param>
+    /// <param name="valueExpression">A value expression.</param>
+    /// <returns>
+    ///     The same instance so that multiple calls to
+    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, TProperty)" /> can be chained.
+    /// </returns>
+    public SetPropertyCalls<TSource> SetProperty<TProperty>(
+        Expression<Func<TSource, TProperty>> propertyExpression,
+        TProperty valueExpression)
+    {
+        // We pass in the value as a ConstantExpression; but it will get parameterized by the funcletizer as any method argument that isn't
+        // inside a lambda (just like parameters to Skip/Take).
+        SetProperty(propertyExpression, Expression.Constant(valueExpression, typeof(TProperty)));
+        return this;
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
@@ -61,11 +61,6 @@ WHERE [OrderID] < 10300"));
             RelationalStrings.NoSetPropertyInvocation,
             () => base.Update_without_property_to_set_throws(async));
 
-    public override Task Update_with_invalid_lambda_throws(bool async)
-        => AssertTranslationFailed(
-            RelationalStrings.InvalidArgumentToExecuteUpdate,
-            () => base.Update_with_invalid_lambda_throws(async));
-
     public override Task Update_with_invalid_lambda_in_set_property_throws(bool async)
         => AssertTranslationFailed(
             RelationalStrings.InvalidPropertyInSetProperty(
@@ -74,7 +69,7 @@ WHERE [OrderID] < 10300"));
 
     public override Task Update_multiple_tables_throws(bool async)
         => AssertTranslationFailed(
-            RelationalStrings.MultipleTablesInExecuteUpdate("c => c.Customer.ContactName", "c => c.e.OrderDate"),
+            RelationalStrings.MultipleTablesInExecuteUpdate("c => c.e.OrderDate", "c => c.Customer.ContactName"),
             () => base.Update_multiple_tables_throws(async));
 
     public override Task Update_unmapped_property_throws(bool async)

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesTestBase.cs
@@ -35,7 +35,7 @@ public abstract class TPTFiltersInheritanceBulkUpdatesTestBase<TFixture>(TFixtur
 
     public override Task Update_base_and_derived_types(bool async)
         => AssertTranslationFailed(
-            RelationalStrings.MultipleTablesInExecuteUpdate("e => e.Name", "e => e.FoundOn"),
+            RelationalStrings.MultipleTablesInExecuteUpdate("e => e.FoundOn", "e => e.Name"),
             () => base.Update_base_and_derived_types(async));
 
     // Keyless entities are mapped as TPH only

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesTestBase.cs
@@ -49,7 +49,7 @@ public abstract class TPTInheritanceBulkUpdatesTestBase<TFixture> : InheritanceB
 
     public override Task Update_base_and_derived_types(bool async)
         => AssertTranslationFailed(
-            RelationalStrings.MultipleTablesInExecuteUpdate("e => e.Name", "e => e.FoundOn"),
+            RelationalStrings.MultipleTablesInExecuteUpdate("e => e.FoundOn", "e => e.Name"),
             () => base.Update_base_and_derived_types(async));
 
     // Keyless entities are mapped as TPH only

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -727,7 +727,7 @@ Assert.Equal(1, await context.Blogs.CountAsync());
 """);
 
     [ConditionalFact]
-    public virtual Task Terminating_ExecuteUpdate()
+    public virtual Task Terminating_ExecuteUpdate_with_lambda()
         => Test(
             """
 await context.Database.BeginTransactionAsync();
@@ -739,7 +739,19 @@ Assert.Equal(1, await context.Blogs.CountAsync(b => b.Id == 9 && b.Name == "Blog
 """);
 
     [ConditionalFact]
-    public virtual Task Terminating_ExecuteUpdateAsync()
+    public virtual Task Terminating_ExecuteUpdate_without_lambda()
+        => Test(
+            """
+await context.Database.BeginTransactionAsync();
+
+var newValue = "NewValue";
+var rowsAffected = context.Blogs.Where(b => b.Id > 8).ExecuteUpdate(setters => setters.SetProperty(b => b.Name, newValue));
+Assert.Equal(1, rowsAffected);
+Assert.Equal(1, await context.Blogs.CountAsync(b => b.Id == 9 && b.Name == "NewValue"));
+""");
+
+    [ConditionalFact]
+    public virtual Task Terminating_ExecuteUpdateAsync_with_lambda()
         => Test(
             """
 await context.Database.BeginTransactionAsync();
@@ -748,6 +760,18 @@ var suffix = "Suffix";
 var rowsAffected = await context.Blogs.Where(b => b.Id > 8).ExecuteUpdateAsync(setters => setters.SetProperty(b => b.Name, b => b.Name + suffix));
 Assert.Equal(1, rowsAffected);
 Assert.Equal(1, await context.Blogs.CountAsync(b => b.Id == 9 && b.Name == "Blog2Suffix"));
+""");
+
+    [ConditionalFact]
+    public virtual Task Terminating_ExecuteUpdateAsync_without_lambda()
+        => Test(
+            """
+await context.Database.BeginTransactionAsync();
+
+var newValue = "NewValue";
+var rowsAffected = await context.Blogs.Where(b => b.Id > 8).ExecuteUpdateAsync(setters => setters.SetProperty(b => b.Name, newValue));
+Assert.Equal(1, rowsAffected);
+Assert.Equal(1, await context.Blogs.CountAsync(b => b.Id == 9 && b.Name == "NewValue"));
 """);
 
     #endregion Reducing terminating operators

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
@@ -34,7 +34,7 @@ public class BulkUpdatesAsserter(IBulkUpdatesFixtureBase queryFixture, Func<Expr
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Expression<Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>>> setPropertyCalls,
+        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter)
         where TResult : class

--- a/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
@@ -33,7 +33,7 @@ public abstract class BulkUpdatesTestBase<TFixture> : IClassFixture<TFixture>
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Expression<Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>>> setPropertyCalls,
+        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter = null)
         where TResult : class

--- a/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -321,7 +321,7 @@ public abstract class NonSharedModelBulkUpdatesTestBase : NonSharedModelTestBase
         bool async,
         Func<TContext> contextCreator,
         Func<TContext, IQueryable<TResult>> query,
-        Expression<Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>>> setPropertyCalls,
+        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
         int rowsAffectedCount)
         where TResult : class
         where TContext : DbContext

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -48,16 +48,6 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Update_with_invalid_lambda_throws(bool async)
-        => AssertUpdate(
-            async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID < 10250),
-            e => e,
-            s => s.Maybe(e => e),
-            rowsAffectedCount: 0);
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Update_with_invalid_lambda_in_set_property_throws(bool async)
         => AssertUpdate(
             async,
@@ -397,6 +387,17 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
             s => s.SetProperty(c => c.ContactName, "Updated"),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_constant_via_lambda(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, _ => "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 

--- a/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
@@ -35,7 +35,7 @@ public class BulkUpdatesAsserter(IBulkUpdatesFixtureBase queryFixture, Func<Expr
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Expression<Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>>> setPropertyCalls,
+        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter)
         where TResult : class

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/ComplexTypeBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/ComplexTypeBulkUpdatesSqlServerTest.cs
@@ -35,8 +35,10 @@ WHERE [c].[Name] = N'Monty Elias'
 
         AssertExecuteUpdateSql(
             """
+@p='12345'
+
 UPDATE [c]
-SET [c].[ShippingAddress_ZipCode] = 12345
+SET [c].[ShippingAddress_ZipCode] = @p
 FROM [Customer] AS [c]
 WHERE [c].[ShippingAddress_ZipCode] = 7728
 """);
@@ -48,8 +50,10 @@ WHERE [c].[ShippingAddress_ZipCode] = 7728
 
         AssertExecuteUpdateSql(
             """
+@p='United States Modified' (Size = 4000)
+
 UPDATE [c]
-SET [c].[ShippingAddress_Country_FullName] = N'United States Modified'
+SET [c].[ShippingAddress_Country_FullName] = @p
 FROM [Customer] AS [c]
 WHERE [c].[ShippingAddress_Country_Code] = N'US'
 """);
@@ -61,10 +65,12 @@ WHERE [c].[ShippingAddress_Country_Code] = N'US'
 
         AssertExecuteUpdateSql(
             """
+@p='54321'
+
 UPDATE [c]
-SET [c].[BillingAddress_ZipCode] = 54321,
+SET [c].[Name] = [c].[Name] + N'Modified',
     [c].[ShippingAddress_ZipCode] = [c].[BillingAddress_ZipCode],
-    [c].[Name] = [c].[Name] + N'Modified'
+    [c].[BillingAddress_ZipCode] = @p
 FROM [Customer] AS [c]
 WHERE [c].[ShippingAddress_ZipCode] = 7728
 """);
@@ -76,8 +82,10 @@ WHERE [c].[ShippingAddress_ZipCode] = 7728
 
         AssertExecuteUpdateSql(
             """
+@p='12345'
+
 UPDATE [c]
-SET [c].[ShippingAddress_ZipCode] = 12345
+SET [c].[ShippingAddress_ZipCode] = @p
 FROM [Customer] AS [c]
 """);
     }
@@ -88,9 +96,11 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
+@p='54321'
+
 UPDATE [c]
-SET [c].[BillingAddress_ZipCode] = 54321,
-    [c].[ShippingAddress_ZipCode] = [c].[BillingAddress_ZipCode]
+SET [c].[ShippingAddress_ZipCode] = [c].[BillingAddress_ZipCode],
+    [c].[BillingAddress_ZipCode] = @p
 FROM [Customer] AS [c]
 """);
     }
@@ -108,20 +118,20 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
-@complex_type_newAddress_AddressLine1='New AddressLine1' (Size = 4000)
-@complex_type_newAddress_AddressLine2='New AddressLine2' (Size = 4000)
-@complex_type_newAddress_Tags='["new_tag1","new_tag2"]' (Size = 4000)
-@complex_type_newAddress_ZipCode='99999' (Nullable = true)
-@complex_type_newAddress_Code='FR' (Size = 4000)
-@complex_type_newAddress_FullName='France' (Size = 4000)
+@complex_type_p_AddressLine1='New AddressLine1' (Size = 4000)
+@complex_type_p_AddressLine2='New AddressLine2' (Size = 4000)
+@complex_type_p_Tags='["new_tag1","new_tag2"]' (Size = 4000)
+@complex_type_p_ZipCode='99999' (Nullable = true)
+@complex_type_p_Code='FR' (Size = 4000)
+@complex_type_p_FullName='France' (Size = 4000)
 
 UPDATE [c]
-SET [c].[ShippingAddress_AddressLine1] = @complex_type_newAddress_AddressLine1,
-    [c].[ShippingAddress_AddressLine2] = @complex_type_newAddress_AddressLine2,
-    [c].[ShippingAddress_Tags] = @complex_type_newAddress_Tags,
-    [c].[ShippingAddress_ZipCode] = @complex_type_newAddress_ZipCode,
-    [c].[ShippingAddress_Country_Code] = @complex_type_newAddress_Code,
-    [c].[ShippingAddress_Country_FullName] = @complex_type_newAddress_FullName
+SET [c].[ShippingAddress_AddressLine1] = @complex_type_p_AddressLine1,
+    [c].[ShippingAddress_AddressLine2] = @complex_type_p_AddressLine2,
+    [c].[ShippingAddress_Tags] = @complex_type_p_Tags,
+    [c].[ShippingAddress_ZipCode] = @complex_type_p_ZipCode,
+    [c].[ShippingAddress_Country_Code] = @complex_type_p_Code,
+    [c].[ShippingAddress_Country_FullName] = @complex_type_p_FullName
 FROM [Customer] AS [c]
 """);
     }
@@ -132,12 +142,12 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
-@complex_type_newCountry_Code='FR' (Size = 4000)
-@complex_type_newCountry_FullName='France' (Size = 4000)
+@complex_type_p_Code='FR' (Size = 4000)
+@complex_type_p_FullName='France' (Size = 4000)
 
 UPDATE [c]
-SET [c].[ShippingAddress_Country_Code] = @complex_type_newCountry_Code,
-    [c].[ShippingAddress_Country_FullName] = @complex_type_newCountry_FullName
+SET [c].[ShippingAddress_Country_Code] = @complex_type_p_Code,
+    [c].[ShippingAddress_Country_FullName] = @complex_type_p_FullName
 FROM [Customer] AS [c]
 """);
     }
@@ -165,13 +175,20 @@ FROM [Customer] AS [c]
 
         AssertExecuteUpdateSql(
             """
+@complex_type_p_AddressLine1='New AddressLine1' (Size = 4000)
+@complex_type_p_AddressLine2='New AddressLine2' (Size = 4000)
+@complex_type_p_Tags='["new_tag1","new_tag2"]' (Size = 4000)
+@complex_type_p_ZipCode='99999' (Nullable = true)
+@complex_type_p_Code='FR' (Size = 4000)
+@complex_type_p_FullName='France' (Size = 4000)
+
 UPDATE [c]
-SET [c].[ShippingAddress_AddressLine1] = N'New AddressLine1',
-    [c].[ShippingAddress_AddressLine2] = N'New AddressLine2',
-    [c].[ShippingAddress_Tags] = N'["new_tag1","new_tag2"]',
-    [c].[ShippingAddress_ZipCode] = 99999,
-    [c].[ShippingAddress_Country_Code] = N'FR',
-    [c].[ShippingAddress_Country_FullName] = N'France'
+SET [c].[ShippingAddress_AddressLine1] = @complex_type_p_AddressLine1,
+    [c].[ShippingAddress_AddressLine2] = @complex_type_p_AddressLine2,
+    [c].[ShippingAddress_Tags] = @complex_type_p_Tags,
+    [c].[ShippingAddress_ZipCode] = @complex_type_p_ZipCode,
+    [c].[ShippingAddress_Country_Code] = @complex_type_p_Code,
+    [c].[ShippingAddress_Country_FullName] = @complex_type_p_FullName
 FROM [Customer] AS [c]
 """);
     }
@@ -224,8 +241,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='["new_tag1","new_tag2"]' (Size = 4000)
+
 UPDATE [c]
-SET [c].[ShippingAddress_Tags] = N'["new_tag1","new_tag2"]'
+SET [c].[ShippingAddress_Tags] = @p
 FROM [Customer] AS [c]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -68,8 +68,10 @@ FROM [Owner] AS [o]
 
         AssertSql(
             """
+@p='SomeValue' (Size = 4000)
+
 UPDATE [o0]
-SET [o0].[Value] = N'SomeValue'
+SET [o0].[Value] = @p
 FROM [Owner] AS [o]
 INNER JOIN [OwnedCollection] AS [o0] ON [o].[Id] = [o0].[OwnerId]
 """);
@@ -81,8 +83,10 @@ INNER JOIN [OwnedCollection] AS [o0] ON [o].[Id] = [o0].[OwnerId]
 
         AssertSql(
             """
+@p='SomeValue' (Size = 4000)
+
 UPDATE [o]
-SET [o].[Title] = N'SomeValue'
+SET [o].[Title] = @p
 FROM [Owner] AS [o]
 """);
     }
@@ -105,8 +109,10 @@ FROM [Owner] AS [o]
 
         AssertSql(
             """
+@p='NewValue' (Size = 4000)
+
 UPDATE [o]
-SET [o].[Title] = N'NewValue'
+SET [o].[Title] = @p
 FROM [Owner] AS [o]
 INNER JOIN [Owner] AS [o0] ON [o].[Id] = [o0].[Id]
 """);
@@ -119,8 +125,8 @@ INNER JOIN [Owner] AS [o0] ON [o].[Id] = [o0].[Id]
         AssertSql(
             """
 UPDATE [o]
-SET [o].[OwnedReference_Number] = CAST(LEN([o].[Title]) AS int),
-    [o].[Title] = COALESCE(CONVERT(varchar(11), [o].[OwnedReference_Number]), '')
+SET [o].[Title] = COALESCE(CONVERT(varchar(11), [o].[OwnedReference_Number]), ''),
+    [o].[OwnedReference_Number] = CAST(LEN([o].[Title]) AS int)
 FROM [Owner] AS [o]
 """);
     }
@@ -144,8 +150,8 @@ FROM [Blogs] AS [b]
         AssertSql(
             """
 UPDATE [b0]
-SET [b0].[Rating] = CAST(LEN([b0].[Title]) AS int),
-    [b0].[Title] = CONVERT(varchar(11), [b0].[Rating])
+SET [b0].[Title] = CONVERT(varchar(11), [b0].[Rating]),
+    [b0].[Rating] = CAST(LEN([b0].[Title]) AS int)
 FROM [Blogs] AS [b]
 INNER JOIN [BlogsPart1] AS [b0] ON [b].[Id] = [b0].[Id]
 """);
@@ -209,8 +215,10 @@ FROM [Blogs] AS [b]
 
         AssertSql(
             """
+@p='Updated' (Size = 4000)
+
 UPDATE [b]
-SET [b].[Data] = N'Updated'
+SET [b].[Data] = @p
 FROM [Blogs] AS [b]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -611,10 +611,12 @@ WHERE [o].[OrderID] < 10276
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 -- MyUpdate
 
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -623,6 +625,21 @@ WHERE [c].[CustomerID] LIKE N'F%'
     public override async Task Update_Where_set_constant(bool async)
     {
         await base.Update_Where_set_constant(async);
+
+        AssertExecuteUpdateSql(
+            """
+@p='Updated' (Size = 30)
+
+UPDATE [c]
+SET [c].[ContactName] = @p
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+""");
+    }
+
+    public override async Task Update_Where_set_constant_via_lambda(bool async)
+    {
+        await base.Update_Where_set_constant_via_lambda(async);
 
         AssertExecuteUpdateSql(
             """
@@ -639,10 +656,11 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
 @customer='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @customer
 """,
@@ -662,8 +680,10 @@ WHERE 0 = 1
 """,
             //
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE 0 = 1
 """);
@@ -675,10 +695,10 @@ WHERE 0 = 1
 
         AssertExecuteUpdateSql(
             """
-@value='Abc' (Size = 30)
+@p='Abc' (Size = 30)
 
 UPDATE [c]
-SET [c].[ContactName] = @value
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -705,8 +725,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Abc' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Abc'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -718,10 +740,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
-@container_Containee_Property='Abc' (Size = 30)
+@p='Abc' (Size = 30)
 
 UPDATE [c]
-SET [c].[ContactName] = @container_Containee_Property
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -733,10 +755,11 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 30)
 @p='4'
 
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p0
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -755,9 +778,10 @@ INNER JOIN (
         AssertExecuteUpdateSql(
             """
 @p='4'
+@p0='Updated' (Size = 30)
 
 UPDATE TOP(@p) [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p0
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -769,11 +793,12 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p1='Updated' (Size = 30)
 @p='2'
 @p0='4'
 
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p1
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -791,8 +816,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -808,10 +835,11 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 30)
 @p='4'
 
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p0
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -829,10 +857,11 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 30)
 @p='4'
 
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p0
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT TOP(@p) [c].[CustomerID]
@@ -849,11 +878,12 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p1='Updated' (Size = 30)
 @p='2'
 @p0='4'
 
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p1
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -871,11 +901,12 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p3='Updated' (Size = 30)
 @p='2'
 @p0='6'
 
 UPDATE [c1]
-SET [c1].[ContactName] = N'Updated'
+SET [c1].[ContactName] = @p3
 FROM [Customers] AS [c1]
 INNER JOIN (
     SELECT [c0].[CustomerID]
@@ -898,8 +929,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = (
     SELECT TOP(1) [o].[CustomerID]
@@ -915,8 +948,10 @@ WHERE [c].[CustomerID] = (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = (
     SELECT TOP(1) (
@@ -942,8 +977,10 @@ WHERE [c].[CustomerID] = (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
     SELECT (
@@ -964,8 +1001,10 @@ WHERE [c].[CustomerID] IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c0]
-SET [c0].[ContactName] = N'Updated'
+SET [c0].[ContactName] = @p
 FROM [Customers] AS [c0]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -995,8 +1034,10 @@ WHERE [c].[City] = N'Seattle'
 
         AssertExecuteUpdateSql(
             """
+@p='1'
+
 UPDATE [o]
-SET [o].[Quantity] = CAST(1 AS smallint)
+SET [o].[Quantity] = CAST(@p AS smallint)
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
@@ -1065,8 +1106,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -1092,13 +1135,6 @@ WHERE [c].[CustomerID] LIKE N'F%'
         AssertExecuteUpdateSql();
     }
 
-    public override async Task Update_with_invalid_lambda_throws(bool async)
-    {
-        await base.Update_with_invalid_lambda_throws(async);
-
-        AssertExecuteUpdateSql();
-    }
-
     public override async Task Update_Where_multiple_set(bool async)
     {
         await base.Update_Where_multiple_set(async);
@@ -1106,10 +1142,11 @@ WHERE [c].[CustomerID] LIKE N'F%'
         AssertExecuteUpdateSql(
             """
 @value='Abc' (Size = 30)
+@p='Seattle' (Size = 15)
 
 UPDATE [c]
-SET [c].[City] = N'Seattle',
-    [c].[ContactName] = @value
+SET [c].[ContactName] = @value,
+    [c].[City] = @p
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'
 """);
@@ -1142,8 +1179,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c1]
-SET [c1].[ContactName] = N'Updated'
+SET [c1].[ContactName] = @p
 FROM [Customers] AS [c1]
 INNER JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1163,8 +1202,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c1]
-SET [c1].[ContactName] = N'Updated'
+SET [c1].[ContactName] = @p
 FROM [Customers] AS [c1]
 INNER JOIN (
     SELECT [c].[CustomerID]
@@ -1184,8 +1225,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c1]
-SET [c1].[ContactName] = N'Updated'
+SET [c1].[ContactName] = @p
 FROM [Customers] AS [c1]
 INNER JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1205,8 +1248,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c1]
-SET [c1].[ContactName] = N'Updated'
+SET [c1].[ContactName] = @p
 FROM [Customers] AS [c1]
 INNER JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1226,8 +1271,10 @@ INNER JOIN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 INNER JOIN (
     SELECT [o].[CustomerID]
@@ -1244,8 +1291,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 LEFT JOIN (
     SELECT [o].[CustomerID]
@@ -1262,8 +1311,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT 1 AS empty
@@ -1280,8 +1331,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 CROSS APPLY (
     SELECT 1 AS empty
@@ -1298,8 +1351,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT 1 AS empty
@@ -1316,8 +1371,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT 1 AS empty
@@ -1339,8 +1396,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT 1 AS empty
@@ -1362,8 +1421,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 30)
+
 UPDATE [c]
-SET [c].[ContactName] = N'Updated'
+SET [c].[ContactName] = @p
 FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT 1 AS empty
@@ -1468,8 +1529,10 @@ WHERE [c].[CustomerID] LIKE N'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='1'
+
 UPDATE [o]
-SET [o].[Quantity] = CAST(1 AS smallint)
+SET [o].[Quantity] = CAST(@p AS smallint)
 FROM [Order Details] AS [o]
 INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -134,8 +134,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [k]
-SET [k].[Name] = N'SomeOtherKiwi'
+SET [k].[Name] = @p
 FROM [Kiwi] AS [k]
 WHERE [k].[CountryId] = 1
 """);
@@ -147,8 +149,10 @@ WHERE [k].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint)
+SET [k].[FoundOn] = @p
 FROM [Kiwi] AS [k]
 WHERE [k].[CountryId] = 1
 """);
@@ -160,8 +164,10 @@ WHERE [k].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -182,9 +188,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4000)
+@p0='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint),
-    [k].[Name] = N'Kiwi'
+SET [k].[Name] = @p,
+    [k].[FoundOn] = @p0
 FROM [Kiwi] AS [k]
 WHERE [k].[CountryId] = 1
 """);
@@ -196,8 +205,10 @@ WHERE [k].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
@@ -134,8 +134,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [k]
-SET [k].[Name] = N'SomeOtherKiwi'
+SET [k].[Name] = @p
 FROM [Kiwi] AS [k]
 """);
     }
@@ -146,8 +148,10 @@ FROM [Kiwi] AS [k]
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint)
+SET [k].[FoundOn] = @p
 FROM [Kiwi] AS [k]
 """);
     }
@@ -158,8 +162,10 @@ FROM [Kiwi] AS [k]
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -180,9 +186,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4000)
+@p0='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint),
-    [k].[Name] = N'Kiwi'
+SET [k].[Name] = @p,
+    [k].[FoundOn] = @p0
 FROM [Kiwi] AS [k]
 """);
     }
@@ -193,8 +202,10 @@ FROM [Kiwi] AS [k]
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -212,8 +223,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [c]
-SET [c].[SugarGrams] = 0
+SET [c].[SugarGrams] = @p
 FROM [Coke] AS [c]
 """);
     }
@@ -224,8 +237,10 @@ FROM [Coke] AS [c]
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [c]
-SET [c].[SugarGrams] = 0
+SET [c].[SugarGrams] = @p
 FROM [Coke] AS [c]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -138,8 +138,10 @@ WHERE [a].[Id] IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'Animal'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[CountryId] = 1 AND [a].[Name] = N'Great spotted kiwi'
 """);
@@ -151,8 +153,10 @@ WHERE [a].[CountryId] = 1 AND [a].[Name] = N'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'NewBird'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[CountryId] = 1 AND [a].[Discriminator] = N'Kiwi'
 """);
@@ -171,8 +175,10 @@ WHERE [a].[CountryId] = 1 AND [a].[Discriminator] = N'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'SomeOtherKiwi'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 """);
@@ -184,8 +190,10 @@ WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [a]
-SET [a].[FoundOn] = CAST(0 AS tinyint)
+SET [a].[FoundOn] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 """);
@@ -197,9 +205,12 @@ WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4000)
+@p0='0' (Size = 1)
+
 UPDATE [a]
-SET [a].[FoundOn] = CAST(0 AS tinyint),
-    [a].[Name] = N'Kiwi'
+SET [a].[Name] = @p,
+    [a].[FoundOn] = @p0
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 """);
@@ -211,8 +222,10 @@ WHERE [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -227,8 +240,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqlServerTest.cs
@@ -136,8 +136,10 @@ WHERE [a].[Id] IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'Animal'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Name] = N'Great spotted kiwi'
 """);
@@ -149,8 +151,10 @@ WHERE [a].[Name] = N'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'NewBird'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'
 """);
@@ -169,8 +173,10 @@ WHERE [a].[Discriminator] = N'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'SomeOtherKiwi'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'
 """);
@@ -182,8 +188,10 @@ WHERE [a].[Discriminator] = N'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [a]
-SET [a].[FoundOn] = CAST(0 AS tinyint)
+SET [a].[FoundOn] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'
 """);
@@ -195,8 +203,10 @@ WHERE [a].[Discriminator] = N'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -211,9 +221,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4000)
+@p0='0' (Size = 1)
+
 UPDATE [a]
-SET [a].[FoundOn] = CAST(0 AS tinyint),
-    [a].[Name] = N'Kiwi'
+SET [a].[Name] = @p,
+    [a].[FoundOn] = @p0
 FROM [Animals] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'
 """);
@@ -225,8 +238,10 @@ WHERE [a].[Discriminator] = N'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -248,8 +263,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [d]
-SET [d].[SugarGrams] = 0
+SET [d].[SugarGrams] = @p
 FROM [Drinks] AS [d]
 WHERE [d].[Discriminator] = 1
 """);
@@ -261,8 +278,10 @@ WHERE [d].[Discriminator] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [d]
-SET [d].[SugarGrams] = 0
+SET [d].[SugarGrams] = @p
 FROM [Drinks] AS [d]
 WHERE [d].[Discriminator] = 1
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -100,8 +100,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'Animal'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[CountryId] = 1 AND [a].[Name] = N'Great spotted kiwi'
 """);
@@ -113,8 +115,10 @@ WHERE [a].[CountryId] = 1 AND [a].[Name] = N'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'NewBird'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
 WHERE [a].[CountryId] = 1 AND [k].[Id] IS NOT NULL
@@ -134,8 +138,10 @@ WHERE [a].[CountryId] = 1 AND [k].[Id] IS NOT NULL
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'SomeOtherKiwi'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
@@ -149,8 +155,10 @@ WHERE [a].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint)
+SET [k].[FoundOn] = @p
 FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
@@ -171,8 +179,10 @@ WHERE [a].[CountryId] = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -187,8 +197,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqlServerTest.cs
@@ -84,8 +84,10 @@ public class TPTInheritanceBulkUpdatesSqlServerTest : TPTInheritanceBulkUpdatesT
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'Animal'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 WHERE [a].[Name] = N'Great spotted kiwi'
 """);
@@ -97,8 +99,10 @@ WHERE [a].[Name] = N'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'NewBird'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
 WHERE [k].[Id] IS NOT NULL
@@ -118,8 +122,10 @@ WHERE [k].[Id] IS NOT NULL
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 4000)
+
 UPDATE [a]
-SET [a].[Name] = N'SomeOtherKiwi'
+SET [a].[Name] = @p
 FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
@@ -132,8 +138,10 @@ INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
 
         AssertExecuteUpdateSql(
             """
+@p='0' (Size = 1)
+
 UPDATE [k]
-SET [k].[FoundOn] = CAST(0 AS tinyint)
+SET [k].[FoundOn] = @p
 FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
@@ -153,8 +161,10 @@ INNER JOIN [Kiwi] AS [k] ON [a].[Id] = [k].[Id]
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -169,8 +179,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 4000)
+
 UPDATE [c]
-SET [c].[Name] = N'Monovia'
+SET [c].[Name] = @p
 FROM [Countries] AS [c]
 WHERE (
     SELECT COUNT(*)
@@ -193,8 +205,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [c]
-SET [c].[SugarGrams] = 0
+SET [c].[SugarGrams] = @p
 FROM [Drinks] AS [d]
 INNER JOIN [Coke] AS [c] ON [d].[Id] = [c].[Id]
 """);
@@ -206,8 +220,10 @@ INNER JOIN [Coke] AS [c] ON [d].[Id] = [c].[Id]
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE [c]
-SET [c].[SugarGrams] = 0
+SET [c].[SugarGrams] = @p
 FROM [Drinks] AS [d]
 INNER JOIN [Coke] AS [c] ON [d].[Id] = [c].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -12,7 +12,7 @@ public class PrecompiledQuerySqlServerTest(
         IClassFixture<PrecompiledQuerySqlServerTest.PrecompiledQuerySqlServerFixture>
 {
     protected override bool AlwaysPrintGeneratedSources
-        => true;
+        => false;
 
     #region Expression types
 
@@ -1372,9 +1372,9 @@ FROM [Blogs] AS [b]
 """);
     }
 
-    public override async Task Terminating_ExecuteUpdate()
+    public override async Task Terminating_ExecuteUpdate_with_lambda()
     {
-        await base.Terminating_ExecuteUpdate();
+        await base.Terminating_ExecuteUpdate_with_lambda();
 
         AssertSql(
             """
@@ -1393,9 +1393,30 @@ WHERE [b].[Id] = 9 AND [b].[Name] = N'Blog2Suffix'
 """);
     }
 
-    public override async Task Terminating_ExecuteUpdateAsync()
+    public override async Task Terminating_ExecuteUpdate_without_lambda()
     {
-        await base.Terminating_ExecuteUpdateAsync();
+        await base.Terminating_ExecuteUpdate_without_lambda();
+
+        AssertSql(
+            """
+@newValue='NewValue' (Size = 4000)
+
+UPDATE [b]
+SET [b].[Name] = @newValue
+FROM [Blogs] AS [b]
+WHERE [b].[Id] > 8
+""",
+            //
+            """
+SELECT COUNT(*)
+FROM [Blogs] AS [b]
+WHERE [b].[Id] = 9 AND [b].[Name] = N'NewValue'
+""");
+    }
+
+    public override async Task Terminating_ExecuteUpdateAsync_with_lambda()
+    {
+        await base.Terminating_ExecuteUpdateAsync_with_lambda();
 
         AssertSql(
             """
@@ -1411,6 +1432,27 @@ WHERE [b].[Id] > 8
 SELECT COUNT(*)
 FROM [Blogs] AS [b]
 WHERE [b].[Id] = 9 AND [b].[Name] = N'Blog2Suffix'
+""");
+    }
+
+    public override async Task Terminating_ExecuteUpdateAsync_without_lambda()
+    {
+        await base.Terminating_ExecuteUpdateAsync_without_lambda();
+
+        AssertSql(
+            """
+@newValue='NewValue' (Size = 4000)
+
+UPDATE [b]
+SET [b].[Name] = @newValue
+FROM [Blogs] AS [b]
+WHERE [b].[Id] > 8
+""",
+            //
+            """
+SELECT COUNT(*)
+FROM [Blogs] AS [b]
+WHERE [b].[Id] = 9 AND [b].[Name] = N'NewValue'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -189,8 +189,10 @@ ORDER BY [v].[Name]
 
         AssertSql(
             """
+@p='1'
+
 UPDATE [v]
-SET [v].[SeatingCapacity] = 1
+SET [v].[SeatingCapacity] = @p
 FROM [Vehicles] AS [v]
 """,
             //

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -68,8 +68,10 @@ DELETE FROM "Owner" AS "o"
 
         AssertSql(
             """
+@p='SomeValue' (Size = 9)
+
 UPDATE "OwnedCollection" AS "o0"
-SET "Value" = 'SomeValue'
+SET "Value" = @p
 FROM "Owner" AS "o"
 INNER JOIN "OwnedCollection" AS "o0" ON "o"."Id" = "o0"."OwnerId"
 """);
@@ -81,8 +83,10 @@ INNER JOIN "OwnedCollection" AS "o0" ON "o"."Id" = "o0"."OwnerId"
 
         AssertSql(
             """
+@p='SomeValue' (Size = 9)
+
 UPDATE "Owner" AS "o"
-SET "Title" = 'SomeValue'
+SET "Title" = @p
 """);
     }
 
@@ -103,8 +107,10 @@ SET "Title" = COALESCE("o"."Title", '') || '_Suffix'
 
         AssertSql(
             """
+@p='NewValue' (Size = 8)
+
 UPDATE "Owner" AS "o"
-SET "Title" = 'NewValue'
+SET "Title" = @p
 FROM "Owner" AS "o0"
 WHERE "o"."Id" = "o0"."Id"
 """);
@@ -117,8 +123,8 @@ WHERE "o"."Id" = "o0"."Id"
         AssertSql(
             """
 UPDATE "Owner" AS "o"
-SET "OwnedReference_Number" = length("o"."Title"),
-    "Title" = COALESCE(CAST("o"."OwnedReference_Number" AS TEXT), '')
+SET "Title" = COALESCE(CAST("o"."OwnedReference_Number" AS TEXT), ''),
+    "OwnedReference_Number" = length("o"."Title")
 """);
     }
 
@@ -140,8 +146,8 @@ SET "CreationTimestamp" = '2020-01-01 00:00:00'
         AssertSql(
             """
 UPDATE "BlogsPart1" AS "b0"
-SET "Rating" = length("b0"."Title"),
-    "Title" = CAST("b0"."Rating" AS TEXT)
+SET "Title" = CAST("b0"."Rating" AS TEXT),
+    "Rating" = length("b0"."Title")
 FROM "Blogs" AS "b"
 WHERE "b"."Id" = "b0"."Id"
 """);
@@ -209,8 +215,10 @@ DELETE FROM "Blogs" AS "b"
 
         AssertSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Blogs" AS "b"
-SET "Data" = 'Updated'
+SET "Data" = @p
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -590,10 +590,12 @@ WHERE EXISTS (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 -- MyUpdate
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -601,6 +603,20 @@ WHERE "c"."CustomerID" LIKE 'F%'
     public override async Task Update_Where_set_constant(bool async)
     {
         await base.Update_Where_set_constant(async);
+
+        AssertExecuteUpdateSql(
+            """
+@p='Updated' (Size = 7)
+
+UPDATE "Customers" AS "c"
+SET "ContactName" = @p
+WHERE "c"."CustomerID" LIKE 'F%'
+""");
+    }
+
+    public override async Task Update_Where_set_constant_via_lambda(bool async)
+    {
+        await base.Update_Where_set_constant_via_lambda(async);
 
         AssertExecuteUpdateSql(
             """
@@ -616,10 +632,11 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
 @customer='ALFKI' (Size = 5)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" = @customer
 """,
             //
@@ -638,8 +655,10 @@ WHERE 0
 """,
             //
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE 0
 """);
     }
@@ -650,10 +669,10 @@ WHERE 0
 
         AssertExecuteUpdateSql(
             """
-@value='Abc' (Size = 3)
+@p='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = @value
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -678,8 +697,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Abc' (Size = 3)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Abc'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -690,10 +711,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
-@container_Containee_Property='Abc' (Size = 3)
+@p='Abc' (Size = 3)
 
 UPDATE "Customers" AS "c"
-SET "ContactName" = @container_Containee_Property
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -704,10 +725,11 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 7)
 @p='4'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p0
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -724,10 +746,11 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 7)
 @p='4'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p0
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -744,11 +767,12 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p1='Updated' (Size = 7)
 @p0='4'
 @p='2'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p1
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -765,8 +789,10 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -782,10 +808,11 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 7)
 @p='4'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p0
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -803,10 +830,11 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p0='Updated' (Size = 7)
 @p='4'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p0
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -824,11 +852,12 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p1='Updated' (Size = 7)
 @p0='4'
 @p='2'
 
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p1
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -846,11 +875,12 @@ WHERE "c0"."CustomerID" = "c1"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p3='Updated' (Size = 7)
 @p0='6'
 @p='2'
 
 UPDATE "Customers" AS "c1"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p3
 FROM (
     SELECT "c0"."CustomerID"
     FROM (
@@ -873,8 +903,10 @@ WHERE "c1"."CustomerID" = "c2"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" = (
     SELECT "o"."CustomerID"
     FROM "Orders" AS "o"
@@ -890,8 +922,10 @@ WHERE "c"."CustomerID" = (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" = (
     SELECT (
         SELECT "o0"."CustomerID"
@@ -918,8 +952,10 @@ WHERE "c"."CustomerID" = (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" IN (
     SELECT (
         SELECT "c0"."CustomerID"
@@ -940,8 +976,10 @@ WHERE "c"."CustomerID" IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT DISTINCT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
     FROM "Customers" AS "c"
@@ -975,8 +1013,10 @@ WHERE "o0"."OrderID" = "s"."OrderID"
 
         AssertExecuteUpdateSql(
             """
+@p='1'
+
 UPDATE "Order Details" AS "o"
-SET "Quantity" = CAST(1 AS INTEGER)
+SET "Quantity" = CAST(@p AS INTEGER)
 FROM "Orders" AS "o0"
 LEFT JOIN "Customers" AS "c" ON "o0"."CustomerID" = "c"."CustomerID"
 WHERE "o"."OrderID" = "o0"."OrderID" AND "c"."City" = 'Seattle'
@@ -1040,8 +1080,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -1065,13 +1107,6 @@ WHERE "c"."CustomerID" LIKE 'F%'
         AssertExecuteUpdateSql();
     }
 
-    public override async Task Update_with_invalid_lambda_throws(bool async)
-    {
-        await base.Update_with_invalid_lambda_throws(async);
-
-        AssertExecuteUpdateSql();
-    }
-
     public override async Task Update_Where_multiple_set(bool async)
     {
         await base.Update_Where_multiple_set(async);
@@ -1079,10 +1114,11 @@ WHERE "c"."CustomerID" LIKE 'F%'
         AssertExecuteUpdateSql(
             """
 @value='Abc' (Size = 3)
+@p='Seattle' (Size = 7)
 
 UPDATE "Customers" AS "c"
-SET "City" = 'Seattle',
-    "ContactName" = @value
+SET "ContactName" = @value,
+    "City" = @p
 WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
@@ -1114,8 +1150,10 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c1"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
     FROM "Customers" AS "c"
@@ -1135,8 +1173,10 @@ WHERE "c1"."CustomerID" = "u"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c1"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -1156,8 +1196,10 @@ WHERE "c1"."CustomerID" = "u"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c1"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
     FROM "Customers" AS "c"
@@ -1177,8 +1219,10 @@ WHERE "c1"."CustomerID" = "e"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c1"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
     FROM "Customers" AS "c"
@@ -1198,8 +1242,10 @@ WHERE "c1"."CustomerID" = "i"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "o"."CustomerID"
     FROM "Orders" AS "o"
@@ -1215,8 +1261,10 @@ WHERE "c"."CustomerID" = "o0"."CustomerID" AND "c"."CustomerID" LIKE 'F%'
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c0"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
@@ -1237,8 +1285,10 @@ WHERE "c0"."CustomerID" = "s"."CustomerID"
 
         AssertExecuteUpdateSql(
             """
+@p='Updated' (Size = 7)
+
 UPDATE "Customers" AS "c"
-SET "ContactName" = 'Updated'
+SET "ContactName" = @p
 FROM (
     SELECT 1
     FROM "Orders" AS "o"

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -131,8 +131,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 13)
+
 UPDATE "Kiwi" AS "k"
-SET "Name" = 'SomeOtherKiwi'
+SET "Name" = @p
 WHERE "k"."CountryId" = 1
 """);
     }
@@ -143,8 +145,10 @@ WHERE "k"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 WHERE "k"."CountryId" = 1
 """);
     }
@@ -155,8 +159,10 @@ WHERE "k"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM (
@@ -176,9 +182,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4)
+@p0='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0,
-    "Name" = 'Kiwi'
+SET "Name" = @p,
+    "FoundOn" = @p0
 WHERE "k"."CountryId" = 1
 """);
     }
@@ -189,8 +198,10 @@ WHERE "k"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM (

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
@@ -131,8 +131,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 13)
+
 UPDATE "Kiwi" AS "k"
-SET "Name" = 'SomeOtherKiwi'
+SET "Name" = @p
 """);
     }
 
@@ -142,8 +144,10 @@ SET "Name" = 'SomeOtherKiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 """);
     }
 
@@ -153,8 +157,10 @@ SET "FoundOn" = 0
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM (
@@ -174,9 +180,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4)
+@p0='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0,
-    "Name" = 'Kiwi'
+SET "Name" = @p,
+    "FoundOn" = @p0
 """);
     }
 
@@ -186,8 +195,10 @@ SET "FoundOn" = 0,
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM (
@@ -211,8 +222,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Coke" AS "c"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 """);
     }
 
@@ -222,8 +235,10 @@ SET "SugarGrams" = 0
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Coke" AS "c"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -133,8 +133,10 @@ WHERE "a"."CountryId" = 1 AND "a"."Id" IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 6)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'Animal'
+SET "Name" = @p
 WHERE "a"."CountryId" = 1 AND "a"."Name" = 'Great spotted kiwi'
 """);
     }
@@ -145,8 +147,10 @@ WHERE "a"."CountryId" = 1 AND "a"."Name" = 'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 7)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'NewBird'
+SET "Name" = @p
 WHERE "a"."CountryId" = 1 AND "a"."Discriminator" = 'Kiwi'
 """);
     }
@@ -164,8 +168,10 @@ WHERE "a"."CountryId" = 1 AND "a"."Discriminator" = 'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 13)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'SomeOtherKiwi'
+SET "Name" = @p
 WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 """);
     }
@@ -176,8 +182,10 @@ WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Animals" AS "a"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 """);
     }
@@ -188,8 +196,10 @@ WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -203,9 +213,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4)
+@p0='0'
+
 UPDATE "Animals" AS "a"
-SET "FoundOn" = 0,
-    "Name" = 'Kiwi'
+SET "Name" = @p,
+    "FoundOn" = @p0
 WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 """);
     }
@@ -216,8 +229,10 @@ WHERE "a"."Discriminator" = 'Kiwi' AND "a"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesSqliteTest.cs
@@ -131,8 +131,10 @@ WHERE "a"."Id" IN (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 6)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'Animal'
+SET "Name" = @p
 WHERE "a"."Name" = 'Great spotted kiwi'
 """);
     }
@@ -143,8 +145,10 @@ WHERE "a"."Name" = 'Great spotted kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='NewBird' (Size = 7)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'NewBird'
+SET "Name" = @p
 WHERE "a"."Discriminator" = 'Kiwi'
 """);
     }
@@ -162,8 +166,10 @@ WHERE "a"."Discriminator" = 'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='SomeOtherKiwi' (Size = 13)
+
 UPDATE "Animals" AS "a"
-SET "Name" = 'SomeOtherKiwi'
+SET "Name" = @p
 WHERE "a"."Discriminator" = 'Kiwi'
 """);
     }
@@ -174,8 +180,10 @@ WHERE "a"."Discriminator" = 'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Animals" AS "a"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 WHERE "a"."Discriminator" = 'Kiwi'
 """);
     }
@@ -186,8 +194,10 @@ WHERE "a"."Discriminator" = 'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -201,9 +211,12 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Kiwi' (Size = 4)
+@p0='0'
+
 UPDATE "Animals" AS "a"
-SET "FoundOn" = 0,
-    "Name" = 'Kiwi'
+SET "Name" = @p,
+    "FoundOn" = @p0
 WHERE "a"."Discriminator" = 'Kiwi'
 """);
     }
@@ -214,8 +227,10 @@ WHERE "a"."Discriminator" = 'Kiwi'
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -236,8 +251,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Drinks" AS "d"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 WHERE "d"."Discriminator" = 1
 """);
     }
@@ -248,8 +265,10 @@ WHERE "d"."Discriminator" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Drinks" AS "d"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 WHERE "d"."Discriminator" = 1
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -100,8 +100,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 6)
+
 UPDATE "Animals" AS "a0"
-SET "Name" = 'Animal'
+SET "Name" = @p
 FROM (
     SELECT "a"."Id"
     FROM "Animals" AS "a"
@@ -132,8 +134,10 @@ WHERE "a0"."Id" = "s"."Id"
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 FROM "Animals" AS "a"
 INNER JOIN "Birds" AS "b" ON "a"."Id" = "b"."Id"
 WHERE "a"."Id" = "k"."Id" AND "a"."CountryId" = 1
@@ -146,8 +150,10 @@ WHERE "a"."Id" = "k"."Id" AND "a"."CountryId" = 1
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -168,8 +174,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqliteTest.cs
@@ -85,8 +85,10 @@ public class TPTInheritanceBulkUpdatesSqliteTest(
 
         AssertExecuteUpdateSql(
             """
+@p='Animal' (Size = 6)
+
 UPDATE "Animals" AS "a0"
-SET "Name" = 'Animal'
+SET "Name" = @p
 FROM (
     SELECT "a"."Id"
     FROM "Animals" AS "a"
@@ -117,8 +119,10 @@ WHERE "a0"."Id" = "s"."Id"
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Kiwi" AS "k"
-SET "FoundOn" = 0
+SET "FoundOn" = @p
 FROM "Animals" AS "a"
 INNER JOIN "Birds" AS "b" ON "a"."Id" = "b"."Id"
 WHERE "a"."Id" = "k"."Id"
@@ -131,8 +135,10 @@ WHERE "a"."Id" = "k"."Id"
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -153,8 +159,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='Monovia' (Size = 7)
+
 UPDATE "Countries" AS "c"
-SET "Name" = 'Monovia'
+SET "Name" = @p
 WHERE (
     SELECT COUNT(*)
     FROM "Animals" AS "a"
@@ -176,8 +184,10 @@ WHERE (
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Coke" AS "c"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 FROM "Drinks" AS "d"
 WHERE "d"."Id" = "c"."Id"
 """);
@@ -189,8 +199,10 @@ WHERE "d"."Id" = "c"."Id"
 
         AssertExecuteUpdateSql(
             """
+@p='0'
+
 UPDATE "Coke" AS "c"
-SET "SugarGrams" = 0
+SET "SugarGrams" = @p
 FROM "Drinks" AS "d"
 WHERE "d"."Id" = "c"."Id"
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
@@ -15,8 +15,10 @@ public class TableSplittingSqliteTest(ITestOutputHelper testOutputHelper) : Tabl
 
         AssertSql(
             """
+@p='1'
+
 UPDATE "Vehicles" AS "v"
-SET "SeatingCapacity" = 1
+SET "SeatingCapacity" = @p
 """,
             //
             """


### PR DESCRIPTION
This PR changes ExecuteUpdate to accept `Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>>` instead of `Expression<Func<SetPropertyCalls<TSource>, SetPropertyCalls<TSource>>>`. This allows mainly for easy dynamic composition of setters (but has other advantages), and is more in-line with how LINQ operators generally work.

* ExecuteUpdate needs to add an expression node to the tree just like any other operator, so that that node can get translated properly. Previously we just got an expression tree directly as the argument, but now get a `Func`; so this `Func` must be evaluated immediately, and its results (which are a set of property/value selector pairs) integrated into the tree.
* The funcletizer must also be able to properly process the tree fragment produced by ExecuteUpdate; this means that we can't e.g. simply shove a ConstantExpression into it. Instead, we construct a NewArrayExpression representing all the tuples (the funcletizer will visit into it), and later in translation we "parse" that back into the property/value selectors, to be passed to TranslateExecuteUpdate.
* Precompilation of this new mode is tricky in various ways...
    * Before, ExecuteUpdate just got a single expression tree argument, so it was the same as all other LINQ operators; but we now have a non-expression argument, which, when evaluated, produces an expression argument. This requires special handling in precompilation, to parse the user's `SetProperty()` calls and actually evaluate them, just as the ExecuteUpdate operator implementation does for non-precompilation.
    * In effect, precompilation needs to do for ExecuteUpdate exactly what we have been doing for non-precompilation - the code just moves around.

Closes #32018
Closes #35361

