### PR TITLE
More relationship test fixes

### DIFF
--- a/test/EFCore.Specification.Tests/Query/Relationships/Include/NavigationIncludeTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/Include/NavigationIncludeTestBase.cs
@@ -25,7 +25,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<RelationshipsRootEntity>(x => x.OptionalReferenceTrunk!)));
 
     [ConditionalTheory]
@@ -34,7 +33,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.CollectionTrunk),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<RelationshipsRootEntity>(x => x.CollectionTrunk)));
 
     [ConditionalTheory]
@@ -60,7 +58,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.RequiredReferenceTrunk.RequiredReferenceBranch),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,
@@ -73,7 +70,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.RequiredReferenceTrunk.CollectionBranch),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,
@@ -86,7 +82,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk!.OptionalReferenceBranch),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,
@@ -99,7 +94,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.OptionalReferenceTrunk!.CollectionBranch),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,
@@ -112,7 +106,6 @@ public abstract class NavigationIncludeTestBase<TFixture>(TFixture fixture) : Qu
         => AssertQuery(
             async,
             ss => ss.Set<RelationshipsRootEntity>().Include(x => x.CollectionTrunk).ThenInclude(x => x.CollectionBranch),
-            assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,

--- a/test/EFCore.Specification.Tests/Query/Relationships/OwnedRelationshipsFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/OwnedRelationshipsFixtureBase.cs
@@ -507,9 +507,11 @@ public abstract class OwnedRelationshipsFixtureBase : RelationshipsQueryFixtureB
         }
 
         Assert.Equal(expected.CollectionBranch.Count, actual.CollectionBranch?.Count ?? 0);
+        var expectedCollection = expected.CollectionBranch.OrderBy(e => e.Name).ToList();
+        var actualCollection = actual.CollectionBranch is null ? [] : actual.CollectionBranch.OrderBy(e => e.Name).ToList();
         for (var i = 0; i < expected.CollectionBranch.Count; i++)
         {
-            AssertOwnedBranch(expected.CollectionBranch[i], actual.CollectionBranch![i]);
+            AssertOwnedBranch(expectedCollection[i], actualCollection![i]);
         }
     }
 
@@ -526,9 +528,11 @@ public abstract class OwnedRelationshipsFixtureBase : RelationshipsQueryFixtureB
         }
 
         Assert.Equal(expected.CollectionLeaf.Count, actual.CollectionLeaf?.Count ?? 0);
+        var expectedCollection = expected.CollectionLeaf.OrderBy(e => e.Name).ToList();
+        var actualCollection = actual.CollectionLeaf is null ? [] : actual.CollectionLeaf.OrderBy(e => e.Name).ToList();
         for (var i = 0; i < expected.CollectionLeaf.Count; i++)
         {
-            AssertOwnedLeaf(expected.CollectionLeaf[i], actual.CollectionLeaf![i]);
+            AssertOwnedLeaf(expectedCollection[i], actualCollection![i]);
         }
     }
 

--- a/test/EFCore.Specification.Tests/Query/Relationships/Projection/ProjectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/Projection/ProjectionTestBase.cs
@@ -59,8 +59,8 @@ public abstract class ProjectionTestBase<TFixture>(TFixture fixture) : QueryTest
                 Assert.Equal(e.Id, a.Id);
                 AssertEqual(e.RequiredReferenceBranch, a.RequiredReferenceBranch);
                 AssertEqual(e.OptionalReferenceLeaf, a.OptionalReferenceLeaf);
