### PR TITLE
Revert "[release/2.3] Use latest available Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources"

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,7 +15,7 @@
   <!-- These are package versions that should not be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Pinned">
     <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>2.1.1</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
-    <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion Condition="'$(PB_ISFINALBUILD)' == 'true'">2.3.*</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
+    <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion Condition="'$(PB_ISFINALBUILD)' == 'true'">2.3.0</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>2.1.23</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.1</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>


### PR DESCRIPTION
Floating versions aren't allowed in 2.3 - I just pushed the 2.3.0 package to the legacy feed instead