### PR TITLE
Fix to #35299 - EF Core InMemory database throws an argument exception on Nullable<>.ToString

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -888,8 +888,10 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
         if (methodCallExpression.Object != null
             && @object!.Type.IsNullableType()
             && methodCallExpression.Method.Name != nameof(Nullable<int>.GetValueOrDefault)
-            && (!@object!.Type.IsNullableValueType()
-                || methodCallExpression.Method.Name != nameof(Nullable<int>.ToString)))
+            && !(@object!.Type.IsNullableValueType()
+                && methodCallExpression.Method.Name == nameof(Nullable<int>.ToString)
+                && methodCallExpression.Method.DeclaringType != null
+                && methodCallExpression.Method.DeclaringType.IsNullableType()))
         {
             var result = (Expression)methodCallExpression.Update(
                 Expression.Convert(@object, methodCallExpression.Object.Type),

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -147,4 +147,28 @@ public class GearsOfWarQueryInMemoryTest(GearsOfWarQueryInMemoryFixture fixture)
     // Right join not supported in InMemory
     public override Task Correlated_collections_on_RightJoin_with_predicate(bool async)
         => AssertTranslationFailed(() => base.Correlated_collections_on_RightJoin_with_predicate(async));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_ToString_on_non_nullable_property_of_an_optional_entity(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<CogTag>().Select(x => new
+            {
+                Id = x.Id,
+                SquadIdString = x.Gear.SquadId.ToString()
+            }),
+            ss => ss.Set<CogTag>().Select(x => new
+            {
+                Id = x.Id,
+                SquadIdString = x.Gear == null ? null : x.Gear.SquadId.ToString()
+            }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.SquadIdString, a.SquadIdString);
+            });
+    }
 }


### PR DESCRIPTION
Problem was that when rewriting the (inmemory) query, sometimes we change the nullability of the expression fragment. (e.g. when accessing a property on an optional entity). We then have a logic to compensate for the change. E.g. when the modified fragment was a caller of a method, we add a null check and only call the method (as non-nullable argument) if the value is not null. This way we can retain the method signature as it was. In 9, we added some exemptions to this logic, e.g. `GetValueOrDefault`, or `Nullable<>.ToString`, which don't need the compensation. Problem was that we were matching the ToString method incorrectly, only looking at the method name, so we would also match non-nullable ToString(). Fix is to look at the declaring type of the ToString method as well to make sure it's nullable<T>, otherwise apply the compensation.

Fixes #35299