### PR TITLE
Enhance GetETagPropertyName method to handle ETag lookup in both entity and base types

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -276,7 +276,9 @@ public static class CosmosEntityTypeExtensions
     /// <param name="entityType">The entity type to get the etag property name for.</param>
     /// <returns>The name of the etag property.</returns>
     public static string? GetETagPropertyName(this IReadOnlyEntityType entityType)
-        => entityType[CosmosAnnotationNames.ETagName] as string;
+        => entityType[CosmosAnnotationNames.ETagName] as string
+            ?? entityType.BaseType?.GetETagPropertyName()
+            ?? null;
 
     /// <summary>
     ///     Sets the name of the property that is used to store the ETag key.


### PR DESCRIPTION
Enhance GetETagPropertyName method to handle ETag lookup in both entity and base types

- Added test to cover this scenario and ensure proper functionality

Fixes #35336 

Please check whether the PR fulfills these requirements

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

