### PR TITLE
Fix to #35239 - EF9: SaveChanges() is significantly slower in .NET9 vs. .NET8 when using .ToJson() Mapping vs. PostgreSQL Legacy POCO mapping

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -191,10 +192,10 @@ public class CosmosTypeMappingSource : TypeMappingSource
         var unwrappedType = elementType.UnwrapNullableType();
 
         return (ValueComparer)Activator.CreateInstance(
-            elementType == unwrappedType
-                ? typeof(StringDictionaryComparer<,>).MakeGenericType(dictType, elementType)
-                : typeof(NullableStringDictionaryComparer<,>).MakeGenericType(unwrappedType, dictType),
-            elementMapping.Comparer)!;
+            typeof(StringDictionaryComparer<,>).MakeGenericType(dictType, elementType),
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            elementMapping.Comparer.ComposeConversion(elementType))!;
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 
     // This ensures that the element reader/writers are not null when using Cosmos dictionary type mappings, but

--- a/src/EFCore/ChangeTracking/Internal/ConvertingValueComparer.cs
+++ b/src/EFCore/ChangeTracking/Internal/ConvertingValueComparer.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+
+using static Expression;
+
+/// <summary>
+///     A composable value comparer that accepts a value comparer, and exposes it as a value comparer for a base type.
+///     Used when a collection comparer over e.g. object[] is needed over a specific element type (e.g. int)
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class ConvertingValueComparer<TTo, TFrom> : ValueComparer<TTo>, IInfrastructure<ValueComparer>
+{
+    private readonly ValueComparer<TFrom> _valueComparer;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ConvertingValueComparer(ValueComparer<TFrom> valueComparer)
+        : base(
+            CreateEquals(valueComparer),
+            CreateHashCode(valueComparer),
+            CreateSnapshot(valueComparer))
+        => _valueComparer = valueComparer;
+
+    private static Expression<Func<TTo?, TTo?, bool>> CreateEquals(ValueComparer<TFrom> valueComparer)
+    {
+        var p1 = Parameter(typeof(TTo), "v1");
+        var p2 = Parameter(typeof(TTo), "v2");
+
+        var body = typeof(TTo).IsAssignableFrom(typeof(TFrom))
+            ? valueComparer.EqualsExpression.Body
+            : valueComparer.ExtractEqualsBody(
+                Convert(p1, typeof(TFrom)),
+                Convert(p2, typeof(TFrom)));
+
+        return Lambda<Func<TTo?, TTo?, bool>>(
+            body,
+            p1,
+            p2);
+    }
+
+    private static Expression<Func<TTo, int>> CreateHashCode(ValueComparer<TFrom> valueComparer)
+    {
+        var p = Parameter(typeof(TTo), "v");
+
+        var body = typeof(TTo).IsAssignableFrom(typeof(TFrom))
+            ? valueComparer.HashCodeExpression.Body
+            : valueComparer.ExtractHashCodeBody(
+                Convert(p, typeof(TFrom)));
+
+        return Lambda<Func<TTo, int>>(
+            body,
+            p);
+    }
+
+    private static Expression<Func<TTo, TTo>> CreateSnapshot(ValueComparer<TFrom> valueComparer)
+    {
+        var p = Parameter(typeof(TTo), "v");
+
+        // types must match exactly as we have both covariance and contravariance case here
+        var body = typeof(TTo) == typeof(TFrom)
+            ? valueComparer.SnapshotExpression.Body
+            : Convert(
+                valueComparer.ExtractSnapshotBody(
+                    Convert(p, typeof(TFrom))),
+                typeof(TTo));
+
+        return Lambda<Func<TTo, TTo>>(
+            body,
+            p);
+    }
+
+    ValueComparer IInfrastructure<ValueComparer>.Instance
+        => _valueComparer;
+}

--- a/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
@@ -25,4 +25,34 @@ public static class ValueComparerExtensions
                 : (ValueComparer)Activator.CreateInstance(
                     typeof(NullableValueComparer<>).MakeGenericType(valueComparer.Type),
                     valueComparer)!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static ValueComparer? ComposeConversion(this ValueComparer? valueComparer, Type targetClrType)
