### PR TITLE
SQLite: implement MAX/MIN/ORDER BY for `decimal`

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -133,24 +133,28 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         LambdaExpression keySelector,
         bool ascending)
     {
-        var translation = base.TranslateOrderBy(source, keySelector, ascending);
+        var translation = TranslateLambdaExpression(source, keySelector);
         if (translation == null)
         {
             return null;
         }
 
-        var orderingExpression = ((SelectExpression)translation.QueryExpression).Orderings.Last();
-        var orderingExpressionType = GetProviderType(orderingExpression.Expression);
+        var orderingExpressionType = GetProviderType(translation);
         if (orderingExpressionType == typeof(DateTimeOffset)
-            || orderingExpressionType == typeof(decimal)
             || orderingExpressionType == typeof(TimeSpan)
             || orderingExpressionType == typeof(ulong))
         {
             throw new NotSupportedException(
                 SqliteStrings.OrderByNotSupported(orderingExpressionType.ShortDisplayName()));
         }
+        else if (orderingExpressionType == typeof(decimal))
+        {
+            translation = new CollateExpression(translation, "EF_DECIMAL");
+        }
 
-        return translation;
+        ((SelectExpression)source.QueryExpression).ApplyOrdering(new OrderingExpression(translation, ascending));
+
+        return source;
     }
 
     /// <summary>
@@ -164,24 +168,28 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         LambdaExpression keySelector,
         bool ascending)
     {
-        var translation = base.TranslateThenBy(source, keySelector, ascending);
+        var translation = TranslateLambdaExpression(source, keySelector);
         if (translation == null)
         {
             return null;
         }
 
-        var orderingExpression = ((SelectExpression)translation.QueryExpression).Orderings.Last();
-        var orderingExpressionType = GetProviderType(orderingExpression.Expression);
+        var orderingExpressionType = GetProviderType(translation);
         if (orderingExpressionType == typeof(DateTimeOffset)
-            || orderingExpressionType == typeof(decimal)
             || orderingExpressionType == typeof(TimeSpan)
             || orderingExpressionType == typeof(ulong))
         {
             throw new NotSupportedException(
                 SqliteStrings.OrderByNotSupported(orderingExpressionType.ShortDisplayName()));
         }
+        else if (orderingExpressionType == typeof(decimal))
+        {
+            translation = new CollateExpression(translation, "EF_DECIMAL");
+        }
 
-        return translation;
+        ((SelectExpression)source.QueryExpression).AppendOrdering(new OrderingExpression(translation, ascending));
+
+        return source;
     }
 
     /// <summary>
@@ -467,9 +475,9 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
                 Tables:
                 [
                     TableValuedFunctionExpression
-                    {
-                        Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var jsonArrayColumn]
-                    } jsonEachExpression
+                {
+                    Name: "json_each", Schema: null, IsBuiltIn: true, Arguments: [var jsonArrayColumn]
+                } jsonEachExpression
                 ],
                 Predicate: null,
                 GroupBy: [],
@@ -529,16 +537,16 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
     protected override bool IsNaturallyOrdered(SelectExpression selectExpression)
     {
         return selectExpression is
-            {
-                Tables: [var mainTable, ..],
-                Orderings:
+        {
+            Tables: [var mainTable, ..],
+            Orderings:
                 [
-                    {
-                        Expression: ColumnExpression { Name: JsonEachKeyColumnName } orderingColumn,
-                        IsAscending: true
-                    }
+                {
+                    Expression: ColumnExpression { Name: JsonEachKeyColumnName } orderingColumn,
+                    IsAscending: true
+                }
                 ]
-            }
+        }
             && orderingColumn.TableAlias == mainTable.Alias
             && IsJsonEachKeyColumn(selectExpression, orderingColumn);
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
@@ -70,12 +70,22 @@ public class SqliteQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     && source.Selector is SqlExpression maxSqlExpression:
                     var maxArgumentType = GetProviderType(maxSqlExpression);
                     if (maxArgumentType == typeof(DateTimeOffset)
-                        || maxArgumentType == typeof(decimal)
                         || maxArgumentType == typeof(TimeSpan)
                         || maxArgumentType == typeof(ulong))
                     {
                         throw new NotSupportedException(
                             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), maxArgumentType.ShortDisplayName()));
