### PR TITLE
[release/8.0-staging] Transform Span-based overloads to Enumerable in funcletizer

### DIFF
--- a/.github/workflows/TestCosmos.yaml
+++ b/.github/workflows/TestCosmos.yaml
@@ -35,7 +35,7 @@ jobs:
         shell: cmd
 
       - name: Publish Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
Backports part of #35339
Fixes #35100

### Description

C# 14 (currently in preview) is introducing [first-class spans](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/first-class-span-types), which changes the Roslyn overload resolution to prefer Span-based overloads in some cases. Unfortunately, the newly selected overloads, which have Span parameters, are unsupported in EF since the LINQ expression tree interpreter is used internally, and it does not support ref structs.

This problem already been fixed for EF 10 in #35339. However, users on older of EF Core who switch to .NET 10/C# 14 will still hit this issue. This PR proposes backporting the fix to EF Core 8.0 to ensure these users aren't affected.

### Customer impact

Some very basic query patterns will start failing when trying to use EF Core 8.0 with C# 14, e.g.:

```c#
var data = new[] { "Foo", "Bar" };
_ = await context.Blogs.Where(b => data.Contains(b.Name)).ToListAsync();
```

### How found

Reported by users on 10.

### Regression

Yes, in the combination of EF Core 8.0 and C# 14.

### Testing

Older versions of EF aren't tested with later versions of C#/NET; manual testing was performed.

### Risk

Very low - very targeted expression tree transformation; added quirk.

