### PR TITLE
Navigation test refactoring initial work

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -34,17 +34,6 @@ WHERE (c["Discriminator"] = "Basic")
 """);
             });
 
-    public override async Task Basic_json_projection_owned_collection_branch(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            //issue #31696
-            await Assert.ThrowsAsync<NullReferenceException>(
-                () => base.Basic_json_projection_owned_collection_branch(async));
-        }
-    }
-
     public override async Task Basic_json_projection_owned_collection_branch_NoTrackingWithIdentityResolution(bool async)
     {
         // Always throws for sync.
@@ -67,21 +56,6 @@ WHERE (c["Discriminator"] = "Basic")
         }
     }
 
-    public override Task Basic_json_projection_owned_collection_root(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owned_collection_root(a);
-
-                // TODO: issue #34067 (?)
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
     public override Task Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -89,20 +63,6 @@ WHERE (c["Discriminator"] = "Basic")
                 await base.Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(a);
 
                 // TODO: issue #34067 (?)
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owned_reference_branch(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owned_reference_branch(async);
-
                 AssertSql(
                     """
 SELECT VALUE c
@@ -122,36 +82,6 @@ WHERE (c["Discriminator"] = "Basic")
 SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owned_reference_duplicated(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owned_reference_duplicated(async);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-ORDER BY c["Id"]
-""");
-            });
-
-    public override Task Basic_json_projection_owned_reference_duplicated2(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owned_reference_duplicated2(async);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-ORDER BY c["Id"]
 """);
             });
 
@@ -199,21 +129,6 @@ WHERE (c["Discriminator"] = "Basic")
 """);
             });
 
-    public override Task Basic_json_projection_owned_reference_root(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owned_reference_root(a);
-
-                // TODO: issue #34067 (?)
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
     public override Task Basic_json_projection_owned_reference_root_NoTrackingWithIdentityResolution(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -226,48 +141,6 @@ WHERE (c["Discriminator"] = "Basic")
 SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owner_entity(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owner_entity_duplicated(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity_duplicated(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity_duplicated_NoTracking(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "SingleOwned")
 """);
             });
 
@@ -285,53 +158,11 @@ WHERE (c["Discriminator"] = "SingleOwned")
 """);
             });
 
-    public override Task Basic_json_projection_owner_entity_NoTracking(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity_NoTracking(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
     public override Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
             {
                 await base.Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owner_entity_twice(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity_twice(a);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
-    public override Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Basic_json_projection_owner_entity_twice_NoTracking(a);
 
                 AssertSql(
                     """
@@ -1151,16 +982,6 @@ WHERE (c["Discriminator"] = "Basic")
             () => base.Json_collection_OrderByDescending_Skip_ElementAt(async),
             CosmosStrings.LimitOffsetNotSupportedInSubqueries + Environment.NewLine + CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
-    [ConditionalTheory(Skip = "issue #34349")]
-    public override Task Json_collection_SelectMany(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_collection_SelectMany(a);
-
-                AssertSql("");
-            });
-
     [ConditionalTheory(Skip = "issue #34335")]
     public override Task Json_collection_Select_entity_collection_ElementAt(bool async)
         => base.Json_collection_Select_entity_collection_ElementAt(async);
@@ -1323,16 +1144,6 @@ WHERE (c["$type"] IN ("JsonEntityInheritanceBase", "JsonEntityInheritanceDerived
     public override Task Json_nested_collection_filter_in_projection(bool async)
         => AssertTranslationFailed(
             () => base.Json_nested_collection_filter_in_projection(async));
-
-    [ConditionalTheory(Skip = "issue #34349")]
-    public override Task Json_nested_collection_SelectMany(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_nested_collection_SelectMany(a);
-
-                AssertSql("");
-            });
 
     public override Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
         => Fixture.NoSyncTest(
@@ -2098,30 +1909,6 @@ WHERE (c["Discriminator"] = "Basic")
                     async),
             CosmosStrings.LimitOffsetNotSupportedInSubqueries);
 
