### PR TITLE
Revert preview3 dependency updates before branching to preview 3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,83 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="System.Text.Json" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="System.Text.Encodings.Web" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Asn1" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="System.Formats.Asn1" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="10.0.0-preview.3.25123.2">
+    <Dependency Name="System.Runtime.Caching" Version="10.0.0-preview.2.25114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2a51ee3fd10c2a5af5d44e710ef804813f73bf75</Sha>
+      <Sha>42423ef91c9f23381d99dee708fa55336318debc</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25120.6">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25113.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ecdb2f499cb5f5c99b58fba1a14fdf977c56e1ac</Sha>
+      <Sha>ea0a0a28cccd4b63a9ec40df53ef2df260ffa5b1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="10.0.0-beta.25120.6">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="10.0.0-beta.25113.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ecdb2f499cb5f5c99b58fba1a14fdf977c56e1ac</Sha>
+      <Sha>ea0a0a28cccd4b63a9ec40df53ef2df260ffa5b1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25120.6">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25113.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ecdb2f499cb5f5c99b58fba1a14fdf977c56e1ac</Sha>
+      <Sha>ea0a0a28cccd4b63a9ec40df53ef2df260ffa5b1</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,24 +16,24 @@
     <UsingToolXliff>False</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/runtime">
-    <MicrosoftExtensionsCachingMemoryVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsCachingMemoryVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyModelVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsHostFactoryResolverSourcesVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsHostFactoryResolverSourcesVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.3.25123.2</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftNETCoreAppRefVersion>10.0.0-preview.3.25123.2</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.3.25123.2</MicrosoftNETCoreAppRuntimewinx64Version>
-    <SystemTextEncodingsWebVersion>10.0.0-preview.3.25123.2</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>10.0.0-preview.3.25123.2</SystemTextJsonVersion>
-    <SystemFormatsAsn1Version>10.0.0-preview.3.25123.2</SystemFormatsAsn1Version>
-    <SystemRuntimeCachingVersion>10.0.0-preview.3.25123.2</SystemRuntimeCachingVersion>
+    <MicrosoftExtensionsCachingMemoryVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsCachingMemoryVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyModelVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsHostFactoryResolverSourcesVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsHostFactoryResolverSourcesVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.2.25114.1</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftNETCoreAppRefVersion>10.0.0-preview.2.25114.1</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.2.25114.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <SystemTextEncodingsWebVersion>10.0.0-preview.2.25114.1</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>10.0.0-preview.2.25114.1</SystemTextJsonVersion>
+    <SystemFormatsAsn1Version>10.0.0-preview.2.25114.1</SystemFormatsAsn1Version>
+    <SystemRuntimeCachingVersion>10.0.0-preview.2.25114.1</SystemRuntimeCachingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/arcade">
-    <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.25120.6</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.25113.2</MicrosoftDotNetBuildTasksTemplatingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
     <MicrosoftBuildFrameworkVersion>17.8.3</MicrosoftBuildFrameworkVersion>

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -76,11 +76,12 @@ jobs:
       fetchDepth: 3
       clean: true
       
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Asset Manifests
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifact
       inputs:
         artifactName: AssetManifests
-        targetPath: '$(Build.StagingDirectory)/AssetManifests'
+        downloadPath: '$(Build.StagingDirectory)/Download'
+        checkDownloadedFiles: true
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     
@@ -94,7 +95,7 @@ jobs:
         scriptLocation: scriptPath
         scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
-          /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
+          /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
           /p:OfficialBuildId=$(Build.BuildNumber)

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.13.0" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.12.0" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -383,8 +383,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.13.0
-  $defaultXCopyMSBuildVersion = '17.13.0'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.12.0
+  $defaultXCopyMSBuildVersion = '17.12.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.2.25118.3",
+    "version": "10.0.100-preview.2.25081.1",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.2.25118.3",
+    "dotnet": "10.0.100-preview.2.25081.1",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimewinx64Version)"
@@ -13,7 +13,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25120.6",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25120.6"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25113.2",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25113.2"
   }
 }


### PR DESCRIPTION
Revert "Update dependencies from https://github.com/dotnet/runtime build 20250223.2 (#35673)"

This reverts commit e2a5f01d041d97630f4852371a6614497f69bdb1.

Revert "Update dependencies from https://github.com/dotnet/arcade build 20250220.6 (#35672)"

This reverts commit 1f3e50c49cb932a4510215bd5d5247ac4497f38e.