-                AssertCollection(e.CollectionLeaf, a.CollectionLeaf, ordered: true);
-                AssertCollection(e.CollectionBranch, a.CollectionBranch, ordered: true);
+                AssertCollection(e.CollectionLeaf, a.CollectionLeaf, ordered: false);
+                AssertCollection(e.CollectionBranch, a.CollectionBranch, ordered: false);
                 Assert.Equal(e.Name, a.Name);
             });
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Include/NavigationIncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Include/NavigationIncludeSqlServerTest.cs
@@ -13,6 +13,18 @@ public class NavigationIncludeSqlServerTest
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    public override async Task Include_trunk_required(bool async)
+    {
+        await base.Include_trunk_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+""");
+    }
+
     public override async Task Include_trunk_optional(bool async)
     {
         await base.Include_trunk_optional(async);
@@ -24,6 +36,109 @@ FROM [RootEntities] AS [r]
 LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
 """);
     }
+
+    public override async Task Include_trunk_collection(bool async)
+    {
+        await base.Include_trunk_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[Id] = [t].[CollectionRootId]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Include_trunk_required_optional_and_collection(bool async)
+    {
+        await base.Include_trunk_required_optional_and_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [t0].[Id], [t0].[CollectionRootId], [t0].[Name], [t0].[OptionalReferenceBranchId], [t0].[RequiredReferenceBranchId], [t1].[Id], [t1].[CollectionRootId], [t1].[Name], [t1].[OptionalReferenceBranchId], [t1].[RequiredReferenceBranchId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [TrunkEntities] AS [t0] ON [r].[OptionalReferenceTrunkId] = [t0].[Id]
+LEFT JOIN [TrunkEntities] AS [t1] ON [r].[Id] = [t1].[CollectionRootId]
+ORDER BY [r].[Id], [t].[Id], [t0].[Id]
+""");
+    }
+
+    public override async Task Include_branch_required_required(bool async)
+    {
+        await base.Include_branch_required_required(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+INNER JOIN [BranchEntities] AS [b] ON [t].[RequiredReferenceBranchId] = [b].[Id]
+""");
+    }
+
+    public override async Task Include_branch_required_collection(bool async)
+    {
+        await base.Include_branch_required_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+    public override async Task Include_branch_optional_optional(bool async)
+    {
+        await base.Include_branch_optional_optional(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[OptionalReferenceBranchId] = [b].[Id]
+""");
+    }
+
+    public override async Task Include_branch_optional_collection(bool async)
+    {
+        await base.Include_branch_optional_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id], [b].[CollectionTrunkId], [b].[Name], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN [TrunkEntities] AS [t] ON [r].[OptionalReferenceTrunkId] = [t].[Id]
+LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+ORDER BY [r].[Id], [t].[Id]
+""");
+    }
+
+    public override async Task Include_branch_collection_collection(bool async)
+    {
+        await base.Include_branch_collection_collection(async);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalReferenceTrunkId], [r].[RequiredReferenceTrunkId], [s].[Id], [s].[CollectionRootId], [s].[Name], [s].[OptionalReferenceBranchId], [s].[RequiredReferenceBranchId], [s].[Id0], [s].[CollectionTrunkId], [s].[Name0], [s].[OptionalReferenceLeafId], [s].[RequiredReferenceLeafId]
+FROM [RootEntities] AS [r]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[CollectionRootId], [t].[Name], [t].[OptionalReferenceBranchId], [t].[RequiredReferenceBranchId], [b].[Id] AS [Id0], [b].[CollectionTrunkId], [b].[Name] AS [Name0], [b].[OptionalReferenceLeafId], [b].[RequiredReferenceLeafId]
+    FROM [TrunkEntities] AS [t]
+    LEFT JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
+) AS [s] ON [r].[Id] = [s].[CollectionRootId]
+ORDER BY [r].[Id], [s].[Id]
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/ComplexNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/ComplexNoTrackingProjectionSqlServerTest.cs
@@ -147,6 +147,10 @@ INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/ComplexProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/ComplexProjectionSqlServerTest.cs
@@ -147,6 +147,10 @@ INNER JOIN [TrunkEntities] AS [t] ON [r].[RequiredReferenceTrunkId] = [t].[Id]
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationNoTrackingProjectionSqlServerTest.cs
@@ -183,6 +183,10 @@ INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationProjectionSqlServerTest.cs
@@ -183,6 +183,10 @@ INNER JOIN [BranchEntities] AS [b] ON [t].[Id] = [b].[CollectionTrunkId]
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationReferenceNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationReferenceNoTrackingProjectionSqlServerTest.cs
@@ -212,6 +212,10 @@ ORDER BY [r].[Id]
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationReferenceProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/NavigationReferenceProjectionSqlServerTest.cs
@@ -212,6 +212,10 @@ ORDER BY [r].[Id]
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonNoTrackingProjectionSqlServerTest.cs
@@ -162,6 +162,22 @@ CROSS APPLY OPENJSON([r].[OptionalReferenceTrunk], '$.CollectionBranch') WITH (
 """);
     }
 
+    public override async Task Project_branch_collection_element_using_indexer_constant(bool async)
+    {
+        await base.Project_branch_collection_element_using_indexer_constant(async);
+
+        AssertSql(
+            """
+SELECT JSON_QUERY([r].[RequiredReferenceTrunk], '$.CollectionBranch'), [r].[Id]
+FROM [RootEntities] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonProjectionSqlServerTest.cs
@@ -54,6 +54,10 @@ public class OwnedJsonProjectionSqlServerTest
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonReferenceNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonReferenceNoTrackingProjectionSqlServerTest.cs
@@ -176,6 +176,10 @@ ORDER BY [r].[Id]
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonReferenceProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonReferenceProjectionSqlServerTest.cs
@@ -76,6 +76,10 @@ FROM [RootEntities] AS [r]
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonTypeNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonTypeNoTrackingProjectionSqlServerTest.cs
@@ -14,4 +14,8 @@ public class OwnedJsonTypeNoTrackingProjectionSqlServerTest
         Fixture.TestSqlLoggerFactory.Clear();
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonTypeReferenceNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedJsonTypeReferenceNoTrackingProjectionSqlServerTest.cs
@@ -14,4 +14,8 @@ public class OwnedJsonTypeReferenceNoTrackingProjectionSqlServerTest
         Fixture.TestSqlLoggerFactory.Clear();
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedNoTrackingProjectionSqlServerTest.cs
@@ -223,6 +223,10 @@ ORDER BY [r].[Id], [r0].[RelationshipsTrunkEntityRelationshipsRootEntityId], [r0
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedProjectionSqlServerTest.cs
@@ -51,6 +51,10 @@ public class OwnedProjectionSqlServerTest
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedReferenceNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedReferenceNoTrackingProjectionSqlServerTest.cs
@@ -420,6 +420,10 @@ ORDER BY [r].[Id], [r2].[Id], [r1].[RelationshipsBranchEntityRelationshipsTrunkE
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedReferenceProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedReferenceProjectionSqlServerTest.cs
@@ -189,6 +189,10 @@ ORDER BY [r].[Id], [s0].[RelationshipsRootEntityId], [s0].[Id1], [s0].[Relations
         AssertSql();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedTableSplittingNoTrackingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedTableSplittingNoTrackingProjectionSqlServerTest.cs
@@ -264,6 +264,10 @@ ORDER BY [r].[Id], [r0].[RelationshipsRootEntityId], [r1].[RelationshipsTrunkEnt
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedTableSplittingReferenceProjectionNoTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Projection/OwnedTableSplittingReferenceProjectionNoTrackingSqlServerTest.cs
@@ -492,6 +492,10 @@ ORDER BY [r].[Id], [s].[Id], [s].[RelationshipsRootEntityId], [s].[Relationships
 """);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
The first remoes some ordering assumptions in the relationship tests, which were causing PG to tail. I think we should in general think a bit more about what we do (and don't do) with ordering in these tests.

The 2nd commit adds missing SQL baselines to the relationship tests, and adds Check_all_tests_overridden everywhere.