-    [ConditionalTheory(Skip = "issue #34350")]
-    public override Task Json_projection_with_deduplication(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_projection_with_deduplication(a);
-
-                AssertSql("");
-            });
-
-    public override Task Json_projection_with_deduplication_reverse_order(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_projection_with_deduplication_reverse_order(async);
-
-                AssertSql(
-                    """
-SELECT VALUE c
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-""");
-            });
-
     public override Task Json_property_in_predicate(bool async)
         => Fixture.NoSyncTest(
             async, async a =>
@@ -2313,22 +2100,6 @@ FROM root c
 WHERE (c["Discriminator"] = "SingleOwned")
 """);
             });
-
-    public override Task Project_json_entity_FirstOrDefault_subquery(bool async)
-        => AssertTranslationFailed(
-            () => base.Project_json_entity_FirstOrDefault_subquery(async));
-
-    public override Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
-        => AssertTranslationFailed(
-            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication(async));
-
-    public override Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
-        => AssertTranslationFailed(
-            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async));
-
-    public override Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
-        => AssertTranslationFailed(
-            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async));
 
     public override Task Project_json_entity_FirstOrDefault_subquery_with_binding_on_top(bool async)
         => AssertTranslationFailed(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryCosmosTest.cs
@@ -1,0 +1,317 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class JsonRelationshipsInProjectionNoTrackingQueryCosmosTest : JsonRelationshipsInProjectionQueryTestBase<JsonRelationshipsQueryCosmosFixture>
+{
+    private readonly NoTrackingRewriter _noTrackingRewriter = new();
+
+    public JsonRelationshipsInProjectionNoTrackingQueryCosmosTest(JsonRelationshipsQueryCosmosFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        var rewritten = _noTrackingRewriter.Visit(serverQueryExpression);
+
+        return rewritten;
+    }
+
+    public override Task Project_root(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_root(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+""");
+            });
+
+    public override Task Project_trunk_optional(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_trunk_optional(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_trunk_required(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_trunk_required(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_trunk_collection(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_trunk_collection(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_branch_required_required(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_branch_required_required(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_branch_required_optional(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_branch_required_optional(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        if (async)
+        {
+            //issue #31696
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => base.Project_branch_required_collection(async));
+
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+        }
+    }
+
+    public override Task Project_branch_optional_required(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_branch_optional_required(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override Task Project_branch_optional_optional(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_branch_optional_optional(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+            });
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        if (async)
+        {
+            //issue #31696
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => base.Project_branch_optional_collection(async));
+
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+        }
+    }
+
+    public override async Task Project_branch_collection_element_using_indexer_constant(bool async)
+    {
+        if (async)
+        {
+            //issue #31696
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => base.Project_branch_collection_element_using_indexer_constant(async));
+
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+        }
+    }
+
+    public override Task Project_root_duplicated(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_root_duplicated(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+""");
+            });
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        if (async)
+        {
+            //issue #31696
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => base.Project_trunk_and_branch_duplicated(async));
+
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+        }
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        if (async)
+        {
+            //issue #31696
+            await Assert.ThrowsAsync<NullReferenceException>(
+                () => base.Project_trunk_and_trunk_duplicated(async));
+
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+ORDER BY c["Id"]
+""");
+        }
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        if (async)
+        {
+            //issue #35702
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => base.Project_multiple_branch_leaf(async));
+
+            AssertSql();
+        }
+    }
+
+    public override Task Project_leaf_trunk_root(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Project_leaf_trunk_root(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+""");
+            });
+
+
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => AssertTranslationFailed(
+            () => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => AssertTranslationFailed(
+            () => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => AssertTranslationFailed(
+            () => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async));
+
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => AssertTranslationFailed(
+            () => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async));
+
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => AssertTranslationFailed(
+            () => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async));
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        if (async)
+        {
+            //issue #34349
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                () => base.SelectMany_trunk_collection(async));
+
+            AssertSql();
+        }
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        if (async)
+        {
+            //issue #34349
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                () => base.SelectMany_required_trunk_reference_branch_collection(async));
+
+            AssertSql();
+        }
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        if (async)
+        {
+            //issue #34349
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                () => base.SelectMany_optional_trunk_reference_branch_collection(async));
+
+            AssertSql();
+        }
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/JsonRelationshipsQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/JsonRelationshipsQueryCosmosFixture.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class JsonRelationshipsQueryCosmosFixture : JsonRelationshipsQueryFixtureBase
+{
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected override ITestStoreFactory TestStoreFactory
+        => CosmosTestStoreFactory.Instance;
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+    => base.AddOptions(
+        builder.ConfigureWarnings(
+            w => w.Ignore(CosmosEventId.NoPartitionKeyDefined)));
+
+    public Task NoSyncTest(bool async, Func<bool, Task> testCode)
+        => CosmosTestHelpers.Instance.NoSyncTest(async, testCode);
+
+    public void NoSyncTest(Action testCode)
+        => CosmosTestHelpers.Instance.NoSyncTest(testCode);
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .ToContainer("RootEntities")
+            .HasDiscriminatorInJsonId()
+            .HasDiscriminator<string>("Discriminator").HasValue("Root");
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .ToContainer("RootEntities");
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+using Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -25,6 +27,19 @@ public class InMemoryComplianceTest : ComplianceTestBase
         typeof(NonSharedModelBulkUpdatesTestBase),
         typeof(NorthwindBulkUpdatesTestBase<>),
         typeof(JsonQueryTestBase<>),
+
+        // TODO: implement later once things are baked
+        typeof(ComplexRelationshipsInProjectionNoTrackingQueryTestBase<>),
+        typeof(ComplexRelationshipsInProjectionQueryTestBase<>),
+        typeof(EntityRelationshipsInProjectionNoTrackingQueryTestBase<>),
+        typeof(EntityRelationshipsInProjectionQueryTestBase<>),
+        typeof(JsonRelationshipsInProjectionNoTrackingQueryTestBase<>),
+        typeof(JsonRelationshipsInProjectionQueryTestBase<>),
+        typeof(OwnedRelationshipsInProjectionNoTrackingQueryTestBase<>),
+        typeof(OwnedRelationshipsInProjectionQueryTestBase<>),
+        typeof(RelationshipsInProjectionQueryTestBase<>),
+        typeof(EntityRelationshipsIncludeQueryTestBase<>),
+        typeof(RelationshipsIncludeQueryTestBase<>),
     };
 
     protected override Assembly TargetAssembly { get; } = typeof(InMemoryComplianceTest).Assembly;

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/ComplexRelationshipsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/ComplexRelationshipsQueryRelationalFixtureBase.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class ComplexRelationshipsQueryRelationalFixtureBase : ComplexRelationshipsQueryFixtureBase
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>().ToTable("RootEntities");
+        modelBuilder.Entity<RelationshipsTrunkEntity>().ToTable("TrunkEntities");
+        modelBuilder.Entity<RelationshipsTrunkEntity>().Property(x => x.Id).ValueGeneratedNever();
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/EntityRelationshipsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/EntityRelationshipsQueryRelationalFixtureBase.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class EntityRelationshipsQueryRelationalFixtureBase : EntityRelationshipsQueryFixtureBase
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>().ToTable("RootEntities");
+        modelBuilder.Entity<RelationshipsTrunkEntity>().ToTable("TrunkEntities");
+        modelBuilder.Entity<RelationshipsBranchEntity>().ToTable("BranchEntities");
+        modelBuilder.Entity<RelationshipsLeafEntity>().ToTable("LeafEntities");
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class ComplexRelationshipsInProjectionNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(fixture)
+        where TFixture : ComplexRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class ComplexRelationshipsInProjectionQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : ComplexRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : ComplexRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class EntityRelationshipsInProjectionNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : EntityRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class EntityRelationshipsInProjectionQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : EntityRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class JsonRelationshipsInProjectionNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : JsonRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(fixture)
+        where TFixture : JsonRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class JsonRelationshipsInProjectionQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : JsonRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : JsonRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class OwnedRelationshipsInProjectionNoTrackingQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : OwnedRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(fixture)
+        where TFixture : OwnedRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class OwnedRelationshipsInProjectionQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : OwnedRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : OwnedRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/Include/EntityRelationshipsIncludeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/Include/EntityRelationshipsIncludeQueryRelationalTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+
+public abstract class EntityRelationshipsIncludeQueryRelationalTestBase<TFixture>(TFixture fixture)
+    : EntityRelationshipsIncludeQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryRelationalFixtureBase, new()
+{
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/JsonRelationshipsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/JsonRelationshipsQueryRelationalFixtureBase.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class JsonRelationshipsQueryRelationalFixtureBase : JsonRelationshipsQueryFixtureBase
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>().ToTable("RootEntities");
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsOne(x => x.OptionalReferenceTrunk).ToJson();
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsOne(x => x.RequiredReferenceTrunk).ToJson();
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsMany(x => x.CollectionTrunk).ToJson();
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedRelationshipsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedRelationshipsQueryRelationalFixtureBase.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class OwnedRelationshipsQueryRelationalFixtureBase : OwnedRelationshipsQueryFixtureBase
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>().ToTable("RootEntities");
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsOne(x => x.OptionalReferenceTrunk, b =>
+            {
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.ToTable("Root_OptionalReferenceTrunk_CollectionBranch");
+
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf");
+                    });
+                });
+            });
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsOne(x => x.RequiredReferenceTrunk, b =>
+            {
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.ToTable("Root_RequiredReferenceTrunk_CollectionBranch");
+
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf");
+                    });
+                });
+            });
+        modelBuilder.Entity<RelationshipsRootEntity>().Navigation(x => x.RequiredReferenceTrunk).IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsMany(x => x.CollectionTrunk, b =>
+            {
+                b.ToTable("Root_CollectionTrunk");
+
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf");
+                    });
+                });
+
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.ToTable("Root_CollectionTrunk_CollectionBranch");
+
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.ToTable("Root_CollectionTrunk_CollectionBranch_CollectionLeaf");
+                    });
+                });
+            });
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -100,7 +100,7 @@ public class TestSqlLoggerFactory : ListLoggerFactory
             var testInfo = testName + " : " + lineNumber + FileNewLine;
             const string indent = FileNewLine + "                ";
 
-            if (Environment.GetEnvironmentVariable("EF_TEST_REWRITE_BASELINES")?.ToUpper() is "1" or "TRUE")
+            //if (Environment.GetEnvironmentVariable("EF_TEST_REWRITE_BASELINES")?.ToUpper() is "1" or "TRUE")
             {
                 RewriteSourceWithNewBaseline(fileName, lineNumber);
             }

--- a/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -12,20 +12,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 {
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity_NoTracking(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().AsNoTracking());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
@@ -33,62 +19,10 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity_duplicated(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => new { First = x, Second = x }),
-            elementSorter: e => e.First.Id,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.First, a.First);
-                AssertEqual(e.Second, a.Second);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntitySingleOwned>().Select(x => new { First = x, Second = x }).AsNoTracking(),
-            elementSorter: e => e.First.Id,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.First, a.First);
-                AssertEqual(e.Second, a.Second);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntitySingleOwned>().Select(x => new { First = x, Second = x }).AsNoTrackingWithIdentityResolution(),
-            elementSorter: e => e.First.Id,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.First, a.First);
-                AssertEqual(e.Second, a.Second);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity_twice(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => new { First = x, Second = x }),
-            elementSorter: e => e.First.Id,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.First, a.First);
-                AssertEqual(e.Second, a.Second);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => new { First = x, Second = x }).AsNoTracking(),
             elementSorter: e => e.First.Id,
             elementAsserter: (e, a) =>
             {
@@ -111,41 +45,10 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_reference_root(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot).AsNoTracking());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_reference_root_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot).AsNoTrackingWithIdentityResolution());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_reference_duplicated(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => new
-                    {
-                        Root1 = x.OwnedReferenceRoot,
-                        Branch1 = x.OwnedReferenceRoot.OwnedReferenceBranch,
-                        Root2 = x.OwnedReferenceRoot,
-                        Branch2 = x.OwnedReferenceRoot.OwnedReferenceBranch,
-                    }).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.Root1, a.Root1);
-                AssertEqual(e.Root2, a.Root2);
-                AssertEqual(e.Branch1, a.Branch1);
-                AssertEqual(e.Branch2, a.Branch2);
-            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -169,30 +72,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 AssertEqual(e.Root2, a.Root2);
                 AssertEqual(e.Branch1, a.Branch1);
                 AssertEqual(e.Branch2, a.Branch2);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_reference_duplicated2(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => new
-                    {
-                        Root1 = x.OwnedReferenceRoot,
-                        Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                        Root2 = x.OwnedReferenceRoot,
-                        Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                    }).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.Root1, a.Root1);
-                AssertEqual(e.Root2, a.Root2);
-                AssertEqual(e.Leaf1, a.Leaf1);
-                AssertEqual(e.Leaf2, a.Leaf2);
             });
 
     [ConditionalTheory]
@@ -221,14 +100,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_collection_root(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot).AsNoTracking(),
-            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_collection_root_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
@@ -237,25 +108,10 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_reference_branch(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch).AsNoTracking());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch).AsNoTrackingWithIdentityResolution());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Basic_json_projection_owned_collection_branch(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedCollectionBranch).AsNoTracking(),
-            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -326,52 +182,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             {
                 Assert.Equal(e.Id, a.Id);
                 Assert.Equal(e.Enum, a.Enum);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Json_projection_with_deduplication(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>().Select(
-                x => new
-                {
-                    x.Id,
-                    x.OwnedReferenceRoot.OwnedReferenceBranch,
-                    x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                    x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
-                    x.OwnedReferenceRoot.OwnedCollectionBranch,
-                    x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething
-                }).AsNoTracking(),
-            elementSorter: e => e.Id,
-            elementAsserter: (e, a) =>
-            {
-                Assert.Equal(e.Id, a.Id);
-                AssertEqual(e.OwnedReferenceBranch, a.OwnedReferenceBranch);
-                AssertEqual(e.OwnedReferenceLeaf, a.OwnedReferenceLeaf);
-                AssertCollection(e.OwnedCollectionLeaf, a.OwnedCollectionLeaf, ordered: true);
-                AssertCollection(e.OwnedCollectionBranch, a.OwnedCollectionBranch, ordered: true);
-                Assert.Equal(e.SomethingSomething, a.SomethingSomething);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Json_projection_with_deduplication_reverse_order(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .Select(
-                    x => new
-                    {
-                        x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                        x.OwnedReferenceRoot,
-                        x
-                    }).AsNoTracking(),
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.OwnedReferenceLeaf, a.OwnedReferenceLeaf);
-                AssertEqual(e.OwnedReferenceRoot, a.OwnedReferenceRoot);
-                AssertEqual(e.x, a.x);
             });
 
     [ConditionalTheory]
@@ -682,20 +492,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Project_json_entity_FirstOrDefault_subquery(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => ss.Set<JsonEntityBasic>()
-                        .OrderBy(xx => xx.Id)
-                        .Select(xx => xx.OwnedReferenceRoot)
-                        .FirstOrDefault().OwnedReferenceBranch)
-                .AsNoTracking());
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
     public virtual Task Project_json_entity_FirstOrDefault_subquery_with_binding_on_top(bool async)
         => AssertQueryScalar(
             async,
@@ -726,84 +522,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                                     .OrderBy(xx => xx.Id)
                                     .Select(xx => xx.OwnedReferenceRoot)
                                     .FirstOrDefault().OwnedReferenceBranch)));
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => ss.Set<JsonEntityBasic>()
-                        .OrderBy(xx => xx.Id)
-                        .Select(
-                            xx => new
-                            {
-                                x.OwnedReferenceRoot.OwnedCollectionBranch,
-                                xx.OwnedReferenceRoot,
-                                xx.OwnedReferenceRoot.OwnedReferenceBranch,
-                                xx.OwnedReferenceRoot.Name,
-                                x.OwnedReferenceRoot.OwnedReferenceBranch.Enum
-                            }).FirstOrDefault()).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.OwnedReferenceRoot, a.OwnedReferenceRoot);
-                AssertEqual(e.OwnedReferenceBranch, a.OwnedReferenceBranch);
-                AssertEqual(e.Name, a.Name);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => ss.Set<JsonEntityBasic>()
-                        .OrderBy(xx => xx.Id)
-                        .Select(
-                            xx => new
-                            {
-                                x.OwnedReferenceRoot.OwnedCollectionBranch,
-                                xx.OwnedReferenceRoot,
-                                xx.OwnedReferenceRoot.OwnedReferenceBranch,
-                                xx.OwnedReferenceRoot.Name,
-                                x.OwnedReferenceRoot.OwnedReferenceBranch.Enum
-                            }).FirstOrDefault()).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) =>
-            {
-                AssertCollection(e.OwnedCollectionBranch, a.OwnedCollectionBranch, ordered: true);
-                AssertEqual(e.OwnedReferenceRoot, a.OwnedReferenceRoot);
-                AssertEqual(e.OwnedReferenceBranch, a.OwnedReferenceBranch);
-                AssertEqual(e.Name, a.Name);
-                AssertEqual(e.Enum, a.Enum);
-            });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .OrderBy(x => x.Id)
-                .Select(
-                    x => ss.Set<JsonEntityBasic>()
-                        .OrderBy(xx => xx.Id)
-                        .Select(
-                            xx => new
-                            {
-                                x.OwnedReferenceRoot.OwnedCollectionBranch,
-                                xx.OwnedReferenceRoot,
-                                xx.OwnedReferenceRoot.OwnedReferenceBranch,
-                                xx.OwnedReferenceRoot.Name,
-                                x.OwnedReferenceRoot.OwnedReferenceBranch.Enum
-                            }).FirstOrDefault().OwnedCollectionBranch).AsNoTracking(),
-            assertOrder: true,
-            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1488,26 +1206,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 AssertCollection(e.First, a.First, ordered: true);
                 AssertCollection(e.Second, a.Second);
             });
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Json_collection_SelectMany(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .SelectMany(x => x.OwnedCollectionRoot)
-                .AsNoTracking(),
-            elementSorter: e => (e.Number, e.Name));
-
-    [ConditionalTheory]
-    [MemberData(nameof(IsAsyncData))]
-    public virtual Task Json_nested_collection_SelectMany(bool async)
-        => AssertQuery(
-            async,
-            ss => ss.Set<JsonEntityBasic>()
-                .SelectMany(x => x.OwnedReferenceRoot.OwnedCollectionBranch)
-                .AsNoTracking(),
-            elementSorter: e => (e.Enum, e.Date, e.NullableEnum, e.Fraction));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexRelationshipsQueryFixtureBase.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class ComplexRelationshipsQueryFixtureBase : RelationshipsQueryFixtureBase
+{
+    protected override string StoreName => "ComplexRelationshipsQueryTest";
+
+    protected override Task SeedAsync(RelationshipsContext context)
+    {
+        var rootEntities = RelationshipsData.CreateRootEntities();
+        var trunkEntities = RelationshipsData.CreateTrunkEntitiesWithOwnerships();
+
+        RelationshipsData.WireUp(rootEntities, trunkEntities, [], [], wireUpRootToTrunkOnly: true);
+
+        context.Set<RelationshipsRootEntity>().AddRange(rootEntities);
+        context.Set<RelationshipsTrunkEntity>().AddRange(trunkEntities);
+
+        return context.SaveChangesAsync();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasOne(x => x.OptionalReferenceTrunk)
+            .WithOne(x => x.OptionalReferenceInverseRoot)
+            .HasForeignKey<RelationshipsRootEntity>(x => x.OptionalReferenceTrunkId)
+            .IsRequired(false);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasOne(x => x.RequiredReferenceTrunk)
+            .WithOne(x => x.RequiredReferenceInverseRoot)
+            .HasForeignKey<RelationshipsRootEntity>(x => x.RequiredReferenceTrunkId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasMany(x => x.CollectionTrunk)
+            .WithOne(x => x.CollectionInverseRoot)
+            .HasForeignKey(x => x.CollectionRootId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // TODO: issue #31376 - complex optional references
+        modelBuilder.Entity<RelationshipsTrunkEntity>()
+            .Ignore(x => x.OptionalReferenceBranch);
+
+        modelBuilder.Entity<RelationshipsTrunkEntity>()
+            .ComplexProperty(x => x.RequiredReferenceBranch, bb =>
+            {
+                bb.IsRequired(true);
+                bb.Ignore(x => x.Id);
+                bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                bb.Ignore(x => x.OptionalReferenceLeafId);
+
+                // TODO: issue #31376 - complex optional references
+                bb.Ignore(x => x.OptionalReferenceLeaf);
+
+                bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                bb.Ignore(x => x.RequiredReferenceLeafId);
+                bb.ComplexProperty(x => x.RequiredReferenceLeaf, bbb =>
+                {
+                    bbb.IsRequired(true);
+                    bbb.Ignore(x => x.Id);
+                    bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                    bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                    bbb.Ignore(x => x.CollectionInverseBranch);
+                    bbb.Ignore(x => x.CollectionBranchId);
+                });
+
+                bb.Ignore(x => x.CollectionInverseTrunk);
+                bb.Ignore(x => x.CollectionTrunkId);
+                bb.Ignore(x => x.CollectionLeaf);
+            });
+
+        // TODO: issue #31237 - complex collections
+        modelBuilder.Entity<RelationshipsTrunkEntity>().Ignore(x => x.CollectionBranch);
+    }
+
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
+    {
+        { typeof(RelationshipsRootEntity), e => ((RelationshipsRootEntity?)e)?.Id },
+        { typeof(RelationshipsTrunkEntity), e => ((RelationshipsTrunkEntity?)e)?.Id },
+        { typeof(RelationshipsBranchEntity), e => ((RelationshipsBranchEntity?)e)?.Name },
+        { typeof(RelationshipsLeafEntity), e => ((RelationshipsLeafEntity?)e)?.Name }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
+    {
+        {
+            typeof(RelationshipsRootEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsRootEntity)e!;
+                    var aa = (RelationshipsRootEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsTrunkEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsTrunkEntity)e!;
+                    var aa = (RelationshipsTrunkEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+
+                    AssertOwnedBranch(ee.RequiredReferenceBranch, aa.RequiredReferenceBranch);
+
+                    // TODO: issue #31376 - complex optional references
+                    //Assert.Equal(ee.OptionalReferenceBranch == null, aa.OptionalReferenceBranch == null);
+
+                    if (ee.OptionalReferenceBranch != null && aa.OptionalReferenceBranch != null)
+                    {
+                        AssertOwnedBranch(ee.OptionalReferenceBranch, aa.OptionalReferenceBranch);
+                    }
+                }
+            }
+        },
+        {
+            typeof(RelationshipsBranchEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsBranchEntity)e!;
+                    var aa = (RelationshipsBranchEntity)a;
+                    AssertOwnedBranch(ee, aa);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsLeafEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsLeafEntity)e!;
+                    var aa = (RelationshipsLeafEntity)a;
+                    AssertOwnedLeaf(ee, aa);
+                }
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public static void AssertOwnedBranch(RelationshipsBranchEntity expected, RelationshipsBranchEntity actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+
+        AssertOwnedLeaf(expected.RequiredReferenceLeaf, actual.RequiredReferenceLeaf);
+
+        // TODO: issue #31376 - complex optional references
+        //Assert.Equal(expected.OptionalReferenceLeaf == null, actual.OptionalReferenceLeaf == null);
+        //if (expected.OptionalReferenceLeaf != null && actual.OptionalReferenceLeaf != null)
+        //{
+        //    AssertOwnedLeaf(expected.OptionalReferenceLeaf, actual.OptionalReferenceLeaf);
+        //}
+    }
+
+    public static void AssertOwnedLeaf(RelationshipsLeafEntity expected, RelationshipsLeafEntity actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/EntityRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/EntityRelationshipsQueryFixtureBase.cs
@@ -1,0 +1,179 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class EntityRelationshipsQueryFixtureBase : RelationshipsQueryFixtureBase
+{
+    protected override string StoreName => "EntityRelationshipsQueryTest";
+
+    protected override Task SeedAsync(RelationshipsContext context)
+    {
+        var rootEntities = RelationshipsData.CreateRootEntities();
+        var trunkEntities = RelationshipsData.CreateTrunkEntities();
+        var branchEntities = RelationshipsData.CreateBranchEntities();
+        var leafEntities = RelationshipsData.CreateLeafEntities();
+
+        RelationshipsData.WireUp(rootEntities, trunkEntities, branchEntities, leafEntities, wireUpRootToTrunkOnly: false);
+
+        context.Set<RelationshipsRootEntity>().AddRange(rootEntities);
+        context.Set<RelationshipsTrunkEntity>().AddRange(trunkEntities);
+        context.Set<RelationshipsBranchEntity>().AddRange(branchEntities);
+        context.Set<RelationshipsLeafEntity>().AddRange(leafEntities);
+
+        return context.SaveChangesAsync();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsTrunkEntity>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<RelationshipsBranchEntity>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<RelationshipsLeafEntity>().Property(x => x.Id).ValueGeneratedNever();
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasOne(x => x.OptionalReferenceTrunk)
+            .WithOne(x => x.OptionalReferenceInverseRoot)
+            .HasForeignKey<RelationshipsRootEntity>(x => x.OptionalReferenceTrunkId)
+            .IsRequired(false);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasOne(x => x.RequiredReferenceTrunk)
+            .WithOne(x => x.RequiredReferenceInverseRoot)
+            .HasForeignKey<RelationshipsRootEntity>(x => x.RequiredReferenceTrunkId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .HasMany(x => x.CollectionTrunk)
+            .WithOne(x => x.CollectionInverseRoot)
+            .HasForeignKey(x => x.CollectionRootId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<RelationshipsTrunkEntity>()
+            .HasOne(x => x.OptionalReferenceBranch)
+            .WithOne(x => x.OptionalReferenceInverseTrunk)
+            .HasForeignKey<RelationshipsTrunkEntity>(x => x.OptionalReferenceBranchId)
+            .IsRequired(false);
+
+        modelBuilder.Entity<RelationshipsTrunkEntity>()
+            .HasOne(x => x.RequiredReferenceBranch)
+            .WithOne(x => x.RequiredReferenceInverseTrunk)
+            .HasForeignKey<RelationshipsTrunkEntity>(x => x.RequiredReferenceBranchId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsTrunkEntity>()
+            .HasMany(x => x.CollectionBranch)
+            .WithOne(x => x.CollectionInverseTrunk)
+            .HasForeignKey(x => x.CollectionTrunkId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<RelationshipsBranchEntity>()
+            .HasOne(x => x.OptionalReferenceLeaf)
+            .WithOne(x => x.OptionalReferenceInverseBranch)
+            .HasForeignKey<RelationshipsBranchEntity>(x => x.OptionalReferenceLeafId)
+            .IsRequired(false);
+
+        modelBuilder.Entity<RelationshipsBranchEntity>()
+            .HasOne(x => x.RequiredReferenceLeaf)
+            .WithOne(x => x.RequiredReferenceInverseBranch)
+            .HasForeignKey<RelationshipsBranchEntity>(x => x.RequiredReferenceLeafId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsBranchEntity>()
+            .HasMany(x => x.CollectionLeaf)
+            .WithOne(x => x.CollectionInverseBranch)
+            .HasForeignKey(x => x.CollectionBranchId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
+    {
+        { typeof(RelationshipsRootEntity), e => ((RelationshipsRootEntity?)e)?.Id },
+        { typeof(RelationshipsTrunkEntity), e => ((RelationshipsTrunkEntity?)e)?.Id },
+        { typeof(RelationshipsBranchEntity), e => ((RelationshipsBranchEntity?)e)?.Id },
+        { typeof(RelationshipsLeafEntity), e => ((RelationshipsLeafEntity?)e)?.Id }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
+    {
+        {
+            typeof(RelationshipsRootEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsRootEntity)e!;
+                    var aa = (RelationshipsRootEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.RequiredReferenceTrunkId, aa.RequiredReferenceTrunkId);
+                    Assert.Equal(ee.OptionalReferenceTrunkId, aa.OptionalReferenceTrunkId);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsTrunkEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsTrunkEntity)e!;
+                    var aa = (RelationshipsTrunkEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.RequiredReferenceBranchId, aa.RequiredReferenceBranchId);
+                    Assert.Equal(ee.OptionalReferenceBranchId, aa.OptionalReferenceBranchId);
+                    Assert.Equal(ee.CollectionRootId, aa.CollectionRootId);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsBranchEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsBranchEntity)e!;
+                    var aa = (RelationshipsBranchEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.RequiredReferenceLeafId, aa.RequiredReferenceLeafId);
+                    Assert.Equal(ee.OptionalReferenceLeafId, aa.OptionalReferenceLeafId);
+                    Assert.Equal(ee.CollectionTrunkId, aa.CollectionTrunkId);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsLeafEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsLeafEntity)e!;
+                    var aa = (RelationshipsLeafEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CollectionBranchId, aa.CollectionBranchId);
+                }
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQueryTestBase.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class ComplexRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(TFixture fixture)
+    : ComplexRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : ComplexRelationshipsQueryFixtureBase, new()
+{
+    private readonly NoTrackingRewriter _noTrackingRewriter = new();
+
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        var rewritten = _noTrackingRewriter.Visit(serverQueryExpression);
+
+        return rewritten;
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQueryTestBase.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class ComplexRelationshipsInProjectionQueryTestBase<TFixture>(TFixture fixture)
+    : RelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : ComplexRelationshipsQueryFixtureBase, new()
+{
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_everything(bool async)
+        => AssertQuery(
+            async,
+            ss => from r in ss.Set<RelationshipsRootEntity>()
+                  join t in ss.Set<RelationshipsTrunkEntity>() on r.Id equals t.Id
+                  select new { r, t },
+            elementSorter: e => e.r.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.r, a.r);
+                AssertEqual(e.t, a.t);
+            });
+
+    [ConditionalTheory(Skip = "issue #31412")]
+    public override Task Project_branch_required_optional(bool async)
+        => base.Project_branch_required_optional(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_branch_required_collection(bool async)
+        => base.Project_branch_required_collection(async);
+
+    [ConditionalTheory(Skip = "issue #31376")]
+    public override Task Project_branch_optional_optional(bool async)
+        => base.Project_branch_optional_optional(async);
+
+    [ConditionalTheory(Skip = "issue #31412")]
+    public override Task Project_branch_optional_required(bool async)
+        => base.Project_branch_optional_required(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_branch_optional_collection(bool async)
+        => base.Project_branch_optional_collection(async);
+
+    public override Task Project_root_duplicated(bool async)
+        => base.Project_root_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue #31412")]
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => base.Project_trunk_and_branch_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue #31412")]
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => base.Project_trunk_and_trunk_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_multiple_branch_leaf(bool async)
+        => base.Project_multiple_branch_leaf(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue #31412")]
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task SelectMany_trunk_collection(bool async)
+        => base.SelectMany_trunk_collection(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_required_trunk_reference_branch_collection(async);
+
+    [ConditionalTheory(Skip = "issue #31237")]
+    public override Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_optional_trunk_reference_branch_collection(async);
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQueryTestBase.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class EntityRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(TFixture fixture)
+    : EntityRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryFixtureBase, new()
+{
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        return base.RewriteServerQueryExpression(serverQueryExpression);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQueryTestBase.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class EntityRelationshipsInProjectionQueryTestBase<TFixture>(TFixture fixture)
+    : RelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryFixtureBase, new()
+{
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_everything(bool async)
+        => AssertQuery(
+            async,
+            ss => from r in ss.Set<RelationshipsRootEntity>()
+                  join t in ss.Set<RelationshipsTrunkEntity>() on r.Id equals t.Id
+                  join b in ss.Set<RelationshipsBranchEntity>() on t.Id equals b.Id
+                  join l in ss.Set<RelationshipsLeafEntity>() on b.Id equals l.Id
+                  select new { r, t, b, l },
+            elementSorter: e => e.r.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.r, a.r);
+                AssertEqual(e.t, a.t);
+                AssertEqual(e.b, a.b);
+                AssertEqual(e.l, a.l);
+            });
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQueryTestBase.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class JsonRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(TFixture fixture)
+    : JsonRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : JsonRelationshipsQueryFixtureBase, new()
+{
+    private readonly NoTrackingRewriter _noTrackingRewriter = new();
+
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        var rewritten = _noTrackingRewriter.Visit(serverQueryExpression);
+
+        return rewritten;
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQueryTestBase.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class JsonRelationshipsInProjectionQueryTestBase<TFixture>(TFixture fixture)
+    : RelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : JsonRelationshipsQueryFixtureBase, new()
+{
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_collection_element_using_indexer_constant(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee.Name));
+
+
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/NoTrackingRewriter.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/NoTrackingRewriter.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class NoTrackingRewriter : ExpressionVisitor
+{
+    private static readonly MethodInfo AsNoTrackingMethodInfo
+        = typeof(EntityFrameworkQueryableExtensions).GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking))!;
+
+    protected override Expression VisitExtension(Expression expression)
+    {
+        if (expression is EntityQueryRootExpression eqr)
+        {
+            return Expression.Call(AsNoTrackingMethodInfo.MakeGenericMethod(eqr.ElementType), eqr);
+        }
+
+        return base.VisitExtension(expression);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQueryTestBase.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class OwnedRelationshipsInProjectionNoTrackingQueryTestBase<TFixture>(TFixture fixture)
+    : OwnedRelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : OwnedRelationshipsQueryFixtureBase, new()
+{
+    private readonly NoTrackingRewriter _noTrackingRewriter = new();
+
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        var rewritten = _noTrackingRewriter.Visit(serverQueryExpression);
+
+        return rewritten;
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQueryTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public abstract class OwnedRelationshipsInProjectionQueryTestBase<TFixture>(TFixture fixture)
+    : RelationshipsInProjectionQueryTestBase<TFixture>(fixture)
+        where TFixture : OwnedRelationshipsQueryFixtureBase, new()
+{
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/InProjection/RelationshipsInProjectionQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/InProjection/RelationshipsInProjectionQueryTestBase.cs
@@ -1,0 +1,326 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+/// <summary>
+/// Tests for using navigations in projection - mostly to test shaper code around
+/// </summary>
+public abstract class RelationshipsInProjectionQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
+    where TFixture : RelationshipsQueryFixtureBase, new()
+{
+    protected RelationshipsContext CreateContext()
+        => Fixture.CreateContext();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_root(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_trunk_optional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.OptionalReferenceTrunk),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_trunk_required(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_trunk_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.CollectionTrunk),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee.Name));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_required_required(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.RequiredReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_required_optional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.OptionalReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_required_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee.Name));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_optional_required(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.RequiredReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_optional_optional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.OptionalReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_branch_optional_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().OrderBy(x => x.Id).Select(x => x.RequiredReferenceTrunk.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee.Name));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_root_duplicated(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Select(x => new { First = x, Second = x }),
+            elementSorter: e => e.First.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.First, a.First);
+                AssertEqual(e.Second, a.Second);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_trunk_and_branch_duplicated(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => new
+                    {
+                        Trunk1 = x.OptionalReferenceTrunk,
+                        Branch1 = x.OptionalReferenceTrunk!.RequiredReferenceBranch,
+                        Trunk2 = x.OptionalReferenceTrunk,
+                        Branch2 = x.OptionalReferenceTrunk.RequiredReferenceBranch,
+                    }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Trunk1, a.Trunk1);
+                AssertEqual(e.Trunk2, a.Trunk2);
+                AssertEqual(e.Branch1, a.Branch1);
+                AssertEqual(e.Branch2, a.Branch2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_trunk_and_trunk_duplicated(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => new
+                    {
+                        Trunk1 = x.RequiredReferenceTrunk,
+                        Leaf1 = x.RequiredReferenceTrunk!.OptionalReferenceBranch!.RequiredReferenceLeaf,
+                        Trunk2 = x.RequiredReferenceTrunk,
+                        Leaf2 = x.RequiredReferenceTrunk.OptionalReferenceBranch.RequiredReferenceLeaf,
+                    }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Trunk1, a.Trunk1);
+                AssertEqual(e.Trunk2, a.Trunk2);
+                AssertEqual(e.Leaf1, a.Leaf1);
+                AssertEqual(e.Leaf2, a.Leaf2);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_multiple_branch_leaf(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Select(
+                x => new
+                {
+                    x.Id,
+                    x.RequiredReferenceTrunk.RequiredReferenceBranch,
+                    x.RequiredReferenceTrunk.RequiredReferenceBranch.OptionalReferenceLeaf,
+                    x.RequiredReferenceTrunk.RequiredReferenceBranch.CollectionLeaf,
+                    x.RequiredReferenceTrunk.CollectionBranch,
+                    x.RequiredReferenceTrunk.RequiredReferenceBranch.OptionalReferenceLeaf!.Name
+                }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                AssertEqual(e.RequiredReferenceBranch, a.RequiredReferenceBranch);
+                AssertEqual(e.OptionalReferenceLeaf, a.OptionalReferenceLeaf);
+                AssertCollection(e.CollectionLeaf, a.CollectionLeaf, ordered: true);
+                AssertCollection(e.CollectionBranch, a.CollectionBranch, ordered: true);
+                Assert.Equal(e.Name, a.Name);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_leaf_trunk_root(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .Select(
+                    x => new
+                    {
+                        x.RequiredReferenceTrunk.RequiredReferenceBranch.RequiredReferenceLeaf,
+                        x.RequiredReferenceTrunk,
+                        x
+                    }),
+            elementSorter: e => e.x.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.RequiredReferenceLeaf, a.RequiredReferenceLeaf);
+                AssertEqual(e.RequiredReferenceTrunk, a.RequiredReferenceTrunk);
+                AssertEqual(e.x, a.x);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => ss.Set<RelationshipsRootEntity>()
+                        .OrderBy(xx => xx.Id)
+                        .Select(xx => xx.RequiredReferenceTrunk)
+                        .FirstOrDefault()!.RequiredReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => ss.Set<RelationshipsRootEntity>()
+                        .OrderBy(xx => xx.Id)
+                        .Select(xx => xx.OptionalReferenceTrunk)
+                        .FirstOrDefault()!.OptionalReferenceBranch),
+            assertOrder: true);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => ss.Set<RelationshipsRootEntity>()
+                        .OrderBy(xx => xx.Id)
+                        .Select(xx => xx.RequiredReferenceTrunk)
+                        .FirstOrDefault()!.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => ss.Set<RelationshipsRootEntity>()
+                        .OrderBy(xx => xx.Id)
+                        .Select(
+                            xx => new
+                            {
+                                OuterBranch = x.RequiredReferenceTrunk.CollectionBranch,
+                                xx.RequiredReferenceTrunk,
+                                xx.RequiredReferenceTrunk.RequiredReferenceBranch,
+                                xx.RequiredReferenceTrunk.Name,
+                                OuterName = x.RequiredReferenceTrunk!.RequiredReferenceBranch.Name
+                            }).FirstOrDefault()),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertCollection(e.OuterBranch, a.OuterBranch);
+                AssertEqual(e.RequiredReferenceTrunk, a.RequiredReferenceTrunk);
+                AssertEqual(e.RequiredReferenceBranch, a.RequiredReferenceBranch);
+                AssertEqual(e.Name, a.Name);
+                AssertEqual(e.OuterName, a.OuterName);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .OrderBy(x => x.Id)
+                .Select(
+                    x => ss.Set<RelationshipsRootEntity>()
+                        .OrderBy(xx => xx.Id)
+                        .Select(
+                            xx => new
+                            {
+                                OuterBranchCollection = x.RequiredReferenceTrunk.CollectionBranch,
+                                xx.RequiredReferenceTrunk,
+                                xx.RequiredReferenceTrunk.RequiredReferenceBranch,
+                                xx.RequiredReferenceTrunk.Name,
+                                OuterName = x.RequiredReferenceTrunk.RequiredReferenceBranch.Name
+                            }).FirstOrDefault()!.OuterBranchCollection),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task SelectMany_trunk_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .SelectMany(x => x.CollectionTrunk));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .SelectMany(x => x.RequiredReferenceTrunk.CollectionBranch));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .SelectMany(x => x.OptionalReferenceTrunk!.CollectionBranch),
+            ss => ss.Set<RelationshipsRootEntity>()
+                .SelectMany(x => x.OptionalReferenceTrunk.Maybe(xx => xx!.CollectionBranch) ?? new List<RelationshipsBranchEntity>()));
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/Include/EntityRelationshipsIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/Include/EntityRelationshipsIncludeQueryTestBase.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+
+public class EntityRelationshipsIncludeQueryTestBase<TFixture>(TFixture fixture)
+    : RelationshipsIncludeQueryTestBase<TFixture>(fixture)
+        where TFixture : EntityRelationshipsQueryFixtureBase, new()
+{
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/Include/RelationshipsIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/Include/RelationshipsIncludeQueryTestBase.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+
+public abstract class RelationshipsIncludeQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
+    where TFixture : RelationshipsQueryFixtureBase, new()
+{
+    protected RelationshipsContext CreateContext()
+        => Fixture.CreateContext();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_trunk_required(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.RequiredReferenceTrunk),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<RelationshipsRootEntity>(x => x.RequiredReferenceTrunk)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_trunk_optional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<RelationshipsRootEntity>(x => x.OptionalReferenceTrunk!)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_trunk_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.CollectionTrunk),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<RelationshipsRootEntity>(x => x.CollectionTrunk)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_trunk_required_optional_and_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>()
+                .Include(x => x.RequiredReferenceTrunk)
+                .Include(x => x.OptionalReferenceTrunk)
+                .Include(x => x.CollectionTrunk),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.RequiredReferenceTrunk),
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.OptionalReferenceTrunk!),
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.CollectionTrunk)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_branch_required_required(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.RequiredReferenceTrunk.RequiredReferenceBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.RequiredReferenceTrunk),
+                new ExpectedInclude<RelationshipsTrunkEntity>(x => x.RequiredReferenceBranch, "RequiredReferenceTrunk")));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_branch_required_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.RequiredReferenceTrunk.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.RequiredReferenceTrunk),
+                new ExpectedInclude<RelationshipsTrunkEntity>(x => x.CollectionBranch, "RequiredReferenceTrunk")));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_branch_optional_optional(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk!.OptionalReferenceBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.OptionalReferenceTrunk!),
+                new ExpectedInclude<RelationshipsTrunkEntity>(x => x.OptionalReferenceBranch!, "OptionalReferenceTrunk")));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_branch_optional_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk!.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.OptionalReferenceTrunk!),
+                new ExpectedInclude<RelationshipsTrunkEntity>(x => x.CollectionBranch, "OptionalReferenceTrunk")));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Include_branch_collection_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<RelationshipsRootEntity>().Include(x => x.CollectionTrunk).ThenInclude(x => x.CollectionBranch),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertInclude(
+                e,
+                a,
+                new ExpectedInclude<RelationshipsRootEntity>(x => x.CollectionTrunk!),
+                new ExpectedInclude<RelationshipsTrunkEntity>(x => x.CollectionBranch, "CollectionTrunk")));
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/JsonRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/JsonRelationshipsQueryFixtureBase.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class JsonRelationshipsQueryFixtureBase : OwnedRelationshipsQueryFixtureBase
+{
+    protected override string StoreName => "JsonRelationshipsQueryTest";
+
+    protected override Task SeedAsync(RelationshipsContext context)
+    {
+        var rootEntitiesWithOwnerships = RelationshipsData.CreateRootEntitiesWithOwnerships();
+        context.Set<RelationshipsRootEntity>().AddRange(rootEntitiesWithOwnerships);
+
+        return context.SaveChangesAsync();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        // TODO: consider creating model explicitly (and derive from base fixture rather than owned) once we agree on the shape etc.
+        base.OnModelCreating(modelBuilder, context);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/OwnedRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/OwnedRelationshipsQueryFixtureBase.cs
@@ -1,0 +1,539 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class OwnedRelationshipsQueryFixtureBase : RelationshipsQueryFixtureBase
+{
+    protected override string StoreName => "OwnedRelationshipsQueryTest";
+
+    protected override Task SeedAsync(RelationshipsContext context)
+    {
+        var rootEntitiesWithOwnerships = RelationshipsData.CreateRootEntitiesWithOwnerships();
+        context.Set<RelationshipsRootEntity>().AddRange(rootEntitiesWithOwnerships);
+
+        return context.SaveChangesAsync();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsOne(x => x.OptionalReferenceTrunk, b =>
+            {
+                b.Ignore(x => x.Id);
+                b.Ignore(x => x.OptionalReferenceInverseRoot);
+                b.Ignore(x => x.OptionalReferenceBranchId);
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.OptionalReferenceBranch).IsRequired(false);
+
+                b.Ignore(x => x.RequiredReferenceInverseRoot);
+                b.Ignore(x => x.RequiredReferenceBranchId);
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.RequiredReferenceBranch).IsRequired(true);
+
+                b.Ignore(x => x.CollectionInverseRoot);
+                b.Ignore(x => x.CollectionRootId);
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+            });
+        modelBuilder.Entity<RelationshipsRootEntity>().Navigation(x => x.OptionalReferenceTrunk).IsRequired(false);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsOne(x => x.RequiredReferenceTrunk, b =>
+            {
+                b.Ignore(x => x.Id);
+                b.Ignore(x => x.OptionalReferenceInverseRoot);
+                b.Ignore(x => x.OptionalReferenceBranchId);
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.OptionalReferenceBranch).IsRequired(false);
+
+                b.Ignore(x => x.RequiredReferenceInverseRoot);
+                b.Ignore(x => x.RequiredReferenceBranchId);
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.RequiredReferenceBranch).IsRequired(true);
+
+                b.Ignore(x => x.CollectionInverseRoot);
+                b.Ignore(x => x.CollectionRootId);
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+            });
+        modelBuilder.Entity<RelationshipsRootEntity>().Navigation(x => x.RequiredReferenceTrunk).IsRequired(true);
+
+        modelBuilder.Entity<RelationshipsRootEntity>()
+            .OwnsMany(x => x.CollectionTrunk, b =>
+            {
+                b.Ignore(x => x.Id);
+                b.Ignore(x => x.OptionalReferenceInverseRoot);
+                b.Ignore(x => x.OptionalReferenceBranchId);
+                b.OwnsOne(x => x.OptionalReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.OptionalReferenceBranch).IsRequired(false);
+
+                b.Ignore(x => x.RequiredReferenceInverseRoot);
+                b.Ignore(x => x.RequiredReferenceBranchId);
+                b.OwnsOne(x => x.RequiredReferenceBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+                b.Navigation(x => x.RequiredReferenceBranch).IsRequired(true);
+
+                b.Ignore(x => x.CollectionInverseRoot);
+                b.Ignore(x => x.CollectionRootId);
+                b.OwnsMany(x => x.CollectionBranch, bb =>
+                {
+                    bb.Ignore(x => x.Id);
+                    bb.Ignore(x => x.OptionalReferenceInverseTrunk);
+                    bb.Ignore(x => x.OptionalReferenceLeafId);
+                    bb.OwnsOne(x => x.OptionalReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.OptionalReferenceLeaf).IsRequired(false);
+
+                    bb.Ignore(x => x.RequiredReferenceInverseTrunk);
+                    bb.Ignore(x => x.RequiredReferenceLeafId);
+                    bb.OwnsOne(x => x.RequiredReferenceLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                    bb.Navigation(x => x.RequiredReferenceLeaf).IsRequired(true);
+
+                    bb.Ignore(x => x.CollectionInverseTrunk);
+                    bb.Ignore(x => x.CollectionTrunkId);
+                    bb.OwnsMany(x => x.CollectionLeaf, bbb =>
+                    {
+                        bbb.Ignore(x => x.Id);
+                        bbb.Ignore(x => x.OptionalReferenceInverseBranch);
+                        bbb.Ignore(x => x.RequiredReferenceInverseBranch);
+                        bbb.Ignore(x => x.CollectionInverseBranch);
+                        bbb.Ignore(x => x.CollectionBranchId);
+                    });
+                });
+            });
+    }
+
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
+    {
+        { typeof(RelationshipsRootEntity), e => ((RelationshipsRootEntity?)e)?.Id },
+        { typeof(RelationshipsTrunkEntity), e => ((RelationshipsTrunkEntity?)e)?.Name },
+        { typeof(RelationshipsBranchEntity), e => ((RelationshipsBranchEntity?)e)?.Name },
+        { typeof(RelationshipsLeafEntity), e => ((RelationshipsLeafEntity?)e)?.Name }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
+    {
+        {
+            typeof(RelationshipsRootEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsRootEntity)e!;
+                    var aa = (RelationshipsRootEntity)a;
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    AssertOwnedTrunk(ee.RequiredReferenceTrunk, aa.RequiredReferenceTrunk);
+                    Assert.Equal(ee.OptionalReferenceTrunk == null, aa.OptionalReferenceTrunk == null);
+
+                    if (ee.OptionalReferenceTrunk != null && aa.OptionalReferenceTrunk != null)
+                    {
+                        AssertOwnedTrunk(ee.OptionalReferenceTrunk, aa.OptionalReferenceTrunk);
+                    }
+
+                    // TODO: cosmos may return null for empty collections, consider having separate asserters for cosmos
+                    // once models are established (to avoid multiple copy-paste while we iterate over it initially)
+                    Assert.Equal(ee.CollectionTrunk.Count, aa.CollectionTrunk?.Count ?? 0);
+                    for (var i = 0; i < ee.CollectionTrunk.Count; i++)
+                    {
+                        AssertOwnedTrunk(ee.CollectionTrunk[i], aa.CollectionTrunk![i]);
+                    }
+                }
+            }
+        },
+        {
+            typeof(RelationshipsTrunkEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsTrunkEntity)e!;
+                    var aa = (RelationshipsTrunkEntity)a;
+                    AssertOwnedTrunk(ee, aa);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsBranchEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsBranchEntity)e!;
+                    var aa = (RelationshipsBranchEntity)a;
+                    AssertOwnedBranch(ee, aa);
+                }
+            }
+        },
+        {
+            typeof(RelationshipsLeafEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (RelationshipsLeafEntity)e!;
+                    var aa = (RelationshipsLeafEntity)a;
+                    AssertOwnedLeaf(ee, aa);
+                }
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public static void AssertOwnedTrunk(RelationshipsTrunkEntity expected, RelationshipsTrunkEntity actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+
+        AssertOwnedBranch(expected.RequiredReferenceBranch, actual.RequiredReferenceBranch);
+
+        Assert.Equal(expected.OptionalReferenceBranch == null, actual.OptionalReferenceBranch == null);
+        if (expected.OptionalReferenceBranch != null && actual.OptionalReferenceBranch != null)
+        {
+            AssertOwnedBranch(expected.OptionalReferenceBranch, actual.OptionalReferenceBranch);
+        }
+
+        Assert.Equal(expected.CollectionBranch.Count, actual.CollectionBranch?.Count ?? 0);
+        for (var i = 0; i < expected.CollectionBranch.Count; i++)
+        {
+            AssertOwnedBranch(expected.CollectionBranch[i], actual.CollectionBranch![i]);
+        }
+    }
+
+    public static void AssertOwnedBranch(RelationshipsBranchEntity expected, RelationshipsBranchEntity actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+
+        AssertOwnedLeaf(expected.RequiredReferenceLeaf, actual.RequiredReferenceLeaf);
+
+        Assert.Equal(expected.OptionalReferenceLeaf == null, actual.OptionalReferenceLeaf == null);
+        if (expected.OptionalReferenceLeaf != null && actual.OptionalReferenceLeaf != null)
+        {
+            AssertOwnedLeaf(expected.OptionalReferenceLeaf, actual.OptionalReferenceLeaf);
+        }
+
+        Assert.Equal(expected.CollectionLeaf.Count, actual.CollectionLeaf?.Count ?? 0);
+        for (var i = 0; i < expected.CollectionLeaf.Count; i++)
+        {
+            AssertOwnedLeaf(expected.CollectionLeaf[i], actual.CollectionLeaf![i]);
+        }
+    }
+
+    public static void AssertOwnedLeaf(RelationshipsLeafEntity expected, RelationshipsLeafEntity actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsQueryFixtureBase.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public abstract class RelationshipsQueryFixtureBase : SharedStoreFixtureBase<RelationshipsContext>, IQueryFixtureBase
+{
+    private RelationshipsData? _expectedData;
+
+    public Func<DbContext> GetContextCreator()
+        => () => CreateContext();
+
+    public virtual ISetSource GetExpectedData()
+        => _expectedData ??= new RelationshipsData();
+
+    protected override Task SeedAsync(RelationshipsContext context)
+    {
+        throw new InvalidOperationException("Override this method in dervided fixtures.");
+    }
+
+    public abstract IReadOnlyDictionary<Type, object> EntitySorters { get; }
+
+    //public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
+    //{
+    //    { typeof(RelationshipsRootEntity), e => ((RelationshipsRootEntity?)e)?.Id },
+    //    { typeof(RelationshipsTrunkEntity), e => ((RelationshipsTrunkEntity?)e)?.Id },
+    //    { typeof(RelationshipsBranchEntity), e => ((RelationshipsBranchEntity?)e)?.Id },
+    //    { typeof(RelationshipsLeafEntity), e => ((RelationshipsLeafEntity?)e)?.Id }
+    //}.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public abstract IReadOnlyDictionary<Type, object> EntityAsserters { get; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        modelBuilder.Entity<RelationshipsRootEntity>().Property(x => x.Id).ValueGeneratedNever();
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsBranchEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsBranchEntity.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsBranchEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public int? OptionalReferenceLeafId { get; set; }
+    public RelationshipsLeafEntity? OptionalReferenceLeaf { get; set; } = null!;
+
+    public int RequiredReferenceLeafId { get; set; }
+    public RelationshipsLeafEntity RequiredReferenceLeaf { get; set; } = null!;
+    public List<RelationshipsLeafEntity> CollectionLeaf { get; set; } = null!;
+
+    public RelationshipsTrunkEntity? OptionalReferenceInverseTrunk { get; set; } = null!;
+
+    public RelationshipsTrunkEntity RequiredReferenceInverseTrunk { get; set; } = null!;
+
+    public int? CollectionTrunkId { get; set; }
+    public RelationshipsTrunkEntity CollectionInverseTrunk { get; set; } = null!;
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsContext.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsContext(DbContextOptions options) : DbContext(options)
+{
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsData.cs
@@ -1,0 +1,312 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsData : ISetSource
+{
+    public RelationshipsData()
+    {
+        RootEntities = CreateRootEntities();
+        TrunkEntities = CreateTrunkEntities();
+        BranchEntities = CreateBranchEntities();
+        LeafEntities = CreateLeafEntities();
+
+        WireUp(RootEntities, TrunkEntities, BranchEntities, LeafEntities, wireUpRootToTrunkOnly: false);
+    }
+
+    public IReadOnlyList<RelationshipsRootEntity> RootEntities { get; }
+    public IReadOnlyList<RelationshipsTrunkEntity> TrunkEntities { get; }
+    public IReadOnlyList<RelationshipsBranchEntity> BranchEntities { get; }
+    public IReadOnlyList<RelationshipsLeafEntity> LeafEntities { get; }
+
+    public static IReadOnlyList<RelationshipsRootEntity> CreateRootEntitiesWithOwnerships()
+    {
+        var roots = new List<RelationshipsRootEntity>();
+        for (var i = 0; i < 16; i++)
+        {
+            roots.Add(BuildRootEntity(i));
+        }
+
+        return roots;
+    }
+
+    public static IReadOnlyList<RelationshipsTrunkEntity> CreateTrunkEntitiesWithOwnerships()
+    {
+        var trunks = new List<RelationshipsTrunkEntity>();
+        for (var i = 0; i < 16; i++)
+        {
+            trunks.Add(BuildTrunkEntity(i));
+        }
+
+        return trunks;
+    }
+
+    private static RelationshipsRootEntity BuildRootEntity(int i)
+    {
+        var root = new RelationshipsRootEntity { Id = i + 1, Name = "Root " + (i + 1) };
+        root.RequiredReferenceTrunk = BuildTrunkEntity(15 - i);
+        if (i < 8)
+        {
+            root.OptionalReferenceTrunk = BuildTrunkEntity(i);
+        }
+
+        root.CollectionTrunk = new List<RelationshipsTrunkEntity>();
+        if (i % 4 == 0)
+        {
+            root.CollectionTrunk.Add(BuildTrunkEntity(i + 1));
+            root.CollectionTrunk.Add(BuildTrunkEntity(i + 2));
+            if (i == 0)
+            {
+                root.CollectionTrunk.Add(BuildTrunkEntity(4));
+            }
+        }
+
+        return root;
+    }
+
+    private static RelationshipsTrunkEntity BuildTrunkEntity(int i)
+    {
+        var trunk = new RelationshipsTrunkEntity { Id = i + 1, Name = "Trunk " + (i + 1) };
+        trunk.RequiredReferenceBranch = BuildBranchEntity(15 - i);
+
+        if (i % 8 < 4)
+        {
+            trunk.OptionalReferenceBranch = BuildBranchEntity(i);
+        }
+
+        trunk.CollectionBranch = new List<RelationshipsBranchEntity>();
+        if (i % 4 == 0)
+        {
+            trunk.CollectionBranch.Add(BuildBranchEntity(i + 1));
+            trunk.CollectionBranch.Add(BuildBranchEntity(i + 2));
+            if (i == 4)
+            {
+                trunk.CollectionBranch.Add(BuildBranchEntity(8));
+            }
+        }
+
+        return trunk;
+    }
+
+    private static RelationshipsBranchEntity BuildBranchEntity(int i)
+    {
+        var branch = new RelationshipsBranchEntity { Id = i + 1, Name = "Branch " + (i + 1) };
+        branch.RequiredReferenceLeaf = BuildLeafEntity(15 - i);
+
+        if (i % 4 < 2)
+        {
+            branch.OptionalReferenceLeaf = BuildLeafEntity(i);
+        }
+
+        branch.CollectionLeaf = new List<RelationshipsLeafEntity>();
+        if (i % 4 == 0)
+        {
+            branch.CollectionLeaf.Add(BuildLeafEntity(i + 1));
+            branch.CollectionLeaf.Add(BuildLeafEntity(i + 2));
+            if (i == 8)
+            {
+                branch.CollectionLeaf.Add(BuildLeafEntity(12));
+            }
+        }
+
+        return branch;
+    }
+
+    private static RelationshipsLeafEntity BuildLeafEntity(int i)
+        => new RelationshipsLeafEntity { Id = i + 1, Name = "Leaf " + (i + 1) };
+
+    public static IReadOnlyList<RelationshipsRootEntity> CreateRootEntities()
+    {
+        var roots = new List<RelationshipsRootEntity>();
+
+        var id = 0;
+        for (var i = 0; i < 16; i++)
+        {
+            roots.Add(new RelationshipsRootEntity { Id = ++id, Name = "Root " + id });
+        }
+
+        return roots;
+    }
+
+    public static IReadOnlyList<RelationshipsTrunkEntity> CreateTrunkEntities()
+    {
+        var trunks = new List<RelationshipsTrunkEntity>();
+
+        var id = 0;
+        for (var i = 0; i < 16; i++)
+        {
+            trunks.Add(new RelationshipsTrunkEntity { Id = ++id, Name = "Trunk " + id });
+        }
+
+        return trunks;
+    }
+
+    public static IReadOnlyList<RelationshipsBranchEntity> CreateBranchEntities()
+    {
+        var branches = new List<RelationshipsBranchEntity>();
+
+        var id = 0;
+        for (var i = 0; i < 16; i++)
+        {
+            branches.Add(new RelationshipsBranchEntity { Id = ++id, Name = "Branch " + id });
+        }
+
+        return branches;
+    }
+
+    public static IReadOnlyList<RelationshipsLeafEntity> CreateLeafEntities()
+    {
+        var leaves = new List<RelationshipsLeafEntity>();
+
+        var id = 0;
+        for (var i = 0; i < 16; i++)
+        {
+            leaves.Add(new RelationshipsLeafEntity { Id = ++id, Name = "Leaf " + id });
+        }
+
+        return leaves;
+    }
+
+
+    public static void WireUp(
+        IReadOnlyList<RelationshipsRootEntity> rootEntities,
+        IReadOnlyList<RelationshipsTrunkEntity> trunkEntities,
+        IReadOnlyList<RelationshipsBranchEntity> branchEntities,
+        IReadOnlyList<RelationshipsLeafEntity> leafEntities,
+        bool wireUpRootToTrunkOnly)
+    {
+        for (int i = 0; i < 16; i++)
+        {
+            rootEntities[i].RequiredReferenceTrunk = trunkEntities[15 - i];
+            rootEntities[i].RequiredReferenceTrunkId = trunkEntities[15 - i].Id;
+            trunkEntities[15 - i].RequiredReferenceInverseRoot = rootEntities[i];
+
+            if (!wireUpRootToTrunkOnly)
+            {
+                trunkEntities[i].RequiredReferenceBranch = branchEntities[15 - i];
+                trunkEntities[i].RequiredReferenceBranchId = branchEntities[15 - i].Id;
+                branchEntities[15 - i].RequiredReferenceInverseTrunk = trunkEntities[i];
+
+                branchEntities[i].RequiredReferenceLeaf = leafEntities[15 - i];
+                branchEntities[i].RequiredReferenceLeafId = leafEntities[15 - i].Id;
+                leafEntities[15 - i].RequiredReferenceInverseBranch = branchEntities[i];
+            }
+
+            rootEntities[i].CollectionTrunk = new List<RelationshipsTrunkEntity>();
+
+            if (i < 8)
+            {
+                rootEntities[i].OptionalReferenceTrunk = trunkEntities[i];
+                rootEntities[i].OptionalReferenceTrunkId = trunkEntities[i].Id;
+                trunkEntities[i].OptionalReferenceInverseRoot = rootEntities[i];
+            }
+
+            if (!wireUpRootToTrunkOnly)
+            {
+                if (i % 8 < 4)
+                {
+                    trunkEntities[i].OptionalReferenceBranch = branchEntities[i];
+                    trunkEntities[i].OptionalReferenceBranchId = branchEntities[i].Id;
+                    branchEntities[i].OptionalReferenceInverseTrunk = trunkEntities[i];
+                }
+
+                if (i % 4 < 2)
+                {
+                    branchEntities[i].OptionalReferenceLeaf = leafEntities[i];
+                    branchEntities[i].OptionalReferenceLeafId = leafEntities[i].Id;
+                    leafEntities[i].OptionalReferenceInverseBranch = branchEntities[i];
+                }
+
+                trunkEntities[i].CollectionBranch = new List<RelationshipsBranchEntity>();
+                branchEntities[i].CollectionLeaf = new List<RelationshipsLeafEntity>();
+            }
+
+            if (i % 4 == 0)
+            {
+                rootEntities[i].CollectionTrunk.AddRange(trunkEntities[i + 1], trunkEntities[i + 2]);
+                if (i == 0)
+                {
+                    rootEntities[i].CollectionTrunk.Add(trunkEntities[4]);
+                }
+
+                trunkEntities[i + 1].CollectionInverseRoot = rootEntities[i];
+                trunkEntities[i + 1].CollectionRootId = rootEntities[i].Id;
+
+                trunkEntities[i + 2].CollectionInverseRoot = rootEntities[i];
+                trunkEntities[i + 2].CollectionRootId = rootEntities[i].Id;
+
+                if (i == 0)
+                {
+                    trunkEntities[4].CollectionInverseRoot = rootEntities[i];
+                    trunkEntities[4].CollectionRootId = rootEntities[i].Id;
+                }
+
+                if (!wireUpRootToTrunkOnly)
+                {
+                    trunkEntities[i].CollectionBranch.AddRange(branchEntities[i + 1], branchEntities[i + 2]);
+                    if (i == 4)
+                    {
+                        trunkEntities[i].CollectionBranch.Add(branchEntities[8]);
+                    }
+
+                    branchEntities[i + 1].CollectionInverseTrunk = trunkEntities[i];
+                    branchEntities[i + 1].CollectionTrunkId = trunkEntities[i].Id;
+
+                    branchEntities[i + 2].CollectionInverseTrunk = trunkEntities[i];
+                    branchEntities[i + 2].CollectionTrunkId = trunkEntities[i].Id;
+
+                    if (i == 4)
+                    {
+                        branchEntities[8].CollectionInverseTrunk = trunkEntities[i];
+                        branchEntities[8].CollectionTrunkId = trunkEntities[i].Id;
+                    }
+
+                    branchEntities[i].CollectionLeaf.AddRange(leafEntities[i + 1], leafEntities[i + 2]);
+                    if (i == 8)
+                    {
+                        branchEntities[i].CollectionLeaf.Add(leafEntities[12]);
+                    }
+
+                    leafEntities[i + 1].CollectionInverseBranch = branchEntities[i];
+                    leafEntities[i + 1].CollectionBranchId = branchEntities[i].Id;
+
+                    leafEntities[i + 2].CollectionInverseBranch = branchEntities[i];
+                    leafEntities[i + 2].CollectionBranchId = branchEntities[i].Id;
+
+                    if (i == 8)
+                    {
+                        leafEntities[12].CollectionInverseBranch = branchEntities[i];
+                        leafEntities[12].CollectionBranchId = branchEntities[i].Id;
+                    }
+                }
+            }
+        }
+    }
+
+    public IQueryable<TEntity> Set<TEntity>()
+        where TEntity : class
+    {
+        if (typeof(TEntity) == typeof(RelationshipsRootEntity))
+        {
+            return (IQueryable<TEntity>)RootEntities.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(RelationshipsTrunkEntity))
+        {
+            return (IQueryable<TEntity>)TrunkEntities.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(RelationshipsBranchEntity))
+        {
+            return (IQueryable<TEntity>)BranchEntities.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(RelationshipsLeafEntity))
+        {
+            return (IQueryable<TEntity>)LeafEntities.AsQueryable();
+        }
+
+        throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsLeafEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsLeafEntity.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsLeafEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public RelationshipsBranchEntity OptionalReferenceInverseBranch { get; set; } = null!;
+
+    public RelationshipsBranchEntity RequiredReferenceInverseBranch { get; set; } = null!;
+
+    public int? CollectionBranchId { get; set; }
+    public RelationshipsBranchEntity CollectionInverseBranch { get; set; } = null!;
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsRootEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsRootEntity.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsRootEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public int? OptionalReferenceTrunkId { get; set; }
+    public RelationshipsTrunkEntity? OptionalReferenceTrunk { get; set; } = null!;
+
+    public int RequiredReferenceTrunkId { get; set; }
+    public RelationshipsTrunkEntity RequiredReferenceTrunk { get; set; } = null!;
+    public List<RelationshipsTrunkEntity> CollectionTrunk { get; set; } = null!;
+}

--- a/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsTrunkEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/RelationshipsModel/RelationshipsTrunkEntity.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+public class RelationshipsTrunkEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public int? OptionalReferenceBranchId { get; set; }
+    public RelationshipsBranchEntity? OptionalReferenceBranch { get; set; } = null!;
+
+    public int RequiredReferenceBranchId { get; set; }
+    public RelationshipsBranchEntity RequiredReferenceBranch { get; set; } = null!;
+
+    public List<RelationshipsBranchEntity> CollectionBranch { get; set; } = null!;
+
+    public RelationshipsRootEntity? OptionalReferenceInverseRoot { get; set; } = null!;
+
+    public RelationshipsRootEntity RequiredReferenceInverseRoot { get; set; } = null!;
+
+    public int? CollectionRootId { get; set; }
+    public RelationshipsRootEntity CollectionInverseRoot { get; set; } = null!;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
@@ -17,28 +17,6 @@ public class JsonQueryJsonTypeSqlServerTest : JsonQueryRelationalTestBase<JsonQu
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    public override async Task Basic_json_projection_owner_entity(bool async)
-    {
-        await base.Basic_json_projection_owner_entity(async);
-
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owner_entity_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_NoTracking(async);
-
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
     public override async Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
     {
         await base.Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(async);
@@ -50,27 +28,27 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owner_entity_duplicated(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_duplicated(async);
+//    public override async Task Basic_json_projection_owner_entity_duplicated(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_duplicated(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
+//    public override async Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
-FROM [JsonEntitiesSingleOwned] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
+//FROM [JsonEntitiesSingleOwned] AS [j]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(bool async)
     {
@@ -83,27 +61,27 @@ FROM [JsonEntitiesSingleOwned] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owner_entity_twice(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_twice(async);
+//    public override async Task Basic_json_projection_owner_entity_twice(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_twice(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_twice_NoTracking(async);
+//    public override async Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_twice_NoTracking(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owner_entity_twice_NoTrackingWithIdentityResolution(bool async)
     {
@@ -112,17 +90,6 @@ FROM [JsonEntitiesBasic] AS [j]
         AssertSql(
             """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_reference_root(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_root(async);
-
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -138,17 +105,17 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_duplicated(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_duplicated(async);
+//    public override async Task Basic_json_projection_owned_reference_duplicated(bool async)
+//    {
+//        await base.Basic_json_projection_owned_reference_duplicated(async);
 
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
-FROM [JsonEntitiesBasic] AS [j]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
+//FROM [JsonEntitiesBasic] AS [j]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owned_reference_duplicated_NoTrackingWithIdentityResolution(bool async)
     {
@@ -162,17 +129,17 @@ ORDER BY [j].[Id]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_duplicated2(async);
+//    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
+//    {
+//        await base.Basic_json_projection_owned_reference_duplicated2(async);
 
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
-FROM [JsonEntitiesBasic] AS [j]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
+//FROM [JsonEntitiesBasic] AS [j]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owned_reference_duplicated2_NoTrackingWithIdentityResolution(bool async)
     {
@@ -183,17 +150,6 @@ ORDER BY [j].[Id]
 SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_collection_root(bool async)
-    {
-        await base.Basic_json_projection_owned_collection_root(async);
-
-        AssertSql(
-            """
-SELECT [j].[OwnedCollectionRoot], [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
@@ -208,17 +164,6 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_branch(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_branch(async);
-
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
     public override async Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
     {
         await base.Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(async);
@@ -226,17 +171,6 @@ FROM [JsonEntitiesBasic] AS [j]
         AssertSql(
             """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_collection_branch(bool async)
-    {
-        await base.Basic_json_projection_owned_collection_branch(async);
-
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -319,27 +253,27 @@ FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
 
-    public override async Task Json_projection_with_deduplication(bool async)
-    {
-        await base.Json_projection_with_deduplication(async);
+//    public override async Task Json_projection_with_deduplication(bool async)
+//    {
+//        await base.Json_projection_with_deduplication(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Json_projection_with_deduplication_reverse_order(bool async)
-    {
-        await base.Json_projection_with_deduplication_reverse_order(async);
+//    public override async Task Json_projection_with_deduplication_reverse_order(bool async)
+//    {
+//        await base.Json_projection_with_deduplication_reverse_order(async);
 
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
     public override async Task Json_property_in_predicate(bool async)
     {
@@ -694,22 +628,22 @@ LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
 """);
     }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c], [j0].[Id]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c], [j0].[Id]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Project_json_entity_FirstOrDefault_subquery_with_binding_on_top(bool async)
     {
@@ -734,56 +668,56 @@ ORDER BY [j].[Id]
             @"");
     }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Json_entity_with_inheritance_basic_projection(bool async)
     {
@@ -1629,45 +1563,45 @@ ORDER BY [j].[Id], [o0].[SomethingSomething]
 """);
     }
 
-    public override async Task Json_collection_SelectMany(bool async)
-    {
-        await base.Json_collection_SelectMany(async);
+//    public override async Task Json_collection_SelectMany(bool async)
+//    {
+//        await base.Json_collection_SelectMany(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [o].[Name], [o].[Names], [o].[Number], [o].[Numbers], [o].[OwnedCollectionBranch], [o].[OwnedReferenceBranch]
-FROM [JsonEntitiesBasic] AS [j]
-CROSS APPLY OPENJSON(CAST([j].[OwnedCollectionRoot] AS nvarchar(max)), '$') WITH (
-    [Name] nvarchar(max) '$.Name',
-    [Names] nvarchar(max) '$.Names' AS JSON,
-    [Number] int '$.Number',
-    [Numbers] nvarchar(max) '$.Numbers' AS JSON,
-    [OwnedCollectionBranch] nvarchar(max) '$.OwnedCollectionBranch' AS JSON,
-    [OwnedReferenceBranch] nvarchar(max) '$.OwnedReferenceBranch' AS JSON
-) AS [o]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [o].[Name], [o].[Names], [o].[Number], [o].[Numbers], [o].[OwnedCollectionBranch], [o].[OwnedReferenceBranch]
+//FROM [JsonEntitiesBasic] AS [j]
+//CROSS APPLY OPENJSON(CAST([j].[OwnedCollectionRoot] AS nvarchar(max)), '$') WITH (
+//    [Name] nvarchar(max) '$.Name',
+//    [Names] nvarchar(max) '$.Names' AS JSON,
+//    [Number] int '$.Number',
+//    [Numbers] nvarchar(max) '$.Numbers' AS JSON,
+//    [OwnedCollectionBranch] nvarchar(max) '$.OwnedCollectionBranch' AS JSON,
+//    [OwnedReferenceBranch] nvarchar(max) '$.OwnedReferenceBranch' AS JSON
+//) AS [o]
+//""");
+//    }
 
-    public override async Task Json_nested_collection_SelectMany(bool async)
-    {
-        await base.Json_nested_collection_SelectMany(async);
+//    public override async Task Json_nested_collection_SelectMany(bool async)
+//    {
+//        await base.Json_nested_collection_SelectMany(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [o].[Date], [o].[Enum], [o].[Enums], [o].[Fraction], [o].[NullableEnum], [o].[NullableEnums], [o].[OwnedCollectionLeaf], [o].[OwnedReferenceLeaf]
-FROM [JsonEntitiesBasic] AS [j]
-CROSS APPLY OPENJSON(CAST([j].[OwnedReferenceRoot] AS nvarchar(max)), '$.OwnedCollectionBranch') WITH (
-    [Date] datetime2 '$.Date',
-    [Enum] int '$.Enum',
-    [Enums] nvarchar(max) '$.Enums' AS JSON,
-    [Fraction] decimal(18,2) '$.Fraction',
-    [NullableEnum] int '$.NullableEnum',
-    [NullableEnums] nvarchar(max) '$.NullableEnums' AS JSON,
-    [OwnedCollectionLeaf] nvarchar(max) '$.OwnedCollectionLeaf' AS JSON,
-    [OwnedReferenceLeaf] nvarchar(max) '$.OwnedReferenceLeaf' AS JSON
-) AS [o]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [o].[Date], [o].[Enum], [o].[Enums], [o].[Fraction], [o].[NullableEnum], [o].[NullableEnums], [o].[OwnedCollectionLeaf], [o].[OwnedReferenceLeaf]
+//FROM [JsonEntitiesBasic] AS [j]
+//CROSS APPLY OPENJSON(CAST([j].[OwnedReferenceRoot] AS nvarchar(max)), '$.OwnedCollectionBranch') WITH (
+//    [Date] datetime2 '$.Date',
+//    [Enum] int '$.Enum',
+//    [Enums] nvarchar(max) '$.Enums' AS JSON,
+//    [Fraction] decimal(18,2) '$.Fraction',
+//    [NullableEnum] int '$.NullableEnum',
+//    [NullableEnums] nvarchar(max) '$.NullableEnums' AS JSON,
+//    [OwnedCollectionLeaf] nvarchar(max) '$.OwnedCollectionLeaf' AS JSON,
+//    [OwnedReferenceLeaf] nvarchar(max) '$.OwnedReferenceLeaf' AS JSON
+//) AS [o]
+//""");
+//    }
 
     public override async Task Json_collection_of_primitives_SelectMany(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -17,28 +17,6 @@ public class JsonQuerySqlServerTest : JsonQueryRelationalTestBase<JsonQuerySqlSe
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    public override async Task Basic_json_projection_owner_entity(bool async)
-    {
-        await base.Basic_json_projection_owner_entity(async);
-
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owner_entity_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_NoTracking(async);
-
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
     public override async Task Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(bool async)
     {
         await base.Basic_json_projection_owner_entity_NoTrackingWithIdentityResolution(async);
@@ -50,27 +28,27 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owner_entity_duplicated(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_duplicated(async);
+//    public override async Task Basic_json_projection_owner_entity_duplicated(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_duplicated(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
+//    public override async Task Basic_json_projection_owner_entity_duplicated_NoTracking(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
-FROM [JsonEntitiesSingleOwned] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
+//FROM [JsonEntitiesSingleOwned] AS [j]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owner_entity_duplicated_NoTrackingWithIdentityResolution(bool async)
     {
@@ -83,27 +61,27 @@ FROM [JsonEntitiesSingleOwned] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owner_entity_twice(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_twice(async);
+//    public override async Task Basic_json_projection_owner_entity_twice(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_twice(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
-    {
-        await base.Basic_json_projection_owner_entity_twice_NoTracking(async);
+//    public override async Task Basic_json_projection_owner_entity_twice_NoTracking(bool async)
+//    {
+//        await base.Basic_json_projection_owner_entity_twice_NoTracking(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owner_entity_twice_NoTrackingWithIdentityResolution(bool async)
     {
@@ -112,17 +90,6 @@ FROM [JsonEntitiesBasic] AS [j]
         AssertSql(
             """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_reference_root(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_root(async);
-
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -138,17 +105,17 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_duplicated(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_duplicated(async);
+//    public override async Task Basic_json_projection_owned_reference_duplicated(bool async)
+//    {
+//        await base.Basic_json_projection_owned_reference_duplicated(async);
 
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
-FROM [JsonEntitiesBasic] AS [j]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
+//FROM [JsonEntitiesBasic] AS [j]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owned_reference_duplicated_NoTrackingWithIdentityResolution(bool async)
     {
@@ -162,17 +129,17 @@ ORDER BY [j].[Id]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_duplicated2(async);
+//    public override async Task Basic_json_projection_owned_reference_duplicated2(bool async)
+//    {
+//        await base.Basic_json_projection_owned_reference_duplicated2(async);
 
-        AssertSql(
-            """
-SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
-FROM [JsonEntitiesBasic] AS [j]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
+//FROM [JsonEntitiesBasic] AS [j]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Basic_json_projection_owned_reference_duplicated2_NoTrackingWithIdentityResolution(bool async)
     {
@@ -183,17 +150,6 @@ ORDER BY [j].[Id]
 SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_collection_root(bool async)
-    {
-        await base.Basic_json_projection_owned_collection_root(async);
-
-        AssertSql(
-            """
-SELECT [j].[OwnedCollectionRoot], [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
@@ -208,17 +164,6 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Basic_json_projection_owned_reference_branch(bool async)
-    {
-        await base.Basic_json_projection_owned_reference_branch(async);
-
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
     public override async Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
     {
         await base.Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(async);
@@ -226,17 +171,6 @@ FROM [JsonEntitiesBasic] AS [j]
         AssertSql(
             """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
-
-    public override async Task Basic_json_projection_owned_collection_branch(bool async)
-    {
-        await base.Basic_json_projection_owned_collection_branch(async);
-
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -319,27 +253,27 @@ FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
 
-    public override async Task Json_projection_with_deduplication(bool async)
-    {
-        await base.Json_projection_with_deduplication(async);
+//    public override async Task Json_projection_with_deduplication(bool async)
+//    {
+//        await base.Json_projection_with_deduplication(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
-    public override async Task Json_projection_with_deduplication_reverse_order(bool async)
-    {
-        await base.Json_projection_with_deduplication_reverse_order(async);
+//    public override async Task Json_projection_with_deduplication_reverse_order(bool async)
+//    {
+//        await base.Json_projection_with_deduplication_reverse_order(async);
 
-        AssertSql(
-            """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+//FROM [JsonEntitiesBasic] AS [j]
+//""");
+//    }
 
     public override async Task Json_property_in_predicate(bool async)
     {
@@ -641,22 +575,22 @@ LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
 """);
     }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c], [j0].[Id]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c], [j0].[Id]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Project_json_entity_FirstOrDefault_subquery_with_binding_on_top(bool async)
     {
@@ -681,56 +615,56 @@ ORDER BY [j].[Id]
             @"");
     }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0], [j1].[Id0], [j1].[c1], [j1].[c2], [j1].[c3], [j1].[c4]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS int) AS [c3], 1 AS [c4]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
-    {
-        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async);
+//    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
+//    {
+//        await base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async);
 
-        AssertSql(
-            """
-SELECT [j1].[c], [j1].[Id], [j1].[c0]
-FROM [JsonEntitiesBasic] AS [j]
-OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
-    FROM [JsonEntitiesBasic] AS [j0]
-    ORDER BY [j0].[Id]
-) AS [j1]
-ORDER BY [j].[Id]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j1].[c], [j1].[Id], [j1].[c0]
+//FROM [JsonEntitiesBasic] AS [j]
+//OUTER APPLY (
+//    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
+//    FROM [JsonEntitiesBasic] AS [j0]
+//    ORDER BY [j0].[Id]
+//) AS [j1]
+//ORDER BY [j].[Id]
+//""");
+//    }
 
     public override async Task Json_entity_with_inheritance_basic_projection(bool async)
     {
@@ -1542,47 +1476,47 @@ ORDER BY [j].[Id], [o0].[SomethingSomething]
 """);
     }
 
-    public override async Task Json_collection_SelectMany(bool async)
-    {
-        await base.Json_collection_SelectMany(async);
+//    public override async Task Json_collection_SelectMany(bool async)
+//    {
+//        await base.Json_collection_SelectMany(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [o].[Id], [o].[Name], [o].[Names], [o].[Number], [o].[Numbers], [o].[OwnedCollectionBranch], [o].[OwnedReferenceBranch]
-FROM [JsonEntitiesBasic] AS [j]
-CROSS APPLY OPENJSON([j].[OwnedCollectionRoot], '$') WITH (
-    [Id] int '$.Id',
-    [Name] nvarchar(max) '$.Name',
-    [Names] nvarchar(max) '$.Names' AS JSON,
-    [Number] int '$.Number',
-    [Numbers] nvarchar(max) '$.Numbers' AS JSON,
-    [OwnedCollectionBranch] nvarchar(max) '$.OwnedCollectionBranch' AS JSON,
-    [OwnedReferenceBranch] nvarchar(max) '$.OwnedReferenceBranch' AS JSON
-) AS [o]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [o].[Id], [o].[Name], [o].[Names], [o].[Number], [o].[Numbers], [o].[OwnedCollectionBranch], [o].[OwnedReferenceBranch]
+//FROM [JsonEntitiesBasic] AS [j]
+//CROSS APPLY OPENJSON([j].[OwnedCollectionRoot], '$') WITH (
+//    [Id] int '$.Id',
+//    [Name] nvarchar(max) '$.Name',
+//    [Names] nvarchar(max) '$.Names' AS JSON,
+//    [Number] int '$.Number',
+//    [Numbers] nvarchar(max) '$.Numbers' AS JSON,
+//    [OwnedCollectionBranch] nvarchar(max) '$.OwnedCollectionBranch' AS JSON,
+//    [OwnedReferenceBranch] nvarchar(max) '$.OwnedReferenceBranch' AS JSON
+//) AS [o]
+//""");
+//    }
 
-    public override async Task Json_nested_collection_SelectMany(bool async)
-    {
-        await base.Json_nested_collection_SelectMany(async);
+//    public override async Task Json_nested_collection_SelectMany(bool async)
+//    {
+//        await base.Json_nested_collection_SelectMany(async);
 
-        AssertSql(
-            """
-SELECT [j].[Id], [o].[Date], [o].[Enum], [o].[Enums], [o].[Fraction], [o].[Id], [o].[NullableEnum], [o].[NullableEnums], [o].[OwnedCollectionLeaf], [o].[OwnedReferenceLeaf]
-FROM [JsonEntitiesBasic] AS [j]
-CROSS APPLY OPENJSON([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') WITH (
-    [Date] datetime2 '$.Date',
-    [Enum] int '$.Enum',
-    [Enums] nvarchar(max) '$.Enums' AS JSON,
-    [Fraction] decimal(18,2) '$.Fraction',
-    [Id] int '$.Id',
-    [NullableEnum] int '$.NullableEnum',
-    [NullableEnums] nvarchar(max) '$.NullableEnums' AS JSON,
-    [OwnedCollectionLeaf] nvarchar(max) '$.OwnedCollectionLeaf' AS JSON,
-    [OwnedReferenceLeaf] nvarchar(max) '$.OwnedReferenceLeaf' AS JSON
-) AS [o]
-""");
-    }
+//        AssertSql(
+//            """
+//SELECT [j].[Id], [o].[Date], [o].[Enum], [o].[Enums], [o].[Fraction], [o].[Id], [o].[NullableEnum], [o].[NullableEnums], [o].[OwnedCollectionLeaf], [o].[OwnedReferenceLeaf]
+//FROM [JsonEntitiesBasic] AS [j]
+//CROSS APPLY OPENJSON([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') WITH (
+//    [Date] datetime2 '$.Date',
+//    [Enum] int '$.Enum',
+//    [Enums] nvarchar(max) '$.Enums' AS JSON,
+//    [Fraction] decimal(18,2) '$.Fraction',
+//    [Id] int '$.Id',
+//    [NullableEnum] int '$.NullableEnum',
+//    [NullableEnums] nvarchar(max) '$.NullableEnums' AS JSON,
+//    [OwnedCollectionLeaf] nvarchar(max) '$.OwnedCollectionLeaf' AS JSON,
+//    [OwnedReferenceLeaf] nvarchar(max) '$.OwnedReferenceLeaf' AS JSON
+//) AS [o]
+//""");
+//    }
 
     public override async Task Json_collection_of_primitives_SelectMany(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexRelationshipsQuerySqlServerFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class ComplexRelationshipsQuerySqlServerFixture : ComplexRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/EntityRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/EntityRelationshipsQuerySqlServerFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class EntityRelationshipsQuerySqlServerFixture : EntityRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
@@ -1,0 +1,228 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class ComplexRelationshipsInProjectionNoTrackingQuerySqlServerTest
+    : ComplexRelationshipsInProjectionNoTrackingQueryRelationalTestBase<ComplexRelationshipsQuerySqlServerFixture>
+{
+    public ComplexRelationshipsInProjectionNoTrackingQuerySqlServerTest(ComplexRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_everything(bool async)
+    {
+        await base.Project_everything(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[Id]
+""");
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQuerySqlServerTest.cs
@@ -1,0 +1,228 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class ComplexRelationshipsInProjectionQuerySqlServerTest
+    : ComplexRelationshipsInProjectionQueryRelationalTestBase<ComplexRelationshipsQuerySqlServerFixture>
+{
+    public ComplexRelationshipsInProjectionQuerySqlServerTest(ComplexRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_everything(bool async)
+    {
+        await base.Project_everything(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[Id]
+""");
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[RequiredReferenceBranch_Name], [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql();
+    }       
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT [t].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t].[RequiredReferenceBranch_Name], [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql();
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
@@ -1,0 +1,404 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class EntityRelationshipsInProjectionNoTrackingQuerySqlServerTest
+    : EntityRelationshipsInProjectionNoTrackingQueryRelationalTestBase<EntityRelationshipsQuerySqlServerFixture>
+{
+    public EntityRelationshipsInProjectionNoTrackingQuerySqlServerTest(EntityRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_everything(bool async)
+    {
+        await base.Project_everything(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [l].[Id], [l].[CollectionBranchId], [l].[Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[Id]
+INNER JOIN [LeafEntities] AS [l] ON [b].[Id] = [l].[Id]
+""");
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [l].[Id], [l].[CollectionBranchId], [l].[Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+LEFT JOIN [LeafEntities] AS [l] ON [b].[RequiredReferenceLeafId] = [l].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [l].[Id], [l].[CollectionBranchId], [l].[Name], [t].[Id], [l0].[Id], [l0].[CollectionBranchId], [l0].[Name], [b0].[Id], [b0].[CollectionTrunkId], [b0].[Name], [b0].[OptionalReferenceLeafId], [b0].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+LEFT JOIN [LeafEntities] AS [l] ON [b].[OptionalReferenceLeafId] = [l].[Id]
+LEFT JOIN [LeafEntities] AS [l0] ON [b].[Id] = [l0].[CollectionBranchId]
+LEFT JOIN [BranchEntities] AS [b0] ON [t].[Id] = [b0].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [b].[Id], [l].[Id], [l0].[Id]
+""");
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT [l].[Id], [l].[CollectionBranchId], [l].[Name], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+INNER JOIN [LeafEntities] AS [l] ON [b].[RequiredReferenceLeafId] = [l].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [s].[Id], [s].[CollectionTrunkId], [s].[Name], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t] ON [r0].[RequiredReferenceTrunkId] = [t].[Id]
+    INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [s].[Id], [s].[CollectionTrunkId], [s].[Name], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+    FROM [RootEntities] AS [r0]
+    LEFT JOIN [TrunkEntities] AS [t] ON [r0].[OptionalReferenceTrunkId] = [t].[Id]
+    LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [s].[Id], [s].[Id0], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [s].[c]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id], [t].[Id] AS [Id0]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t] ON [r0].[RequiredReferenceTrunkId] = [t].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+LEFT JOIN [BranchEntities] AS [b] ON [s].[Id0] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [s].[Id], [s].[Id0]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [s].[Id1], [s].[Id], [s].[Id0], [b1].[Id], [b1].[CollectionTrunkId], [b1].[Name], [b1].[OptionalReferenceLeafId], [b1].[RequiredReferenceLeafId], [s].[CollectionRootId], [s].[Name], [s].[OptionalReferenceBranchId], [s].[RequiredReferenceBranchId], [s].[CollectionTrunkId], [s].[Name0], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId], [s].[Name1], [s].[c]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+OUTER APPLY (
+    SELECT TOP(1) [t0].[Id], [t0].[CollectionRootId], [t0].[Name], [t0].[OptionalReferenceBranchId], [t0].[RequiredReferenceBranchId], [b0].[Id] AS [Id0], [b0].[CollectionTrunkId], [b0].[Name] AS [Name0], [b0].[OptionalReferenceLeafId], [b0].[RequiredReferenceLeafId], [b].[Name] AS [Name1], 1 AS [c], [r0].[Id] AS [Id1]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t0] ON [r0].[RequiredReferenceTrunkId] = [t0].[Id]
+    INNER JOIN [BranchEntities] AS [b0] ON [t0].[RequiredReferenceBranchId] = [b0].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+LEFT JOIN [BranchEntities] AS [b1] ON [t].[Id] = [b1].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [b].[Id], [s].[Id1], [s].[Id], [s].[Id0]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [r1].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [r1].[c]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [r1].[Id]
+""");
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+""");
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+""");
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+""");
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQuerySqlServerTest.cs
@@ -1,0 +1,373 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class EntityRelationshipsInProjectionQuerySqlServerTest
+    : EntityRelationshipsInProjectionQueryRelationalTestBase<EntityRelationshipsQuerySqlServerFixture>
+{
+    public EntityRelationshipsInProjectionQuerySqlServerTest(EntityRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_everything(bool async)
+    {
+        await base.Project_everything(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [l].[Id], [l].[CollectionBranchId], [l].[Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[Id]
+INNER JOIN [LeafEntities] AS [l] ON [b].[Id] = [l].[Id]
+""");
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+"""
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [l].[Id], [l].[CollectionBranchId], [l].[Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+LEFT JOIN [LeafEntities] AS [l] ON [b].[RequiredReferenceLeafId] = [l].[Id]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [l].[Id], [l].[CollectionBranchId], [l].[Name], [t].[Id], [l0].[Id], [l0].[CollectionBranchId], [l0].[Name], [b0].[Id], [b0].[CollectionTrunkId], [b0].[Name], [b0].[OptionalReferenceLeafId], [b0].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+LEFT JOIN [LeafEntities] AS [l] ON [b].[OptionalReferenceLeafId] = [l].[Id]
+LEFT JOIN [LeafEntities] AS [l0] ON [b].[Id] = [l0].[CollectionBranchId]
+LEFT JOIN [BranchEntities] AS [b0] ON [t].[Id] = [b0].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [b].[Id], [l].[Id], [l0].[Id]
+""");
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT [l].[Id], [l].[CollectionBranchId], [l].[Name], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+INNER JOIN [LeafEntities] AS [l] ON [b].[RequiredReferenceLeafId] = [l].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [s].[Id], [s].[CollectionTrunkId], [s].[Name], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t] ON [r0].[RequiredReferenceTrunkId] = [t].[Id]
+    INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [s].[Id], [s].[CollectionTrunkId], [s].[Name], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+    FROM [RootEntities] AS [r0]
+    LEFT JOIN [TrunkEntities] AS [t] ON [r0].[OptionalReferenceTrunkId] = [t].[Id]
+    LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [s].[Id], [s].[Id0], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [s].[c]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id], [t].[Id] AS [Id0]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t] ON [r0].[RequiredReferenceTrunkId] = [t].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+LEFT JOIN [BranchEntities] AS [b] ON [s].[Id0] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [s].[Id], [s].[Id0]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [b].[Id], [s].[Id1], [s].[Id], [s].[Id0], [b1].[Id], [b1].[CollectionTrunkId], [b1].[Name], [b1].[OptionalReferenceLeafId], [b1].[RequiredReferenceLeafId], [s].[CollectionRootId], [s].[Name], [s].[OptionalReferenceBranchId], [s].[RequiredReferenceBranchId], [s].[CollectionTrunkId], [s].[Name0], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId], [s].[Name1], [s].[c]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+OUTER APPLY (
+    SELECT TOP(1) [t0].[Id], [t0].[CollectionRootId], [t0].[Name], [t0].[OptionalReferenceBranchId], [t0].[RequiredReferenceBranchId], [b0].[Id] AS [Id0], [b0].[CollectionTrunkId], [b0].[Name] AS [Name0], [b0].[OptionalReferenceLeafId], [b0].[RequiredReferenceLeafId], [b].[Name] AS [Name1], 1 AS [c], [r0].[Id] AS [Id1]
+    FROM [RootEntities] AS [r0]
+    INNER JOIN [TrunkEntities] AS [t0] ON [r0].[RequiredReferenceTrunkId] = [t0].[Id]
+    INNER JOIN [BranchEntities] AS [b0] ON [t0].[RequiredReferenceBranchId] = [b0].[Id]
+    ORDER BY [r0].[Id]
+) AS [s]
+LEFT JOIN [BranchEntities] AS [b1] ON [t].[Id] = [b1].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [b].[Id], [s].[Id1], [s].[Id], [s].[Id0]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [t].[Id], [r1].[Id], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId], [r1].[c]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id], [r1].[Id]
+""");
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+""");
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+""");
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+""");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
@@ -1,0 +1,371 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class JsonRelationshipsInProjectionNoTrackingQuerySqlServerTest
+    : JsonRelationshipsInProjectionNoTrackingQueryRelationalTestBase<JsonRelationshipsQuerySqlServerFixture>
+{
+    public JsonRelationshipsInProjectionNoTrackingQuerySqlServerTest(JsonRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [r].[OptionalReferenceTrunk], [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[RequiredReferenceTrunk], [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[CollectionTrunk], [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.OptionalReferenceBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.OptionalReferenceBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+
+
+
+
+
+
+
+
+
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[OptionalReferenceTrunk], [r].[Id], JSON_QUERY([r].[OptionalReferenceTrunk], '$.RequiredReferenceBranch'), [r].[OptionalReferenceTrunk], JSON_QUERY([r].[OptionalReferenceTrunk], '$.RequiredReferenceBranch')
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[RequiredReferenceTrunk], [r].[Id], JSON_QUERY([r].[RequiredReferenceTrunk], '$.OptionalReferenceBranch.RequiredReferenceLeaf'), [r].[RequiredReferenceTrunk], JSON_QUERY([r].[RequiredReferenceTrunk], '$.OptionalReferenceBranch.RequiredReferenceLeaf')
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch'), JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch.OptionalReferenceLeaf'), JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch.CollectionLeaf'), JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch'), JSON_VALUE([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch.OptionalReferenceLeaf.Name')
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch.RequiredReferenceLeaf'), [r].[Id], [r].[RequiredReferenceTrunk], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [r1].[c], [r1].[Id]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) JSON_QUERY([r0].[RequiredReferenceTrunk], '$.RequiredReferenceBranch') AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [r1].[c], [r1].[Id]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) JSON_QUERY([r0].[OptionalReferenceTrunk], '$.OptionalReferenceBranch') AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql(
+            """
+SELECT [r1].[c], [r1].[Id], [r1].[c0]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) JSON_QUERY([r0].[RequiredReferenceTrunk], '$.CollectionBranch') AS [c], [r0].[Id], 1 AS [c0]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [r1].[c], [r1].[Id], [r1].[c0], [r1].[Id0], [r1].[c1], [r1].[c2], [r1].[c3], [r1].[c4]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch') AS [c], [r].[Id], [r0].[RequiredReferenceTrunk] AS [c0], [r0].[Id] AS [Id0], JSON_QUERY([r0].[RequiredReferenceTrunk], '$.RequiredReferenceBranch') AS [c1], JSON_VALUE([r0].[RequiredReferenceTrunk], '$.Name') AS [c2], JSON_VALUE([r].[RequiredReferenceTrunk], '$.RequiredReferenceBranch.Name') AS [c3], 1 AS [c4]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql(
+            """
+SELECT [r1].[c], [r1].[Id], [r1].[c0]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch') AS [c], [r].[Id], 1 AS [c0]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r1]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [c].[Name], [c].[CollectionBranch], [c].[OptionalReferenceBranch], [c].[RequiredReferenceBranch]
+FROM [RootEntities] AS [r]
+CROSS APPLY OPENJSON([r].[CollectionTrunk], '$') WITH (
+    [Name] nvarchar(max) '$.Name',
+    [CollectionBranch] nvarchar(max) '$.CollectionBranch' AS JSON,
+    [OptionalReferenceBranch] nvarchar(max) '$.OptionalReferenceBranch' AS JSON,
+    [RequiredReferenceBranch] nvarchar(max) '$.RequiredReferenceBranch' AS JSON
+) AS [c]
+""");
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [c].[Name], [c].[CollectionLeaf], [c].[OptionalReferenceLeaf], [c].[RequiredReferenceLeaf]
+FROM [RootEntities] AS [r]
+CROSS APPLY OPENJSON([r].[RequiredReferenceTrunk], '$.CollectionBranch') WITH (
+    [Name] nvarchar(max) '$.Name',
+    [CollectionLeaf] nvarchar(max) '$.CollectionLeaf' AS JSON,
+    [OptionalReferenceLeaf] nvarchar(max) '$.OptionalReferenceLeaf' AS JSON,
+    [RequiredReferenceLeaf] nvarchar(max) '$.RequiredReferenceLeaf' AS JSON
+) AS [c]
+""");
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [c].[Name], [c].[CollectionLeaf], [c].[OptionalReferenceLeaf], [c].[RequiredReferenceLeaf]
+FROM [RootEntities] AS [r]
+CROSS APPLY OPENJSON([r].[OptionalReferenceTrunk], '$.CollectionBranch') WITH (
+    [Name] nvarchar(max) '$.Name',
+    [CollectionLeaf] nvarchar(max) '$.CollectionLeaf' AS JSON,
+    [OptionalReferenceLeaf] nvarchar(max) '$.OptionalReferenceLeaf' AS JSON,
+    [RequiredReferenceLeaf] nvarchar(max) '$.RequiredReferenceLeaf' AS JSON
+) AS [c]
+""");
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQuerySqlServerTest.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class JsonRelationshipsInProjectionQuerySqlServerTest
+    : JsonRelationshipsInProjectionQueryRelationalTestBase<JsonRelationshipsQuerySqlServerFixture>
+{
+    public JsonRelationshipsInProjectionQuerySqlServerTest(JsonRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk], [r].[CollectionTrunk], [r].[OptionalReferenceTrunk], [r].[RequiredReferenceTrunk]
+FROM [RootEntities] AS [r]
+""");
+    }
+
+    public override Task Project_trunk_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_optional(async));
+
+    public override Task Project_trunk_required(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_required(async));
+
+    public override Task Project_trunk_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_collection(async));
+
+    public override Task Project_branch_required_required(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_required(async));
+
+    public override Task Project_branch_required_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_optional(async));
+
+    public override Task Project_branch_required_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_collection(async));
+
+    public override  Task Project_branch_optional_required(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_required(async));
+
+    public override Task Project_branch_optional_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_optional(async));
+
+    public override Task Project_branch_optional_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_collection(async));
+
+    public override Task Project_branch_collection_element_using_indexer_constant(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_collection_element_using_indexer_constant(async));
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_and_branch_duplicated(async));
+
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_and_trunk_duplicated(async));
+
+    public override Task Project_multiple_branch_leaf(bool async)
+        => AssertCantTrackJson(() => base.Project_multiple_branch_leaf(async));
+
+    public override Task Project_leaf_trunk_root(bool async)
+        => AssertCantTrackJson(() => base.Project_leaf_trunk_root(async));
+
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => AssertCantTrackJson(() => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => AssertCantTrackJson(() => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async));
+
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => AssertCantTrackJson(() => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async));
+
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => AssertCantTrackJson(() => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async));
+
+    public override Task SelectMany_trunk_collection(bool async)
+        => AssertCantTrackJson(() => base.SelectMany_trunk_collection(async));
+
+    public override Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => AssertCantTrackJson(() => base.SelectMany_required_trunk_reference_branch_collection(async));
+
+    public override Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => AssertCantTrackJson(() => base.SelectMany_optional_trunk_reference_branch_collection(async));
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    private async Task AssertCantTrackJson(Func<Task> test)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(test)).Message;
+
+        Assert.Equal(RelationalStrings.JsonEntityOrCollectionProjectedAtRootLevelInTrackingQuery("AsNoTracking"), message);
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonTypeRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/JsonTypeRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+// Only adding NoTracking version - no point to do both and most of the tests don't work in tracking (projecting without owner)
+[SqlServerCondition(SqlServerCondition.SupportsJsonType)]
+public class JsonTypeRelationshipsInProjectionNoTrackingQuerySqlServerTest
+    : RelationshipsInProjectionQueryTestBase<JsonTypeRelationshipsQuerySqlServerFixture>
+{
+    private readonly NoTrackingRewriter _noTrackingRewriter = new();
+
+    public JsonTypeRelationshipsInProjectionNoTrackingQuerySqlServerTest(JsonTypeRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
+    {
+        var rewritten = _noTrackingRewriter.Visit(serverQueryExpression);
+
+        return rewritten;
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQuerySqlServerTest.cs
@@ -1,0 +1,635 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class OwnedRelationshipsInProjectionNoTrackingQuerySqlServerTest
+    : OwnedRelationshipsInProjectionNoTrackingQueryRelationalTestBase<OwnedRelationshipsQuerySqlServerFixture>
+{
+    public OwnedRelationshipsInProjectionNoTrackingQuerySqlServerTest(OwnedRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [s0].[OptionalReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[Name1], [s0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RequiredReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s0].[Name2], [s0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_Name], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [s1].[Name0], [s1].[OptionalReferenceLeaf_Name], [s1].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r8].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_Name], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[Name], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [s2].[Name0], [s2].[OptionalReferenceLeaf_Name], [s2].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r11].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [r12].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1] AS [Id10], [s].[Name] AS [Name0], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10] AS [Id100], [s].[Name0] AS [Name00], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r3].[Id1] AS [Id11], [r3].[Name] AS [Name1], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r4].[Id1] AS [Id12], [r4].[Name] AS [Name2], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r0]
+    LEFT JOIN (
+        SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+    ) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r5]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+) AS [s1] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name], [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r10].[RelationshipsBranchEntityId1], [r10].[Id1] AS [Id10], [r10].[Name] AS [Name0], [r9].[OptionalReferenceLeaf_Name], [r9].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r9]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r10] ON [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r9].[Id1] = [r10].[RelationshipsBranchEntityId1]
+) AS [s2] ON [r].[Id] = [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r11] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r12] ON [r].[Id] = [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[OptionalReferenceTrunk_Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r2] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r2] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r3] ON [r].[Id] = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [s0].[OptionalReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[Name1], [s0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RequiredReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s0].[Name2], [s0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1] AS [Id10], [s].[Name] AS [Name0], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10] AS [Id100], [s].[Name0] AS [Name00], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r3].[Id1] AS [Id11], [r3].[Name] AS [Name1], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r4].[Id1] AS [Id12], [r4].[Name] AS [Name2], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r0]
+    LEFT JOIN (
+        SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+    ) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsRootEntityId]
+ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11]
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r0] ON [r].[Id] = [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r0] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r0] ON [r].[Id] = [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r0] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [s0].[OptionalReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[Name1], [s0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RequiredReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s0].[Name2], [s0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_Name], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [s1].[Name0], [s1].[OptionalReferenceLeaf_Name], [s1].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r8].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_Name], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[Name], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [s2].[Name0], [s2].[OptionalReferenceLeaf_Name], [s2].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r11].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [r12].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s4].[RelationshipsRootEntityId], [s4].[Id1], [s4].[Name], [s4].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsTrunkEntityId1], [s4].[Id10], [s4].[Name0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s4].[RelationshipsBranchEntityId1], [s4].[Id100], [s4].[Name00], [s4].[OptionalReferenceLeaf_Name], [s4].[RequiredReferenceLeaf_Name], [s4].[OptionalReferenceBranch_Name], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s4].[Id11], [s4].[Name1], [s4].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s4].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s4].[RequiredReferenceBranch_Name], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s4].[Id12], [s4].[Name2], [s4].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s4].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[Id1], [s5].[Name], [s5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[RelationshipsBranchEntityId1], [s5].[Id10], [s5].[Name0], [s5].[OptionalReferenceLeaf_Name], [s5].[RequiredReferenceLeaf_Name], [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r20].[Id1], [r20].[Name], [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r21].[Id1], [r21].[Name], [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[Id1], [s6].[Name], [s6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[RelationshipsBranchEntityId1], [s6].[Id10], [s6].[Name0], [s6].[OptionalReferenceLeaf_Name], [s6].[RequiredReferenceLeaf_Name], [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r24].[Id1], [r24].[Name], [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r25].[Id1], [r25].[Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1] AS [Id10], [s].[Name] AS [Name0], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10] AS [Id100], [s].[Name0] AS [Name00], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r3].[Id1] AS [Id11], [r3].[Name] AS [Name1], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r4].[Id1] AS [Id12], [r4].[Name] AS [Name2], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r0]
+    LEFT JOIN (
+        SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+    ) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r5]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+) AS [s1] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name], [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r10].[RelationshipsBranchEntityId1], [r10].[Id1] AS [Id10], [r10].[Name] AS [Name0], [r9].[OptionalReferenceLeaf_Name], [r9].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r9]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r10] ON [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r9].[Id1] = [r10].[RelationshipsBranchEntityId1]
+) AS [s2] ON [r].[Id] = [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r11] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r12] ON [r].[Id] = [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r13].[RelationshipsRootEntityId], [r13].[Id1], [r13].[Name], [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsTrunkEntityId1], [s3].[Id1] AS [Id10], [s3].[Name] AS [Name0], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s3].[RelationshipsBranchEntityId1], [s3].[Id10] AS [Id100], [s3].[Name0] AS [Name00], [s3].[OptionalReferenceLeaf_Name], [s3].[RequiredReferenceLeaf_Name], [r13].[OptionalReferenceBranch_Name], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r16].[Id1] AS [Id11], [r16].[Name] AS [Name1], [r13].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r13].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r13].[RequiredReferenceBranch_Name], [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r17].[Id1] AS [Id12], [r17].[Name] AS [Name2], [r13].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r13].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r13]
+    LEFT JOIN (
+        SELECT [r14].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r14].[RelationshipsTrunkEntityId1], [r14].[Id1], [r14].[Name], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r15].[RelationshipsBranchEntityId1], [r15].[Id1] AS [Id10], [r15].[Name] AS [Name0], [r14].[OptionalReferenceLeaf_Name], [r14].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r14]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r15] ON [r14].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r14].[RelationshipsTrunkEntityId1] = [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r14].[Id1] = [r15].[RelationshipsBranchEntityId1]
+    ) AS [s3] ON [r13].[RelationshipsRootEntityId] = [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r13].[Id1] = [s3].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r16] ON CASE
+        WHEN [r13].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r13].[RelationshipsRootEntityId]
+    END = [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r13].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r13].[Id1]
+    END = [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r17] ON [r13].[RelationshipsRootEntityId] = [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r13].[Id1] = [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s4] ON [r].[Id] = [s4].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r18].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r18].[Id1], [r18].[Name], [r19].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r19].[RelationshipsBranchEntityId1], [r19].[Id1] AS [Id10], [r19].[Name] AS [Name0], [r18].[OptionalReferenceLeaf_Name], [r18].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r18]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r19] ON [r18].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r19].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r18].[Id1] = [r19].[RelationshipsBranchEntityId1]
+) AS [s5] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r20] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r21] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r22].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r22].[Id1], [r22].[Name], [r23].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r23].[RelationshipsBranchEntityId1], [r23].[Id1] AS [Id10], [r23].[Name] AS [Name0], [r22].[OptionalReferenceLeaf_Name], [r22].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r22]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r23] ON [r22].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r23].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r22].[Id1] = [r23].[RelationshipsBranchEntityId1]
+) AS [s6] ON [r].[Id] = [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r24] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r25] ON [r].[Id] = [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [s4].[RelationshipsRootEntityId], [s4].[Id1], [s4].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsTrunkEntityId1], [s4].[Id10], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s4].[RelationshipsBranchEntityId1], [s4].[Id100], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s4].[Id11], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s4].[Id12], [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[Id1], [s5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[RelationshipsBranchEntityId1], [s5].[Id10], [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r20].[Id1], [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r21].[Id1], [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[Id1], [s6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[RelationshipsBranchEntityId1], [s6].[Id10], [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r24].[Id1], [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[OptionalReferenceTrunk_Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[Id1], [r4].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [s0].[Name0], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r8].[Name], [r9].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r2] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r5]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+) AS [s0] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r9] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r9].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r9].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [s0].[Name0], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[Id1], [r6].[Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r2] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r3] ON [r].[Id] = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r4].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[Id1], [r4].[Name], [r5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[RelationshipsBranchEntityId1], [r5].[Id1] AS [Id10], [r5].[Name] AS [Name0], [r4].[OptionalReferenceLeaf_Name], [r4].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r4]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r5] ON [r4].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r4].[Id1] = [r5].[RelationshipsBranchEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r6] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r7] ON [r].[Id] = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[Id1], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r0] ON [r].[Id] = [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r1] ON [r].[Id] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[RelationshipsBranchEntityId1], [r3].[Id1] AS [Id10], [r3].[Name] AS [Name0], [r2].[OptionalReferenceLeaf_Name], [r2].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r2]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r3] ON [r2].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r2].[Id1] = [r3].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r2].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s1].[RelationshipsRootEntityId], [s1].[Id1], [s1].[Name], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsTrunkEntityId1], [s1].[Id10], [s1].[Name0], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s1].[RelationshipsBranchEntityId1], [s1].[Id100], [s1].[Name00], [s1].[OptionalReferenceLeaf_Name], [s1].[RequiredReferenceLeaf_Name], [s1].[OptionalReferenceBranch_Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s1].[Id11], [s1].[Name1], [s1].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s1].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s1].[RequiredReferenceBranch_Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s1].[Id12], [s1].[Name2], [s1].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s1].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_Name], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[Name], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [s2].[Name0], [s2].[OptionalReferenceLeaf_Name], [s2].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r11].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [r12].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[Id1], [s3].[Name], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsBranchEntityId1], [s3].[Id10], [s3].[Name0], [s3].[OptionalReferenceLeaf_Name], [s3].[RequiredReferenceLeaf_Name], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r15].[Id1], [r15].[Name], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r16].[Id1], [r16].[Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1] AS [Id10], [r1].[Name] AS [Name0], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r2] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r3] ON [r].[Id] = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r4].[RelationshipsRootEntityId], [r4].[Id1], [r4].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id1] AS [Id10], [s0].[Name] AS [Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id10] AS [Id100], [s0].[Name0] AS [Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [r4].[OptionalReferenceBranch_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r7].[Id1] AS [Id11], [r7].[Name] AS [Name1], [r4].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r4].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r4].[RequiredReferenceBranch_Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r8].[Id1] AS [Id12], [r8].[Name] AS [Name2], [r4].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r4].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r4]
+    LEFT JOIN (
+        SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[RelationshipsTrunkEntityId1], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r5]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[RelationshipsTrunkEntityId1] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+    ) AS [s0] ON [r4].[RelationshipsRootEntityId] = [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r4].[Id1] = [s0].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+        WHEN [r4].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r4].[RelationshipsRootEntityId]
+    END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r4].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r4].[Id1]
+    END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON [r4].[RelationshipsRootEntityId] = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r4].[Id1] = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s1] ON [r].[Id] = [s1].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name], [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r10].[RelationshipsBranchEntityId1], [r10].[Id1] AS [Id10], [r10].[Name] AS [Name0], [r9].[OptionalReferenceLeaf_Name], [r9].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r9]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r10] ON [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r9].[Id1] = [r10].[RelationshipsBranchEntityId1]
+) AS [s2] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r11] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r12] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r13].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r13].[Id1], [r13].[Name], [r14].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r14].[RelationshipsBranchEntityId1], [r14].[Id1] AS [Id10], [r14].[Name] AS [Name0], [r13].[OptionalReferenceLeaf_Name], [r13].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r13]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r14] ON [r13].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r14].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r13].[Id1] = [r14].[RelationshipsBranchEntityId1]
+) AS [s3] ON [r].[Id] = [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r15] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r16] ON [r].[Id] = [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[Id1], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [s1].[RelationshipsRootEntityId], [s1].[Id1], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsTrunkEntityId1], [s1].[Id10], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s1].[RelationshipsBranchEntityId1], [s1].[Id100], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s1].[Id11], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s1].[Id12], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[Id1], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsBranchEntityId1], [s3].[Id10], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r15].[Id1], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [r2].[Id], [r2].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [r2].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r2].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [r0].[Id], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r2]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r1] ON [r2].[Id] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r2].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+    {
+        await base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+        AssertSql(
+            """
+SELECT [r2].[Id], [r2].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [r2].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r2].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [r0].[Id], [r0].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r0].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r2]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r1] ON CASE
+    WHEN [r2].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r2].[Id]
+END = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r2].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+    {
+        await base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r3].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r3].[c]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r3]
+LEFT JOIN (
+    SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r1]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+) AS [s] ON [r3].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r3].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r8].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r8].[RequiredReferenceTrunk_Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [s0].[Name0], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [r8].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r8].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r8].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r8].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[Id1], [r6].[Name], [r8].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r8].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r8].[RequiredReferenceTrunk_RequiredReferenceBranch_Name0], [r8].[c]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) [r0].[Id], [r0].[RequiredReferenceTrunk_Name], [r0].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r0].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name] AS [RequiredReferenceTrunk_RequiredReferenceBranch_Name0], 1 AS [c]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r8]
+LEFT JOIN (
+    SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r1]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r3].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[Id1], [r3].[Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[RelationshipsBranchEntityId1], [r4].[Id1] AS [Id10], [r4].[Name] AS [Name0], [r3].[OptionalReferenceLeaf_Name], [r3].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r3]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r4] ON [r3].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r3].[Id1] = [r4].[RelationshipsBranchEntityId1]
+) AS [s0] ON [r8].[Id] = [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r5] ON CASE
+    WHEN [r8].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r8].[Id]
+END = [r5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r6] ON [r8].[Id] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r7] ON [r8].[Id] = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r8].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityId1], [s0].[Id10], [r5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[Id1], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+    {
+        await base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r3].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r3].[c]
+FROM [RootEntities] AS [r]
+OUTER APPLY (
+    SELECT TOP(1) 1 AS [c], [r0].[Id]
+    FROM [RootEntities] AS [r0]
+    ORDER BY [r0].[Id]
+) AS [r3]
+LEFT JOIN (
+    SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r1]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+) AS [s] ON [r].[Id] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [r3].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task SelectMany_trunk_collection(bool async)
+    {
+        await base.SelectMany_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[Id], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1], [s].[Name], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10], [s].[Name0], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r3].[Id1], [r3].[Name], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r4].[Id1], [r4].[Name], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [Root_CollectionTrunk] AS [r0] ON [r].[Id] = [r0].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+    LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+    WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+    WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+ORDER BY [r].[Id], [r0].[RelationshipsRootEntityId], [r0].[Id1], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r3].[Id1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+""");
+    }
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_required_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1], [r1].[Name], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [Root_RequiredReferenceTrunk_CollectionBranch] AS [r0] ON [r].[Id] = [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+ORDER BY [r].[Id], [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+    {
+        await base.SelectMany_optional_trunk_reference_branch_collection(async);
+
+        AssertSql(
+            """
+SELECT [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [r].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1], [r1].[Id1], [r1].[Name], [r0].[OptionalReferenceLeaf_Name], [r0].[RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+INNER JOIN [Root_OptionalReferenceTrunk_CollectionBranch] AS [r0] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r1] ON [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r1].[RelationshipsBranchEntityId1]
+ORDER BY [r].[Id], [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0].[Id1], [r1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsBranchEntityId1]
+""");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQuerySqlServerTest.cs
@@ -1,0 +1,255 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class OwnedRelationshipsInProjectionQuerySqlServerTest
+    : OwnedRelationshipsInProjectionQueryRelationalTestBase<OwnedRelationshipsQuerySqlServerFixture>
+{
+    public OwnedRelationshipsInProjectionQuerySqlServerTest(OwnedRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [s0].[OptionalReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[Name1], [s0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RequiredReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s0].[Name2], [s0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_Name], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [s1].[Name0], [s1].[OptionalReferenceLeaf_Name], [s1].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r8].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_Name], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[Name], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [s2].[Name0], [s2].[OptionalReferenceLeaf_Name], [s2].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r11].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [r12].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1] AS [Id10], [s].[Name] AS [Name0], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10] AS [Id100], [s].[Name0] AS [Name00], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r3].[Id1] AS [Id11], [r3].[Name] AS [Name1], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r4].[Id1] AS [Id12], [r4].[Name] AS [Name2], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r0]
+    LEFT JOIN (
+        SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+    ) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r5]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+) AS [s1] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name], [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r10].[RelationshipsBranchEntityId1], [r10].[Id1] AS [Id10], [r10].[Name] AS [Name0], [r9].[OptionalReferenceLeaf_Name], [r9].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r9]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r10] ON [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r9].[Id1] = [r10].[RelationshipsBranchEntityId1]
+) AS [s2] ON [r].[Id] = [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r11] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r12] ON [r].[Id] = [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Name], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[Name0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[Name00], [s0].[OptionalReferenceLeaf_Name], [s0].[RequiredReferenceLeaf_Name], [s0].[OptionalReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[Name1], [s0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s0].[RequiredReferenceBranch_Name], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s0].[Name2], [s0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_Name], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[Name], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [s1].[Name0], [s1].[OptionalReferenceLeaf_Name], [s1].[RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r7].[Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [r8].[Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[OptionalReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_Name], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[Name], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [s2].[Name0], [s2].[OptionalReferenceLeaf_Name], [s2].[RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r11].[Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_Name], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [r12].[Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r].[RequiredReferenceTrunk_RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s4].[RelationshipsRootEntityId], [s4].[Id1], [s4].[Name], [s4].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsTrunkEntityId1], [s4].[Id10], [s4].[Name0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s4].[RelationshipsBranchEntityId1], [s4].[Id100], [s4].[Name00], [s4].[OptionalReferenceLeaf_Name], [s4].[RequiredReferenceLeaf_Name], [s4].[OptionalReferenceBranch_Name], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s4].[Id11], [s4].[Name1], [s4].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [s4].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [s4].[RequiredReferenceBranch_Name], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s4].[Id12], [s4].[Name2], [s4].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [s4].[RequiredReferenceBranch_RequiredReferenceLeaf_Name], [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[Id1], [s5].[Name], [s5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[RelationshipsBranchEntityId1], [s5].[Id10], [s5].[Name0], [s5].[OptionalReferenceLeaf_Name], [s5].[RequiredReferenceLeaf_Name], [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r20].[Id1], [r20].[Name], [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r21].[Id1], [r21].[Name], [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[Id1], [s6].[Name], [s6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[RelationshipsBranchEntityId1], [s6].[Id10], [s6].[Name0], [s6].[OptionalReferenceLeaf_Name], [s6].[RequiredReferenceLeaf_Name], [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r24].[Id1], [r24].[Name], [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r25].[Id1], [r25].[Name]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [r0].[RelationshipsRootEntityId], [r0].[Id1], [r0].[Name], [s].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsTrunkEntityId1], [s].[Id1] AS [Id10], [s].[Name] AS [Name0], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s].[RelationshipsBranchEntityId1], [s].[Id10] AS [Id100], [s].[Name0] AS [Name00], [s].[OptionalReferenceLeaf_Name], [s].[RequiredReferenceLeaf_Name], [r0].[OptionalReferenceBranch_Name], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r3].[Id1] AS [Id11], [r3].[Name] AS [Name1], [r0].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r0].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r0].[RequiredReferenceBranch_Name], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r4].[Id1] AS [Id12], [r4].[Name] AS [Name2], [r0].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r0].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r0]
+    LEFT JOIN (
+        SELECT [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r1].[RelationshipsTrunkEntityId1], [r1].[Id1], [r1].[Name], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r2].[RelationshipsBranchEntityId1], [r2].[Id1] AS [Id10], [r2].[Name] AS [Name0], [r1].[OptionalReferenceLeaf_Name], [r1].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r1]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r2] ON [r1].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r1].[RelationshipsTrunkEntityId1] = [r2].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r1].[Id1] = [r2].[RelationshipsBranchEntityId1]
+    ) AS [s] ON [r0].[RelationshipsRootEntityId] = [s].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [s].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r3] ON CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[RelationshipsRootEntityId]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r0].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r0].[Id1]
+    END = [r3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r4] ON [r0].[RelationshipsRootEntityId] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r0].[Id1] = [r4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s0] ON [r].[Id] = [s0].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r5].[Id1], [r5].[Name], [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r6].[RelationshipsBranchEntityId1], [r6].[Id1] AS [Id10], [r6].[Name] AS [Name0], [r5].[OptionalReferenceLeaf_Name], [r5].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r5]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r6] ON [r5].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r5].[Id1] = [r6].[RelationshipsBranchEntityId1]
+) AS [s1] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r7] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r8] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r9].[Id1], [r9].[Name], [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r10].[RelationshipsBranchEntityId1], [r10].[Id1] AS [Id10], [r10].[Name] AS [Name0], [r9].[OptionalReferenceLeaf_Name], [r9].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r9]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r10] ON [r9].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r10].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r9].[Id1] = [r10].[RelationshipsBranchEntityId1]
+) AS [s2] ON [r].[Id] = [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r11] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r12] ON [r].[Id] = [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r13].[RelationshipsRootEntityId], [r13].[Id1], [r13].[Name], [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsTrunkEntityId1], [s3].[Id1] AS [Id10], [s3].[Name] AS [Name0], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s3].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s3].[RelationshipsBranchEntityId1], [s3].[Id10] AS [Id100], [s3].[Name0] AS [Name00], [s3].[OptionalReferenceLeaf_Name], [s3].[RequiredReferenceLeaf_Name], [r13].[OptionalReferenceBranch_Name], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId10], [r16].[Id1] AS [Id11], [r16].[Name] AS [Name1], [r13].[OptionalReferenceBranch_OptionalReferenceLeaf_Name], [r13].[OptionalReferenceBranch_RequiredReferenceLeaf_Name], [r13].[RequiredReferenceBranch_Name], [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AS [RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AS [RelationshipsBranchEntityRelationshipsTrunkEntityId11], [r17].[Id1] AS [Id12], [r17].[Name] AS [Name2], [r13].[RequiredReferenceBranch_OptionalReferenceLeaf_Name], [r13].[RequiredReferenceBranch_RequiredReferenceLeaf_Name]
+    FROM [Root_CollectionTrunk] AS [r13]
+    LEFT JOIN (
+        SELECT [r14].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r14].[RelationshipsTrunkEntityId1], [r14].[Id1], [r14].[Name], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [r15].[RelationshipsBranchEntityId1], [r15].[Id1] AS [Id10], [r15].[Name] AS [Name0], [r14].[OptionalReferenceLeaf_Name], [r14].[RequiredReferenceLeaf_Name]
+        FROM [Root_CollectionTrunk_CollectionBranch] AS [r14]
+        LEFT JOIN [Root_CollectionTrunk_CollectionBranch_CollectionLeaf] AS [r15] ON [r14].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r14].[RelationshipsTrunkEntityId1] = [r15].[RelationshipsBranchEntityRelationshipsTrunkEntityId1] AND [r14].[Id1] = [r15].[RelationshipsBranchEntityId1]
+    ) AS [s3] ON [r13].[RelationshipsRootEntityId] = [s3].[RelationshipsTrunkEntityRelationshipsRootEntityId] AND [r13].[Id1] = [s3].[RelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r16] ON CASE
+        WHEN [r13].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r13].[RelationshipsRootEntityId]
+    END = [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND CASE
+        WHEN [r13].[OptionalReferenceBranch_Name] IS NOT NULL THEN [r13].[Id1]
+    END = [r16].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+    LEFT JOIN [Root_CollectionTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r17] ON [r13].[RelationshipsRootEntityId] = [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r13].[Id1] = [r17].[RelationshipsBranchEntityRelationshipsTrunkEntityId1]
+) AS [s4] ON [r].[Id] = [s4].[RelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r18].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r18].[Id1], [r18].[Name], [r19].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r19].[RelationshipsBranchEntityId1], [r19].[Id1] AS [Id10], [r19].[Name] AS [Name0], [r18].[OptionalReferenceLeaf_Name], [r18].[RequiredReferenceLeaf_Name]
+    FROM [Root_OptionalReferenceTrunk_CollectionBranch] AS [r18]
+    LEFT JOIN [Root_OptionalReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r19] ON [r18].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r19].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r18].[Id1] = [r19].[RelationshipsBranchEntityId1]
+) AS [s5] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_Name] IS NOT NULL THEN [r].[Id]
+END = [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r20] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_OptionalReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r21] ON CASE
+    WHEN [r].[OptionalReferenceTrunk_RequiredReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN (
+    SELECT [r22].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r22].[Id1], [r22].[Name], [r23].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r23].[RelationshipsBranchEntityId1], [r23].[Id1] AS [Id10], [r23].[Name] AS [Name0], [r22].[OptionalReferenceLeaf_Name], [r22].[RequiredReferenceLeaf_Name]
+    FROM [Root_RequiredReferenceTrunk_CollectionBranch] AS [r22]
+    LEFT JOIN [Root_RequiredReferenceTrunk_CollectionBranch_CollectionLeaf] AS [r23] ON [r22].[RelationshipsTrunkEntityRelationshipsRootEntityId] = [r23].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId] AND [r22].[Id1] = [r23].[RelationshipsBranchEntityId1]
+) AS [s6] ON [r].[Id] = [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_OptionalReferenceBranch_CollectionLeaf] AS [r24] ON CASE
+    WHEN [r].[RequiredReferenceTrunk_OptionalReferenceBranch_Name] IS NOT NULL THEN [r].[Id]
+END = [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+LEFT JOIN [Root_RequiredReferenceTrunk_RequiredReferenceBranch_CollectionLeaf] AS [r25] ON [r].[Id] = [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsTrunkEntityId1], [s0].[Id10], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s0].[RelationshipsBranchEntityId1], [s0].[Id100], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s0].[Id11], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s0].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s0].[Id12], [s1].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[Id1], [s1].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s1].[RelationshipsBranchEntityId1], [s1].[Id10], [r7].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r7].[Id1], [r8].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r8].[Id1], [s2].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[Id1], [s2].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s2].[RelationshipsBranchEntityId1], [s2].[Id10], [r11].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r11].[Id1], [r12].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r12].[Id1], [s4].[RelationshipsRootEntityId], [s4].[Id1], [s4].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsTrunkEntityId1], [s4].[Id10], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId1], [s4].[RelationshipsBranchEntityId1], [s4].[Id100], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId0], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId10], [s4].[Id11], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId1], [s4].[RelationshipsBranchEntityRelationshipsTrunkEntityId11], [s4].[Id12], [s5].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[Id1], [s5].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s5].[RelationshipsBranchEntityId1], [s5].[Id10], [r20].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r20].[Id1], [r21].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r21].[Id1], [s6].[RelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[Id1], [s6].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [s6].[RelationshipsBranchEntityId1], [s6].[Id10], [r24].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId], [r24].[Id1], [r25].[RelationshipsBranchEntityRelationshipsTrunkEntityRelationshipsRootEntityId]
+""");
+    }
+
+    public override Task Project_trunk_optional(bool async)
+        => AssertCantTrackOwned(() => base.Project_trunk_optional(async));
+
+    public override Task Project_trunk_required(bool async)
+        => AssertCantTrackOwned(() => base.Project_trunk_required(async));
+
+    public override Task Project_trunk_collection(bool async)
+        => AssertCantTrackOwned(() => base.Project_trunk_collection(async));
+
+    public override Task Project_branch_required_required(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_required_required(async));
+
+    public override Task Project_branch_required_optional(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_required_optional(async));
+
+    public override Task Project_branch_required_collection(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_required_collection(async));
+
+    public override Task Project_branch_optional_required(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_optional_required(async));
+
+    public override Task Project_branch_optional_optional(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_optional_optional(async));
+
+    public override Task Project_branch_optional_collection(bool async)
+        => AssertCantTrackOwned(() => base.Project_branch_optional_collection(async));
+
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => AssertCantTrackOwned(() => base.Project_trunk_and_branch_duplicated(async));
+
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => AssertCantTrackOwned(() => base.Project_trunk_and_trunk_duplicated(async));
+
+    public override Task Project_multiple_branch_leaf(bool async)
+        => AssertCantTrackOwned(() => base.Project_multiple_branch_leaf(async));
+
+    public override Task Project_leaf_trunk_root(bool async)
+        => AssertCantTrackOwned(() => base.Project_leaf_trunk_root(async));
+
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => AssertCantTrackOwned(() => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => AssertCantTrackOwned(() => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async));
+
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => AssertCantTrackOwned(() => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async));
+
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => AssertCantTrackOwned(() => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async));
+
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => AssertCantTrackOwned(() => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async));
+
+    public override Task SelectMany_trunk_collection(bool async)
+        => AssertCantTrackOwned(() => base.SelectMany_trunk_collection(async));
+
+    public override Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => AssertCantTrackOwned(() => base.SelectMany_required_trunk_reference_branch_collection(async));
+
+    public override Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => AssertCantTrackOwned(() => base.SelectMany_optional_trunk_reference_branch_collection(async));
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    private async Task AssertCantTrackOwned(Func<Task> test)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(test)).Message;
+
+        Assert.Equal(CoreStrings.OwnedEntitiesCannotBeTrackedWithoutTheirOwner, message);
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Include/EntityRelationshipsIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Include/EntityRelationshipsIncludeQuerySqlServerTest.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+
+public class EntityRelationshipsIncludeQuerySqlServerTest
+    : EntityRelationshipsIncludeQueryRelationalTestBase<EntityRelationshipsQuerySqlServerFixture>
+{
+    public EntityRelationshipsIncludeQuerySqlServerTest(EntityRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Include_trunk_optional(bool async)
+    {
+        await base.Include_trunk_optional(async);
+
+        AssertSql(
+"""
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+""");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/JsonRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/JsonRelationshipsQuerySqlServerFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class JsonRelationshipsQuerySqlServerFixture : JsonRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/JsonTypeRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/JsonTypeRelationshipsQuerySqlServerFixture.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.RelationshipsModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class JsonTypeRelationshipsQuerySqlServerFixture : JsonRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override string StoreName => "JsonTypeRelationshipsQueryTest";
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsOne(x => x.RequiredReferenceTrunk).HasColumnType("json");
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsOne(x => x.OptionalReferenceTrunk).HasColumnType("json");
+        modelBuilder.Entity<RelationshipsRootEntity>().OwnsMany(x => x.CollectionTrunk).HasColumnType("json");
+    }
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqlServerEventId.JsonTypeExperimental)));
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedRelationshipsQuerySqlServerFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class OwnedRelationshipsQuerySqlServerFixture : OwnedRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -42,33 +42,33 @@ FROM "JsonEntitiesBasic" AS "j"
 """);
     }
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Project_json_entity_FirstOrDefault_subquery(async)))
-            .Message);
+    //public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Project_json_entity_FirstOrDefault_subquery(async)))
+    //        .Message);
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication(async)))
-            .Message);
+    //public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication(async)))
+    //        .Message);
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async)))
-            .Message);
+    //public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async)))
+    //        .Message);
 
-    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async)))
-            .Message);
+    //public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async)))
+    //        .Message);
 
     public override async Task Json_collection_Any_with_predicate(bool async)
     {
@@ -347,12 +347,12 @@ WHERE "j"."Reference" ->> 'BoolConvertedToStringYN' = 'Y'
                 () => base.Json_multiple_collection_projections(async)))
             .Message);
 
-    public override async Task Json_collection_SelectMany(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Json_collection_SelectMany(async)))
-            .Message);
+    //public override async Task Json_collection_SelectMany(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Json_collection_SelectMany(async)))
+    //        .Message);
 
     public override async Task Json_collection_skip_take_in_projection(bool async)
         => Assert.Equal(
@@ -375,12 +375,12 @@ WHERE "j"."Reference" ->> 'BoolConvertedToStringYN' = 'Y'
                 () => base.Json_nested_collection_filter_in_projection(async)))
             .Message);
 
-    public override async Task Json_nested_collection_SelectMany(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Json_nested_collection_SelectMany(async)))
-            .Message);
+    //public override async Task Json_nested_collection_SelectMany(bool async)
+    //    => Assert.Equal(
+    //        SqliteStrings.ApplyNotSupported,
+    //        (await Assert.ThrowsAsync<InvalidOperationException>(
+    //            () => base.Json_nested_collection_SelectMany(async)))
+    //        .Message);
 
     public override async Task Json_collection_of_primitives_SelectMany(bool async)
         => Assert.Equal(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/ComplexRelationshipsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/ComplexRelationshipsQuerySqliteFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class ComplexRelationshipsQuerySqliteFixture : ComplexRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/EntityRelationshipsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/EntityRelationshipsQuerySqliteFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class EntityRelationshipsQuerySqliteFixture : EntityRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class ComplexRelationshipsInProjectionNoTrackingQuerySqliteTest
+    : ComplexRelationshipsInProjectionNoTrackingQueryRelationalTestBase<ComplexRelationshipsQuerySqliteFixture>
+{
+    public ComplexRelationshipsInProjectionNoTrackingQuerySqliteTest(ComplexRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/ComplexRelationshipsInProjectionQuerySqliteTest.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class ComplexRelationshipsInProjectionQuerySqliteTest
+    : ComplexRelationshipsInProjectionQueryRelationalTestBase<ComplexRelationshipsQuerySqliteFixture>
+{
+    public ComplexRelationshipsInProjectionQuerySqliteTest(ComplexRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class EntityRelationshipsInProjectionNoTrackingQuerySqliteTest
+    : EntityRelationshipsInProjectionNoTrackingQueryRelationalTestBase<EntityRelationshipsQuerySqliteFixture>
+{
+    public EntityRelationshipsInProjectionNoTrackingQuerySqliteTest(EntityRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async)))
+            .Message);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/EntityRelationshipsInProjectionQuerySqliteTest.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class EntityRelationshipsInProjectionQuerySqliteTest
+    : EntityRelationshipsInProjectionQueryRelationalTestBase<EntityRelationshipsQuerySqliteFixture>
+{
+    public EntityRelationshipsInProjectionQuerySqliteTest(EntityRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async)))
+            .Message);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
@@ -1,0 +1,254 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class JsonRelationshipsInProjectionNoTrackingQuerySqliteTest
+    : JsonRelationshipsInProjectionNoTrackingQueryRelationalTestBase<JsonRelationshipsQuerySqliteFixture>
+{
+    public JsonRelationshipsInProjectionNoTrackingQuerySqliteTest(JsonRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT "r"."Id", "r"."Name", "r"."OptionalReferenceTrunkId", "r"."RequiredReferenceTrunkId", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk"
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override async Task Project_trunk_optional(bool async)
+    {
+        await base.Project_trunk_optional(async);
+
+        AssertSql(
+            """
+SELECT "r"."OptionalReferenceTrunk", "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_trunk_required(bool async)
+    {
+        await base.Project_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk", "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_trunk_collection(bool async)
+    {
+        await base.Project_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT "r"."CollectionTrunk", "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_required_required(bool async)
+    {
+        await base.Project_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'RequiredReferenceBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_required_optional(bool async)
+    {
+        await base.Project_branch_required_optional(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'OptionalReferenceBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_required_collection(bool async)
+    {
+        await base.Project_branch_required_collection(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'CollectionBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_optional_required(bool async)
+    {
+        await base.Project_branch_optional_required(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'RequiredReferenceBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_optional_optional(bool async)
+    {
+        await base.Project_branch_optional_optional(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'OptionalReferenceBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_branch_optional_collection(bool async)
+    {
+        await base.Project_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> 'CollectionBranch', "r"."Id"
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+        AssertSql(
+            """
+SELECT "r"."Id", "r"."Name", "r"."OptionalReferenceTrunkId", "r"."RequiredReferenceTrunkId", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk"
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override async Task Project_trunk_and_branch_duplicated(bool async)
+    {
+        await base.Project_trunk_and_branch_duplicated(async);
+
+        AssertSql(
+            """
+SELECT "r"."OptionalReferenceTrunk", "r"."Id", "r"."OptionalReferenceTrunk" ->> 'RequiredReferenceBranch', "r"."OptionalReferenceTrunk", "r"."OptionalReferenceTrunk" ->> 'RequiredReferenceBranch'
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_trunk_and_trunk_duplicated(bool async)
+    {
+        await base.Project_trunk_and_trunk_duplicated(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk", "r"."Id", "r"."RequiredReferenceTrunk" ->> '$.OptionalReferenceBranch.RequiredReferenceLeaf', "r"."RequiredReferenceTrunk", "r"."RequiredReferenceTrunk" ->> '$.OptionalReferenceBranch.RequiredReferenceLeaf'
+FROM "RootEntities" AS "r"
+ORDER BY "r"."Id"
+""");
+    }
+
+    public override async Task Project_multiple_branch_leaf(bool async)
+    {
+        await base.Project_multiple_branch_leaf(async);
+
+        AssertSql(
+            """
+SELECT "r"."Id", "r"."RequiredReferenceTrunk" ->> 'RequiredReferenceBranch', "r"."RequiredReferenceTrunk" ->> '$.RequiredReferenceBranch.OptionalReferenceLeaf', "r"."RequiredReferenceTrunk" ->> '$.RequiredReferenceBranch.CollectionLeaf', "r"."RequiredReferenceTrunk" ->> 'CollectionBranch', "r"."RequiredReferenceTrunk" ->> '$.RequiredReferenceBranch.OptionalReferenceLeaf.Name'
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override async Task Project_leaf_trunk_root(bool async)
+    {
+        await base.Project_leaf_trunk_root(async);
+
+        AssertSql(
+            """
+SELECT "r"."RequiredReferenceTrunk" ->> '$.RequiredReferenceBranch.RequiredReferenceLeaf', "r"."Id", "r"."RequiredReferenceTrunk", "r"."Name", "r"."OptionalReferenceTrunkId", "r"."RequiredReferenceTrunkId", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk"
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async)))
+            .Message);
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_optional_trunk_reference_branch_collection(async)))
+            .Message);
+
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_required_trunk_reference_branch_collection(async)))
+            .Message);
+
+
+    public override async Task SelectMany_trunk_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_trunk_collection(async)))
+            .Message);
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/JsonRelationshipsInProjectionQuerySqliteTest.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class JsonRelationshipsInProjectionQuerySqliteTest
+    : JsonRelationshipsInProjectionQueryRelationalTestBase<JsonRelationshipsQuerySqliteFixture>
+{
+    public JsonRelationshipsInProjectionQuerySqliteTest(JsonRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_root(bool async)
+    {
+        await base.Project_root(async);
+
+        AssertSql(
+            """
+SELECT "r"."Id", "r"."Name", "r"."OptionalReferenceTrunkId", "r"."RequiredReferenceTrunkId", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk"
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override async Task Project_root_duplicated(bool async)
+    {
+        await base.Project_root_duplicated(async);
+
+    AssertSql(
+        """
+SELECT "r"."Id", "r"."Name", "r"."OptionalReferenceTrunkId", "r"."RequiredReferenceTrunkId", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk", "r"."CollectionTrunk", "r"."OptionalReferenceTrunk", "r"."RequiredReferenceTrunk"
+FROM "RootEntities" AS "r"
+""");
+    }
+
+    public override Task Project_trunk_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_optional(async));
+
+    public override Task Project_trunk_required(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_required(async));
+
+    public override Task Project_trunk_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_collection(async));
+
+    public override Task Project_branch_required_required(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_required(async));
+
+    public override Task Project_branch_required_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_optional(async));
+
+    public override Task Project_branch_required_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_required_collection(async));
+
+    public override  Task Project_branch_optional_required(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_required(async));
+
+    public override Task Project_branch_optional_optional(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_optional(async));
+
+    public override Task Project_branch_optional_collection(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_optional_collection(async));
+
+    public override Task Project_branch_collection_element_using_indexer_constant(bool async)
+        => AssertCantTrackJson(() => base.Project_branch_collection_element_using_indexer_constant(async));
+
+    public override Task Project_leaf_trunk_root(bool async)
+        => AssertCantTrackJson(() => base.Project_leaf_trunk_root(async));
+
+    public override Task Project_multiple_branch_leaf(bool async)
+        => AssertCantTrackJson(() => base.Project_multiple_branch_leaf(async));
+
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_and_branch_duplicated(async));
+
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => AssertCantTrackJson(() => base.Project_trunk_and_trunk_duplicated(async));
+
+    public override async Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async)))
+            .Message);
+
+    public override async Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async)))
+            .Message);
+
+    public override async Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_optional_trunk_reference_branch_collection(async)))
+            .Message);
+
+
+    public override async Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_required_trunk_reference_branch_collection(async)))
+            .Message);
+
+
+    public override async Task SelectMany_trunk_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_trunk_collection(async)))
+            .Message);
+
+    private async Task AssertCantTrackJson(Func<Task> test)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(test)).Message;
+
+        Assert.Equal(RelationalStrings.JsonEntityOrCollectionProjectedAtRootLevelInTrackingQuery("AsNoTracking"), message);
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionNoTrackingQuerySqliteTest.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class OwnedRelationshipsInProjectionNoTrackingQuerySqliteTest
+    : OwnedRelationshipsInProjectionNoTrackingQueryRelationalTestBase<OwnedRelationshipsQuerySqliteFixture>
+{
+    public OwnedRelationshipsInProjectionNoTrackingQuerySqliteTest(OwnedRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_root(bool async)
+        => base.Project_root(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_optional(bool async)
+        => base.Project_trunk_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_required(bool async)
+        => base.Project_trunk_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_collection(bool async)
+        => base.Project_trunk_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_required(bool async)
+        => base.Project_branch_required_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_optional(bool async)
+        => base.Project_branch_required_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_collection(bool async)
+        => base.Project_branch_required_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_required(bool async)
+        => base.Project_branch_optional_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_optional(bool async)
+        => base.Project_branch_optional_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_collection(bool async)
+        => base.Project_branch_optional_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_root_duplicated(bool async)
+        => base.Project_root_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => base.Project_trunk_and_branch_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => base.Project_trunk_and_trunk_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_multiple_branch_leaf(bool async)
+        => base.Project_multiple_branch_leaf(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_leaf_trunk_root(bool async)
+        => base.Project_leaf_trunk_root(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_trunk_collection(bool async)
+        => base.SelectMany_trunk_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_required_trunk_reference_branch_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_optional_trunk_reference_branch_collection(async);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/InProjection/OwnedRelationshipsInProjectionQuerySqliteTest.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.InProjection;
+
+public class OwnedRelationshipsInProjectionQuerySqliteTest
+    : OwnedRelationshipsInProjectionQueryRelationalTestBase<OwnedRelationshipsQuerySqliteFixture>
+{
+    public OwnedRelationshipsInProjectionQuerySqliteTest(OwnedRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_root(bool async)
+        => base.Project_root(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_optional(bool async)
+        => base.Project_trunk_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_required(bool async)
+        => base.Project_trunk_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_collection(bool async)
+        => base.Project_trunk_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_required(bool async)
+        => base.Project_branch_required_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_optional(bool async)
+        => base.Project_branch_required_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_required_collection(bool async)
+        => base.Project_branch_required_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_required(bool async)
+        => base.Project_branch_optional_required(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_optional(bool async)
+        => base.Project_branch_optional_optional(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_branch_optional_collection(bool async)
+        => base.Project_branch_optional_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_root_duplicated(bool async)
+        => base.Project_root_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_and_branch_duplicated(bool async)
+        => base.Project_trunk_and_branch_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_trunk_and_trunk_duplicated(bool async)
+        => base.Project_trunk_and_trunk_duplicated(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_multiple_branch_leaf(bool async)
+        => base.Project_multiple_branch_leaf(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_leaf_trunk_root(bool async)
+        => base.Project_leaf_trunk_root(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_required_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_required_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(bool async)
+        => base.Project_subquery_root_set_optional_trunk_FirstOrDefault_branch(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_trunk_FirstOrDefault_collection(bool async)
+        => base.Project_subquery_root_set_trunk_FirstOrDefault_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(bool async)
+        => base.Project_subquery_root_set_complex_projection_including_references_to_outer_FirstOrDefault(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(bool async)
+        => base.Project_subquery_root_set_complex_projection_FirstOrDefault_project_reference_to_outer(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_trunk_collection(bool async)
+        => base.SelectMany_trunk_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_required_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_required_trunk_reference_branch_collection(async);
+
+    [ConditionalTheory(Skip = "issue 26708")]
+    public override Task SelectMany_optional_trunk_reference_branch_collection(bool async)
+        => base.SelectMany_optional_trunk_reference_branch_collection(async);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/Include/EntityRelationshipsIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/Include/EntityRelationshipsIncludeQuerySqliteTest.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships.Include;
+
+public class EntityRelationshipsIncludeQuerySqliteTest
+    : EntityRelationshipsIncludeQueryRelationalTestBase<EntityRelationshipsQuerySqliteFixture>
+{
+    public EntityRelationshipsIncludeQuerySqliteTest(EntityRelationshipsQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/JsonRelationshipsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/JsonRelationshipsQuerySqliteFixture.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class JsonRelationshipsQuerySqliteFixture : JsonRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedRelationshipsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedRelationshipsQuerySqliteFixture.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+namespace Microsoft.EntityFrameworkCore.Query.Relationships;
+
+public class OwnedRelationshipsQuerySqliteFixture : OwnedRelationshipsQueryRelationalFixtureBase, ITestSqlLoggerFactory
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+}


### PR DESCRIPTION
**Motivation:**
We want to be able to re-use existing navigation tests (currently spread around multiple test classes - complex navs, gears of war, northwind, json)
for the upcoming optional complex types, complex collections and json-mapped complex types (all highly requested features in EF).
We also want to be able to increase coverage for existing features, e.g. we have very good coverage of navigations in json test suite, but it's not used for regular or owned entities.
This work can also be used by provider writers (e.g. Mongo) to boost their coverage.

**Details:**
- using common model for entity, owned, json and complex type navigations
- 4 levels: root, trunk, branch, leaf
- optional reference, required reference (dependent to principal), collection
- for now just testing projection scenarios as proof of concept (tracking / notracking)

**TODO:**
- fix owned sqlite model,
- add model with inheritance,
- move actual tests from existing test suites,
- add migration check (that model can be migrated to from scratch and that noop is actual noop),
- implement InMemory tests.