+    {
+        if (valueComparer is null || valueComparer.Type == targetClrType)
+        {
+            return valueComparer;
+        }
+
+        if (targetClrType.IsNullableValueType() && valueComparer.Type.IsValueType)
+        {
+            var nonNullableTargetClrType = targetClrType.UnwrapNullableType();
+
+            // we call ComposeConversion to apply ConvertingValueComparer if necessary
+            // for cases where target type and element type differ by nullability AND the base type itself
+            // e.g int? vs long
+            return (ValueComparer)Activator.CreateInstance(
+                typeof(NullableValueComparer<>).MakeGenericType(nonNullableTargetClrType),
+                valueComparer.ComposeConversion(nonNullableTargetClrType))!;
+        }
+
+        return (ValueComparer)Activator.CreateInstance(
+            typeof(ConvertingValueComparer<,>).MakeGenericType(targetClrType, valueComparer.Type),
+            valueComparer)!;
+    }
 }

--- a/src/EFCore/ChangeTracking/ListOfReferenceTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfReferenceTypesComparer.cs
@@ -30,13 +30,13 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
             && typeof(TConcreteList).GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>));
 
     private static readonly MethodInfo CompareMethod = typeof(ListOfReferenceTypesComparer<TConcreteList, TElement>).GetMethod(
-        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(object), typeof(ValueComparer)])!;
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(object), typeof(Func<TElement, TElement, bool>)])!;
 
     private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfReferenceTypesComparer<TConcreteList, TElement>).GetMethod(
-        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable), typeof(ValueComparer)])!;
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable), typeof(Func<TElement, int>)])!;
 
     private static readonly MethodInfo SnapshotMethod = typeof(ListOfReferenceTypesComparer<TConcreteList, TElement>).GetMethod(
-        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(ValueComparer)])!;
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(object), typeof(Func<TElement, TElement>)])!;
 
     /// <summary>
     ///     Creates a new instance of the list comparer.
@@ -62,13 +62,12 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
         var prm1 = Expression.Parameter(typeof(object), "a");
         var prm2 = Expression.Parameter(typeof(object), "b");
 
-        // (a, b) => Compare(a, b, elementComparer)
         return Expression.Lambda<Func<object?, object?, bool>>(
             Expression.Call(
                 CompareMethod,
                 prm1,
                 prm2,
-                elementComparer.ConstructorExpression),
+                elementComparer.EqualsExpression),
             prm1,
             prm2);
     }
@@ -77,14 +76,13 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
     {
         var prm = Expression.Parameter(typeof(object), "o");
 
-        //o => GetHashCode((IEnumerable)o, elementComparer)
         return Expression.Lambda<Func<object, int>>(
             Expression.Call(
                 GetHashCodeMethod,
                 Expression.Convert(
                     prm,
                     typeof(IEnumerable)),
-                elementComparer.ConstructorExpression),
+                elementComparer.HashCodeExpression),
             prm);
     }
 
@@ -92,16 +90,15 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
     {
         var prm = Expression.Parameter(typeof(object), "source");
 
-        //source => Snapshot(source, elementComparer)
         return Expression.Lambda<Func<object, object>>(
             Expression.Call(
                 SnapshotMethod,
                 prm,
-                elementComparer.ConstructorExpression),
+                elementComparer.SnapshotExpression),
             prm);
     }
 
-    private static bool Compare(object? a, object? b, ValueComparer elementComparer)
+    private static bool Compare(object? a, object? b, Func<TElement?, TElement?, bool> elementCompare)
     {
         if (ReferenceEquals(a, b))
         {
@@ -143,7 +140,7 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
                     return false;
                 }
 
-                if (!elementComparer.Equals(el1, el2))
+                if (!elementCompare(el1, el2))
                 {
                     return false;
                 }
@@ -155,29 +152,29 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
         throw new InvalidOperationException(
             CoreStrings.BadListType(
                 (a is IList<TElement?> ? b : a).GetType().ShortDisplayName(),
-                typeof(IList<>).MakeGenericType(elementComparer.Type).ShortDisplayName()));
+                typeof(IList<>).MakeGenericType(typeof(TElement)).ShortDisplayName()));
     }
 
-    private static int GetHashCode(IEnumerable source, ValueComparer elementComparer)
+    private static int GetHashCode(IEnumerable source, Func<TElement?, int> elementGetHashCode)
     {
         var hash = new HashCode();
 
         foreach (var el in source)
         {
-            hash.Add(el == null ? 0 : elementComparer.GetHashCode(el));
+            hash.Add(el == null ? 0 : elementGetHashCode((TElement?)el));
         }
 
         return hash.ToHashCode();
     }
 
