### PR TITLE
[release/2.3] Use latest available Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,7 +15,7 @@
   <!-- These are package versions that should not be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Pinned">
     <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>2.1.1</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
-    <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion Condition="'$(PB_ISFINALBUILD)' == 'true'">2.3.0</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
+    <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion Condition="'$(PB_ISFINALBUILD)' == 'true'">2.3.*</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>2.1.23</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.1</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>


### PR DESCRIPTION
Use the latest available 2.3 version of `Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources`, which will be the one just produced by the build (which is what we want anyways, as we don't publish that package anywhere public anymore).

Follow-up to https://github.com/dotnet/efcore/pull/34973