+                    }
+                    else if (maxArgumentType == typeof(decimal))
+                    {
+                        maxSqlExpression = CombineTerms(source, maxSqlExpression);
+                        return _sqlExpressionFactory.Function(
+                            "ef_max",
+                            [maxSqlExpression],
+                            nullable: true,
+                            argumentsPropagateNullability: [false],
+                            maxSqlExpression.Type,
+                            maxSqlExpression.TypeMapping);
                     }
 
                     break;
@@ -86,12 +96,22 @@ public class SqliteQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     && source.Selector is SqlExpression minSqlExpression:
                     var minArgumentType = GetProviderType(minSqlExpression);
                     if (minArgumentType == typeof(DateTimeOffset)
-                        || minArgumentType == typeof(decimal)
                         || minArgumentType == typeof(TimeSpan)
                         || minArgumentType == typeof(ulong))
                     {
                         throw new NotSupportedException(
                             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), minArgumentType.ShortDisplayName()));
+                    }
+                    else if (minArgumentType == typeof(decimal))
+                    {
+                        minSqlExpression = CombineTerms(source, minSqlExpression);
+                        return _sqlExpressionFactory.Function(
+                            "ef_min",
+                            [minSqlExpression],
+                            nullable: true,
+                            argumentsPropagateNullability: [false],
+                            minSqlExpression.Type,
+                            minSqlExpression.TypeMapping);
                     }
 
                     break;

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -179,6 +179,10 @@ public class SqliteRelationalConnection : RelationalConnection, ISqliteRelationa
                         ? value
                         : sum.Value + value.Value,
                 isDeterministic: true);
+
+            sqliteConnection.CreateCollation(
+                "EF_DECIMAL",
+                (x, y) => decimal.Compare(decimal.Parse(x), decimal.Parse(y)));
         }
         else
         {

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -155,6 +155,22 @@ public class SqliteRelationalConnection : RelationalConnection, ISqliteRelationa
                 isDeterministic: true);
 
             sqliteConnection.CreateAggregate(
+                "ef_max",
+                seed: null,
+                (decimal? max, decimal? value) => max is null
+                    ? value
+                    : value is null ? max : decimal.Max(max.Value, value.Value),
+                isDeterministic: true);
+
+            sqliteConnection.CreateAggregate(
+                "ef_min",
+                seed: null,
+                (decimal? min, decimal? value) => min is null
+                    ? value
+                    : value is null ? min : decimal.Min(min.Value, value.Value),
+                isDeterministic: true);
+
+            sqliteConnection.CreateAggregate(
                 "ef_sum",
                 seed: null,
                 (decimal? sum, decimal? value) => value is null

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1401,12 +1401,6 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
 
         var ex = Assert.Throws<NotSupportedException>(
             () => query
-                .OrderBy(e => e.TestNullableDecimal)
-                .First());
-        Assert.Equal(SqliteStrings.OrderByNotSupported("decimal"), ex.Message);
-
-        ex = Assert.Throws<NotSupportedException>(
-            () => query
                 .OrderBy(e => e.TestNullableDateTimeOffset)
                 .First());
         Assert.Equal(SqliteStrings.OrderByNotSupported("DateTimeOffset"), ex.Message);
@@ -1458,12 +1452,6 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
 
         var ex = Assert.Throws<NotSupportedException>(
             () => query
-                .ThenBy(e => e.TestNullableDecimal)
-                .First());
-        Assert.Equal(SqliteStrings.OrderByNotSupported("decimal"), ex.Message);
-
-        ex = Assert.Throws<NotSupportedException>(
-            () => query
                 .ThenBy(e => e.TestNullableDateTimeOffset)
                 .First());
         Assert.Equal(SqliteStrings.OrderByNotSupported("DateTimeOffset"), ex.Message);
@@ -1479,6 +1467,119 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
                 .ThenBy(e => e.TestNullableUnsignedInt64)
                 .First());
         Assert.Equal(SqliteStrings.OrderByNotSupported("ulong"), ex.Message);
