### PR TITLE
[release/9.0-staging] Cosmos Full Text Search support (query part)

### DIFF
--- a/src/EFCore.Analyzers/EFDiagnostics.cs
+++ b/src/EFCore.Analyzers/EFDiagnostics.cs
@@ -19,4 +19,5 @@ public static class EFDiagnostics
     public const string MetricsExperimental = "EF9101";
     public const string PagingExperimental = "EF9102";
     public const string CosmosVectorSearchExperimental = "EF9103";
+    public const string CosmosFullTextSearchExperimental = "EF9104";
 }

--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -12,6 +12,7 @@
     <NoWarn>$(NoWarn);EF9101</NoWarn> <!-- Metrics is experimental -->
     <NoWarn>$(NoWarn);EF9102</NoWarn> <!-- Paging is experimental -->
     <NoWarn>$(NoWarn);EF9103</NoWarn> <!-- Vector search is experimental -->
+    <NoWarn>$(NoWarn);EF9104</NoWarn> <!-- Full-text search is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -53,6 +53,60 @@ public static class CosmosDbFunctionsExtensions
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CoalesceUndefined)));
 
     /// <summary>
+    ///     Checks if the specified property contains the given keyword using full-text search.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="property">The property to search.</param>
+    /// <param name="keyword">The keyword to search for.</param>
+    /// <returns><see langword="true" /> if the property contains the keyword; otherwise, <see langword="false" />.</returns>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public static bool FullTextContains(this DbFunctions _, string property, string keyword)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FullTextContains)));
+
+    /// <summary>
+    ///     Checks if the specified property contains all the given keywords using full-text search.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="property">The property to search.</param>
+    /// <param name="keywords">The keywords to search for.</param>
+    /// <returns><see langword="true" /> if the property contains all the keywords; otherwise, <see langword="false" />.</returns>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public static bool FullTextContainsAll(this DbFunctions _, string property, params string[] keywords)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FullTextContainsAll)));
+
+    /// <summary>
+    ///     Checks if the specified property contains any of the given keywords using full-text search.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="property">The property to search.</param>
+    /// <param name="keywords">The keywords to search for.</param>
+    /// <returns><see langword="true" /> if the property contains any of the keywords; otherwise, <see langword="false" />.</returns>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public static bool FullTextContainsAny(this DbFunctions _, string property, params string[] keywords)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FullTextContainsAny)));
+
+    /// <summary>
+    ///     Returns the full-text search score for the specified property and keywords.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="property">The property to search.</param>
+    /// <param name="keywords">The keywords to search for.</param>
+    /// <returns>The full-text search score.</returns>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public static double FullTextScore(this DbFunctions _, string property, string[] keywords)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FullTextScore)));
+
+    /// <summary>
+    ///     Combines scores provided by two or more specified functions.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="functions">The functions to compute the score for.</param>
+    /// <returns>The combined score.</returns>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public static double Rrf(this DbFunctions _, params double[] functions)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Rrf)));
+
+    /// <summary>
     ///     Returns the distance between two vectors, using the distance function and data type defined using
     ///     <see
     ///         cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />

--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -89,11 +89,11 @@ public static class CosmosDbFunctionsExtensions
     ///     Returns the full-text search score for the specified property and keywords.
     /// </summary>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="property">The property to search.</param>
-    /// <param name="keywords">The keywords to search for.</param>
+    /// <param name="property">The property to score.</param>
+    /// <param name="keywords">The keywords to score by.</param>
     /// <returns>The full-text search score.</returns>
     [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
-    public static double FullTextScore(this DbFunctions _, string property, string[] keywords)
+    public static double FullTextScore(this DbFunctions _, string property, params string[] keywords)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FullTextScore)));
 
     /// <summary>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -328,6 +328,28 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 param1, param2);
 
         /// <summary>