-    private static IList<TElement?> Snapshot(object source, ValueComparer elementComparer)
+    private static IList<TElement?> Snapshot(object source, Func<TElement?, TElement?> elementSnapshot)
     {
         if (source is not IList<TElement?> sourceList)
         {
             throw new InvalidOperationException(
                 CoreStrings.BadListType(
                     source.GetType().ShortDisplayName(),
-                    typeof(IList<>).MakeGenericType(elementComparer.Type).ShortDisplayName()));
+                    typeof(IList<>).MakeGenericType(typeof(TElement)).ShortDisplayName()));
         }
 
         if (IsArray)
@@ -186,7 +183,7 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
             for (var i = 0; i < sourceList.Count; i++)
             {
                 var instance = sourceList[i];
-                snapshot[i] = instance == null ? null : (TElement?)elementComparer.Snapshot(instance);
+                snapshot[i] = instance == null ? null : elementSnapshot(instance);
             }
 
             return snapshot;
@@ -196,7 +193,7 @@ public sealed class ListOfReferenceTypesComparer<TConcreteList, TElement> : Valu
             var snapshot = IsReadOnly ? new List<TElement?>() : (IList<TElement?>)Activator.CreateInstance<TConcreteList>()!;
             foreach (var e in sourceList)
             {
-                snapshot.Add(e == null ? null : (TElement?)elementComparer.Snapshot(e));
+                snapshot.Add(e == null ? null : elementSnapshot(e));
             }
 
             return IsReadOnly

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -312,12 +312,6 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
                 : new ValueComparer<T>(favorStructuralComparisons);
     }
 
