### PR TITLE
[release/9.0] Don't suppress transactions when creating the history repository

### DIFF
--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -219,8 +219,7 @@ public abstract class HistoryRepository : IHistoryRepository
     private IReadOnlyList<MigrationCommand> GetCreateIfNotExistsCommands()
         => Dependencies.MigrationsSqlGenerator.Generate([new SqlOperation
         {
-            Sql = GetCreateIfNotExistsScript(),
-            SuppressTransaction = true
+            Sql = GetCreateIfNotExistsScript()
         }]);
 
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -286,6 +286,62 @@ public abstract class MigrationsInfrastructureTestBase<TFixture> : IClassFixture
     }
 
     [ConditionalFact]
+    public virtual void Can_apply_two_migrations_in_transaction()
+    {
+        using var db = Fixture.CreateContext();
+        db.Database.EnsureDeleted();
+        GiveMeSomeTime(db);
+        db.GetService<IRelationalDatabaseCreator>().Create();
+
+        var strategy = db.Database.CreateExecutionStrategy();
+        strategy.Execute(() =>
+        {
+            using var transaction = db.Database.BeginTransaction();
+            var migrator = db.GetService<IMigrator>();
+            migrator.Migrate("Migration1");
+            migrator.Migrate("Migration2");
+
+            var history = db.GetService<IHistoryRepository>();
+            Assert.Collection(
+                history.GetAppliedMigrations(),
+                x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+                x => Assert.Equal("00000000000002_Migration2", x.MigrationId));
+        });
+
+        Assert.Equal(
+            LogLevel.Warning,
+            Fixture.TestSqlLoggerFactory.Log.First(l => l.Id == RelationalEventId.MigrationsUserTransactionWarning).Level);
+    }
+
+    [ConditionalFact]
+    public virtual async Task Can_apply_two_migrations_in_transaction_async()
+    {
+        using var db = Fixture.CreateContext();
+        await db.Database.EnsureDeletedAsync();
+        await GiveMeSomeTimeAsync(db);
+        await db.GetService<IRelationalDatabaseCreator>().CreateAsync();
+
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            using var transaction = db.Database.BeginTransactionAsync();
+            var migrator = db.GetService<IMigrator>();
+            await migrator.MigrateAsync("Migration1");
+            await migrator.MigrateAsync("Migration2");
+
+            var history = db.GetService<IHistoryRepository>();
+            Assert.Collection(
+                await history.GetAppliedMigrationsAsync(),
+                x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+                x => Assert.Equal("00000000000002_Migration2", x.MigrationId));
+        });
+
+        Assert.Equal(
+            LogLevel.Warning,
+            Fixture.TestSqlLoggerFactory.Log.First(l => l.Id == RelationalEventId.MigrationsUserTransactionWarning).Level);
+    }
+
+    [ConditionalFact]
     public virtual async Task Can_generate_no_migration_script()
     {
         using var db = Fixture.CreateEmptyContext();
@@ -549,6 +605,7 @@ public abstract class MigrationsInfrastructureFixtureBase
                 e => e
                     .Log(RelationalEventId.PendingModelChangesWarning)
                     .Log(RelationalEventId.NonTransactionalMigrationOperationWarning)
+                    .Log(RelationalEventId.MigrationsUserTransactionWarning)
             );
 
     protected override bool ShouldLogCategory(string logCategory)

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -122,16 +122,14 @@ public class MigrationCommandExecutorTest
                 Assert.Equal(
                     RelationalStrings.TransactionSuppressedMigrationInUserTransaction,
                     (await Assert.ThrowsAsync<NotSupportedException>(
-                        async ()
-                            => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection))).Message);
+                        async () => await migrationCommandExecutor.ExecuteNonQueryAsync(commandList, fakeConnection))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.TransactionSuppressedMigrationInUserTransaction,
                     Assert.Throws<NotSupportedException>(
-                        ()
-                            => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection)).Message);
+                        () => migrationCommandExecutor.ExecuteNonQuery(commandList, fakeConnection)).Message);
             }
 
             tx.Rollback();

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -1184,8 +1184,8 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
                     b.Property(e => e.ByteArray5)
                         .HasConversion(
                             new ValueConverter<byte[], byte[]>(
-                                v => v.Reverse().Concat(new byte[] { 4, 20 }).ToArray(),
-                                v => v.Reverse().Skip(2).ToArray()),
+                                v => ((IEnumerable<byte>)v).Reverse().Concat(new byte[] { 4, 20 }).ToArray(),
+                                v => ((IEnumerable<byte>)v).Reverse().Skip(2).ToArray()),
                             bytesComparer)
                         .HasMaxLength(7);
 


### PR DESCRIPTION
Fixes #35127
Addresses https://github.com/dotnet/docs-aspire/issues/2151

### Description

When applying migrations the first time to a database EF creates a history table to keep track of the applied migrations.

In EF 9.0 this action was made idempotent to mitigate issues from concurrent applications as for some providers this is done before acquiring an exclusive migrations lock.

However, it was erroneously suppressing transactions.

### Customer impact

When calling `Migrate` in an explicit transaction an exception is thrown. This is common in Aspire scenarios. The workaround is to remove the explicit transaction.

### How found

Multiple customer reports on 9 (5 so far).

### Regression

Yes, from 8.

### Testing

Tests added.

### Risk

Low.