### PR TITLE
Make Cosmos tests faster

### DIFF
--- a/.github/workflows/TestCosmos.yaml
+++ b/.github/workflows/TestCosmos.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Start Cosmos Emulator
         run: |
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-          Start-CosmosDbEmulator -Timeout 360
+          Start-CosmosDbEmulator -Timeout 540 -NoUI -NoTelemetry -NoFirewall -EnablePreview
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
-using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Newtonsoft.Json;

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -27,7 +27,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
         using (var context = contextFactory.CreateContext())
         {
             ListLoggerFactory.Clear();
-            context.Database.EnsureCreated();
 
             context.Add(customer);
 
@@ -37,7 +36,7 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
             Assert.Equal(LogLevel.Information, logEntry.Level);
             Assert.Contains("CreateItem", logEntry.Message);
 
-            Assert.Equal(3, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
+            Assert.Equal(1, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
         }
 
         using (var context = contextFactory.CreateContext())
@@ -111,8 +110,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -189,8 +186,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
         string storeId = null;
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             var entry = await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -258,102 +253,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
     }
 
     [ConditionalFact]
-    public async Task Can_add_update_untracked_properties()
-    {
-        var contextFactory = await InitializeAsync<DbContext>(
-            b => b.Entity<Customer>(),
-            shouldLogCategory: _ => true,
-            onConfiguring: o => o.ConfigureWarnings(w => w.Log(CosmosEventId.SyncNotSupported, CosmosEventId.NoPartitionKeyDefined)));
-
-        var customer = new Customer { Id = 42, Name = "Theon" };
-
-        using (var context = contextFactory.CreateContext())
-        {
-            context.Database.EnsureCreated();
-
-            var entry = context.Add(customer);
-
-            context.SaveChanges();
-
-            var document = entry.Property<JObject>("__jObject").CurrentValue;
-            Assert.NotNull(document);
-            Assert.Equal("Theon", document["Name"]);
-
-            context.Remove(customer);
-
-            context.SaveChanges();
-
-            Assert.Equal(4, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            Assert.Empty(context.Set<Customer>().ToList());
-
-            var entry = context.Add(customer);
-
-            entry.Property<JObject>("__jObject").CurrentValue = new JObject { ["key1"] = "value1" };
-
-            context.SaveChanges();
-
-            var document = entry.Property<JObject>("__jObject").CurrentValue;
-            Assert.NotNull(document);
-            Assert.Equal("Theon", document["Name"]);
-            Assert.Equal("value1", document["key1"]);
-
-            document["key2"] = "value2";
-            entry.State = EntityState.Modified;
-            context.SaveChanges();
-
-            Assert.Equal(7, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<Customer>().Single();
-
-            Assert.Equal(42, customerFromStore.Id);
-            Assert.Equal("Theon", customerFromStore.Name);
-
-            var entry = context.Entry(customerFromStore);
-            var document = entry.Property<JObject>("__jObject").CurrentValue;
-            Assert.Equal("value1", document["key1"]);
-            Assert.Equal("value2", document["key2"]);
-
-            document["key1"] = "value1.1";
-            customerFromStore.Name = "Theon Greyjoy";
-
-            context.SaveChanges();
-
-            Assert.Equal(9, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<Customer>().Single();
-
-            Assert.Equal("Theon Greyjoy", customerFromStore.Name);
-
-            var entry = context.Entry(customerFromStore);
-            var document = entry.Property<JObject>("__jObject").CurrentValue;
-            Assert.Equal("value1.1", document["key1"]);
-            Assert.Equal("value2", document["key2"]);
-
-            context.Remove(customerFromStore);
-
-            context.SaveChanges();
-
-            Assert.Equal(11, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            Assert.Empty(context.Set<Customer>().ToList());
-            Assert.Equal(12, ListLoggerFactory.Log.Count(l => l.Id == CosmosEventId.SyncNotSupported));
-        }
-    }
-
-    [ConditionalFact]
     public async Task Can_add_update_untracked_properties_async()
     {
         var contextFactory = await InitializeAsync<DbContext>(
@@ -365,8 +264,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             var entry = await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -472,8 +369,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -540,8 +435,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             var entry = await context.AddAsync(customer);
 
             Assert.Equal("0001-01-01T00:00:00.0000000|Theon^2F^5C^23^5C^5C^3F", entry.CurrentValues["__id"]);
@@ -636,8 +529,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -983,8 +874,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1060,8 +949,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         await using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             Assert.Null(
                 context.Model.FindEntityType(typeof(CustomerWithResourceId))!
                     .FindProperty(CosmosJsonIdConvention.DefaultIdPropertyName));
@@ -1109,70 +996,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
     }
 
     [ConditionalFact]
-    public async Task Can_read_with_find_with_resource_id()
-    {
-        var contextFactory = await InitializeAsync<PartitionKeyContextWithResourceId>(
-            shouldLogCategory: _ => true,
-            onConfiguring: o => o.ConfigureWarnings(w => w.Log(CosmosEventId.SyncNotSupported)));
-
-        const int pk1 = 1;
-        const int pk2 = 2;
-
-        var customer = new CustomerWithResourceId
-        {
-            id = "42",
-            Name = "Theon",
-            PartitionKey1 = pk1,
-            PartitionKey2 = 3.15m
-        };
-
-        using (var context = contextFactory.CreateContext())
-        {
-            context.Database.EnsureCreated();
-
-            context.Add(customer);
-            context.Add(
-                new CustomerWithResourceId
-                {
-                    id = "42",
-                    Name = "Theon Twin",
-                    PartitionKey1 = pk2,
-                    PartitionKey2 = 3.15m
-                });
-
-            context.SaveChanges();
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<CustomerWithResourceId>()
-                .Find(pk1, 3.15m, "42");
-
-            Assert.Equal("42", customerFromStore.id);
-            Assert.Equal("Theon", customerFromStore.Name);
-            Assert.Equal(pk1, customerFromStore.PartitionKey1);
-            Assert.Equal(3.15m, customerFromStore.PartitionKey2);
-            AssertSql(context, """ReadItem([1.0,3.15], 42)""");
-
-            customerFromStore.Name = "Theon Greyjoy";
-
-            context.SaveChanges();
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<CustomerWithResourceId>()
-                .WithPartitionKey(pk1, 3.15m)
-                .Single();
-
-            Assert.Equal("42", customerFromStore.id);
-            Assert.Equal("Theon Greyjoy", customerFromStore.Name);
-            Assert.Equal(pk1, customerFromStore.PartitionKey1);
-            Assert.Equal(3.15m, customerFromStore.PartitionKey2);
-        }
-    }
-
-    [ConditionalFact]
     public async Task Find_with_empty_resource_id_throws()
     {
         var contextFactory = await InitializeAsync<PartitionKeyContextWithResourceId>(
@@ -1211,8 +1034,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         await using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
             await context.AddAsync(
                 new Customer
@@ -1258,75 +1079,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
     }
 
     [ConditionalFact]
-    public async Task Can_read_with_find_with_partition_key_and_value_generator()
-    {
-        var contextFactory = await InitializeAsync<PartitionKeyContextCustomValueGenerator>(
-            shouldLogCategory: _ => true,
-            onConfiguring: o => o.ConfigureWarnings(w => w.Log(CosmosEventId.SyncNotSupported)),
-            addServices: s => s.AddSingleton<IJsonIdDefinitionFactory, CustomJsonIdDefinitionFactory>());
-
-        const int pk1 = 1;
-        const int pk2 = 2;
-
-        var customer = new Customer
-        {
-            Id = 42,
-            Name = "Theon",
-            PartitionKey1 = pk1,
-            PartitionKey2 = "One",
-            PartitionKey3 = true
-        };
-
-        using (var context = contextFactory.CreateContext())
-        {
-            context.Database.EnsureCreated();
-
-            context.Add(customer);
-            context.Add(
-                new Customer
-                {
-                    Id = 42,
-                    Name = "Theon Twin",
-                    PartitionKey1 = pk2,
-                    PartitionKey2 = "Two",
-                    PartitionKey3 = false
-                });
-
-            context.SaveChanges();
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<Customer>()
-                .Find(pk1, 42, "One", true);
-
-            Assert.Equal(42, customerFromStore.Id);
-            Assert.Equal("Theon", customerFromStore.Name);
-            Assert.Equal(pk1, customerFromStore.PartitionKey1);
-            Assert.Equal("One", customerFromStore.PartitionKey2);
-            Assert.True(customerFromStore.PartitionKey3);
-            AssertSql(context, """ReadItem([1.0,"One",true], Customer-42)""");
-
-            customerFromStore.Name = "Theon Greyjoy";
-
-            context.SaveChanges();
-        }
-
-        using (var context = contextFactory.CreateContext())
-        {
-            var customerFromStore = context.Set<Customer>()
-                .WithPartitionKey(pk1, "One", true)
-                .Single();
-
-            Assert.Equal(42, customerFromStore.Id);
-            Assert.Equal("Theon Greyjoy", customerFromStore.Name);
-            Assert.Equal(pk1, customerFromStore.PartitionKey1);
-            Assert.Equal("One", customerFromStore.PartitionKey2);
-            Assert.True(customerFromStore.PartitionKey3);
-        }
-    }
-
-    [ConditionalFact]
     public async Task Can_read_with_find_with_partition_key_without_value_generator()
     {
         var contextFactory = await InitializeAsync<PartitionKeyContextNoValueGenerator>(
@@ -1346,8 +1098,6 @@ public class EndToEndCosmosTest : NonSharedModelTestBase
 
         using (var context = contextFactory.CreateContext())
         {
-            context.Database.EnsureCreated();
-
             var customerEntry = context.Entry(customer);
             customerEntry.Property(CosmosJsonIdConvention.DefaultIdPropertyName).CurrentValue = "42";
             customerEntry.State = EntityState.Added;
@@ -1436,8 +1186,6 @@ ReadItem([1.0,"One",true], 42)
 
         await using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1464,8 +1212,6 @@ ReadItem([1.0,"One",true], 42)
 
         await using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1492,8 +1238,6 @@ ReadItem([1.0,"One",true], 42)
 
         await using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1659,8 +1403,6 @@ OFFSET 0 LIMIT 1
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1710,8 +1452,6 @@ OFFSET 0 LIMIT 1
 
         using (var context = contextFactory.CreateContext())
         {
-            context.Database.EnsureCreated();
-
             var entry = context.Add(customer);
             entry.Property<string>("EMail").CurrentValue = "theon.g@winterfell.com";
 
@@ -1771,8 +1511,6 @@ OFFSET 0 LIMIT 1
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
@@ -1861,8 +1599,6 @@ OFFSET 0 LIMIT 1
         await Assert.ThrowsAnyAsync<Exception>(
             async () =>
             {
-                await context.Database.EnsureCreatedAsync();
-
                 await context.AddAsync(new ConflictingIncompatibleId { id = 42 });
 
                 await context.SaveChangesAsync();
@@ -1893,8 +1629,6 @@ OFFSET 0 LIMIT 1
 
         using (var context = contextFactory.CreateContext())
         {
-            await context.Database.EnsureCreatedAsync();
-
             await context.AddAsync(entity);
 
             await context.SaveChangesAsync();
@@ -1950,7 +1684,7 @@ OFFSET 0 LIMIT 1
             => modelBuilder.Entity<ConflictingId>();
     }
 
-    [ConditionalTheory(Skip = "Issue #33600 - flaky test")]
+    [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task Can_have_non_string_property_named_Discriminator(bool useDiscriminator)
@@ -1973,7 +1707,6 @@ OFFSET 0 LIMIT 1
             onConfiguring: o => o.ConfigureWarnings(w => w.Log(CosmosEventId.SyncNotSupported, CosmosEventId.NoPartitionKeyDefined)));
 
         using var context = contextFactory.CreateContext();
-        context.Database.EnsureCreated();
 
         var entry = await context.AddAsync(new NonStringDiscriminator { Id = 1 });
         await context.SaveChangesAsync();
@@ -1985,117 +1718,57 @@ OFFSET 0 LIMIT 1
         var baseEntity = await context.Set<NonStringDiscriminator>().OrderBy(e => e.Id).FirstOrDefaultAsync();
         Assert.NotNull(baseEntity);
 
-        if (useDiscriminator)
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
-FROM root c
-WHERE (c["Discriminator"] = 0)
-ORDER BY c["Id"]
-OFFSET 0 LIMIT 1
-""");
-        }
-        else
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
+        AssertSql(
+            context,
+            """
+SELECT VALUE c
 FROM root c
 ORDER BY c["Id"]
 OFFSET 0 LIMIT 1
 """);
-        }
 
         ListLoggerFactory.Clear();
         Assert.Equal(
             baseEntity, await context.Set<NonStringDiscriminator>()
                 .Where(e => e.Discriminator == Discriminator.Base).OrderBy(e => e.Id).FirstOrDefaultAsync());
 
-        if (useDiscriminator)
-        {
             AssertSql(
                 context,
                 """
-SELECT c
-FROM root c
-WHERE ((c["Discriminator"] = 0) AND (c["Discriminator"] = 0))
-ORDER BY c["Id"]
-OFFSET 0 LIMIT 1
-""");
-        }
-        else
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
+SELECT VALUE c
 FROM root c
 WHERE (c["Discriminator"] = 0)
 ORDER BY c["Id"]
 OFFSET 0 LIMIT 1
 """);
-        }
 
         ListLoggerFactory.Clear();
         Assert.Equal(
             baseEntity, await context.Set<NonStringDiscriminator>()
                 .Where(e => e.GetType() == typeof(NonStringDiscriminator)).OrderBy(e => e.Id).FirstOrDefaultAsync());
 
-        if (useDiscriminator)
-        {
             AssertSql(
                 context,
                 """
-SELECT c
-FROM root c
-WHERE (c["Discriminator"] = 0)
-ORDER BY c["Id"]
-OFFSET 0 LIMIT 1
-""");
-        }
-        else
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
+SELECT VALUE c
 FROM root c
 ORDER BY c["Id"]
 OFFSET 0 LIMIT 1
 """);
-        }
 
         ListLoggerFactory.Clear();
         Assert.Equal(
             baseEntity, await context.Set<NonStringDiscriminator>()
                 .Where(e => e is NonStringDiscriminator).OrderBy(e => e.Id).FirstOrDefaultAsync());
 
-        if (useDiscriminator)
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
-FROM root c
-WHERE (c["Discriminator"] = 0)
-ORDER BY c["Id"]
-OFFSET 0 LIMIT 1
-""");
-        }
-        else
-        {
-            AssertSql(
-                context,
-                """
-SELECT c
+        AssertSql(
+            context,
+            """
+SELECT VALUE c
 FROM root c
 ORDER BY c["Id"]
 OFFSET 0 LIMIT 1
 """);
-        }
     }
 
     private class NonStringDiscriminator

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class EndToEndCosmosTest : NonSharedModelTestBase
+public class EndToEndCosmosTest(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     [ConditionalFact]
     public async Task Can_add_update_delete_end_to_end()

--- a/test/EFCore.Cosmos.FunctionalTests/JsonTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/JsonTypesCosmosTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class JsonTypesCosmosTest : JsonTypesTestBase
+public class JsonTypesCosmosTest(NonSharedFixture fixture) : JsonTypesTestBase(fixture)
 {
     public override Task Can_read_write_collection_of_Guid_converted_to_bytes_JSON_values(string expected)
         // Cosmos provider cannot map collections of elements with converters. See Issue #34026.

--- a/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
@@ -5,8 +5,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class MaterializationInterceptionCosmosTest :
-    MaterializationInterceptionTestBase<MaterializationInterceptionCosmosTest.CosmosLibraryContext>
+public class MaterializationInterceptionCosmosTest(NonSharedFixture fixture) :
+    MaterializationInterceptionTestBase<MaterializationInterceptionCosmosTest.CosmosLibraryContext>(fixture)
 {
     public override Task Intercept_query_materialization_with_owned_types_projecting_collection(bool async, bool usePooling)
         => Task.CompletedTask;

--- a/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
@@ -2,4 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Skip the entire assembly if cannot connect to CosmosDb
+
 [assembly: CosmosDbConfiguredCondition]
+
+// Waiting on Task causes deadlocks when run in parallel
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Properties/TestAssemblyCondition.cs
@@ -2,8 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Skip the entire assembly if cannot connect to CosmosDb
-
 [assembly: CosmosDbConfiguredCondition]
-
-// Waiting on Task causes deadlocks when run in parallel
-[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/AdHocJsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/AdHocJsonQueryCosmosTest.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocJsonQueryCosmosTest : AdHocJsonQueryTestBase
+public class AdHocJsonQueryCosmosTest(NonSharedFixture fixture) : AdHocJsonQueryTestBase(fixture)
 {
     #region 21006
 
@@ -879,7 +879,7 @@ $$$$"""
                 "LeafName":"e4 or l"
             }
         }
-    } 
+    }
 }
 """;
 
@@ -1481,7 +1481,7 @@ $$$"""
     "Scenario": "baseline",
     "OptionalReference": {"NestedOptional": { "Text":"or no" }, "NestedRequired": { "Text":"or nr" }, "NestedCollection": [ { "Text":"or nc 1" }, { "Text":"or nc 2" } ] },
     "RequiredReference": {"NestedOptional": { "Text":"rr no" }, "NestedRequired": { "Text":"rr nr" }, "NestedCollection": [ { "Text":"rr nc 1" }, { "Text":"rr nc 2" } ] },
-    "Collection": 
+    "Collection":
     [
         {"NestedOptional": { "Text":"c 1 no" }, "NestedRequired": { "Text":"c 1 nr" }, "NestedCollection": [ { "Text":"c 1 nc 1" }, { "Text":"c 1 nc 2" } ] },
         {"NestedOptional": { "Text":"c 2 no" }, "NestedRequired": { "Text":"c 2 nr" }, "NestedCollection": [ { "Text":"c 2 nc 1" }, { "Text":"c 2 nc 2" } ] }
@@ -1503,7 +1503,7 @@ $$$"""
     "Scenario": "duplicated navigations",
     "OptionalReference": {"NestedOptional": { "Text":"or no" }, "NestedOptional": { "Text":"or no dupnav" }, "NestedRequired": { "Text":"or nr" }, "NestedCollection": [ { "Text":"or nc 1" }, { "Text":"or nc 2" } ], "NestedCollection": [ { "Text":"or nc 1 dupnav" }, { "Text":"or nc 2 dupnav" } ], "NestedRequired": { "Text":"or nr dupnav" } },
     "RequiredReference": {"NestedOptional": { "Text":"rr no" }, "NestedOptional": { "Text":"rr no dupnav" }, "NestedRequired": { "Text":"rr nr" }, "NestedCollection": [ { "Text":"rr nc 1" }, { "Text":"rr nc 2" } ], "NestedCollection": [ { "Text":"rr nc 1 dupnav" }, { "Text":"rr nc 2 dupnav" } ], "NestedRequired": { "Text":"rr nr dupnav" } },
-    "Collection": 
+    "Collection":
     [
         {"NestedOptional": { "Text":"c 1 no" }, "NestedOptional": { "Text":"c 1 no dupnav" }, "NestedRequired": { "Text":"c 1 nr" }, "NestedCollection": [ { "Text":"c 1 nc 1" }, { "Text":"c 1 nc 2" } ], "NestedCollection": [ { "Text":"c 1 nc 1 dupnav" }, { "Text":"c 1 nc 2 dupnav" } ], "NestedRequired": { "Text":"c 1 nr dupnav" } },
         {"NestedOptional": { "Text":"c 2 no" }, "NestedOptional": { "Text":"c 2 no dupnav" }, "NestedRequired": { "Text":"c 2 nr" }, "NestedCollection": [ { "Text":"c 2 nc 1" }, { "Text":"c 2 nc 2" } ], "NestedCollection": [ { "Text":"c 2 nc 1 dupnav" }, { "Text":"c 2 nc 2 dupnav" } ], "NestedRequired": { "Text":"c 2 nr dupnav" } }
@@ -1525,7 +1525,7 @@ $$$"""
     "Scenario": "duplicated scalars",
     "OptionalReference": {"NestedOptional": { "Text":"or no", "Text":"or no dupprop" }, "NestedRequired": { "Text":"or nr", "Text":"or nr dupprop" }, "NestedCollection": [ { "Text":"or nc 1", "Text":"or nc 1 dupprop" }, { "Text":"or nc 2", "Text":"or nc 2 dupprop" } ] },
     "RequiredReference": {"NestedOptional": { "Text":"rr no", "Text":"rr no dupprop" }, "NestedRequired": { "Text":"rr nr", "Text":"rr nr dupprop" }, "NestedCollection": [ { "Text":"rr nc 1", "Text":"rr nc 1 dupprop" }, { "Text":"rr nc 2", "Text":"rr nc 2 dupprop" } ] },
-    "Collection": 
+    "Collection":
     [
         {"NestedOptional": { "Text":"c 1 no", "Text":"c 1 no dupprop" }, "NestedRequired": { "Text":"c 1 nr", "Text":"c 1 nr dupprop" }, "NestedCollection": [ { "Text":"c 1 nc 1", "Text":"c 1 nc 1 dupprop" }, { "Text":"c 1 nc 2", "Text":"c 1 nc 2 dupprop" } ] },
         {"NestedOptional": { "Text":"c 2 no", "Text":"c 2 no dupprop" }, "NestedRequired": { "Text":"c 2 nr", "Text":"c 2 nr dupprop" }, "NestedCollection": [ { "Text":"c 2 nc 1", "Text":"c 2 nc 1 dupprop" }, { "Text":"c 2 nc 2", "Text":"c 2 nc 2 dupprop" } ] }
@@ -1547,7 +1547,7 @@ $$$"""
     "Scenario": "empty navigation property names",
     "OptionalReference": {"": { "Text":"or no" }, "": { "Text":"or nr" }, "": [ { "Text":"or nc 1" }, { "Text":"or nc 2" } ] },
     "RequiredReference": {"": { "Text":"rr no" }, "": { "Text":"rr nr" }, "": [ { "Text":"rr nc 1" }, { "Text":"rr nc 2" } ] },
-    "Collection": 
+    "Collection":
     [
         {"": { "Text":"c 1 no" }, "": { "Text":"c 1 nr" }, "": [ { "Text":"c 1 nc 1" }, { "Text":"c 1 nc 2" } ] },
         {"": { "Text":"c 2 no" }, "": { "Text":"c 2 nr" }, "": [ { "Text":"c 2 nc 1" }, { "Text":"c 2 nc 2" } ] }
@@ -1569,7 +1569,7 @@ $$$"""
     "Scenario": "empty scalar property names",
     "OptionalReference": {"NestedOptional": { "":"or no" }, "NestedRequired": { "":"or nr" }, "NestedCollection": [ { "":"or nc 1" }, { "":"or nc 2" } ] },
     "RequiredReference": {"NestedOptional": { "":"rr no" }, "NestedRequired": { "":"rr nr" }, "NestedCollection": [ { "":"rr nc 1" }, { "":"rr nc 2" } ] },
-    "Collection": 
+    "Collection":
     [
         {"NestedOptional": { "":"c 1 no" }, "NestedRequired": { "":"c 1 nr" }, "NestedCollection": [ { "":"c 1 nc 1" }, { "":"c 1 nc 2" } ] },
         {"NestedOptional": { "":"c 2 no" }, "NestedRequired": { "":"c 2 nr" }, "NestedCollection": [ { "":"c 2 nc 1" }, { "":"c 2 nc 2" } ] }
@@ -1591,7 +1591,7 @@ $$$"""
     "Scenario": "null navigation property names",
     "OptionalReference": {null: { "Text":"or no" }, null: { "Text":"or nr" }, null: [ { "Text":"or nc 1" }, { "Text":"or nc 2" } ] },
     "RequiredReference": {null: { "Text":"rr no" }, null: { "Text":"rr nr" }, null: [ { "Text":"rr nc 1" }, { "Text":"rr nc 2" } ] },
-    "Collection": 
+    "Collection":
     [
         {null: { "Text":"c 1 no" }, null: { "Text":"c 1 nr" }, null: [ { "Text":"c 1 nc 1" }, { "Text":"c 1 nc 2" } ] },
         {null: { "Text":"c 2 no" }, null: { "Text":"c 2 nr" }, null: [ { "Text":"c 2 nc 1" }, { "Text":"c 2 nc 2" } ] }
@@ -1613,7 +1613,7 @@ $$$"""
     "Scenario": "null scalar property names",
     "OptionalReference": {"NestedOptional": { null:"or no", "Text":"or no nonnull" }, "NestedRequired": { null:"or nr", "Text":"or nr nonnull" }, "NestedCollection": [ { null:"or nc 1", "Text":"or nc 1 nonnull" }, { null:"or nc 2", "Text":"or nc 2 nonnull" } ] },
     "RequiredReference": {"NestedOptional": { null:"rr no", "Text":"rr no nonnull" }, "NestedRequired": { null:"rr nr", "Text":"rr nr nonnull" }, "NestedCollection": [ { null:"rr nc 1", "Text":"rr nc 1 nonnull" }, { null:"rr nc 2", "Text":"rr nc 2 nonnull" } ] },
-    "Collection": 
+    "Collection":
     [
         {"NestedOptional": { null:"c 1 no", "Text":"c 1 no nonnull" }, "NestedRequired": { null:"c 1 nr", "Text":"c 1 nr nonnull" }, "NestedCollection": [ { null:"c 1 nc 1", "Text":"c 1 nc 1 nonnull" }, { null:"c 1 nc 2", "Text":"c 1 nc 2 nonnull" } ] },
         {"NestedOptional": { null:"c 2 no", "Text":"c 2 no nonnull" }, "NestedRequired": { null:"c 2 nr", "Text":"c 2 nr nonnull" }, "NestedCollection": [ { null:"c 2 nc 1", "Text":"c 2 nc 1 nonnull" }, { null:"c 2 nc 2", "Text":"c 2 nc 2 nonnull" } ] }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/AdHocMiscellaneousQueryCosmosTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocMiscellaneousQueryCosmosTest : NonSharedModelTestBase
+public class AdHocMiscellaneousQueryCosmosTest(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     #region 21006
 
@@ -45,7 +45,7 @@ public class AdHocMiscellaneousQueryCosmosTest : NonSharedModelTestBase
     {
         var wrapper = (CosmosClientWrapper)context.GetService<ICosmosClientWrapper>();
         var singletonWrapper = context.GetService<ISingletonCosmosClientWrapper>();
-        var entitiesContainer = singletonWrapper.Client.GetContainer(StoreName, containerId: "Entities");
+        var entitiesContainer = singletonWrapper.Client.GetContainer(context.Database.GetCosmosDatabaseId(), containerId: "Entities");
 
         var missingTopLevel =
 $$"""

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class NonSharedPrimitiveCollectionsQueryCosmosTest : NonSharedPrimitiveCollectionsQueryTestBase
+public class NonSharedPrimitiveCollectionsQueryCosmosTest(NonSharedFixture fixture) : NonSharedPrimitiveCollectionsQueryTestBase(fixture)
 {
     #region Support for specific element types
 

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding;
 
-public class CompiledModelCosmosTest : CompiledModelTestBase
+public class CompiledModelCosmosTest(NonSharedFixture fixture) : CompiledModelTestBase(fixture)
 {
     [ConditionalFact]
     public virtual Task Basic_cosmos_model()

--- a/test/EFCore.Cosmos.FunctionalTests/Storage/CosmosDatabaseCreatorTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Storage/CosmosDatabaseCreatorTest.cs
@@ -8,40 +8,27 @@ namespace Microsoft.EntityFrameworkCore.Storage;
 [CosmosCondition(CosmosCondition.DoesNotUseTokenCredential)]
 public class CosmosDatabaseCreatorTest
 {
-    public static readonly IEnumerable<object[]> IsAsyncData = [[false], [true]];
+    public static readonly IEnumerable<object[]> IsAsyncData = [[true]];
 
     [ConditionalFact]
     public async Task EnsureCreated_returns_true_when_database_does_not_exist()
     {
-        await using var testDatabase = CosmosTestStore.Create("NonExisting");
-        try
-        {
-            using var context = new BloggingContext(testDatabase);
-            var creator = context.GetService<IDatabaseCreator>();
-
-            Assert.True(await creator.EnsureCreatedAsync());
-        }
-        finally
-        {
-            await testDatabase.InitializeAsync(testDatabase.ServiceProvider, () => new BloggingContext(testDatabase));
-        }
+        await using var testDatabase = CosmosTestStore.Create("NonExistingDatabase");
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
+        await creator.EnsureDeletedAsync();
+        Assert.True(await creator.EnsureCreatedAsync());
     }
 
     [ConditionalFact]
     public async Task EnsureCreated_returns_true_when_database_exists_but_collections_do_not()
     {
         await using var testDatabase = CosmosTestStore.Create("EnsureCreatedTest");
-        try
-        {
-            using var context = new BloggingContext(testDatabase);
-            var creator = context.GetService<IDatabaseCreator>();
+        await testDatabase.InitializeAsync(testDatabase.ServiceProvider, () => new BaseContext(testDatabase));
 
-            Assert.True(await creator.EnsureCreatedAsync());
-        }
-        finally
-        {
-            await testDatabase.InitializeAsync(testDatabase.ServiceProvider, () => new BloggingContext(testDatabase));
-        }
+        using var context = new BloggingContext(testDatabase);
+        var creator = context.GetService<IDatabaseCreator>();
+        Assert.True(await creator.EnsureCreatedAsync());
     }
 
     [ConditionalTheory]
@@ -97,7 +84,7 @@ public class CosmosDatabaseCreatorTest
             (await Assert.ThrowsAsync<InvalidOperationException>(() => context.Database.EnsureCreatedAsync())).Message);
     }
 
-    private class BloggingContext(CosmosTestStore testStore, bool seed = false) : DbContext
+    private class BaseContext(CosmosTestStore testStore) : DbContext
     {
         private readonly string _connectionUri = testStore.ConnectionUri;
         private readonly string _authToken = testStore.AuthToken;
@@ -111,15 +98,19 @@ public class CosmosDatabaseCreatorTest
                     _authToken,
                     _name,
                     b => b.ApplyConfiguration());
+        }
+    }
+
+    private class BloggingContext(CosmosTestStore testStore, bool seed = false) : BaseContext(testStore)
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
 
             if (seed)
             {
                 optionsBuilder.UseSeeding((_, __) => { });
             }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
         }
 
         public DbSet<Blog> Blogs { get; set; }

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
-// ReSharper disable once CheckNamespace
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class CosmosTestHelpers : TestHelpers

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -271,19 +271,19 @@ public class CosmosTestStore : TestStore
 
         var model = context.GetService<IDesignTimeModel>().Model;
 
-        var modelThrouput = model.GetThroughput();
-        if (modelThrouput == null
+        var modelThroughput = model.GetThroughput();
+        if (modelThroughput == null
             && GetContainersToCreate(model).All(c => c.Throughput == null))
         {
-            modelThrouput = ThroughputProperties.CreateManualThroughput(400);
+            modelThroughput = ThroughputProperties.CreateManualThroughput(400);
         }
 
-        if (modelThrouput != null)
+        if (modelThroughput != null)
         {
             sqlDatabaseCreateUpdateContent.Options = new CosmosDBCreateUpdateConfig
             {
-                Throughput = modelThrouput.Throughput,
-                AutoscaleMaxThroughput = modelThrouput.AutoscaleMaxThroughput
+                Throughput = modelThroughput.Throughput,
+                AutoscaleMaxThroughput = modelThroughput.AutoscaleMaxThroughput
             };
         }
 

--- a/test/EFCore.InMemory.FunctionalTests/JsonTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/JsonTypesInMemoryTest.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class JsonTypesInMemoryTest : JsonTypesTestBase
+public class JsonTypesInMemoryTest(NonSharedFixture fixture) : JsonTypesTestBase(fixture)
 {
     public override Task Can_read_write_point()
         // No built-in JSON support for spatial types in the in-memory provider

--- a/test/EFCore.InMemory.FunctionalTests/MaterializationInterceptionInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/MaterializationInterceptionInMemoryTest.cs
@@ -5,8 +5,8 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class MaterializationInterceptionInMemoryTest :
-    MaterializationInterceptionTestBase<MaterializationInterceptionInMemoryTest.InMemoryLibraryContext>
+public class MaterializationInterceptionInMemoryTest(NonSharedFixture fixture) :
+    MaterializationInterceptionTestBase<MaterializationInterceptionInMemoryTest.InMemoryLibraryContext>(fixture)
 {
     public class InMemoryLibraryContext(DbContextOptions options) : LibraryContext(options)
     {

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocAdvancedMappingsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocAdvancedMappingsQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocAdvancedMappingsQueryInMemoryTest : AdHocAdvancedMappingsQueryTestBase
+public class AdHocAdvancedMappingsQueryInMemoryTest(NonSharedFixture fixture) : AdHocAdvancedMappingsQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocManyToManyQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocManyToManyQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocManyToManyQueryInMemoryTest : AdHocManyToManyQueryTestBase
+public class AdHocManyToManyQueryInMemoryTest(NonSharedFixture fixture) : AdHocManyToManyQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocMiscellaneousQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocMiscellaneousQueryInMemoryTest : AdHocMiscellaneousQueryTestBase
+public class AdHocMiscellaneousQueryInMemoryTest(NonSharedFixture fixture) : AdHocMiscellaneousQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocNavigationsQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocNavigationsQueryInMemoryTest : AdHocNavigationsQueryTestBase
+public class AdHocNavigationsQueryInMemoryTest(NonSharedFixture fixture) : AdHocNavigationsQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocQueryFiltersQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocQueryFiltersQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocQueryFiltersQueryInMemoryTest : AdHocQueryFiltersQueryTestBase
+public class AdHocQueryFiltersQueryInMemoryTest(NonSharedFixture fixture) : AdHocQueryFiltersQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class OwnedEntityQueryInMemoryTest : OwnedEntityQueryTestBase
+public class OwnedEntityQueryInMemoryTest(NonSharedFixture fixture) : OwnedEntityQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Query/SharedTypeQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SharedTypeQueryInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class SharedTypeQueryInMemoryTest : SharedTypeQueryTestBase
+public class SharedTypeQueryInMemoryTest(NonSharedFixture fixture) : SharedTypeQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
@@ -17,7 +17,7 @@ public class GlobalNamespaceContext(DbContextOptions<GlobalNamespaceContext> opt
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding
 {
-    public class CompiledModelInMemoryTest : CompiledModelTestBase
+    public class CompiledModelInMemoryTest(NonSharedFixture fixture) : CompiledModelTestBase(fixture)
     {
         [ConditionalFact]
         public virtual Task Empty_model()

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesRelationalTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
 
-public abstract class NonSharedModelBulkUpdatesRelationalTestBase : NonSharedModelBulkUpdatesTestBase
+public abstract class NonSharedModelBulkUpdatesRelationalTestBase(NonSharedFixture fixture) : NonSharedModelBulkUpdatesTestBase(fixture)
 {
     protected override string StoreName
         => "NonSharedModelBulkUpdatesTests";

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -7,9 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class EntitySplittingTestBase : NonSharedModelTestBase
+public abstract class EntitySplittingTestBase : NonSharedModelTestBase, IClassFixture<NonSharedFixture>
 {
-    protected EntitySplittingTestBase(ITestOutputHelper testOutputHelper)
+    protected EntitySplittingTestBase(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
     {
         // TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }

--- a/test/EFCore.Relational.Specification.Tests/JsonTypesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/JsonTypesRelationalTestBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class JsonTypesRelationalTestBase : JsonTypesTestBase
+public abstract class JsonTypesRelationalTestBase(NonSharedFixture fixture) : JsonTypesTestBase(fixture)
 {
     public override Task Can_read_write_array_of_array_of_array_of_int_JSON_values()
         => NoNestedCollections(

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocAdvancedMappingsQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocAdvancedMappingsQueryRelationalTestBase : AdHocAdvancedMappingsQueryTestBase
+public abstract class AdHocAdvancedMappingsQueryRelationalTestBase(NonSharedFixture fixture) : AdHocAdvancedMappingsQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocJsonQueryRelationalTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocJsonQueryRelationalTestBase : AdHocJsonQueryTestBase
+public abstract class AdHocJsonQueryRelationalTestBase(NonSharedFixture fixture) : AdHocJsonQueryTestBase(fixture)
 {
     #region 21006
 

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocManyToManyQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocManyToManyQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocManyToManyQueryRelationalTestBase : AdHocManyToManyQueryTestBase
+public abstract class AdHocManyToManyQueryRelationalTestBase(NonSharedFixture fixture) : AdHocManyToManyQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -9,7 +9,7 @@ using NameSpace1;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public abstract class AdHocMiscellaneousQueryRelationalTestBase : AdHocMiscellaneousQueryTestBase
+    public abstract class AdHocMiscellaneousQueryRelationalTestBase(NonSharedFixture fixture) : AdHocMiscellaneousQueryTestBase(fixture)
     {
         protected TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocNavigationsQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocNavigationsQueryRelationalTestBase : AdHocNavigationsQueryTestBase
+public abstract class AdHocNavigationsQueryRelationalTestBase(NonSharedFixture fixture) : AdHocNavigationsQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -8,8 +8,13 @@ using static Microsoft.EntityFrameworkCore.TestUtilities.PrecompiledQueryTestHel
 namespace Microsoft.EntityFrameworkCore.Query;
 
 [Collection("PrecompiledQuery")]
-public abstract class AdHocPrecompiledQueryRelationalTestBase(ITestOutputHelper testOutputHelper) : NonSharedModelTestBase
+public abstract class AdHocPrecompiledQueryRelationalTestBase : NonSharedModelTestBase
 {
+    public AdHocPrecompiledQueryRelationalTestBase(ITestOutputHelper testOutputHelper)
+    {
+        TestOutputHelper = testOutputHelper;
+    }
+
     [ConditionalFact]
     public virtual async Task Index_no_evaluatability()
     {
@@ -352,7 +357,7 @@ var books = await context.Books.ToListAsync();
         Action<List<PrecompiledQueryCodeGenerator.QueryPrecompilationError>>? precompilationErrorAsserter = null,
         [CallerMemberName] string callerName = "")
         => PrecompiledQueryTestHelpers.Test(
-            sourceCode, dbContextOptions, dbContextType, interceptorCodeAsserter, precompilationErrorAsserter, testOutputHelper,
+            sourceCode, dbContextOptions, dbContextType, interceptorCodeAsserter, precompilationErrorAsserter, TestOutputHelper!,
             AlwaysPrintGeneratedSources,
             callerName);
 

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -8,9 +8,10 @@ using static Microsoft.EntityFrameworkCore.TestUtilities.PrecompiledQueryTestHel
 namespace Microsoft.EntityFrameworkCore.Query;
 
 [Collection("PrecompiledQuery")]
-public abstract class AdHocPrecompiledQueryRelationalTestBase : NonSharedModelTestBase
+public abstract class AdHocPrecompiledQueryRelationalTestBase: NonSharedModelTestBase, IClassFixture<NonSharedFixture>
 {
-    public AdHocPrecompiledQueryRelationalTestBase(ITestOutputHelper testOutputHelper)
+    public AdHocPrecompiledQueryRelationalTestBase(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
     {
         TestOutputHelper = testOutputHelper;
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocQueryFiltersQueryRelationalTestBase : AdHocQueryFiltersQueryTestBase
+public abstract class AdHocQueryFiltersQueryRelationalTestBase(NonSharedFixture fixture) : AdHocQueryFiltersQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
@@ -218,8 +218,9 @@ public abstract class AdHocQuerySplittingQueryTestBase : NonSharedModelTestBase
 
     private async Task<(Context25225, Context25225)> CreateTwoContext25225()
     {
-        var context1 = (await CreateContext25225Async()).CreateContext();
-        var context2 = (await CreateContext25225Async()).CreateContext();
+        var factory = await CreateContext25225Async();
+        var context1 = factory.CreateContext();
+        var context2 = factory.CreateContext();
 
         // Can't run in parallel with the same connection instance. Issue #22921
         Assert.NotSame(context1.Database.GetDbConnection(), context2.Database.GetDbConnection());
@@ -231,10 +232,14 @@ public abstract class AdHocQuerySplittingQueryTestBase : NonSharedModelTestBase
         => await InitializeAsync<Context25225>(
             seed: c => c.SeedAsync(),
             onConfiguring: o => SetQuerySplittingBehavior(o, QuerySplittingBehavior.SplitQuery),
-            createTestStore: () => CreateTestStore25225());
+            createTestStore: CreateTestStore25225);
 
-    protected virtual Task<TestStore> CreateTestStore25225()
-        => Task.FromResult(base.CreateTestStore());
+    protected virtual TestStore CreateTestStore25225()
+    {
+        var testStore = (RelationalTestStore)base.CreateTestStore();
+        testStore.UseConnectionString = true;
+        return testStore;
+    }
 
     private static IQueryable<Context25225.ParentViewModel> SelectParent25225(Context25225 context, Guid parentId)
         => context
@@ -379,7 +384,7 @@ public abstract class AdHocQuerySplittingQueryTestBase : NonSharedModelTestBase
                 {
                     blog.Id,
                     Posts = blog.Posts.Select(
-                        blogPost => new 
+                        blogPost => new
                         {
                             blogPost.Id,
                             blogPost.Author

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocQuerySplittingQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocQuerySplittingQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocQuerySplittingQueryTests";

--- a/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
@@ -8,9 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class EntitySplittingQueryTestBase : NonSharedModelTestBase
+public abstract class EntitySplittingQueryTestBase: NonSharedModelTestBase, IClassFixture<NonSharedFixture>
 {
-    protected EntitySplittingQueryTestBase()
+    protected EntitySplittingQueryTestBase(NonSharedFixture fixture)
+        : base(fixture)
         => _setSourceCreator = GetSetSourceCreator();
 
     [ConditionalTheory]

--- a/test/EFCore.Relational.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class NonSharedPrimitiveCollectionsQueryRelationalTestBase : NonSharedPrimitiveCollectionsQueryTestBase
+public abstract class NonSharedPrimitiveCollectionsQueryRelationalTestBase(NonSharedFixture fixture) : NonSharedPrimitiveCollectionsQueryTestBase(fixture)
 {
     // On relational databases, byte[] gets mapped to a special binary data type, which isn't queryable as a regular primitive collection.
     [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsProceduralQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsProceduralQueryTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class OperatorsProceduralQueryTestBase : NonSharedModelTestBase
+public abstract class OperatorsProceduralQueryTestBase : NonSharedModelTestBase, IClassFixture<NonSharedFixture>
 {
     private static readonly MethodInfo LikeMethodInfo
         = typeof(DbFunctionsExtensions).GetRuntimeMethod(
@@ -27,7 +27,8 @@ public abstract class OperatorsProceduralQueryTestBase : NonSharedModelTestBase
 
     protected ExpectedQueryRewritingVisitor ExpectedQueryRewriter { get; init; }
 
-    protected OperatorsProceduralQueryTestBase()
+    protected OperatorsProceduralQueryTestBase(NonSharedFixture fixture)
+        : base(fixture)
     {
         Binaries =
         [

--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.Operators;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
+public abstract class OperatorsQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected OperatorsData ExpectedData { get; init; } = OperatorsData.Instance;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class OwnedEntityQueryRelationalTestBase : OwnedEntityQueryTestBase
+public abstract class OwnedEntityQueryRelationalTestBase(NonSharedFixture fixture) : OwnedEntityQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class SharedTypeQueryRelationalTestBase : SharedTypeQueryTestBase
+public abstract class SharedTypeQueryRelationalTestBase(NonSharedFixture fixture) : SharedTypeQueryTestBase(fixture)
 {
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;

--- a/test/EFCore.Relational.Specification.Tests/Query/ToSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ToSqlQueryTestBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public abstract class ToSqlQueryTestBase : NonSharedModelTestBase
+public abstract class ToSqlQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "ToSqlQueryTests";

--- a/test/EFCore.Relational.Specification.Tests/Scaffolding/CompiledModelRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Scaffolding/CompiledModelRelationalTestBase.cs
@@ -5,12 +5,11 @@
 
 using System.Data;
 using System.Runtime.CompilerServices;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding;
 
-public abstract class CompiledModelRelationalTestBase : CompiledModelTestBase
+public abstract class CompiledModelRelationalTestBase(NonSharedFixture fixture) : CompiledModelTestBase(fixture)
 {
     [ConditionalFact]
     public virtual Task BigModel_with_JSON_columns()

--- a/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TPTTableSplittingTestBase(ITestOutputHelper testOutputHelper) : TableSplittingTestBase(testOutputHelper)
+public abstract class TPTTableSplittingTestBase(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : TableSplittingTestBase(fixture, testOutputHelper)
 {
     public override Task Can_use_optional_dependents_with_shared_concurrency_tokens()
         // TODO: Issue #22060

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection.Emit;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
@@ -10,9 +9,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class TableSplittingTestBase : NonSharedModelTestBase
+public abstract class TableSplittingTestBase : NonSharedModelTestBase, IClassFixture<NonSharedFixture>
 {
-    protected TableSplittingTestBase(ITestOutputHelper testOutputHelper)
+    protected TableSplittingTestBase(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
     {
         // TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }

--- a/test/EFCore.Relational.Specification.Tests/Update/NonSharedModelUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/NonSharedModelUpdatesTestBase.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Update;
 
-public abstract class NonSharedModelUpdatesTestBase : NonSharedModelTestBase
+public abstract class NonSharedModelUpdatesTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "NonSharedModelUpdatesTestBase";

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public abstract class StoredProcedureUpdateTestBase : NonSharedModelTestBase
+public abstract class StoredProcedureUpdateTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "StoredProcedureUpdateTest";

--- a/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
 
-public abstract class NonSharedModelBulkUpdatesTestBase : NonSharedModelTestBase
+public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "NonSharedModelBulkUpdatesTests";

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -3975,7 +3975,7 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
             existingObject: existingObject,
             facets: facets);
 
-    protected virtual async Task Can_read_and_write_JSON_value<TEntity, TModel>(
+    protected virtual Task Can_read_and_write_JSON_value<TEntity, TModel>(
         Action<ModelBuilder> buildModel,
         Action<ModelConfigurationBuilder>? configureConventions,
         string propertyName,
@@ -3986,7 +3986,7 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
         Dictionary<string, object?>? facets = null)
         where TEntity : class
     {
-        var contextFactory = await CreateContextFactory<DbContext>(
+        var contextFactory = CreateContextFactory<DbContext>(
             buildModel,
             configureConventions: configureConventions);
         using var context = contextFactory.CreateContext();
@@ -4060,6 +4060,8 @@ public abstract class JsonTypesTestBase : NonSharedModelTestBase
         {
             Assert.Null(element);
         }
+
+        return Task.CompletedTask;
     }
 
     protected override string StoreName

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -17,7 +17,7 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class JsonTypesTestBase : NonSharedModelTestBase
+public abstract class JsonTypesTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     [ConditionalTheory]
     [InlineData(sbyte.MinValue, """{"Prop":-128}""")]

--- a/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class MaterializationInterceptionTestBase<TContext> : SingletonInterceptorsTestBase<TContext>
+public abstract class MaterializationInterceptionTestBase<TContext>(NonSharedFixture fixture) : SingletonInterceptorsTestBase<TContext>(fixture)
     where TContext : SingletonInterceptorsTestBase<TContext>.LibraryContext
 {
     protected override string StoreName

--- a/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
@@ -11,25 +11,30 @@ public abstract class NonSharedModelTestBase : IAsyncLifetime
 
     protected abstract string StoreName { get; }
     protected abstract ITestStoreFactory TestStoreFactory { get; }
+    protected NonSharedFixture? Fixture { get; set; }
+    protected virtual ITestOutputHelper? TestOutputHelper { get; set; }
 
     private ServiceProvider? _serviceProvider;
-
     protected IServiceProvider ServiceProvider
         => _serviceProvider
             ?? throw new InvalidOperationException(
                 $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
 
     private TestStore? _testStore;
-
     protected TestStore TestStore
         => _testStore
             ?? throw new InvalidOperationException(
                 $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
 
     private ListLoggerFactory? _listLoggerFactory;
-
     protected ListLoggerFactory ListLoggerFactory
         => _listLoggerFactory ??= (ListLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+    protected NonSharedModelTestBase()
+    { }
+
+    protected NonSharedModelTestBase(NonSharedFixture fixture)
+        => Fixture = fixture;
 
     public virtual Task InitializeAsync()
         => Task.CompletedTask;
@@ -41,13 +46,25 @@ public abstract class NonSharedModelTestBase : IAsyncLifetime
         Action<ModelConfigurationBuilder>? configureConventions = null,
         Func<TContext, Task>? seed = null,
         Func<string, bool>? shouldLogCategory = null,
-        Func<Task<TestStore>>? createTestStore = null,
+        Func<TestStore>? createTestStore = null,
         bool usePooling = true,
         bool useServiceProvider = true)
         where TContext : DbContext
     {
-        var contextFactory = await CreateContextFactory<TContext>(
-            onModelCreating, onConfiguring, addServices, configureConventions, shouldLogCategory, createTestStore, usePooling,
+        if (Fixture == null && _testStore != null)
+        {
+            await _testStore.DisposeAsync();
+            _serviceProvider?.Dispose();
+        }
+
+        var contextFactory = CreateContextFactory<TContext>(
+            onModelCreating,
+            onConfiguring,
+            addServices,
+            configureConventions,
+            shouldLogCategory,
+            createTestStore,
+            usePooling,
             useServiceProvider);
 
         await TestStore.InitializeAsync(_serviceProvider, contextFactory.CreateContext, seed == null ? null : c => seed((TContext)c));
@@ -57,20 +74,28 @@ public abstract class NonSharedModelTestBase : IAsyncLifetime
         return contextFactory;
     }
 
-    protected async Task<ContextFactory<TContext>> CreateContextFactory<TContext>(
+    protected virtual ContextFactory<TContext> CreateContextFactory<TContext>(
         Action<ModelBuilder>? onModelCreating = null,
         Action<DbContextOptionsBuilder>? onConfiguring = null,
         Func<IServiceCollection, IServiceCollection>? addServices = null,
         Action<ModelConfigurationBuilder>? configureConventions = null,
         Func<string, bool>? shouldLogCategory = null,
-        Func<Task<TestStore>>? createTestStore = null,
+        Func<TestStore>? createTestStore = null,
         bool usePooling = true,
         bool useServiceProvider = true)
         where TContext : DbContext
     {
-        _testStore = createTestStore != null
-            ? await createTestStore()
-            : CreateTestStore();
+        if (createTestStore != null)
+        {
+            _testStore = createTestStore();
+            Fixture = null;
+        }
+        else
+        {
+            _testStore = Fixture != null
+                ? Fixture.GetOrCreateTestStore(CreateTestStore)
+                : CreateTestStore();
+        }
 
         shouldLogCategory ??= _ => false;
         var services = AddServices(
@@ -144,7 +169,7 @@ public abstract class NonSharedModelTestBase : IAsyncLifetime
 
     public virtual async Task DisposeAsync()
     {
-        if (_testStore != null)
+        if (Fixture == null && _testStore != null)
         {
             await _testStore.DisposeAsync();
             _testStore = null;

--- a/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocAdvancedMappingsQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocAdvancedMappingsQueryTests";

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 // ReSharper disable ClassNeverInstantiated.Local
-public abstract class AdHocComplexTypeQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocComplexTypeQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     #region 33449
 

--- a/test/EFCore.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocJsonQueryTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocJsonQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocJsonQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocJsonQueryTests";

--- a/test/EFCore.Specification.Tests/Query/AdHocManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocManyToManyQueryTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class AdHocManyToManyQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocManyToManyQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocManyToManyQueryTests";

--- a/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class AdHocMiscellaneousQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocMiscellaneousQueryTests";

--- a/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocNavigationsQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocNavigationsQueryTests";

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocQueryFiltersQueryTestBase : NonSharedModelTestBase
+public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "AdHocQueryFiltersQueryTests";

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 using static Expression;
 
-public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedModelTestBase
+public abstract class NonSharedPrimitiveCollectionsQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     #region Support for specific element types
 

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class OwnedEntityQueryTestBase : NonSharedModelTestBase
+public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "OwnedEntityQueryTests";

--- a/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public abstract class SharedTypeQueryTestBase : NonSharedModelTestBase
+public abstract class SharedTypeQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "SharedTypeQueryTests";

--- a/test/EFCore.Specification.Tests/Query/Translations/BasicTypesQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/BasicTypesQueryFixtureBase.cs
@@ -13,7 +13,7 @@ public abstract class BasicTypesQueryFixtureBase : SharedStoreFixtureBase<BasicT
         => "BasicTypesTest";
 
     public Func<DbContext> GetContextCreator()
-        => () => CreateContext();
+        => CreateContext;
 
     protected override Task SeedAsync(BasicTypesContext context)
     {

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -1973,7 +1973,7 @@ namespace TestNamespace
         [CallerMemberName] string testName = "")
         where TContext : DbContext
     {
-        var contextFactory = await CreateContextFactory<TContext>(
+        var contextFactory = CreateContextFactory<TContext>(
             modelBuilder =>
             {
                 var model = modelBuilder.Model;
@@ -2031,17 +2031,16 @@ namespace TestNamespace
 
         if (useContext != null)
         {
+            await TestStore.InitializeAsync(ServiceProvider, contextFactory.CreateContext);
             ListLoggerFactory.Clear();
-            var testStore = await TestStore.InitializeAsync(ServiceProvider, contextFactory.CreateContext);
-            await using var _ = testStore;
 
-            using var compiledModelContext = (await CreateContextFactory<TContext>(
+            using var compiledModelContext = CreateContextFactory<TContext>(
                     onConfiguring: options =>
                     {
                         onConfiguring?.Invoke(options);
                         options.UseModel(compiledModel);
                     },
-                    addServices: addServices))
+                    addServices: addServices)
                 .CreateContext();
             await useContext(compiledModelContext);
         }

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -15,7 +15,7 @@ using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding;
 
-public abstract class CompiledModelTestBase : NonSharedModelTestBase
+public abstract class CompiledModelTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     [ConditionalFact]
     public virtual Task SimpleModel()

--- a/test/EFCore.Specification.Tests/SingletonInterceptorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/SingletonInterceptorsTestBase.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class SingletonInterceptorsTestBase<TContext> : NonSharedModelTestBase
+public abstract class SingletonInterceptorsTestBase<TContext>(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
     where TContext : SingletonInterceptorsTestBase<TContext>.LibraryContext
 {
     protected class Book

--- a/test/EFCore.Specification.Tests/TestUtilities/NonSharedFixture.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/NonSharedFixture.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class NonSharedFixture : IAsyncLifetime
+{
+    private TestStore? _testStore;
+
+    public virtual TestStore GetOrCreateTestStore(Func<TestStore> createTestStore)
+        => _testStore ??= createTestStore();
+
+    public virtual void Dispose()
+    {
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public virtual async Task DisposeAsync()
+    {
+        if (_testStore != null)
+        {
+            await _testStore.DisposeAsync();
+            _testStore = null;
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
 
-public class NonSharedModelBulkUpdatesSqlServerTest : NonSharedModelBulkUpdatesRelationalTestBase
+public class NonSharedModelBulkUpdatesSqlServerTest(NonSharedFixture fixture) : NonSharedModelBulkUpdatesRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class EntitySplittingSqlServerTest(ITestOutputHelper testOutputHelper) : EntitySplittingTestBase(testOutputHelper)
+public class EntitySplittingSqlServerTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : EntitySplittingTestBase(fixture, testOutputHelper)
 {
     [ConditionalFact]
     public virtual async Task Can_roundtrip_with_triggers()

--- a/test/EFCore.SqlServer.FunctionalTests/JsonTypesCustomMappingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/JsonTypesCustomMappingSqlServerTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class JsonTypesCustomMappingSqlServerTest : JsonTypesSqlServerTestBase
+public class JsonTypesCustomMappingSqlServerTest(NonSharedFixture fixture) : JsonTypesSqlServerTestBase(fixture)
 {
     protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
         => serviceCollection.AddSingleton<IRelationalTypeMappingSource, TestSqlServerTypeMappingSource>();

--- a/test/EFCore.SqlServer.FunctionalTests/JsonTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/JsonTypesSqlServerTest.cs
@@ -3,4 +3,4 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class JsonTypesSqlServerTest : JsonTypesSqlServerTestBase;
+public class JsonTypesSqlServerTest(NonSharedFixture fixture) : JsonTypesSqlServerTestBase(fixture);

--- a/test/EFCore.SqlServer.FunctionalTests/JsonTypesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/JsonTypesSqlServerTestBase.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class JsonTypesSqlServerTestBase : JsonTypesRelationalTestBase
+public abstract class JsonTypesSqlServerTestBase(NonSharedFixture fixture) : JsonTypesRelationalTestBase(fixture)
 {
     public override Task Can_read_write_collection_of_fixed_length_string_JSON_values(object? storeType)
         => base.Can_read_write_collection_of_fixed_length_string_JSON_values("nchar(32)");

--- a/test/EFCore.SqlServer.FunctionalTests/MaterializationInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MaterializationInterceptionSqlServerTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class MaterializationInterceptionSqlServerTest :
-    MaterializationInterceptionTestBase<MaterializationInterceptionSqlServerTest.SqlServerLibraryContext>
+public class MaterializationInterceptionSqlServerTest(NonSharedFixture fixture) :
+    MaterializationInterceptionTestBase<MaterializationInterceptionSqlServerTest.SqlServerLibraryContext>(fixture)
 {
     public class SqlServerLibraryContext(DbContextOptions options) : LibraryContext(options)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocAdvancedMappingsQuerySqlServerTest : AdHocAdvancedMappingsQueryRelationalTestBase
+public class AdHocAdvancedMappingsQuerySqlServerTest(NonSharedFixture fixture) : AdHocAdvancedMappingsQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocComplexTypeQuerySqlServerTest : AdHocComplexTypeQueryTestBase
+public class AdHocComplexTypeQuerySqlServerTest(NonSharedFixture fixture) : AdHocComplexTypeQueryTestBase(fixture)
 {
     public override async Task Complex_type_equals_parameter_with_nested_types_with_property_of_same_name()
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerJsonTypeTest.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.SqlClient;
 namespace Microsoft.EntityFrameworkCore.Query;
 
 [SqlServerCondition(SqlServerCondition.SupportsJsonType)]
-public class AdHocJsonQuerySqlServerJsonTypeTest : AdHocJsonQuerySqlServerTestBase
+public class AdHocJsonQuerySqlServerJsonTypeTest(NonSharedFixture fixture) : AdHocJsonQuerySqlServerTestBase(fixture)
 {
     public override async Task Missing_navigation_works_with_deduplication(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTest.cs
@@ -3,6 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocJsonQuerySqlServerTest : AdHocJsonQuerySqlServerTestBase
+public class AdHocJsonQuerySqlServerTest(NonSharedFixture fixture) : AdHocJsonQuerySqlServerTestBase(fixture)
 {
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public abstract class AdHocJsonQuerySqlServerTestBase : AdHocJsonQueryRelationalTestBase
+public abstract class AdHocJsonQuerySqlServerTestBase(NonSharedFixture fixture) : AdHocJsonQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocManyToManyQuerySqlServerTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocManyToManyQuerySqlServerTest : AdHocManyToManyQueryRelationalTestBase
+public class AdHocManyToManyQuerySqlServerTest(NonSharedFixture fixture) : AdHocManyToManyQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocMiscellaneousQuerySqlServerTest : AdHocMiscellaneousQueryRelationalTestBase
+public class AdHocMiscellaneousQuerySqlServerTest(NonSharedFixture fixture) : AdHocMiscellaneousQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -40,7 +40,7 @@ INSERT ZeroKey VALUES (NULL)
     {
         var contextFactory = await InitializeAsync<Context5456>(
             seed: c => c.SeedAsync(),
-            createTestStore: async () => await SqlServerTestStore.CreateInitializedAsync(StoreName, multipleActiveResultSets: true));
+            createTestStore: () => SqlServerTestStore.Create(StoreName, multipleActiveResultSets: true));
 
         Parallel.For(
             0, 10, i =>
@@ -75,7 +75,7 @@ INSERT ZeroKey VALUES (NULL)
     {
         var contextFactory = await InitializeAsync<Context5456>(
             seed: c => c.SeedAsync(),
-            createTestStore: async () => await SqlServerTestStore.CreateInitializedAsync(StoreName, multipleActiveResultSets: true));
+            createTestStore: () => SqlServerTestStore.Create(StoreName, multipleActiveResultSets: true));
 
         await Parallel.ForAsync(
             0, 10, async (i, ct) =>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocNavigationsQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocNavigationsQuerySqlServerTest : AdHocNavigationsQueryRelationalTestBase
+public class AdHocNavigationsQuerySqlServerTest(NonSharedFixture fixture) : AdHocNavigationsQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocPrecompiledQuerySqlServerTest(ITestOutputHelper testOutputHelper)
-    : AdHocPrecompiledQueryRelationalTestBase(testOutputHelper)
+public class AdHocPrecompiledQuerySqlServerTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+    : AdHocPrecompiledQueryRelationalTestBase(fixture, testOutputHelper)
 {
     protected override bool AlwaysPrintGeneratedSources
         => false;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocQueryFiltersQuerySqlServerTest : AdHocQueryFiltersQueryRelationalTestBase
+public class AdHocQueryFiltersQuerySqlServerTest(NonSharedFixture fixture) : AdHocQueryFiltersQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocQuerySplittingQuerySqlServerTest : AdHocQuerySplittingQueryTestBase
+public class AdHocQuerySplittingQuerySqlServerTest(NonSharedFixture fixture) : AdHocQuerySplittingQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
@@ -41,8 +41,12 @@ public class AdHocQuerySplittingQuerySqlServerTest : AdHocQuerySplittingQueryTes
         return optionsBuilder;
     }
 
-    protected override async Task<TestStore> CreateTestStore25225()
-        => await SqlServerTestStore.CreateInitializedAsync(StoreName, multipleActiveResultSets: true);
+    protected override TestStore CreateTestStore25225()
+    {
+        var testStore = SqlServerTestStore.Create(StoreName, multipleActiveResultSets: true);
+        testStore.UseConnectionString = true;
+        return testStore;
+    }
 
     public override async Task Can_configure_SingleQuery_at_context_level()
     {
@@ -271,7 +275,7 @@ ORDER BY [p1].[Id]
     {
         var contextFactory = await InitializeAsync<Context21355>(
             seed: c => c.SeedAsync(),
-            createTestStore: async () => await SqlServerTestStore.CreateInitializedAsync(StoreName, multipleActiveResultSets: false));
+            createTestStore: () => SqlServerTestStore.Create(StoreName, multipleActiveResultSets: false));
 
         using var context = contextFactory.CreateContext();
         context.Parents.Include(p => p.Children1).Include(p => p.Children2).AsSplitQuery().ToList();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class EntitySplittingQuerySqlServerTest : EntitySplittingQueryTestBase
+public class EntitySplittingQuerySqlServerTest(NonSharedFixture fixture) : EntitySplittingQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 using static Expression;
 
-public class NonSharedPrimitiveCollectionsQuerySqlServerTest : NonSharedPrimitiveCollectionsQueryRelationalTestBase
+public class NonSharedPrimitiveCollectionsQuerySqlServerTest(NonSharedFixture fixture) : NonSharedPrimitiveCollectionsQueryRelationalTestBase(fixture)
 {
     protected override DbContextOptionsBuilder SetTranslateParameterizedCollectionsToConstants(DbContextOptionsBuilder optionsBuilder)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsProceduralSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsProceduralSqlServerTest.cs
@@ -14,7 +14,8 @@ public class OperatorsProceduralSqlServerTest : OperatorsProceduralQueryTestBase
             nameof(SqlServerDbFunctionsExtensions.AtTimeZone),
             [typeof(DbFunctions), typeof(DateTimeOffset), typeof(string)])!;
 
-    public OperatorsProceduralSqlServerTest(ITestOutputHelper testOutputHelper)
+    public OperatorsProceduralSqlServerTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
     {
         Binaries.AddRange(
             new List<((Type Left, Type Right) InputTypes, Type ResultType, Func<Expression, Expression, Expression> OperatorCreator)>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class OperatorsQuerySqlServerTest : OperatorsQueryTestBase
+public class OperatorsQuerySqlServerTest(NonSharedFixture fixture) : OperatorsQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class OwnedEntityQuerySqlServerTest : OwnedEntityQueryRelationalTestBase
+public class OwnedEntityQuerySqlServerTest(NonSharedFixture fixture) : OwnedEntityQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RawSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RawSqlServerTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class RawSqlServerTest : NonSharedModelTestBase
+public class RawSqlServerTest(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     // Issue #13346, #24623
     [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class SharedTypeQuerySqlServerTest : SharedTypeQueryRelationalTestBase
+public class SharedTypeQuerySqlServerTest(NonSharedFixture fixture) : SharedTypeQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 #nullable disable
 
 [SqlServerCondition(SqlServerCondition.SupportsTemporalTablesCascadeDelete)]
-public class TemporalTableSqlServerTest : NonSharedModelTestBase
+public class TemporalTableSqlServerTest(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string StoreName
         => "TemporalTableSqlServerTest";

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ToSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ToSqlQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class ToSqlQuerySqlServerTest : ToSqlQueryTestBase
+public class ToSqlQuerySqlServerTest(NonSharedFixture fixture) : ToSqlQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/CompiledModelSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/CompiledModelSqlServerTest.cs
@@ -12,7 +12,7 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding;
 
-public class CompiledModelSqlServerTest : CompiledModelRelationalTestBase
+public class CompiledModelSqlServerTest(NonSharedFixture fixture) : CompiledModelRelationalTestBase(fixture)
 {
     protected override void BuildBigModel(ModelBuilder modelBuilder, bool jsonColumns)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class TPTTableSplittingSqlServerTest(ITestOutputHelper testOutputHelper) : TPTTableSplittingTestBase(testOutputHelper)
+public class TPTTableSplittingSqlServerTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : TPTTableSplittingTestBase(fixture, testOutputHelper)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class TableSplittingSqlServerTest(ITestOutputHelper testOutputHelper) : TableSplittingTestBase(testOutputHelper)
+public class TableSplittingSqlServerTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : TableSplittingTestBase(fixture, testOutputHelper)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/AzureSynapseTestStore.cs
@@ -27,8 +27,8 @@ public class AzureSynapseTestStore : SqlServerTestStore
         bool shared = true)
         => new(name, scriptPath: scriptPath, multipleActiveResultSets: multipleActiveResultSets, shared: shared);
 
-    public new static AzureSynapseTestStore Create(string name, bool useFileName = false)
-        => new(name, useFileName, shared: false);
+    public new static AzureSynapseTestStore Create(string name, bool useFileName = false, bool? multipleActiveResultSets = null)
+        => new(name, useFileName, shared: false, multipleActiveResultSets: multipleActiveResultSets);
 
     public new static async Task<AzureSynapseTestStore> CreateInitializedAsync(
         string name,

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data;
-using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 
 #pragma warning disable IDE0022 // Use block body for methods
@@ -36,8 +35,11 @@ public class SqlServerTestStore : RelationalTestStore
         bool shared = true)
         => new(name, scriptPath: scriptPath, multipleActiveResultSets: multipleActiveResultSets, shared: shared);
 
-    public static SqlServerTestStore Create(string name, bool useFileName = false)
-        => new(name, useFileName, shared: false);
+    public static SqlServerTestStore Create(
+        string name,
+        bool useFileName = false,
+        bool? multipleActiveResultSets = null)
+        => new(name, useFileName, shared: false, multipleActiveResultSets: multipleActiveResultSets);
 
     public static async Task<SqlServerTestStore> CreateInitializedAsync(
         string name,

--- a/test/EFCore.SqlServer.FunctionalTests/Update/NonSharedModelUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/NonSharedModelUpdatesSqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public class NonSharedModelUpdatesSqlServerTest : NonSharedModelUpdatesTestBase
+public class NonSharedModelUpdatesSqlServerTest(NonSharedFixture fixture) : NonSharedModelUpdatesTestBase(fixture)
 {
     public override async Task Principal_and_dependent_roundtrips_with_cycle_breaking(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Update/NonSharedModelUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/NonSharedModelUpdatesSqlServerTest.cs
@@ -95,11 +95,10 @@ WHERE [Id] = @p5;
                 mb.Entity<User>().ToTable("Users");
                 mb.Entity<DailyDigest>().ToTable("DailyDigests");
             },
-            createTestStore: () => Task.FromResult<TestStore>(
-                SqlServerTestStore.GetOrCreateWithScriptPath(
+            createTestStore: () => SqlServerTestStore.GetOrCreateWithScriptPath(
                     "Issue29502",
                     Path.Combine("Update", "Issue29502.sql"),
-                    shared: false)));
+                    shared: false));
 
         await ExecuteWithStrategyInTransactionAsync(
             contextFactory,

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public class StoredProcedureUpdateSqlServerTest : StoredProcedureUpdateTestBase
+public class StoredProcedureUpdateSqlServerTest(NonSharedFixture fixture) : StoredProcedureUpdateTestBase(fixture)
 {
     public override async Task Insert_with_output_parameter(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 #nullable disable
 
-public class NonSharedModelBulkUpdatesSqliteTest : NonSharedModelBulkUpdatesRelationalTestBase
+public class NonSharedModelBulkUpdatesSqliteTest(NonSharedFixture fixture) : NonSharedModelBulkUpdatesRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/EntitySplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/EntitySplittingSqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class EntitySplittingSqliteTest(ITestOutputHelper testOutputHelper) : EntitySplittingTestBase(testOutputHelper)
+public class EntitySplittingSqliteTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : EntitySplittingTestBase(fixture, testOutputHelper)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/JsonTypesSqliteTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class JsonTypesSqliteTest : JsonTypesRelationalTestBase
+public class JsonTypesSqliteTest(NonSharedFixture fixture) : JsonTypesRelationalTestBase(fixture)
 {
     public override Task Can_read_write_array_of_list_of_GUID_JSON_values(string expected)
         => base.Can_read_write_array_of_list_of_GUID_JSON_values(

--- a/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
@@ -5,8 +5,8 @@ using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class MaterializationInterceptionSqliteTest :
-    MaterializationInterceptionTestBase<MaterializationInterceptionSqliteTest.SqliteLibraryContext>
+public class MaterializationInterceptionSqliteTest(NonSharedFixture fixture) :
+    MaterializationInterceptionTestBase<MaterializationInterceptionSqliteTest.SqliteLibraryContext>(fixture)
 {
     public override async Task Intercept_query_materialization_with_owned_types_projecting_collection(bool async, bool usePooling)
         => Assert.Equal(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocAdvancedMappingsQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocAdvancedMappingsQuerySqliteTest : AdHocAdvancedMappingsQueryRelationalTestBase
+public class AdHocAdvancedMappingsQuerySqliteTest(NonSharedFixture fixture) : AdHocAdvancedMappingsQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocComplexTypeQuerySqliteTest : AdHocComplexTypeQueryTestBase
+public class AdHocComplexTypeQuerySqliteTest(NonSharedFixture fixture) : AdHocComplexTypeQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocJsonQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocJsonQuerySqliteTest : AdHocJsonQueryRelationalTestBase
+public class AdHocJsonQuerySqliteTest(NonSharedFixture fixture) : AdHocJsonQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocManyToManyQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocManyToManyQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocManyToManyQuerySqliteTest : AdHocManyToManyQueryRelationalTestBase
+public class AdHocManyToManyQuerySqliteTest(NonSharedFixture fixture) : AdHocManyToManyQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocMiscellaneousQuerySqliteTest : AdHocMiscellaneousQueryRelationalTestBase
+public class AdHocMiscellaneousQuerySqliteTest(NonSharedFixture fixture) : AdHocMiscellaneousQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocNavigationsQuerySqliteTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocNavigationsQuerySqliteTest : AdHocNavigationsQueryRelationalTestBase
+public class AdHocNavigationsQuerySqliteTest(NonSharedFixture fixture) : AdHocNavigationsQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocPrecompiledQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocPrecompiledQuerySqliteTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocPrecompiledQuerySqliteTest(ITestOutputHelper testOutputHelper)
-    : AdHocPrecompiledQueryRelationalTestBase(testOutputHelper)
+public class AdHocPrecompiledQuerySqliteTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper)
+    : AdHocPrecompiledQueryRelationalTestBase(fixture, testOutputHelper)
 {
     protected override bool AlwaysPrintGeneratedSources
         => false;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocQueryFiltersQuerySqliteTest : AdHocQueryFiltersQueryRelationalTestBase
+public class AdHocQueryFiltersQuerySqliteTest(NonSharedFixture fixture) : AdHocQueryFiltersQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQuerySplittingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQuerySplittingQuerySqliteTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class AdHocQuerySplittingQuerySqliteTest : AdHocQuerySplittingQueryTestBase
+public class AdHocQuerySplittingQuerySqliteTest(NonSharedFixture fixture) : AdHocQuerySplittingQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class EntitySplittingQuerySqliteTest : EntitySplittingQueryTestBase
+public class EntitySplittingQuerySqliteTest(NonSharedFixture fixture) : EntitySplittingQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class NonSharedPrimitiveCollectionsQuerySqliteTest : NonSharedPrimitiveCollectionsQueryRelationalTestBase
+public class NonSharedPrimitiveCollectionsQuerySqliteTest(NonSharedFixture fixture) : NonSharedPrimitiveCollectionsQueryRelationalTestBase(fixture)
 {
     protected override DbContextOptionsBuilder SetTranslateParameterizedCollectionsToConstants(DbContextOptionsBuilder optionsBuilder)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsProceduralSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsProceduralSqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class OperatorsProceduralSqliteTest : OperatorsProceduralQueryTestBase
+public class OperatorsProceduralSqliteTest(NonSharedFixture fixture) : OperatorsProceduralQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class OperatorsQuerySqliteTest : OperatorsQueryTestBase
+public class OperatorsQuerySqliteTest(NonSharedFixture fixture) : OperatorsQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedEntityQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedEntityQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class OwnedEntityQuerySqliteTest : OwnedEntityQueryRelationalTestBase
+public class OwnedEntityQuerySqliteTest(NonSharedFixture fixture) : OwnedEntityQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SharedTypeQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class SharedTypeQuerySqliteTest : SharedTypeQueryRelationalTestBase
+public class SharedTypeQuerySqliteTest(NonSharedFixture fixture) : SharedTypeQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ToSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ToSqlQuerySqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
-public class ToSqlQuerySqliteTest : ToSqlQueryTestBase
+public class ToSqlQuerySqliteTest(NonSharedFixture fixture) : ToSqlQueryTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/CompiledModelSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/CompiledModelSqliteTest.cs
@@ -12,7 +12,7 @@ using NetTopologySuite.Geometries;
 namespace Microsoft.EntityFrameworkCore.Scaffolding;
 
 [SpatialiteRequired]
-public class CompiledModelSqliteTest : CompiledModelRelationalTestBase
+public class CompiledModelSqliteTest(NonSharedFixture fixture) : CompiledModelRelationalTestBase(fixture)
 {
     protected override void BuildBigModel(ModelBuilder modelBuilder, bool jsonColumns)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/TPTTableSplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TPTTableSplittingSqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class TPTTableSplittingSqliteTest(ITestOutputHelper testOutputHelper) : TPTTableSplittingTestBase(testOutputHelper)
+public class TPTTableSplittingSqliteTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : TPTTableSplittingTestBase(fixture, testOutputHelper)
 {
     public override Task Can_insert_dependent_with_just_one_parent()
         // This scenario is not valid for TPT

--- a/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
-public class TableSplittingSqliteTest(ITestOutputHelper testOutputHelper) : TableSplittingTestBase(testOutputHelper)
+public class TableSplittingSqliteTest(NonSharedFixture fixture, ITestOutputHelper testOutputHelper) : TableSplittingTestBase(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_works_for_table_sharing(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Update/NonSharedModelUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/NonSharedModelUpdatesSqliteTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 #nullable disable
 
-public class NonSharedModelUpdatesSqliteTest : NonSharedModelUpdatesTestBase
+public class NonSharedModelUpdatesSqliteTest(NonSharedFixture fixture) : NonSharedModelUpdatesTestBase(fixture)
 {
     public override async Task Principal_and_dependent_roundtrips_with_cycle_breaking(bool async)
     {


### PR DESCRIPTION
- Avoid re-initializing the database between each NonShared test
- Avoid deleting databases on the emulator
- Run tests in parallel
