### PR TITLE
[release/9.0-staging] Don't throw PendingModelChangesWarning when applying a specific migration

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -3,7 +3,6 @@
 
 using System.Transactions;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Internal;
 
@@ -94,7 +93,7 @@ public class Migrator : IMigrator
     public virtual void Migrate(string? targetMigration)
     {
         var useTransaction = _connection.CurrentTransaction is null;
-        ValidateMigrations(useTransaction);
+        ValidateMigrations(useTransaction, targetMigration);
 
         using var transactionScope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
 
@@ -219,7 +218,7 @@ public class Migrator : IMigrator
         CancellationToken cancellationToken = default)
     {
         var useTransaction = _connection.CurrentTransaction is null;
-        ValidateMigrations(useTransaction);
+        ValidateMigrations(useTransaction, targetMigration);
 
         using var transactionScope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
 
@@ -349,7 +348,7 @@ public class Migrator : IMigrator
         }
     }
 
-    private void ValidateMigrations(bool useTransaction)
+    private void ValidateMigrations(bool useTransaction, string? targetMigration)
     {
         if (!useTransaction
             && _executionStrategy.RetriesOnFailure)
@@ -365,7 +364,8 @@ public class Migrator : IMigrator
         {
             _logger.ModelSnapshotNotFound(this, _migrationsAssembly);
         }
-        else if (RelationalResources.LogPendingModelChanges(_logger).WarningBehavior != WarningBehavior.Ignore
+        else if (targetMigration == null
+            && RelationalResources.LogPendingModelChanges(_logger).WarningBehavior != WarningBehavior.Ignore
             && HasPendingModelChanges())
         {
             var modelSource = (ModelSource)_currentContext.Context.GetService<IModelSource>();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -816,8 +816,7 @@ GO
         {
             using var context = new BloggingContext(
                 Fixture.TestStore.AddProviderOptions(
-                        new DbContextOptionsBuilder().EnableServiceProviderCaching(false))
-                    .ConfigureWarnings(e => e.Log(RelationalEventId.PendingModelChangesWarning)).Options);
+                        new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options);
 
             context.Database.EnsureDeleted();
             GiveMeSomeTime(context);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerFixture.cs
@@ -26,7 +26,6 @@ public class JsonQueryJsonTypeSqlServerFixture : JsonQuerySqlServerFixture
             b =>
             {
                 b.OwnsOne(x => x.OwnedReferenceRoot).ToJson("json_reference_custom_naming").HasColumnType("json");
-                ;
                 b.OwnsMany(x => x.OwnedCollectionRoot).HasColumnType("json").ToJson("json_collection_custom_naming");
             });
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/35342
Port of https://github.com/dotnet/efcore/pull/35343
Improvement of https://github.com/dotnet/efcore/pull/35221

**Description**

In 9.0 we added a runtime warning that would throw by default when updating the database if there are any changes detected in the model that aren't reflected in the latest migration.

However, when applying a specific migration this warning is not relevant and could be confusing.

**Customer impact**

The workaround is to ignore the warning using options.

**How found**

Customer report on 9, part of a large stream of feedback around this warning.

**Regression**

Yes, from 8.

**Testing**

Test added

**Risk**

Low.