### PR TITLE
Update System.Runtime.CompilerServices.Unsafe to 6.1.1 conditionally

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,7 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-maintenance-packages-3b65679f" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-3b65679f/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,6 +32,13 @@
     <SystemFormatsAsn1Version>10.0.0-preview.2.25102.2</SystemFormatsAsn1Version>
     <SystemRuntimeCachingVersion>10.0.0-preview.2.25102.2</SystemRuntimeCachingVersion>
   </PropertyGroup>
+  <!-- The maintenance-packages dependency versions need to be conditionally selected: https://github.com/dotnet/sdk/issues/45155 -->
+  <PropertyGroup Label="Dependencies from dotnet/maintenance-packages (build-source-only)" Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.1</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Dependencies from dotnet/maintenance-packages (not build-source-only)" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/arcade">
     <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.25067.3</MicrosoftDotNetBuildTasksTemplatingVersion>
   </PropertyGroup>


### PR DESCRIPTION
This PR is result of testing the parallel dependency updates to ensure source-build does not break: https://github.com/dotnet/dotnet/pull/133

IMPORTANT: I need to merge this PR at the same time as all the other PRs in the other repos, to prevent breaking the dependency ingestion in the dotnet/sdk repo.