### PR TITLE
Improve LoadExtension to work correctly with dotnet run and lib* named libs

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Data.Sqlite
 
             if (string.IsNullOrEmpty(searchDirs))
             {
-                return Array.Empty<string>();
+                return [];
             }
 
             return searchDirs!.Split([ Path.PathSeparator ], StringSplitOptions.RemoveEmptyEntries);

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Data.Sqlite
         private static readonly StateChangeEventArgs _fromClosedToOpenEventArgs = new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open);
         private static readonly StateChangeEventArgs _fromOpenToClosedEventArgs = new StateChangeEventArgs(ConnectionState.Open, ConnectionState.Closed);
 
+        private static string[]? NativeDllSearchDirectories;
+
         static SqliteConnection()
         {
             Type.GetType("SQLitePCL.Batteries_V2, SQLitePCLRaw.batteries_v2")
@@ -624,11 +626,71 @@ namespace Microsoft.Data.Sqlite
 
         private void LoadExtensionCore(string file, string? proc)
         {
-            var rc = sqlite3_load_extension(Handle, utf8z.FromString(file), utf8z.FromString(proc), out var errmsg);
-            if (rc != SQLITE_OK)
+            SqliteException? firstException = null;
+            foreach (var path in GetLoadExtensionPaths(file))
             {
-                throw new SqliteException(Resources.SqliteNativeError(rc, errmsg.utf8_to_string()), rc, rc);
+                var rc = sqlite3_load_extension(Handle, utf8z.FromString(path), utf8z.FromString(proc), out var errmsg);
+                if (rc == SQLITE_OK)
+                {
+                    return;
+                }
+
+                if (firstException == null)
+                {
+                    // We store the first exception so that error message looks more obvious if file appears in there
+                    firstException = new SqliteException(Resources.SqliteNativeError(rc, errmsg.utf8_to_string()), rc, rc);
+                }
             }
+
+            if (firstException != null)
+            {
+                throw firstException;
+            }
+        }
+
+        private static IEnumerable<string> GetLoadExtensionPaths(string file)
+        {
+            // we always try original input first
+            yield return file;
+
+            string? dirName = Path.GetDirectoryName(file);
+
+            // we don't try to guess directories for user, if they pass a path either absolute or relative - they're on their own
+            if (!string.IsNullOrEmpty(dirName))
+            {
+                yield break;
+            }
+
+            bool shouldTryAddingLibPrefix = !file.StartsWith("lib", StringComparison.Ordinal) && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            if (shouldTryAddingLibPrefix)
+            {
+                yield return $"lib{file}";
+            }
+
+            NativeDllSearchDirectories ??= GetNativeDllSearchDirectories();
+
+            foreach (string dir in NativeDllSearchDirectories)
+            {
+                yield return Path.Combine(dir, file);
+
+                if (shouldTryAddingLibPrefix)
+                {
+                    yield return Path.Combine(dir, $"lib{file}");
+                }
+            }
+        }
+
+        private static string[] GetNativeDllSearchDirectories()
+        {
+            string? searchDirs = AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES") as string;
+
+            if (string.IsNullOrEmpty(searchDirs))
+            {
+                return Array.Empty<string>();
+            }
+
+            return searchDirs!.Split([ Path.PathSeparator ], StringSplitOptions.RemoveEmptyEntries);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently if you package an SQLite extension in the nuget package by placing binaries in the `runtimes/<rid>/native` the extension will work fine when you do `dotnet run -r <rid>` but when using just `dotnet run` it won't pick up the dll because they end up in different directory than an app. Currently host uses property `NATIVE_DLL_SEARCH_DIRECTORIES` to provide all paths where native dlls should be searched for but SQLite doesn't know about its existence. In normal scenario of just loading library this will happen automatically but since SQLite doesn't use that logic we need to account for it so this scenario works correctly.

I've also added searching for libraries with `lib` prefixes because I noticed #24094 - please let me know if we don't want this (SQLite will only make sure correct extension is used for all OSes but it won't take care of the `lib` prefix).

Might also fix this but I haven't tested android: https://github.com/dotnet/efcore/issues/24094