### PR TITLE
Change ExecuteUpdate to accept Action instead of Func parameter

### DIFF
--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -743,7 +743,7 @@ namespace System.Runtime.CompilerServices
 
                         ExpressionTreeFuncletizer.PathNode? evaluatableRootPaths;
 
-                        // ExecuteUpdate requires really special handling: the function accepts a Func<SetPropertyCalls...> argument, but
+                        // ExecuteUpdate requires really special handling: the function accepts a Func<UpdateSettersBuilder...> argument, but
                         // we need to run funcletization on the setter lambdas added via that Func<>.
                         if (operatorMethodCall.Method is
                             {
@@ -753,7 +753,7 @@ namespace System.Runtime.CompilerServices
                             }
                             && operatorMethodCall.Method.DeclaringType == typeof(EntityFrameworkQueryableExtensions))
                         {
-                            // First, statically convert the Func<SetPropertyCalls...> to a NewArrayExpression which represents all the
+                            // First, statically convert the Action<UpdateSettersBuilder> to a NewArrayExpression which represents all the
                             // setters; since that's an expression, we can run the funcletizer on it.
                             var settersExpression = ProcessExecuteUpdate(operatorMethodCall);
                             evaluatableRootPaths = _funcletizer.CalculatePathsToEvaluatableRoots(settersExpression);
@@ -767,8 +767,11 @@ namespace System.Runtime.CompilerServices
                             // If there were captured variables, generate code to evaluate and build the same NewArrayExpression at runtime,
                             // and then fall through to the normal logic, generating variable extractors against that NewArrayExpression
                             // (local var) instead of against the method argument.
-                            code.AppendLine(
-                                $"var setters = {parameterName}(new SetPropertyCalls<{sourceElementTypeName}>()).BuildSettersExpression();");
+                            code.AppendLine($"""
+                                             var setterBuilder = new UpdateSettersBuilder<{sourceElementTypeName}>();
+                                             {parameterName}(setterBuilder);
+                                             var setters = setterBuilder.BuildSettersExpression();
+                                             """);
                             parameterName = "setters";
                             parameterType = typeof(NewArrayExpression);
                         }
@@ -1114,7 +1117,7 @@ namespace System.Runtime.CompilerServices
                 => RewriteToSync(
                     typeof(EntityFrameworkQueryableExtensions).GetMethod(nameof(EntityFrameworkQueryableExtensions.ExecuteDelete))),
 
-            // ExecuteUpdate is special; it accepts a non-expression-tree argument (Func<SetPropertyCalls, SetPropertyCalls>),
+            // ExecuteUpdate is special; it accepts a non-expression-tree argument (Action<UpdateSettersBuilder>),
             // evaluates it immediately, and injects a different MethodCall node into the expression tree with the resulting setter
             // expressions.
             // When statically analyzing ExecuteUpdate, we have to manually perform the same thing.
@@ -1159,11 +1162,11 @@ namespace System.Runtime.CompilerServices
         }
     }
 
-    // Accepts an expression tree representing a series of SetProperty() calls, parses them and passes them through the SetPropertyCalls
-    // builder; returns the resulting NewArrayExpression representing all the setters.
+    // Accepts an expression tree representing a series of SetProperty() calls, parses them and passes them through the
+    // UpdateSettersBuilder; returns the resulting NewArrayExpression representing all the setters.
     private static NewArrayExpression ProcessExecuteUpdate(MethodCallExpression executeUpdateCall)
     {
-        var setPropertyCalls = Activator.CreateInstance<UpdateSettersBuilder>();
+        var settersBuilder = new UpdateSettersBuilder();
         var settersLambda = (LambdaExpression)executeUpdateCall.Arguments[1];
         var settersParameter = settersLambda.Parameters.Single();
         var expression = settersLambda.Body;
@@ -1192,11 +1195,11 @@ namespace System.Runtime.CompilerServices
                         Operand: LambdaExpression unwrappedValueSelector
                     })
                 {
-                    setPropertyCalls.SetProperty(propertySelector, unwrappedValueSelector);
+                    settersBuilder.SetProperty(propertySelector, unwrappedValueSelector);
                 }
                 else
                 {
-                    setPropertyCalls.SetProperty(propertySelector, valueSelector);
+                    settersBuilder.SetProperty(propertySelector, valueSelector);
                 }
 
                 expression = methodCallExpression.Object;
@@ -1206,7 +1209,7 @@ namespace System.Runtime.CompilerServices
             throw new InvalidOperationException(RelationalStrings.InvalidArgumentToExecuteUpdate);
         }
 