+    }
+
+
+    [ConditionalFact]
+    public virtual void Can_query_OrderBy_of_converted_types()
+    {
+        using var context = CreateContext();
+        var min = new BuiltInNullableDataTypes
+        {
+            Id = 221,
+            PartitionId = 207,
+            TestNullableDecimal = 2.000000000000001m,
+            TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+            TestNullableTimeSpan = TimeSpan.FromDays(2),
+            TestNullableUnsignedInt64 = 0
+        };
+        context.Add(min);
+
+        var max = new BuiltInNullableDataTypes
+        {
+            Id = 222,
+            PartitionId = 207,
+            TestNullableDecimal = 10.000000000000001m,
+            TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+            TestNullableTimeSpan = TimeSpan.FromDays(10),
+            TestNullableUnsignedInt64 = long.MaxValue + 1ul
+        };
+        context.Add(max);
+
+        context.SaveChanges();
+
+        Fixture.TestSqlLoggerFactory.Clear();
+
+        var query = context.Set<BuiltInNullableDataTypes>()
+            .Where(e => e.PartitionId == 207);
+
+        var results = query
+            .OrderBy(e => e.TestNullableDecimal)
+            .Select(e => e.Id)
+            .First();
+
+        AssertSql(
+            """
+SELECT "b"."Id"
+FROM "BuiltInNullableDataTypes" AS "b"
+WHERE "b"."PartitionId" = 207
+ORDER BY "b"."TestNullableDecimal" COLLATE EF_DECIMAL
+LIMIT 1
+""");
+
+        var expectedResults = query.AsEnumerable()
+            .OrderBy(e => e.TestNullableDecimal)
+            .Select(e => e.Id)
+            .First();
+
+        Assert.Equal(expectedResults, results);
+    }
+
+    [ConditionalFact]
+    public virtual void Can_query_ThenBy_of_converted_types()
+    {
+        using var context = CreateContext();
+        var min = new BuiltInNullableDataTypes
+        {
+            Id = 223,
+            PartitionId = 208,
+            TestNullableDecimal = 2.000000000000001m,
+            TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+            TestNullableTimeSpan = TimeSpan.FromDays(2),
+            TestNullableUnsignedInt64 = 0
+        };
+        context.Add(min);
+
+        var max = new BuiltInNullableDataTypes
+        {
+            Id = 224,
+            PartitionId = 208,
+            TestNullableDecimal = 10.000000000000001m,
+            TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+            TestNullableTimeSpan = TimeSpan.FromDays(10),
+            TestNullableUnsignedInt64 = long.MaxValue + 1ul
+        };
+        context.Add(max);
+
+        context.SaveChanges();
+
+        Fixture.TestSqlLoggerFactory.Clear();
+
+        var query = context.Set<BuiltInNullableDataTypes>()
+            .Where(e => e.PartitionId == 208);
+
+        var results = query
+            .OrderBy(e => e.PartitionId)
+            .ThenBy(e => e.TestNullableDecimal)
+            .Select(e => e.Id)
+            .First();
+
+        AssertSql(
+            """
+SELECT "b"."Id"
+FROM "BuiltInNullableDataTypes" AS "b"
+WHERE "b"."PartitionId" = 208
+ORDER BY "b"."PartitionId", "b"."TestNullableDecimal" COLLATE EF_DECIMAL
+LIMIT 1
+""");
+
+        var expectedResults = query.AsEnumerable()
+            .OrderBy(e => e.PartitionId)
+            .ThenBy(e => e.TestNullableDecimal)
+            .Select(e => e.Id)
+            .First();
+
+        Assert.Equal(expectedResults, results);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -862,10 +862,7 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
             .Where(e => e.PartitionId == 200)
             .GroupBy(_ => true);
 
-        Assert.Equal(
-            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), typeof(decimal).ShortDisplayName()),
-            Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Min(e => e.TestNullableDecimal)).ToList()).Message);
+        Assert.Equal(2.000000000000001m, query.Select(g => g.Min(e => e.TestNullableDecimal)).Single());
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), typeof(DateTimeOffset).ShortDisplayName()),
@@ -915,10 +912,7 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
             .Where(e => e.PartitionId == 201)
             .GroupBy(_ => true);
 
