### PR TITLE
[release/9.0-staging] Fix to #35239 - EF9: SaveChanges() is significantly slower in .NET9 vs. .NET8 when using .ToJson() Mapping vs. PostgreSQL Legacy POCO mapping

### DIFF
--- a/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfNullableValueTypesComparer.cs
@@ -25,6 +25,9 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
     IInfrastructure<ValueComparer>
     where TElement : struct
 {
+    private static readonly bool UseOldBehavior35239 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35239", out var enabled35239) && enabled35239;
+
     private static readonly bool IsArray = typeof(TConcreteList).IsArray;
 
     private static readonly bool IsReadOnly = IsArray
@@ -33,13 +36,25 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
 
     private static readonly MethodInfo CompareMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic,
+        [typeof(IEnumerable<TElement?>), typeof(IEnumerable<TElement?>), typeof(Func<TElement?, TElement?, bool>)])!;
+
+    private static readonly MethodInfo LegacyCompareMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic,
         [typeof(IEnumerable<TElement?>), typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
 
     private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic,
+        [typeof(IEnumerable<TElement?>), typeof(Func<TElement?, int>)])!;
+
+    private static readonly MethodInfo LegacyGetHashCodeMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic,
         [typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
 
     private static readonly MethodInfo SnapshotMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic,
+        [typeof(IEnumerable<TElement?>), typeof(Func<TElement?, TElement?>)])!;
+
+    private static readonly MethodInfo LegacySnapshotMethod = typeof(ListOfNullableValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic,
         [typeof(IEnumerable<TElement?>), typeof(ValueComparer<TElement?>)])!;
 
@@ -67,10 +82,23 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
         var prm1 = Expression.Parameter(typeof(IEnumerable<TElement?>), "a");
         var prm2 = Expression.Parameter(typeof(IEnumerable<TElement?>), "b");
 
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //(a, b) => Compare(a, b, elementComparer.Equals)
+            return Expression.Lambda<Func<IEnumerable<TElement?>?, IEnumerable<TElement?>?, bool>>(
+                Expression.Call(
+                    CompareMethod,
+                    prm1,
+                    prm2,
+                    elementComparer.EqualsExpression),
+                prm1,
+                prm2);
+        }
+
         //(a, b) => Compare(a, b, (ValueComparer<TElement?>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement?>?, IEnumerable<TElement?>?, bool>>(
             Expression.Call(
-                CompareMethod,
+                LegacyCompareMethod,
                 prm1,
                 prm2,
                 Expression.Convert(
@@ -84,10 +112,21 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
     {
         var prm = Expression.Parameter(typeof(IEnumerable<TElement?>), "o");
 
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //o => GetHashCode(o, elementComparer.GetHashCode)
+            return Expression.Lambda<Func<IEnumerable<TElement?>, int>>(
+            Expression.Call(
+                GetHashCodeMethod,
+                prm,
+                elementComparer.HashCodeExpression),
+            prm);
+        }
+
         //o => GetHashCode(o, (ValueComparer<TElement?>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement?>, int>>(
             Expression.Call(
-                GetHashCodeMethod,
+                LegacyGetHashCodeMethod,
                 prm,
                 Expression.Convert(
                     elementComparer.ConstructorExpression,
@@ -98,16 +137,83 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
     private static Expression<Func<IEnumerable<TElement?>, IEnumerable<TElement?>>> SnapshotLambda(ValueComparer elementComparer)
     {
         var prm = Expression.Parameter(typeof(IEnumerable<TElement?>), "source");
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //source => Snapshot(source, elementComparer.Snapshot)
+            return Expression.Lambda<Func<IEnumerable<TElement?>, IEnumerable<TElement?>>>(
+            Expression.Call(
+                SnapshotMethod,
+                prm,
+                elementComparer.SnapshotExpression),
+            prm);
+        }
 
         //source => Snapshot(source, (ValueComparer<TElement?>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement?>, IEnumerable<TElement?>>>(
             Expression.Call(
-                SnapshotMethod,
+                LegacySnapshotMethod,
                 prm,
                 Expression.Convert(
                     elementComparer.ConstructorExpression,
                     typeof(ValueComparer<TElement?>))),
             prm);
+    }
+
+    private static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, Func<TElement?, TElement?, bool> elementCompare)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a is null)
+        {
+            return b is null;
+        }
+
+        if (b is null)
+        {
+            return false;
+        }
+
+        if (a is IList<TElement?> aList && b is IList<TElement?> bList)
+        {
+            if (aList.Count != bList.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < aList.Count; i++)
+            {
+                var (el1, el2) = (aList[i], bList[i]);
+                if (el1 is null)
+                {
+                    if (el2 is null)
+                    {
+                        continue;
+                    }
+
+                    return false;
+                }
+
+                if (el2 is null)
+                {
+                    return false;
+                }
+
+                if (!elementCompare(el1, el2))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        throw new InvalidOperationException(
+            CoreStrings.BadListType(
+                (a is IList<TElement?> ? b : a).GetType().ShortDisplayName(),
+                typeof(IList<>).MakeGenericType(typeof(TElement).MakeNullable()).ShortDisplayName()));
     }
 
     private static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
@@ -167,6 +273,18 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
                 typeof(IList<>).MakeGenericType(elementComparer.Type.MakeNullable()).ShortDisplayName()));
     }
 