-        return setPropertyCalls.BuildSettersExpression();
+        return settersBuilder.BuildSettersExpression();
     }
 
     /// <summary>

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -1163,7 +1163,7 @@ namespace System.Runtime.CompilerServices
     // builder; returns the resulting NewArrayExpression representing all the setters.
     private static NewArrayExpression ProcessExecuteUpdate(MethodCallExpression executeUpdateCall)
     {
-        var setPropertyCalls = Activator.CreateInstance<SetPropertyCalls>();
+        var setPropertyCalls = Activator.CreateInstance<UpdateSettersBuilder>();
         var settersLambda = (LambdaExpression)executeUpdateCall.Arguments[1];
         var settersParameter = settersLambda.Parameters.Single();
         var expression = settersLambda.Body;
@@ -1175,7 +1175,7 @@ namespace System.Runtime.CompilerServices
                     Method:
                     {
                         IsGenericMethod: true,
-                        Name: nameof(SetPropertyCalls<int>.SetProperty),
+                        Name: nameof(UpdateSettersBuilder<int>.SetProperty),
                         DeclaringType.IsGenericType: true,
                     },
                     Arguments:
@@ -1184,7 +1184,7 @@ namespace System.Runtime.CompilerServices
                         Expression valueSelector
                     ]
                 } methodCallExpression
