### PR TITLE
Make NativeAOT tests buildable again.

### DIFF
--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -5,6 +5,8 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>{RuntimeIdentifier}</RuntimeIdentifier>
     <PublishAot>{PublishAot}</PublishAot>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <NoWarn>$(NoWarn);NU1903;NU1904</NoWarn>
     <_ExtraTrimmerArgs>{ExtraTrimmerArgs} $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
     {AdditionalProperties}
   </PropertyGroup>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -77,12 +77,24 @@
       </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'@(PackageReference)' != ''">
-      <_packageReferences Include="@(PackageReference)" Exclude="Microsoft.DotNet.ILCompiler;Microsoft.NET.ILLink.Tasks" />
+    <ItemGroup>
+      <PackageReferenceWithRealVersionCross Include="@(PackageReference)">
+        <Identity2>%(PackageVersion.Identity)</Identity2>
+        <RealVersion>%(PackageVersion.Version)</RealVersion>
+      </PackageReferenceWithRealVersionCross>
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReferenceWithRealVersion Include="@(PackageReferenceWithRealVersionCross)" KeepMetadata="Version;PrivateAssets" Condition="'%(PackageReferenceWithRealVersionCross.Identity)' == '%(PackageReferenceWithRealVersionCross.Identity2)'">
+        <Version>%(PackageReferenceWithRealVersionCross.RealVersion)</Version>
+      </PackageReferenceWithRealVersion>
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(PackageReferenceWithRealVersion)' != ''">
+      <_packageReferences Include="@(PackageReferenceWithRealVersion)" Exclude="Microsoft.DotNet.ILCompiler;Microsoft.NET.ILLink.Tasks" />
     </ItemGroup>
 
     <ItemGroup Condition="'@(_packageReferences)' != ''">
-      <_additionalPackageReference Include="&lt;PackageReference Include=&quot;%(_packageReferences.Identity)&quot; Version=&quot;%(_packageReferences.Version)&quot; &gt; &#xA;        &lt;PrivateAssets&gt;%(_packageReferences.PrivateAssets)&lt;/PrivateAssets&gt;&#xA;    &lt;/PackageReference&gt;" />
+      <_additionalPackageReference Include="&lt;PackageReference Include=&quot;%(_packageReferences.Identity)&quot; Version=&quot;%(_packageReferences.Version)&quot;&gt;&#xA;        &lt;PrivateAssets&gt;%(_packageReferences.PrivateAssets)&lt;/PrivateAssets&gt;&#xA;    &lt;/PackageReference&gt;" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -84,6 +84,7 @@
       </PackageReferenceWithRealVersionCross>
     </ItemGroup>
     <ItemGroup>
+      <!-- PackageReferenceWithRealVersionCross contains cartesian product, because in MSBuild we can't index into collection, and this will filter proper items, besically doing inner join manually. -->
       <PackageReferenceWithRealVersion Include="@(PackageReferenceWithRealVersionCross)" KeepMetadata="Version;PrivateAssets" Condition="'%(PackageReferenceWithRealVersionCross.Identity)' == '%(PackageReferenceWithRealVersionCross.Identity2)'">
         <Version>%(PackageReferenceWithRealVersionCross.RealVersion)</Version>
       </PackageReferenceWithRealVersion>


### PR DESCRIPTION
This PR makes sure that our NativeAOT tests can be execute again. 

With the switch to CPM, the generated csproj was not right. This changes the logic to not use CPM (to not have collisions with global packages) and explicitly take the versions from `PackageVersion` (with a little bit of MSBuild dance) which gets constructed during the (first) build. With this correct csproj gets generated.