### PR TITLE
Report debug log for connection cancellation

### DIFF
--- a/src/EFCore.Relational/Diagnostics/DbConnectionInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/DbConnectionInterceptor.cs
@@ -97,4 +97,16 @@ public abstract class DbConnectionInterceptor : IDbConnectionInterceptor
         ConnectionErrorEventData eventData,
         CancellationToken cancellationToken = default)
         => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public virtual void ConnectionCanceled(DbConnection connection, ConnectionEndEventData eventData)
+    {
+    }
+
+    /// <inheritdoc />
+    public virtual Task ConnectionCanceledAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/EFCore.Relational/Diagnostics/IDbConnectionInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/IDbConnectionInterceptor.cs
@@ -261,7 +261,7 @@ public interface IDbConnectionInterceptor : IInterceptor
         => Task.CompletedTask;
 
     /// <summary>
-    ///     Called when closing of a connection has failed with an exception.
+    ///     Called when a connection operation (e.g. open) has failed with an exception.
     /// </summary>
     /// <param name="connection">The connection.</param>
     /// <param name="eventData">Contextual information about the connection.</param>
@@ -270,7 +270,7 @@ public interface IDbConnectionInterceptor : IInterceptor
     }
 
     /// <summary>
-    ///     Called when closing of a connection has failed with an exception.
+    ///     Called when a connection operation (e.g. open) has failed with an exception.
     /// </summary>
     /// <param name="connection">The connection.</param>
     /// <param name="eventData">Contextual information about the connection.</param>
@@ -278,5 +278,25 @@ public interface IDbConnectionInterceptor : IInterceptor
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     Task ConnectionFailedAsync(DbConnection connection, ConnectionErrorEventData eventData, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
+    ///     Called when the opening of a connection was canceled.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="eventData">Contextual information about the connection.</param>
+    void ConnectionCanceled(DbConnection connection, ConnectionEndEventData eventData)
+    {
+    }
+
+    /// <summary>
+    ///     Called when the opening of a connection was canceled.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="eventData">Contextual information about the connection.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task ConnectionCanceledAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 }

--- a/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
@@ -463,7 +463,7 @@ public interface IRelationalCommandDiagnosticsLogger : IDiagnosticsLogger<DbLogg
     /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
     /// <param name="connectionId">The correlation ID associated with the <see cref="DbConnection" /> being used.</param>
     /// <param name="startTime">The time that execution began.</param>
-    /// <param name="duration">The amount of time that passed until the exception was raised.</param>
+    /// <param name="duration">The amount of time that passed until the command was canceled.</param>
     /// <param name="commandSource">Source of the command.</param>
     void CommandCanceled(
         IRelationalConnection connection,
@@ -488,7 +488,7 @@ public interface IRelationalCommandDiagnosticsLogger : IDiagnosticsLogger<DbLogg
     /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
     /// <param name="connectionId">The correlation ID associated with the <see cref="DbConnection" /> being used.</param>
     /// <param name="startTime">The time that execution began.</param>
-    /// <param name="duration">The amount of time that passed until the exception was raised.</param>
+    /// <param name="duration">The amount of time that passed until the command was canceled.</param>
     /// <param name="commandSource">Source of the command.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A <see cref="Task" /> representing the async operation.</returns>

--- a/src/EFCore.Relational/Diagnostics/IRelationalConnectionDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/IRelationalConnectionDiagnosticsLogger.cs
@@ -211,6 +211,32 @@ public interface IRelationalConnectionDiagnosticsLogger : IDiagnosticsLogger<DbL
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.ConnectionCanceled" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="startTime">The time that the operation was started.</param>
+    /// <param name="duration">The amount of time that passed until the command was canceled.</param>
+    void ConnectionCanceled(
+        IRelationalConnection connection,
+        DateTimeOffset startTime,
+        TimeSpan duration);
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.ConnectionCanceled" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="startTime">The time that the operation was started.</param>
+    /// <param name="duration">The amount of time that passed until the command was canceled.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the async operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task ConnectionCanceledAsync(
+        IRelationalConnection connection,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Whether <see cref="RelationalEventId.ConnectionCreating" /> or <see cref="RelationalEventId.ConnectionCreated" /> need
     ///     to be logged.
     /// </summary>

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -33,6 +33,7 @@ public static class RelationalEventId
         ConnectionCreated,
         ConnectionDisposing,
         ConnectionDisposed,
+        ConnectionCanceled,
 
         // Command events
         CommandExecuting = CoreEventId.RelationalBaseId + 100,
@@ -216,6 +217,19 @@ public static class RelationalEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId ConnectionError = MakeConnectionId(Id.ConnectionError);
+
+    /// <summary>
+    ///     A <see cref="DbConnection" /> open operation has been canceled.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="ConnectionEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId ConnectionCanceled = MakeConnectionId(Id.ConnectionCanceled);
 
     /// <summary>
     ///     A <see cref="DbConnection" /> is about to be created by EF.

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -140,6 +140,15 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogConnectionCanceled;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogBeginningTransaction;
 
     /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -2146,7 +2146,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(
@@ -2966,6 +2966,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             RelationalEventId.ConnectionError,
                             _resourceManager.GetString("LogConnectionErrorAsDebug")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
+        ///     A connection open was canceled to database '{database}' on server '{server}'.
+        /// </summary>
+        public static EventDefinition<string, string> LogConnectionCanceled(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionCanceled;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionCanceled,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        RelationalEventId.ConnectionCanceled,
+                        LogLevel.Debug,
+                        "RelationalEventId.ConnectionCanceled",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            RelationalEventId.ConnectionCanceled,
+                            _resourceManager.GetString("LogConnectionCanceled")!)));
             }
 
             return (EventDefinition<string, string>)definition;

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -716,6 +716,10 @@
     <value>An error occurred using the connection to database '{database}' on server '{server}'.</value>
     <comment>Debug RelationalEventId.ConnectionError string string</comment>
   </data>