-        Assert.Equal(
-            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), typeof(decimal).ShortDisplayName()),
-            Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Max(e => e.TestNullableDecimal)).ToList()).Message);
+        Assert.Equal(10.000000000000001m, query.Select(g => g.Max(e => e.TestNullableDecimal)).Single());
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), typeof(DateTimeOffset).ShortDisplayName()),

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -29,16 +29,28 @@ GROUP BY "p"."Category"
     }
 
     public override async Task Max_Grouped_from_LINQ_101(bool async)
-        => Assert.Equal(
-            SqliteStrings.AggregateOperationNotSupported("Max", "decimal"),
-            (await Assert.ThrowsAsync<NotSupportedException>(
-                () => base.Max_Grouped_from_LINQ_101(async))).Message);
+    {
+        await base.Max_Grouped_from_LINQ_101(async);
+
+        AssertSql(
+            """
+SELECT "p"."Category", ef_max("p"."UnitPrice") AS "MostExpensivePrice"
+FROM "ProductForLinq" AS "p"
+GROUP BY "p"."Category"
+""");
+    }
 
     public override async Task Min_Grouped_from_LINQ_101(bool async)
-        => Assert.Equal(
-            SqliteStrings.AggregateOperationNotSupported("Min", "decimal"),
-            (await Assert.ThrowsAsync<NotSupportedException>(
-                () => base.Min_Grouped_from_LINQ_101(async))).Message);
+    {
+        await base.Min_Grouped_from_LINQ_101(async);
+
+        AssertSql(
+            """
+SELECT "p"."Category", ef_min("p"."UnitPrice") AS "CheapestPrice"
+FROM "ProductForLinq" AS "p"
+GROUP BY "p"."Category"
+""");
+    }
 
     public override async Task Whats_new_2021_sample_3(bool async)
         => await base.Whats_new_2021_sample_3(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -28,7 +28,7 @@ public class NorthwindFunctionsQuerySqliteTest : NorthwindFunctionsQueryRelation
             """
 SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
 FROM "Order Details" AS "o"
-WHERE "o"."UnitPrice" < 7.0 AND 10 < "o"."ProductID"
+WHERE ef_compare("o"."UnitPrice", '7.0') < 0 AND 10 < "o"."ProductID"
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQuerySqliteFixture.cs
@@ -13,15 +13,6 @@ public class NorthwindQuerySqliteFixture<TModelCustomizer> : NorthwindQueryRelat
     protected override ITestStoreFactory TestStoreFactory
         => SqliteNorthwindTestStoreFactory.Instance;
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
-    {
-        base.OnModelCreating(modelBuilder, context);
-
-        // NB: SQLite doesn't support decimal very well. Using double instead
-        modelBuilder.Entity<OrderDetail>().Property(o => o.UnitPrice).HasConversion<double>();
-        modelBuilder.Entity<Product>().Property(o => o.UnitPrice).HasConversion<double?>();
-    }
-
     protected override Type ContextType
         => typeof(NorthwindSqliteContext);
 }


### PR DESCRIPTION
Fixes #19635.