-    /// <summary>
-    ///     The expression representing construction of this object.
-    /// </summary>
-    [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
-    public abstract Expression ConstructorExpression { get; }
-
     // PublicMethods is required to preserve e.g. GetHashCode
     internal class DefaultValueComparer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T> : ValueComparer<T>
     {

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -372,8 +372,4 @@ public class ValueComparer
     private readonly ConstructorInfo _constructorInfo
         = typeof(ValueComparer<T>).GetConstructor(
             [typeof(Expression<Func<T?, T?, bool>>), typeof(Expression<Func<T, int>>), typeof(Expression<Func<T, T>>)])!;
-
-    /// <inheritdoc />
-    public override Expression ConstructorExpression
-        => New(_constructorInfo, EqualsExpression, HashCodeExpression, SnapshotExpression);
 }

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -174,12 +174,12 @@ public abstract class TypeMappingSourceBase : ITypeMappingSource
                         elementReader);
 
                 elementComparer = (ValueComparer?)Activator.CreateInstance(
-                    elementType.IsNullableValueType() || elementMapping.Comparer.Type.IsNullableValueType()
+                    elementType.IsNullableValueType()
                         ? typeof(ListOfNullableValueTypesComparer<,>).MakeGenericType(typeToInstantiate, elementType.UnwrapNullableType())
                         : elementType.IsValueType
                             ? typeof(ListOfValueTypesComparer<,>).MakeGenericType(typeToInstantiate, elementType)
                             : typeof(ListOfReferenceTypesComparer<,>).MakeGenericType(typeToInstantiate, elementType),
-                    elementMapping.Comparer.ToNullableComparer(elementType)!);
+                    elementMapping.Comparer.ComposeConversion(elementType)!);
 
                 return true;
 

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/Basic_cosmos_model/DataEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/Basic_cosmos_model/DataEntityType.cs
@@ -212,10 +212,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             list.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<List<Dictionary<string, int>>, Dictionary<string, int>>(new StringDictionaryComparer<Dictionary<string, int>, int>(new ValueComparer<int>(
+                comparer: new ListOfReferenceTypesComparer<List<Dictionary<string, int>>, Dictionary<string, int>>(new ConvertingValueComparer<Dictionary<string, int>, object>(new StringDictionaryComparer<Dictionary<string, int>, int>(new ValueComparer<int>(
                     bool (int v1, int v2) => v1 == v2,
                     int (int v) => v,
-                    int (int v) => v))),
+                    int (int v) => v)))),
                 keyComparer: new ValueComparer<List<Dictionary<string, int>>>(
                     bool (List<Dictionary<string, int>> v1, List<Dictionary<string, int>> v2) => object.Equals(v1, v2),
                     int (List<Dictionary<string, int>> v) => ((object)v).GetHashCode(),
@@ -262,10 +262,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             map.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new StringDictionaryComparer<Dictionary<string, string[]>, string[]>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
+                comparer: new StringDictionaryComparer<Dictionary<string, string[]>, string[]>(new ConvertingValueComparer<string[], object>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
                     bool (string v1, string v2) => v1 == v2,
                     int (string v) => ((object)v).GetHashCode(),
-                    string (string v) => v))),
+                    string (string v) => v)))),
                 keyComparer: new ValueComparer<Dictionary<string, string[]>>(
                     bool (Dictionary<string, string[]> v1, Dictionary<string, string[]> v2) => object.Equals(v1, v2),
                     int (Dictionary<string, string[]> v) => ((object)v).GetHashCode(),

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/ManyTypesEntityType.cs
@@ -256,10 +256,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             boolNestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<bool[][], bool[]>(new ListOfValueTypesComparer<bool[], bool>(new ValueComparer<bool>(
+                comparer: new ListOfReferenceTypesComparer<bool[][], bool[]>(new ConvertingValueComparer<bool[], IEnumerable<bool>>(new ListOfValueTypesComparer<bool[], bool>(new ValueComparer<bool>(
                     bool (bool v1, bool v2) => v1 == v2,
                     int (bool v) => ((object)v).GetHashCode(),
-                    bool (bool v) => v))),
+                    bool (bool v) => v)))),
                 keyComparer: new ValueComparer<bool[][]>(
                     bool (bool[][] v1, bool[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (bool[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -786,10 +786,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             charNestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<char[][], char[]>(new ListOfValueTypesComparer<char[], char>(new ValueComparer<char>(
+                comparer: new ListOfReferenceTypesComparer<char[][], char[]>(new ConvertingValueComparer<char[], IEnumerable<char>>(new ListOfValueTypesComparer<char[], char>(new ValueComparer<char>(
                     bool (char v1, char v2) => v1 == v2,
                     int (char v) => ((int)(v)),
-                    char (char v) => v))),
+                    char (char v) => v)))),
                 keyComparer: new ValueComparer<char[][]>(
                     bool (char[][] v1, char[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (char[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -3232,10 +3232,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             int32NestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<int[][], int[]>(new ListOfValueTypesComparer<int[], int>(new ValueComparer<int>(
+                comparer: new ListOfReferenceTypesComparer<int[][], int[]>(new ConvertingValueComparer<int[], IEnumerable<int>>(new ListOfValueTypesComparer<int[], int>(new ValueComparer<int>(
                     bool (int v1, int v2) => v1 == v2,
                     int (int v) => v,
-                    int (int v) => v))),
+                    int (int v) => v)))),
                 keyComparer: new ValueComparer<int[][]>(
                     bool (int[][] v1, int[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (int[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -3466,10 +3466,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             int64NestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<IList<long[]>[], IList<long[]>>(new ListOfReferenceTypesComparer<List<long[]>, long[]>(new ListOfValueTypesComparer<long[], long>(new ValueComparer<long>(
+                comparer: new ListOfReferenceTypesComparer<IList<long[]>[], IList<long[]>>(new ConvertingValueComparer<IList<long[]>, object>(new ListOfReferenceTypesComparer<List<long[]>, long[]>(new ConvertingValueComparer<long[], IEnumerable<long>>(new ListOfValueTypesComparer<long[], long>(new ValueComparer<long>(
                     bool (long v1, long v2) => v1 == v2,
                     int (long v) => ((object)v).GetHashCode(),
-                    long (long v) => v)))),
+                    long (long v) => v)))))),
                 keyComparer: new ValueComparer<IList<long[]>[]>(
                     bool (IList<long[]>[] v1, IList<long[]>[] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (IList<long[]>[] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -3484,10 +3484,10 @@ namespace TestNamespace
                         new JsonCollectionOfStructsReaderWriter<long[], long>(
                             JsonInt64ReaderWriter.Instance))),
                 elementMapping: CosmosTypeMapping.Default.Clone(
-                    comparer: new ListOfReferenceTypesComparer<List<long[]>, long[]>(new ListOfValueTypesComparer<long[], long>(new ValueComparer<long>(
+                    comparer: new ListOfReferenceTypesComparer<List<long[]>, long[]>(new ConvertingValueComparer<long[], IEnumerable<long>>(new ListOfValueTypesComparer<long[], long>(new ValueComparer<long>(
                         bool (long v1, long v2) => v1 == v2,
                         int (long v) => ((object)v).GetHashCode(),
-                        long (long v) => v))),
+                        long (long v) => v)))),
                     keyComparer: new ValueComparer<IList<long[]>>(
                         bool (IList<long[]> v1, IList<long[]> v2) => object.Equals(v1, v2),
                         int (IList<long[]> v) => ((object)v).GetHashCode(),
@@ -3660,10 +3660,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             int8NestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<sbyte[][][], sbyte[][]>(new ListOfReferenceTypesComparer<sbyte[][], sbyte[]>(new ListOfValueTypesComparer<sbyte[], sbyte>(new ValueComparer<sbyte>(
+                comparer: new ListOfReferenceTypesComparer<sbyte[][][], sbyte[][]>(new ConvertingValueComparer<sbyte[][], object>(new ListOfReferenceTypesComparer<sbyte[][], sbyte[]>(new ConvertingValueComparer<sbyte[], IEnumerable<sbyte>>(new ListOfValueTypesComparer<sbyte[], sbyte>(new ValueComparer<sbyte>(
                     bool (sbyte v1, sbyte v2) => v1 == v2,
                     int (sbyte v) => ((int)(v)),
-                    sbyte (sbyte v) => v)))),
+                    sbyte (sbyte v) => v)))))),
                 keyComparer: new ValueComparer<sbyte[][][]>(
                     bool (sbyte[][][] v1, sbyte[][][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (sbyte[][][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -3678,10 +3678,10 @@ namespace TestNamespace
                         new JsonCollectionOfStructsReaderWriter<sbyte[], sbyte>(
                             JsonSByteReaderWriter.Instance))),
                 elementMapping: CosmosTypeMapping.Default.Clone(
-                    comparer: new ListOfReferenceTypesComparer<sbyte[][], sbyte[]>(new ListOfValueTypesComparer<sbyte[], sbyte>(new ValueComparer<sbyte>(
+                    comparer: new ListOfReferenceTypesComparer<sbyte[][], sbyte[]>(new ConvertingValueComparer<sbyte[], IEnumerable<sbyte>>(new ListOfValueTypesComparer<sbyte[], sbyte>(new ValueComparer<sbyte>(
                         bool (sbyte v1, sbyte v2) => v1 == v2,
                         int (sbyte v) => ((int)(v)),
-                        sbyte (sbyte v) => v))),
+                        sbyte (sbyte v) => v)))),
                     keyComparer: new ValueComparer<sbyte[][]>(
                         bool (sbyte[][] v1, sbyte[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                         int (sbyte[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -5681,10 +5681,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             nullableInt32NestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<int?[][], int?[]>(new ListOfNullableValueTypesComparer<int?[], int>(new NullableValueComparer<int>(new ValueComparer<int>(
+                comparer: new ListOfReferenceTypesComparer<int?[][], int?[]>(new ConvertingValueComparer<int?[], IEnumerable<int?>>(new ListOfNullableValueTypesComparer<int?[], int>(new NullableValueComparer<int>(new ValueComparer<int>(
                     bool (int v1, int v2) => v1 == v2,
                     int (int v) => v,
-                    int (int v) => v)))),
+                    int (int v) => v))))),
                 keyComparer: new ValueComparer<int?[][]>(
                     bool (int? [][] v1, int? [][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (int? [][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -5859,10 +5859,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             nullableInt64NestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<List<long?[][]>, long?[][]>(new ListOfReferenceTypesComparer<long?[][], long?[]>(new ListOfNullableValueTypesComparer<long?[], long>(new NullableValueComparer<long>(new ValueComparer<long>(
+                comparer: new ListOfReferenceTypesComparer<List<long?[][]>, long?[][]>(new ConvertingValueComparer<long?[][], object>(new ListOfReferenceTypesComparer<long?[][], long?[]>(new ConvertingValueComparer<long?[], IEnumerable<long?>>(new ListOfNullableValueTypesComparer<long?[], long>(new NullableValueComparer<long>(new ValueComparer<long>(
                     bool (long v1, long v2) => v1 == v2,
                     int (long v) => ((object)v).GetHashCode(),
-                    long (long v) => v))))),
+                    long (long v) => v))))))),
                 keyComparer: new ValueComparer<List<long?[][]>>(
                     bool (List<long? [][]> v1, List<long? [][]> v2) => object.Equals(v1, v2),
                     int (List<long? [][]> v) => ((object)v).GetHashCode(),
@@ -5877,10 +5877,10 @@ namespace TestNamespace
                         new JsonCollectionOfNullableStructsReaderWriter<long?[], long>(
                             JsonInt64ReaderWriter.Instance))),
                 elementMapping: CosmosTypeMapping.Default.Clone(
-                    comparer: new ListOfReferenceTypesComparer<long?[][], long?[]>(new ListOfNullableValueTypesComparer<long?[], long>(new NullableValueComparer<long>(new ValueComparer<long>(
+                    comparer: new ListOfReferenceTypesComparer<long?[][], long?[]>(new ConvertingValueComparer<long?[], IEnumerable<long?>>(new ListOfNullableValueTypesComparer<long?[], long>(new NullableValueComparer<long>(new ValueComparer<long>(
                         bool (long v1, long v2) => v1 == v2,
                         int (long v) => ((object)v).GetHashCode(),
-                        long (long v) => v)))),
+                        long (long v) => v))))),
                     keyComparer: new ValueComparer<long?[][]>(
                         bool (long? [][] v1, long? [][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                         int (long? [][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -6205,10 +6205,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             nullableStringNestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<string[][], string[]>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
+                comparer: new ListOfReferenceTypesComparer<string[][], string[]>(new ConvertingValueComparer<string[], object>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
                     bool (string v1, string v2) => v1 == v2,
                     int (string v) => ((object)v).GetHashCode(),
-                    string (string v) => v))),
+                    string (string v) => v)))),
                 keyComparer: new ValueComparer<string[][]>(
                     bool (string[][] v1, string[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (string[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),
@@ -7077,10 +7077,10 @@ namespace TestNamespace
                 relationshipIndex: -1,
                 storeGenerationIndex: -1);
             stringNestedCollection.TypeMapping = CosmosTypeMapping.Default.Clone(
-                comparer: new ListOfReferenceTypesComparer<string[][], string[]>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
+                comparer: new ListOfReferenceTypesComparer<string[][], string[]>(new ConvertingValueComparer<string[], object>(new ListOfReferenceTypesComparer<string[], string>(new ValueComparer<string>(
                     bool (string v1, string v2) => v1 == v2,
                     int (string v) => ((object)v).GetHashCode(),
-                    string (string v) => v))),
+                    string (string v) => v)))),
                 keyComparer: new ValueComparer<string[][]>(
                     bool (string[][] v1, string[][] v2) => StructuralComparisons.StructuralEqualityComparer.Equals(((object)(v1)), ((object)(v2))),
                     int (string[][] v) => StructuralComparisons.StructuralEqualityComparer.GetHashCode(((object)(v))),


### PR DESCRIPTION
Problem was that as part of AOT refactoring we changed way that we build comparers. Specifically, comparers of collections - ListOfValueTypesComparer, ListOfNullableValueTypesComparer and ListOfReferenceTypesComparer. Before those list comparer Compare, Hashcode and Snapshot methods would take as argument element comparer, which was responsible for comparing elements. We need to be able to express these in code for AOT but we are not able to generate constant of type ValueComparer (or ValueComparer<TElement>) that was needed. As a solution, each comparer now stores expression describing how it can be constructed, so we use that instead (as we are perfectly capable to expressing that in code form). Problem is that now every time compare, snapshot or hashcode method is called for array type, we construct new ValueComparer for the element type. As a result in the reported case we would generate 1000s of comparers which all have to be compiled and that causes huge overhead.

Fix is to pass relevant func from the element comparer to the outer comparer. We only passed the element comparer object to the outer Compare/Hashcode/Snapshot function to call that relevant func. This way we avoid constructing redundant comparers.

Fixes #35239