### PR TITLE
[release/9.0-staging] Make SnapshotModelProcessor idempotent.

### DIFF
--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -52,7 +52,9 @@ public class SnapshotModelProcessor : ISnapshotModelProcessor
     /// </summary>
     public virtual IModel? Process(IReadOnlyModel? model, bool resetVersion = false)
     {
-        if (model == null)
+        if (model == null
+            || model is not Model mutableModel
+            || mutableModel.IsReadOnly)
         {
             return null;
         }
@@ -79,13 +81,10 @@ public class SnapshotModelProcessor : ISnapshotModelProcessor
             }
         }
 
-        if (model is IMutableModel mutableModel)
+        mutableModel.RemoveAnnotation("ChangeDetector.SkipDetectChanges");
+        if (resetVersion)
         {
-            mutableModel.RemoveAnnotation("ChangeDetector.SkipDetectChanges");
-            if (resetVersion)
-            {
-                mutableModel.SetProductVersion(ProductInfo.GetVersion());
-            }
+            mutableModel.SetProductVersion(ProductInfo.GetVersion());
         }
 
         return _modelRuntimeInitializer.Initialize((IModel)model, designTime: true, validationLogger: null);

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -43,7 +43,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             var reporter = new TestOperationReporter();
 
-            new SnapshotModelProcessor(reporter, DummyModelRuntimeInitializer.Instance).Process(model);
+            var processor = new SnapshotModelProcessor(reporter, DummyModelRuntimeInitializer.Instance);
+            processor.Process(model);
 
             AssertAnnotations(model);
             AssertAnnotations(entityType);
@@ -53,6 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             AssertAnnotations(nav1);
             AssertAnnotations(nav2);
             AssertAnnotations(index);
+
+            Assert.Same(model, processor.Process(model));
 
             Assert.Empty(reporter.Messages);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/35146
Port of #35432

### Description
Each EF migration contains a snapshot of the model at the time the migration was created. The snapshots might have been created by an older version of EF, so we need to run them through `SnapshotModelProcessor` to make them conform to the current version of EF.

### Customer impact
In EF9 we changed the way model snapshots are handled to avoid initializing them again. However, when several certain migrations management operations are called in succession this could lead to the snapshots to be processed several times, which will result in an exception most of the times. The workaround is to avoid calling the operations in the same process, but this is not always possible.

### How found
Multiple customer reports on 9.0.0

### Regression
Yes, from 8.0.

### Testing
Test added.

### Risk
Low, this only affects design-time code.