+  <data name="LogConnectionCanceled" xml:space="preserve">
+    <value>A connection open was canceled to database '{database}' on server '{server}'.</value>
+    <comment>Debug RelationalEventId.ConnectionCanceled string string string</comment>
+  </data>
   <data name="LogCreatedTransactionSavepoint" xml:space="preserve">
     <value>Created transaction savepoint.</value>
     <comment>Debug RelationalEventId.CreatedTransactionSavepoint</comment>

--- a/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -54,7 +54,8 @@ public sealed record RelationalConnectionDependencies
         INamedConnectionStringResolver connectionStringResolver,
         IRelationalTransactionFactory relationalTransactionFactory,
         ICurrentDbContext currentContext,
-        IRelationalCommandBuilderFactory relationalCommandBuilderFactory)
+        IRelationalCommandBuilderFactory relationalCommandBuilderFactory,
+        IExceptionDetector exceptionDetector)
     {
         ContextOptions = contextOptions;
         TransactionLogger = transactionLogger;
@@ -63,6 +64,7 @@ public sealed record RelationalConnectionDependencies
         RelationalTransactionFactory = relationalTransactionFactory;
         CurrentContext = currentContext;
         RelationalCommandBuilderFactory = relationalCommandBuilderFactory;
+        ExceptionDetector = exceptionDetector;
     }
 
     /// <summary>
@@ -100,4 +102,9 @@ public sealed record RelationalConnectionDependencies
     ///     Contains the <see cref="DbContext" /> instance currently in use.
     /// </summary>
     public IRelationalCommandBuilderFactory RelationalCommandBuilderFactory { get; init; }