+    private static int GetHashCode(IEnumerable<TElement?> source, Func<TElement?, int> elementGetHashCode)
+    {
+        var hash = new HashCode();
+
+        foreach (var el in source)
+        {
+            hash.Add(el == null ? 0 : elementGetHashCode(el));
+        }
+
+        return hash.ToHashCode();
+    }
+
     private static int GetHashCode(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)
     {
         var hash = new HashCode();
@@ -177,6 +295,41 @@ public sealed class ListOfNullableValueTypesComparer<TConcreteList, TElement> : 
         }
 
         return hash.ToHashCode();
+    }
+
+    private static IList<TElement?> Snapshot(IEnumerable<TElement?> source, Func<TElement?, TElement?> elementSnapshot)
+    {
+        if (source is not IList<TElement?> sourceList)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.BadListType(
+                    source.GetType().ShortDisplayName(),
+                    typeof(IList<>).MakeGenericType(typeof(TElement).MakeNullable()).ShortDisplayName()));
+        }
+
+        if (IsArray)
+        {
+            var snapshot = new TElement?[sourceList.Count];
+            for (var i = 0; i < sourceList.Count; i++)
+            {
+                var instance = sourceList[i];
+                snapshot[i] = instance == null ? null : elementSnapshot(instance);
+            }
+
+            return snapshot;
+        }
+        else
+        {
+            var snapshot = IsReadOnly ? new List<TElement?>() : (IList<TElement?>)Activator.CreateInstance<TConcreteList>()!;
+            foreach (var e in sourceList)
+            {
+                snapshot.Add(e == null ? null : elementSnapshot(e));
+            }
+
+            return IsReadOnly
+                ? (IList<TElement?>)Activator.CreateInstance(typeof(TConcreteList), snapshot)!
+                : snapshot;
+        }
     }
 
     private static IList<TElement?> Snapshot(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)