+        ///     Ordering based on scoring function is not supported inside '{orderByDescending}'. Use '{orderBy}' instead.
+        /// </summary>
+        public static string OrderByDescendingScoringFunction(object? orderByDescending, object? orderBy)
+            => string.Format(
+                GetString("OrderByDescendingScoringFunction", nameof(orderByDescending), nameof(orderBy)),
+                orderByDescending, orderBy);
+
+        /// <summary>
+        ///     Only one ordering using scoring function is allowed. Use 'EF.Functions.{rrf}' method to combine multiple scoring functions.
+        /// </summary>
+        public static string OrderByMultipleScoringFunctionWithoutRrf(object? rrf)
+            => string.Format(
+                GetString("OrderByMultipleScoringFunctionWithoutRrf", nameof(rrf)),
+                rrf);
+
+        /// <summary>
+        ///     Ordering using a scoring function is mutually exclusive with other forms of ordering.
+        /// </summary>
+        public static string OrderByScoringFunctionMixedWithRegularOrderby
+            => GetString("OrderByScoringFunctionMixedWithRegularOrderby");
+
+        /// <summary>
         ///     The entity of type '{entityType}' is mapped as a part of the document mapped to '{missingEntityType}', but there is no tracked entity of this type with the corresponding key value. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
         public static string OrphanedNestedDocument(object? entityType, object? missingEntityType)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -283,6 +283,15 @@
   <data name="OneOfTwoValuesMustBeSet" xml:space="preserve">
     <value>Exactly one of '{param1}' or '{param2}' must be set.</value>
   </data>
+  <data name="OrderByDescendingScoringFunction" xml:space="preserve">
+    <value>Ordering based on scoring function is not supported inside '{orderByDescending}'. Use '{orderBy}' instead.</value>
+  </data>
+  <data name="OrderByMultipleScoringFunctionWithoutRrf" xml:space="preserve">
+    <value>Only one ordering using scoring function is allowed. Use 'EF.Functions.{rrf}' method to combine multiple scoring functions.</value>
+  </data>
+  <data name="OrderByScoringFunctionMixedWithRegularOrderby" xml:space="preserve">
+    <value>Ordering using a scoring function is mutually exclusive with other forms of ordering.</value>
+  </data>
   <data name="OrphanedNestedDocument" xml:space="preserve">
     <value>The entity of type '{entityType}' is mapped as a part of the document mapped to '{missingEntityType}', but there is no tracked entity of this type with the corresponding key value. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -36,7 +36,8 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
             new CosmosRegexTranslator(sqlExpressionFactory),
             new CosmosStringMethodTranslator(sqlExpressionFactory),
             new CosmosTypeCheckingTranslator(sqlExpressionFactory),
-            new CosmosVectorSearchTranslator(sqlExpressionFactory, typeMappingSource)
+            new CosmosVectorSearchTranslator(sqlExpressionFactory, typeMappingSource),
+            new CosmosFullTextSearchTranslator(sqlExpressionFactory, typeMappingSource)
             //new LikeTranslator(sqlExpressionFactory),
             //new EnumHasFlagTranslator(sqlExpressionFactory),
             //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
