### PR TITLE
Fix stack overflow on AsQueryable constants in ExpressionPrinter

### DIFF
--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -469,7 +469,9 @@ public class ExpressionPrinter : ExpressionVisitor
                 printable.Print(this);
                 break;
 
-            case IQueryable queryable:
+            // EnumerableQuery is returned by AsQueryable(), and can be a constant as a result of funcletization.
+            // We need to print these as a regular enumerable as it doesn't represent a query tree.
+            case IQueryable queryable and not EnumerableQuery:
                 Visit(queryable.Expression);
                 break;
 

--- a/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
@@ -188,6 +188,11 @@ public class ExpressionPrinterTest
         => Assert.Equal(
             @"int[] { 1, 2, 3 }",
             _expressionPrinter.PrintExpression(
-                Expression.Constant(
-                    new[] { 1, 2, 3 })));
+                Expression.Constant(new[] { 1, 2, 3 })));
+
+    [ConditionalFact] // #35866
+    public void EnumerableQuery_Constant_printed_correctly()
+        => Assert.Equal(
+            "EnumerableQuery<int> { 1 }",
+            _expressionPrinter.PrintExpression(Expression.Constant(new[] { 1 }.AsQueryable())));
 }


### PR DESCRIPTION
Fixes #35866