+
+    /// <summary>
+    ///     The exception detector.
+    /// </summary>
+    public IExceptionDetector ExceptionDetector { get; init; }
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
@@ -50,6 +50,7 @@ public class FakeDbConnection(
     public override Task OpenAsync(CancellationToken cancellationToken)
     {
         OpenAsyncCount++;
+        cancellationToken.ThrowIfCancellationRequested();
         return base.OpenAsync(cancellationToken);
     }
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -7,35 +7,37 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 
-public class FakeRelationalConnection(IDbContextOptions options = null) : RelationalConnection(
-    new RelationalConnectionDependencies(
-        options ?? CreateOptions(),
-        new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
-            new LoggerFactory(),
-            new LoggingOptions(),
-            new DiagnosticListener("FakeDiagnosticListener"),
-            new TestRelationalLoggingDefinitions(),
-            new NullDbContextLogger()),
-        new RelationalConnectionDiagnosticsLogger(
-            new LoggerFactory(),
-            new LoggingOptions(),
-            new DiagnosticListener("FakeDiagnosticListener"),
-            new TestRelationalLoggingDefinitions(),
-            new NullDbContextLogger(),
-            CreateOptions()),
-        new NamedConnectionStringResolver(options ?? CreateOptions()),
-        new RelationalTransactionFactory(
-            new RelationalTransactionFactoryDependencies(
-                new RelationalSqlGenerationHelper(
-                    new RelationalSqlGenerationHelperDependencies()))),
-        new CurrentDbContext(new FakeDbContext()),
-        new RelationalCommandBuilderFactory(
-            new RelationalCommandBuilderDependencies(
-                new TestRelationalTypeMappingSource(
-                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
-                new ExceptionDetector(),
-                new LoggingOptions()))))
+public class FakeRelationalConnection(IDbContextOptions options = null)
+    : RelationalConnection(
+        new RelationalConnectionDependencies(
+            options ?? CreateOptions(),
+            new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                new LoggerFactory(),
+                new LoggingOptions(),
+                new ListDiagnosticSource(new List<Tuple<string, object>>()),
+                new TestRelationalLoggingDefinitions(),
+                new NullDbContextLogger()),
+            new RelationalConnectionDiagnosticsLogger(
+                new LoggerFactory(),
+                new LoggingOptions(),
+                new ListDiagnosticSource(new List<Tuple<string, object>>()),
+                new TestRelationalLoggingDefinitions(),
+                new NullDbContextLogger(),
+                CreateOptions()),
+            new NamedConnectionStringResolver(options ?? CreateOptions()),
+            new RelationalTransactionFactory(
+                new RelationalTransactionFactoryDependencies(
+                    new RelationalSqlGenerationHelper(
+                        new RelationalSqlGenerationHelperDependencies()))),
+            new CurrentDbContext(new FakeDbContext()),
+            new RelationalCommandBuilderFactory(
+                new RelationalCommandBuilderDependencies(
+                    new TestRelationalTypeMappingSource(
+                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                    new ExceptionDetector(),
+                    new LoggingOptions())),
+            new ExceptionDetector()))
 {
     private DbConnection _connection;
 
@@ -61,6 +63,12 @@ public class FakeRelationalConnection(IDbContextOptions options = null) : Relati
 
     public IReadOnlyList<FakeDbConnection> DbConnections
         => _dbConnections;
+
+    public List<Tuple<string, object>> TransactionDiagnosticEvents
+        => ((ListDiagnosticSource)Dependencies.TransactionLogger.DiagnosticSource).DiagnosticList;
+
+    public List<Tuple<string, object>> ConnectionDiagnosticEvents
+        => ((ListDiagnosticSource)Dependencies.ConnectionLogger.DiagnosticSource).DiagnosticList;
 
     protected override DbConnection CreateDbConnection()
     {

--- a/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerConnectionTest.cs
@@ -89,7 +89,8 @@ public class SqlServerConnectionTest
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
                     new SqlServerExceptionDetector(),
-                    new LoggingOptions())));
+                    new LoggingOptions())),
+            new SqlServerExceptionDetector());
     }
 
     private const string ConnectionString = "Fake Connection String";


### PR DESCRIPTION
#26988 added a distinction between cancellations and other errors, logging the former as debug by default (since cancellations generally aren't actual errors); however, that PR implemented this for command execution only, and not for connection opening.

/cc @AndriySvyryd for rocket science logging framework changes.

Fixes #35708