@@ -9,48 +9,106 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 public partial class CosmosShapedQueryCompilingExpressionVisitor
 {
-    private sealed class InExpressionValuesExpandingExpressionVisitor(
+    private static readonly bool UseOldBehavior35476 =
+          AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35476", out var enabled35476) && enabled35476;
+
+    private sealed class ParameterInliner(
         ISqlExpressionFactory sqlExpressionFactory,
         IReadOnlyDictionary<string, object> parametersValues)
         : ExpressionVisitor
     {
         protected override Expression VisitExtension(Expression expression)
         {
-            if (expression is InExpression inExpression)
+            if (!UseOldBehavior35476)
             {
-                IReadOnlyList<SqlExpression> values;
-
-                switch (inExpression)
-                {
-                    case { Values: IReadOnlyList<SqlExpression> values2 }:
-                        values = values2;
-                        break;
-
-                    // TODO: IN with subquery (return immediately, nothing to do here)
-
-                    case { ValuesParameter: SqlParameterExpression valuesParameter }:
-                    {
-                        var typeMapping = valuesParameter.TypeMapping;
-                        var mutableValues = new List<SqlExpression>();
-                        foreach (var value in (IEnumerable)parametersValues[valuesParameter.Name])
-                        {
-                            mutableValues.Add(sqlExpressionFactory.Constant(value, value?.GetType() ?? typeof(object), typeMapping));
-                        }
-
-                        values = mutableValues;
-                        break;
-                    }
-
-                    default:
-                        throw new UnreachableException();
-                }
-
-                return values.Count == 0
-                    ? sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(false))
-                    : sqlExpressionFactory.In((SqlExpression)Visit(inExpression.Item), values);
+                expression = base.VisitExtension(expression);
             }
 
-            return base.VisitExtension(expression);
+            switch (expression)
+            {
+                // Inlines array parameter of InExpression, transforming: 'item IN (@valuesArray)' to: 'item IN (value1, value2)'
+                case InExpression inExpression:
+                {
+                    IReadOnlyList<SqlExpression> values;
+
+                    switch (inExpression)
+                    {
+                        case { Values: IReadOnlyList<SqlExpression> values2 }:
+                            values = values2;
+                            break;
+
+                        // TODO: IN with subquery (return immediately, nothing to do here)
+
+                        case { ValuesParameter: SqlParameterExpression valuesParameter }:
+                        {
+                            var typeMapping = valuesParameter.TypeMapping;
+                            var mutableValues = new List<SqlExpression>();
+                            foreach (var value in (IEnumerable)parametersValues[valuesParameter.Name])
+                            {
+                                mutableValues.Add(sqlExpressionFactory.Constant(value, value?.GetType() ?? typeof(object), typeMapping));
+                            }
+
+                            values = mutableValues;
+                            break;
+                        }
+
+                        default:
+                            throw new UnreachableException();
+                    }
+
+                    return values.Count == 0
+                        ? sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(false))
+                        : sqlExpressionFactory.In((SqlExpression)Visit(inExpression.Item), values);
+                }
+
+                // Converts Offset and Limit parameters to constants when ORDER BY RANK is detected in the SelectExpression (i.e. we order by scoring function)
+                // Cosmos only supports constants in Offset and Limit for this scenario currently (ORDER BY RANK limitation)
+                case SelectExpression { Orderings: [{ Expression: SqlFunctionExpression { IsScoringFunction: true } }], Limit: var limit, Offset: var offset } hybridSearch
+                    when !UseOldBehavior35476 && (limit is SqlParameterExpression || offset is SqlParameterExpression):
+                {
+                    if (hybridSearch.Limit is SqlParameterExpression limitPrm)
+                    {
+                        hybridSearch.ApplyLimit(
+                            sqlExpressionFactory.Constant(
+                                parametersValues[limitPrm.Name],
+                                limitPrm.TypeMapping));
+                    }
+
+                    if (hybridSearch.Offset is SqlParameterExpression offsetPrm)
+                    {
+                        hybridSearch.ApplyOffset(
+                            sqlExpressionFactory.Constant(
+                                parametersValues[offsetPrm.Name],
+                                offsetPrm.TypeMapping));
+                    }
+
+                    return base.VisitExtension(expression);
+                }
+
+                // Inlines array parameter of full-text functions, transforming FullTextContains(x, @keywordsArray) to FullTextContains(x, keyword1, keyword2)) 
+                case SqlFunctionExpression
+                {
+                    Name: "FullTextContainsAny" or "FullTextContainsAll",
+                    Arguments: [var property, SqlParameterExpression { TypeMapping: { ElementTypeMapping: var elementTypeMapping } } keywords]
+                } fullTextContainsAllAnyFunction
+                when !UseOldBehavior35476:
+                {
+                    var keywordValues = new List<SqlExpression>();
+                    foreach (var value in (IEnumerable)parametersValues[keywords.Name])
+                    {
+                        keywordValues.Add(sqlExpressionFactory.Constant(value, typeof(string), elementTypeMapping));
+                    }
+
+                    return sqlExpressionFactory.Function(
+                        fullTextContainsAllAnyFunction.Name,
+                        [property, .. keywordValues],
+                        fullTextContainsAllAnyFunction.Type,
+                        fullTextContainsAllAnyFunction.TypeMapping);
+                }
+
+                default:
+                    return expression;
+            }
         }
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.PagingQueryingEnumerable.cs
@@ -75,7 +75,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
         private CosmosSqlQuery GenerateQuery()
             => _querySqlGeneratorFactory.Create().GetSqlQuery(
-                (SelectExpression)new InExpressionValuesExpandingExpressionVisitor(
+                (SelectExpression)new ParameterInliner(
                         _sqlExpressionFactory,
                         _cosmosQueryContext.ParameterValues)
                     .Visit(_selectExpression),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -71,7 +71,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
         private CosmosSqlQuery GenerateQuery()
             => _querySqlGeneratorFactory.Create().GetSqlQuery(
-                (SelectExpression)new InExpressionValuesExpandingExpressionVisitor(
+                (SelectExpression)new ParameterInliner(
                         _sqlExpressionFactory,
                         _cosmosQueryContext.ParameterValues)
                     .Visit(_selectExpression),

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/FragmentExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/FragmentExpression.cs
@@ -24,6 +24,14 @@ public class FragmentExpression(string fragment) : Expression, IPrintableExpress
     public virtual string Fragment { get; } = fragment;
 
     /// <inheritdoc />
+    public override ExpressionType NodeType
+        => base.NodeType;
+
+    /// <inheritdoc />
+    public override Type Type
+        => typeof(object);
+
+    /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
         => this;
 

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -16,6 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 [DebuggerDisplay("{PrintShortSql(), nq}")]
 public sealed class SelectExpression : Expression, IPrintableExpression
 {
+    private static readonly bool UseOldBehavior35476 =
+          AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35476", out var enabled35476) && enabled35476;
+
     private IDictionary<ProjectionMember, Expression> _projectionMapping = new Dictionary<ProjectionMember, Expression>();
     private readonly List<SourceExpression> _sources = [];
     private readonly List<ProjectionExpression> _projection = [];
@@ -381,6 +385,12 @@ public sealed class SelectExpression : Expression, IPrintableExpression
     /// </summary>
     public void ApplyOrdering(OrderingExpression orderingExpression)
     {
+        if (!UseOldBehavior35476 && orderingExpression is { Expression: SqlFunctionExpression { IsScoringFunction: true }, IsAscending: false })
+        {
+            throw new InvalidOperationException(
+                CosmosStrings.OrderByDescendingScoringFunction(nameof(Queryable.OrderByDescending), nameof(Queryable.OrderBy)));
+        }
+
         _orderings.Clear();
         _orderings.Add(orderingExpression);
     }
@@ -393,6 +403,19 @@ public sealed class SelectExpression : Expression, IPrintableExpression
     /// </summary>
     public void AppendOrdering(OrderingExpression orderingExpression)
     {
+        if (!UseOldBehavior35476 && _orderings.Count > 0)
+        {
+            var existingScoringFunctionOrdering = _orderings is [{ Expression: SqlFunctionExpression { IsScoringFunction: true } }];
+            var appendingScoringFunctionOrdering = orderingExpression.Expression is SqlFunctionExpression { IsScoringFunction: true };
+            if (appendingScoringFunctionOrdering || existingScoringFunctionOrdering)
+            {
+                throw new InvalidOperationException(
+                    appendingScoringFunctionOrdering && existingScoringFunctionOrdering
+                    ? CosmosStrings.OrderByMultipleScoringFunctionWithoutRrf(nameof(CosmosDbFunctionsExtensions.Rrf))
+                    : CosmosStrings.OrderByScoringFunctionMixedWithRegularOrderby);
+            }
+        }
+
         if (_orderings.FirstOrDefault(o => o.Expression.Equals(orderingExpression.Expression)) == null)
         {
             _orderings.Add(orderingExpression);
@@ -752,6 +775,11 @@ public sealed class SelectExpression : Expression, IPrintableExpression
         if (Orderings.Any())
         {
             expressionPrinter.AppendLine().Append("ORDER BY ");
+            if (!UseOldBehavior35476 && Orderings is [{ Expression: SqlFunctionExpression { IsScoringFunction: true } }])
+            {
+                expressionPrinter.Append("RANK ");
+            }
+
             expressionPrinter.VisitCollection(Orderings);
         }
 

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
@@ -92,7 +92,7 @@ public class SqlFunctionExpression : SqlExpression
         }
 
         return changed
-            ? new SqlFunctionExpression(Name, arguments, Type, TypeMapping)
+            ? new SqlFunctionExpression(Name, IsScoringFunction, arguments, Type, TypeMapping)
             : this;
     }
 
@@ -103,7 +103,7 @@ public class SqlFunctionExpression : SqlExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual SqlFunctionExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
-        => new(Name, Arguments, Type, typeMapping ?? TypeMapping);
+        => new(Name, IsScoringFunction, Arguments, Type, typeMapping ?? TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -114,7 +114,7 @@ public class SqlFunctionExpression : SqlExpression
     public virtual SqlFunctionExpression Update(IReadOnlyList<Expression> arguments)
         => arguments.SequenceEqual(Arguments)
             ? this
-            : new SqlFunctionExpression(Name, arguments, Type, TypeMapping);
+            : new SqlFunctionExpression(Name, IsScoringFunction, arguments, Type, TypeMapping);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SqlFunctionExpression.cs
@@ -3,6 +3,8 @@
 
 // ReSharper disable once CheckNamespace
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>
@@ -24,10 +26,28 @@ public class SqlFunctionExpression : SqlExpression
         IEnumerable<Expression> arguments,
         Type type,
         CoreTypeMapping? typeMapping)
+        : this(name, isScoringFunction: false, arguments, type, typeMapping)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public SqlFunctionExpression(
+        string name,
+        bool isScoringFunction,
+        IEnumerable<Expression> arguments,
+        Type type,
+        CoreTypeMapping? typeMapping)
         : base(type, typeMapping)
     {
         Name = name;
         Arguments = arguments.ToList();
+        IsScoringFunction = isScoringFunction;
     }
 
     /// <summary>
@@ -37,6 +57,15 @@ public class SqlFunctionExpression : SqlExpression
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual string Name { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [Experimental(EFDiagnostics.CosmosFullTextSearchExperimental)]
+    public virtual bool IsScoringFunction { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
@@ -66,6 +66,14 @@ public class CosmosFullTextSearchTranslator(ISqlExpressionFactory sqlExpressionF
                     typeMappingSource.FindMapping(typeof(double))),
 
             nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) or nameof(CosmosDbFunctionsExtensions.FullTextContainsAll)
+                when arguments is [_, SqlExpression property, SqlConstantExpression { Type: var keywordClrType, Value: string[] values } keywords]
+                    && keywordClrType == typeof(string[]) => sqlExpressionFactory.Function(
+                        method.Name == nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) ? "FullTextContainsAny" : "FullTextContainsAll",
+                        [property, .. values.Select(x => sqlExpressionFactory.Constant(x))],
+                        typeof(bool),
+                        typeMappingSource.FindMapping(typeof(bool))),
+
+            nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) or nameof(CosmosDbFunctionsExtensions.FullTextContainsAll)
                 when arguments is [_, SqlExpression property, SqlParameterExpression { Type: var keywordClrType } keywords]
                     && keywordClrType == typeof(string[]) => sqlExpressionFactory.Function(
                         method.Name == nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) ? "FullTextContainsAny" : "FullTextContainsAll",

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CosmosFullTextSearchTranslator(ISqlExpressionFactory sqlExpressionFactory, ITypeMappingSource typeMappingSource)
+    : IMethodCallTranslator
+{
+    private static readonly bool UseOldBehavior35476 =
+          AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35476", out var enabled35476) && enabled35476;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (UseOldBehavior35476 || method.DeclaringType != typeof(CosmosDbFunctionsExtensions))
+        {
+            return null;
+        }
+
+        return method.Name switch
+        {
+            nameof(CosmosDbFunctionsExtensions.FullTextContains)
+                when arguments is [_, var property, var keyword] => sqlExpressionFactory.Function(
+                    "FullTextContains",
+                    [
+                        property,
+                        keyword,
+                    ],
+                    typeof(bool),
+                    typeMappingSource.FindMapping(typeof(bool))),
+
+            nameof(CosmosDbFunctionsExtensions.FullTextScore)
+                when arguments is [_, var property, var keywords] => BuildScoringFunction(
+                    sqlExpressionFactory,
+                    "FullTextScore",
+                    [
+                        property,
+                        keywords,
+                    ],
+                    typeof(double),
+                    typeMappingSource.FindMapping(typeof(double))),
+
+            nameof(CosmosDbFunctionsExtensions.Rrf)
+                when arguments is [_, ArrayConstantExpression functions] => BuildScoringFunction(
+                    sqlExpressionFactory,
+                    "RRF",
+                    functions.Items,
+                    typeof(double),
+                    typeMappingSource.FindMapping(typeof(double))),
+
+            nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) or nameof(CosmosDbFunctionsExtensions.FullTextContainsAll)
+                when arguments is [_, SqlExpression property, SqlParameterExpression { Type: var keywordClrType } keywords]
+                    && keywordClrType == typeof(string[]) => sqlExpressionFactory.Function(
+                        method.Name == nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) ? "FullTextContainsAny" : "FullTextContainsAll",
+                        [property, keywords],
+                        typeof(bool),
+                        typeMappingSource.FindMapping(typeof(bool))),
+
+            nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) or nameof(CosmosDbFunctionsExtensions.FullTextContainsAll)
+                when arguments is [_, SqlExpression property, ArrayConstantExpression keywords] => sqlExpressionFactory.Function(
+                    method.Name == nameof(CosmosDbFunctionsExtensions.FullTextContainsAny) ? "FullTextContainsAny" : "FullTextContainsAll",
+                    [property, .. keywords.Items],
+                    typeof(bool),
+                    typeMappingSource.FindMapping(typeof(bool))),
+
+            _ => null
+        };
+    }
+
+    private SqlExpression BuildScoringFunction(
+        ISqlExpressionFactory sqlExpressionFactory,
+        string functionName,
+        IEnumerable<Expression> arguments,
+        Type returnType,
+        CoreTypeMapping? typeMapping = null)
+    {
+        var typeMappedArguments = new List<Expression>();
+
+        foreach (var argument in arguments)
+        {
+            typeMappedArguments.Add(argument is SqlExpression sqlArgument ? sqlExpressionFactory.ApplyDefaultTypeMapping(sqlArgument) : argument);
+        }
+
+        return new SqlFunctionExpression(
+            functionName,
+            isScoringFunction: true,
+            typeMappedArguments,
+            returnType,
+            typeMapping);
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosVectorSearchTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosVectorSearchTranslator.cs
@@ -18,6 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 public class CosmosVectorSearchTranslator(ISqlExpressionFactory sqlExpressionFactory, ITypeMappingSource typeMappingSource)
     : IMethodCallTranslator
 {
+    private static readonly bool UseOldBehavior35853 =
+          AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35853", out var enabled35853) && enabled35853;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -30,7 +33,15 @@ public class CosmosVectorSearchTranslator(ISqlExpressionFactory sqlExpressionFac
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
-        if (method.DeclaringType != typeof(CosmosDbFunctionsExtensions)
+        if (!UseOldBehavior35853)
+        {
+            if (method.DeclaringType != typeof(CosmosDbFunctionsExtensions)
+                || method.Name != nameof(CosmosDbFunctionsExtensions.VectorDistance))
+            {
+                return null;
+            }
+        }
+        else if (method.DeclaringType != typeof(CosmosDbFunctionsExtensions)
             && method.Name != nameof(CosmosDbFunctionsExtensions.VectorDistance))
         {
             return null;


### PR DESCRIPTION
Limited port of https://github.com/dotnet/efcore/pull/35868
Fixes https://github.com/dotnet/efcore/issues/35476 
Fixes https://github.com/dotnet/efcore/issues/35853 (need to fix this one, otherwise vector translator will try to translate full text methods and fail)

**Description**
This PR enables full-text search queries using EF Core 9 when targeting Azure Cosmos Db. This is one of the flagship new features for Cosmos and the aim here is to help with it's adoption. This is very limited port of the full feature we are adding in EF 10 Preview 4. We are only adding querying capabilities: function stubs for FullTextContains, FullTextContainsAll, FullTextContainsAny, FullTextScore and RRF as well as logic translating these signatures to built-in Cosmos functions. No model building or data manipulation - containers need to be created outside EF (using Cosmos SDK or in the Data Explorer).

**Customer impact**
Customers will be able to use the upcoming full text search capabilities when working with Azure Cosmos Db without the need to upgrade to EF 10 preview.

**How found**
Partner team ask.

**Regression**
No

**Testing**
Extensively tested on EF 10, manual testing on EF9. End-to-end testing is not possible because we can't create containers programmatically (no support for it inside EF Core itself, and the Cosmos SDK which supports it is currently only available in beta, so we can't take dependency on it). Instead, we created containers and data using EF 10, ported all the query tests from EF 10 and ran them using the EF9 bits.

**Risk**
Low. Code here is purely additive and actually localized to only a handful of places in the code: validation in ApplyOrdering/AppendOrdering, FTS method translator, parameter inliner and sql generator. Feature is marked as experimental and quirks have been added.
