### PR TITLE
Fix hashing of `IList` constants in `SqlConstantExpression`

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
@@ -127,5 +127,5 @@ public class SqlConstantExpression : SqlExpression
 
     /// <inheritdoc />
     public override int GetHashCode()
-        => HashCode.Combine(base.GetHashCode(), Value);
+        => HashCode.Combine(base.GetHashCode(), Value is IList list ? list.Count : Value);
 }

--- a/test/EFCore.Relational.Tests/Query/SqlExpressions/SqlConstantExpressionTest.cs
+++ b/test/EFCore.Relational.Tests/Query/SqlExpressions/SqlConstantExpressionTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class SqlConstantExpressionTest
+{
+    [Fact]
+    public void Equals_of_IList_uses_deep_equality()
+    {
+        int[] x = [1, 2, 3];
+
+        var a = new SqlConstantExpression(new[] { x.ToList() }, null);
+        var b = new SqlConstantExpression(new[] { x.ToList() }, null);
+
+        Assert.True(a.Equals(b));
+    }
+
+    [Fact]
+    public void GetHashCode_of_IList_is_consistent_with_Equals()
+    {
+        int[] x = [1, 2, 3];
+
+        var a = new SqlConstantExpression(x.ToList(), null);
+        var b = new SqlConstantExpression(x.ToList(), null);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+}


### PR DESCRIPTION
Since the `Equals` method performs deep comparison of `IList` values, using their `GetHashCode` directly is generally not valid.
Instead, their `Count` is a safe approximation.

Fixes #35372