--- a/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
+++ b/src/EFCore/ChangeTracking/ListOfValueTypesComparer.cs
@@ -23,6 +23,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueComparer<IEnumerable<TElement>>, IInfrastructure<ValueComparer>
     where TElement : struct
 {
+    private static readonly bool UseOldBehavior35239 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35239", out var enabled35239) && enabled35239;
+
     private static readonly bool IsArray = typeof(TConcreteList).IsArray;
 
     private static readonly bool IsReadOnly = IsArray
@@ -31,13 +34,24 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
 
     private static readonly MethodInfo CompareMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic,
+        [typeof(IEnumerable<TElement>), typeof(IEnumerable<TElement>), typeof(Func<TElement, TElement, bool>)])!;
+
+    private static readonly MethodInfo LegacyCompareMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(Compare), BindingFlags.Static | BindingFlags.NonPublic,
         [typeof(IEnumerable<TElement>), typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
 
     private static readonly MethodInfo GetHashCodeMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic,
+        [typeof(IEnumerable<TElement>), typeof(Func<TElement, int>)])!;
+
+    private static readonly MethodInfo LegacyGetHashCodeMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(GetHashCode), BindingFlags.Static | BindingFlags.NonPublic,
         [typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
 
     private static readonly MethodInfo SnapshotMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
+        nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement>), typeof(Func<TElement, TElement>)])!;
+
+    private static readonly MethodInfo LegacySnapshotMethod = typeof(ListOfValueTypesComparer<TConcreteList, TElement>).GetMethod(
         nameof(Snapshot), BindingFlags.Static | BindingFlags.NonPublic, [typeof(IEnumerable<TElement>), typeof(ValueComparer<TElement>)])!;
 
     /// <summary>
@@ -64,10 +78,23 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
         var prm1 = Expression.Parameter(typeof(IEnumerable<TElement>), "a");
         var prm2 = Expression.Parameter(typeof(IEnumerable<TElement>), "b");
 
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //(a, b) => Compare(a, b, elementComparer.Equals)
+            return Expression.Lambda<Func<IEnumerable<TElement>?, IEnumerable<TElement>?, bool>>(
+                Expression.Call(
+                    CompareMethod,
+                    prm1,
+                    prm2,
+                    elementComparer.EqualsExpression),
+                prm1,
+                prm2);
+        }
+
         //(a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement>?, IEnumerable<TElement>?, bool>>(
             Expression.Call(
-                CompareMethod,
+                LegacyCompareMethod,
                 prm1,
                 prm2,
                 Expression.Convert(
@@ -81,10 +108,21 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
     {
         var prm = Expression.Parameter(typeof(IEnumerable<TElement>), "o");
 
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //o => GetHashCode(o, elementComparer.GetHashCode)
+            return Expression.Lambda<Func<IEnumerable<TElement>, int>>(
+            Expression.Call(
+                GetHashCodeMethod,
+                prm,
+                elementComparer.HashCodeExpression),
+            prm);
+        }
+
         //o => GetHashCode(o, (ValueComparer<TElement>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement>, int>>(
             Expression.Call(
-                GetHashCodeMethod,
+                LegacyGetHashCodeMethod,
                 prm,
                 Expression.Convert(
                     elementComparer.ConstructorExpression,
@@ -96,15 +134,68 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
     {
         var prm = Expression.Parameter(typeof(IEnumerable<TElement>), "source");
 
+        if (elementComparer is ValueComparer<TElement> && !UseOldBehavior35239)
+        {
+            //source => Snapshot(source, elementComparer.SnapShot)
+            return Expression.Lambda<Func<IEnumerable<TElement>, IEnumerable<TElement>>>(
+            Expression.Call(
+                SnapshotMethod,
+                prm,
+                elementComparer.SnapshotExpression),
+            prm);
+        }
+
         //source => Snapshot(source, (ValueComparer<TElement>)elementComparer)
         return Expression.Lambda<Func<IEnumerable<TElement>, IEnumerable<TElement>>>(
             Expression.Call(
-                SnapshotMethod,
+                LegacySnapshotMethod,
                 prm,
                 Expression.Convert(
                     elementComparer.ConstructorExpression,
                     typeof(ValueComparer<TElement>))),
             prm);
+    }
+
+    private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, Func<TElement, TElement, bool> elementCompare)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a is null)
+        {
+            return b is null;
+        }
+
+        if (b is null)
+        {
+            return false;
+        }
+
+        if (a is IList<TElement> aList && b is IList<TElement> bList)
+        {
+            if (aList.Count != bList.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < aList.Count; i++)
+            {
+                var (el1, el2) = (aList[i], bList[i]);
+                if (!elementCompare(el1, el2))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        throw new InvalidOperationException(
+            CoreStrings.BadListType(
+                (a is IList<TElement?> ? b : a).GetType().ShortDisplayName(),
+                typeof(IList<>).MakeGenericType(typeof(TElement)).ShortDisplayName()));
     }
 
     private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
@@ -149,6 +240,18 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
                 typeof(IList<>).MakeGenericType(elementComparer.Type).ShortDisplayName()));
     }
 
