### PR TITLE
Remove OSX.13.ARM64.Open Helix queue from PR CI

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -151,7 +151,7 @@ stages:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
-                value: Windows.10.Amd64.Open;OSX.13.Amd64.Open;OSX.13.ARM64.Open;Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-sqlserver-amd64
+                value: Windows.10.Amd64.Open;OSX.13.Amd64.Open;Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-sqlserver-amd64
               - name: _HelixAccessToken
                 value: '' # Needed for public queues
             steps:


### PR DESCRIPTION
To avoid timeouts and reduce run time. It will still be tested against in internal runs.