-                && methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(SetPropertyCalls<>))
+                && methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(UpdateSettersBuilder<>))
             {
                 if (valueSelector is UnaryExpression
                     {

--- a/src/EFCore.Relational/Properties/TypeForwards.cs
+++ b/src/EFCore.Relational/Properties/TypeForwards.cs
@@ -6,4 +6,4 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(AttributeCodeFragment))]
 [assembly: TypeForwardedTo(typeof(MethodCallCodeFragment))]
 [assembly: TypeForwardedTo(typeof(NestedClosureCodeFragment))]
-[assembly: TypeForwardedTo(typeof(SetPropertyCalls<>))]
+[assembly: TypeForwardedTo(typeof(UpdateSettersBuilder<>))]

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -181,7 +181,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
                             var valueSelector = @new.Arguments[1];
 
                             // When the value selector is a bare value type (no lambda), a cast-to-object Convert node needs to be added
-                            // for proper typing (see SetPropertyCalls); remove it here.
+                            // for proper typing (see UpdateSettersBuilder); remove it here.
                             if (valueSelector is UnaryExpression { NodeType: ExpressionType.Convert, Operand: var unwrappedValueSelector }
                                 && valueSelector.Type == typeof(object))
                             {

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -1078,7 +1078,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
     /// <summary>
     ///     Translates
     ///     <see
-    ///         cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Func{SetPropertyCalls{TSource}, SetPropertyCalls{TSource}})" />
+    ///         cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Action{UpdateSettersBuilder{TSource}})" />
     ///     method
     ///     over the given source.
     /// </summary>
@@ -1086,7 +1086,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
     /// <param name="setters">
     ///     The setters for this
     ///     <see
-    ///         cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Func{SetPropertyCalls{TSource}, SetPropertyCalls{TSource}})" />
+    ///         cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Action{UpdateSettersBuilder{TSource}})" />
     ///     call.
     /// </param>
     /// <returns>The non query after translation.</returns>
@@ -1097,7 +1097,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
 
     /// <summary>
     ///     Represents a single setter in an
-    ///     <see cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Func{SetPropertyCalls{TSource}, SetPropertyCalls{TSource}})" />
+    ///     <see cref="EntityFrameworkQueryableExtensions.ExecuteUpdate{TSource}(IQueryable{TSource}, Action{UpdateSettersBuilder{TSource}})" />
     ///     call, i.e. a pair of property and value selectors.
     /// </summary>
     public sealed record ExecuteUpdateSetter(LambdaExpression PropertySelector, Expression ValueExpression);

--- a/src/EFCore/Query/SetPropertyCalls`.cs
+++ b/src/EFCore/Query/SetPropertyCalls`.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <inheritdoc />
-public sealed class SetPropertyCalls<TSource> : SetPropertyCalls
+public sealed class UpdateSettersBuilder<TSource> : UpdateSettersBuilder
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -13,7 +13,7 @@ public sealed class SetPropertyCalls<TSource> : SetPropertyCalls
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public SetPropertyCalls()
+    public UpdateSettersBuilder()
     {
     }
 
@@ -25,10 +25,10 @@ public sealed class SetPropertyCalls<TSource> : SetPropertyCalls
     /// <param name="valueExpression">A value expression.</param>
     /// <returns>
     ///     The same instance so that multiple calls to
-    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, Expression{Func{TSource, TProperty}})" />
+    ///     <see cref="UpdateSettersBuilder{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, Expression{Func{TSource, TProperty}})" />
     ///     can be chained.
     /// </returns>
-    public SetPropertyCalls<TSource> SetProperty<TProperty>(
+    public UpdateSettersBuilder<TSource> SetProperty<TProperty>(
         Expression<Func<TSource, TProperty>> propertyExpression,
         Expression<Func<TSource, TProperty>> valueExpression)
     {
@@ -44,9 +44,9 @@ public sealed class SetPropertyCalls<TSource> : SetPropertyCalls
     /// <param name="valueExpression">A value expression.</param>
     /// <returns>
     ///     The same instance so that multiple calls to
-    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, TProperty)" /> can be chained.
+    ///     <see cref="UpdateSettersBuilder{TSource}.SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, TProperty)" /> can be chained.
     /// </returns>
-    public SetPropertyCalls<TSource> SetProperty<TProperty>(
+    public UpdateSettersBuilder<TSource> SetProperty<TProperty>(
         Expression<Func<TSource, TProperty>> propertyExpression,
         TProperty valueExpression)
     {

--- a/src/EFCore/Query/UpdateSettersBuilder.cs
+++ b/src/EFCore/Query/UpdateSettersBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
-public class SetPropertyCalls
+public class UpdateSettersBuilder
 {
     private readonly List<NewExpression> _setters = new();
 
@@ -42,7 +42,7 @@ public class SetPropertyCalls
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual SetPropertyCalls SetProperty(LambdaExpression propertyExpression, LambdaExpression valueExpression)
+    public virtual UpdateSettersBuilder SetProperty(LambdaExpression propertyExpression, LambdaExpression valueExpression)
     {
         _setters.Add(
             Expression.New(
@@ -60,7 +60,7 @@ public class SetPropertyCalls
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual SetPropertyCalls SetProperty(LambdaExpression propertyExpression, Expression valueExpression)
+    public virtual UpdateSettersBuilder SetProperty(LambdaExpression propertyExpression, Expression valueExpression)
     {
         if (valueExpression.Type.IsValueType)
         {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
@@ -34,7 +34,7 @@ public class BulkUpdatesAsserter(IBulkUpdatesFixtureBase queryFixture, Func<Expr
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
+        Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter)
         where TResult : class

--- a/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
@@ -33,7 +33,7 @@ public abstract class BulkUpdatesTestBase<TFixture> : IClassFixture<TFixture>
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
+        Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter = null)
         where TResult : class

--- a/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -321,7 +321,7 @@ public abstract class NonSharedModelBulkUpdatesTestBase : NonSharedModelTestBase
         bool async,
         Func<TContext> contextCreator,
         Func<TContext, IQueryable<TResult>> query,
-        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
+        Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount)
         where TResult : class
         where TContext : DbContext

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -43,7 +43,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             async,
             ss => ss.Set<OrderDetail>().Where(od => od.OrderID < 10250),
             e => e,
-            s => s,
+            _ => { },
             rowsAffectedCount: 0);
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
@@ -35,7 +35,7 @@ public class BulkUpdatesAsserter(IBulkUpdatesFixtureBase queryFixture, Func<Expr
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TEntity>> entitySelector,
-        Func<SetPropertyCalls<TResult>, SetPropertyCalls<TResult>> setPropertyCalls,
+        Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount,
         Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter)
         where TResult : class


### PR DESCRIPTION
This is a small follow-up to #35257, so part of #32018 (/cc @AndriySvyryd).

This changes ExecuteUpdateAsync to accept an Action instead of a Func, following @aradalvand's suggestion [here](https://github.com/dotnet/efcore/issues/32018#issuecomment-1826889783). This improves the developer experience further, removing the need to have a `return` at the end of the provided lambda. This required some non-trivial changes to CSharpToLinqTranslator, since ExecuteUpdateAsync now expects an `Action<UpdateSettersBuilder>` parameter, but the translated lambda type was currently determined by the body, and so was `Func<UpdateSettersBuilder, UpdateSettersBuilder>`.

This also renames the oddly-named SetPropertyCalls to UpdateSettersBuilder, which better expresses what that type really is (it really is just a builder, which accumulates setter lambda pairs). This is technically an additional breaking change, but any scenario in which SetPropertyCalls was explicitly referenced is already broken by #35257 - so this rename shouldn't in itself affect anyone.