+    private static int GetHashCode(IEnumerable<TElement> source, Func<TElement, int> elementGetHashCode)
+    {
+        var hash = new HashCode();
+
+        foreach (var el in source)
+        {
+            hash.Add(elementGetHashCode(el));
+        }
+
+        return hash.ToHashCode();
+    }
+
     private static int GetHashCode(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
     {
         var hash = new HashCode();
@@ -159,6 +262,41 @@ public sealed class ListOfValueTypesComparer<TConcreteList, TElement> : ValueCom
         }
 
         return hash.ToHashCode();
+    }
+
+    private static IList<TElement> Snapshot(IEnumerable<TElement> source, Func<TElement, TElement> elementSnapshot)
+    {
+        if (source is not IList<TElement> sourceList)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.BadListType(
+                    source.GetType().ShortDisplayName(),
+                    typeof(IList<>).MakeGenericType(typeof(TElement).MakeNullable()).ShortDisplayName()));
+        }
+
+        if (IsArray)
+        {
+            var snapshot = new TElement[sourceList.Count];
+            for (var i = 0; i < sourceList.Count; i++)
+            {
+                var instance = sourceList[i];
+                snapshot[i] = elementSnapshot(instance);
+            }
+
+            return snapshot;
+        }
+        else
+        {
+            var snapshot = IsReadOnly ? new List<TElement>() : (IList<TElement>)Activator.CreateInstance<TConcreteList>()!;
+            foreach (var e in sourceList)
+            {
+                snapshot.Add(elementSnapshot(e));
+            }
+
+            return IsReadOnly
+                ? (IList<TElement>)Activator.CreateInstance(typeof(TConcreteList), snapshot)!
+                : snapshot;
+        }
     }
 
     private static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)


### PR DESCRIPTION
Fixes #35239
Safer version of https://github.com/dotnet/efcore/pull/35326

**Description**

EF9 introduced a change in how we construct ValueComparers for some of our types (specifically collection of scalars/references), in preparation for AOT work. The way the change was implemented may cause a severe performance regression during SaveChanges operation involving multiple entities using collections of primitives (one of our highly requested features). 

**Customer impact**

Customers performing data manipulation operations on entities with collections of primitives may experience significant performance regressions. This may also happen when no data has been changed, but sufficiently large entity graph has been loaded into change tracker. There is no workaround for this issue, apart from changing the model to not use primitive collections (which is unacceptable for majority of customers)

**How found**

Multiple customer reports on EF 9

**Regression**

Yes, from EF8. Note: this is a perf regression only, not a functional regression.

**Testing**

Ad hoc performance test using BenchmarkDotNet. Functional testing already covered by existing tests.

**Risk**

Low. The patch fix has been limited in scope to reduce the risk. Changes should only affect models with primitive collections. Added quirks just to be sure.

**Perf numbers**

Over 20x regression between 8 and 9 for the tested scenario. 

8.0.11

| Method          | Mean     | Error   | StdDev  |
|---------------- |---------:|--------:|--------:|
| SaveChangesTest | 172.1 ms | 1.78 ms | 1.58 ms |


9.0

| Method          | Mean    | Error    | StdDev   |
|---------------- |--------:|---------:|---------:|
| SaveChangesTest | 5.487 s | 0.0621 s | 0.0551 s |


9.0.2 (with fix)

| Method          | Mean     | Error   | StdDev  |
|---------------- |---------:|--------:|--------:|
| SaveChangesTest | 179.8 ms | 1.71 ms | 1.43 ms |
