### PR TITLE
Stop discovering relationships if the target entity type becomes shared

### DIFF
--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -1299,17 +1299,24 @@ public class RelationshipDiscoveryConvention :
             if (ambiguityRemoved)
             {
                 DiscoverRelationships(entityType.Builder, context);
+
+                if (!navigationBuilder.Metadata.IsInModel)
+                {
+                    context.StopProcessing();
+                    return;
+                }
             }
 
             if (targetAmbiguityRemoved)
             {
                 DiscoverRelationships(targetEntityType.Builder, context);
-            }
-        }
 
-        if (!navigationBuilder.Metadata.IsInModel)
-        {
-            context.StopProcessing();
+                if (!navigationBuilder.Metadata.IsInModel)
+                {
+                    context.StopProcessing();
+                    return;
+                }
+            }
         }
     }
 

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -131,7 +131,8 @@ public class ForeignKey : ConventionAnnotatable, IMutableForeignKey, IConvention
     /// </summary>
     public virtual bool IsInModel
         => _builder is not null
-            && DeclaringEntityType.IsInModel;
+            && DeclaringEntityType.IsInModel
+            && PrincipalEntityType.IsInModel;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
@@ -1893,15 +1893,26 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
-        public virtual void Inheritance_where_base_has_multiple_owned_types_works()
+        public virtual void Can_have_multiple_owned_types_on_base()
         {
             var modelBuilder = CreateModelBuilder();
-            modelBuilder.Entity<BaseOwner>();
+            modelBuilder.Entity<BaseOwner>().OwnsOne(o => o.OwnedWithRef1);
             modelBuilder.Entity<DerivedOwner>();
 
             var model = modelBuilder.FinalizeModel();
 
-            Assert.Equal(4, model.GetEntityTypes().Count());
+            Assert.Equal(6, model.GetEntityTypes().Count());
+            var owner = model.FindEntityType(typeof(BaseOwner));
+
+            var ownership1 = owner.FindNavigation(nameof(BaseOwner.Owned1)).ForeignKey;
+            var owned1 = ownership1.DeclaringEntityType;
+            Assert.True(ownership1.IsOwnership);
+            Assert.Same(owner, ownership1.PrincipalEntityType);
+
+            var ownership3 = owner.FindNavigation(nameof(BaseOwner.OwnedWithRef1)).ForeignKey;
+            var owned3 = ownership3.DeclaringEntityType;
+            Assert.True(ownership3.IsOwnership);
+            Assert.Same(owner, ownership3.DependentToPrincipal.TargetEntityType);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.TestModel.cs
@@ -852,22 +852,26 @@ public abstract partial class ModelBuilderTest
     protected class BaseOwner
     {
         public int Id { get; set; }
-        public required OwnedTypeInheritance1 Owned1 { get; set; }
-        public required OwnedTypeInheritance2 Owned2 { get; set; }
+        public OwnedTypeInheritance Owned1 { get; set; } = null!;
+        public OwnedTypeInheritance Owned2 { get; set; } = null!;
+        public OwnedTypeInheritanceWithReference OwnedWithRef1 { get; set; } = null!;
+        public OwnedTypeInheritanceWithReference OwnedWithRef2 { get; set; } = null!;
     }
 
     protected class DerivedOwner : BaseOwner;
 
     [Owned]
-    protected class OwnedTypeInheritance1
+    protected class OwnedTypeInheritance
     {
         public string? Value { get; set; }
     }
 
     [Owned]
-    protected class OwnedTypeInheritance2
+    protected class OwnedTypeInheritanceWithReference
     {
         public string? Value { get; set; }
+        public int OwnerId { get; set; }
+        public BaseOwner? Owner { get; set; }
     }
 
     protected interface IReplaceable


### PR DESCRIPTION
They will be discovered when the convention runs again for the newly added shared type

Fixes #35346