### PR TITLE
[TINY] Fix to #35281 - Migrations: CreateTableBuilder<TColumns> Annotation(string name, object value) should accept object? instead

### DIFF
--- a/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
@@ -178,7 +178,7 @@ public class CreateTableBuilder<TColumns> : OperationBuilder<CreateTableOperatio
     /// <param name="name">The annotation name.</param>
     /// <param name="value">The annotation value.</param>
     /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public new virtual CreateTableBuilder<TColumns> Annotation(string name, object value)
+    public new virtual CreateTableBuilder<TColumns> Annotation(string name, object? value)
         => (CreateTableBuilder<TColumns>)base.Annotation(name, value);
 
     private string[] Map(LambdaExpression columns)

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -10881,7 +10881,7 @@ EXEC(N'ALTER TABLE [Customers] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' +
             })
             .Annotation("SqlServer:IsTemporal", true)
             .Annotation("SqlServer:TemporalHistoryTableName", "CustomersHistory")
-            .Annotation("SqlServer:TemporalHistoryTableSchema", null!)
+            .Annotation("SqlServer:TemporalHistoryTableSchema", null)
             .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
             .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
 


### PR DESCRIPTION
Fixes #35281