### PR TITLE
[release/9.0] Bump version of Cosmos SDK from 3.45 to 3.48 to improve hybrid search experience out of the box

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
 
     <!-- Azure SDK for .NET dependencies -->
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.45.2" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.48.0" />
 
     <!-- SQL Server dependencies -->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />

--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -50,6 +50,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <!-- Microsoft.Azure.Cosmos requires explicit reference to Newtonsoft.Json >= 10.0.2 -->
+    <PackageReference Include="Newtonsoft.Json" />		
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
bumping cosmos sdk version to improve hybrid search experience out of the box - this is a dry run, will incorporate these changes to the proper 9.0 PR once/if we have green light for the bump

Continuation of #35909

**Description**
As part of adding full text search support we realized that some scenarios (specifically hybrid search and some instances of ContainsAll) don't work with the Cosmos SDK that is currently referenced by EFCore.Cosmos 9.x package. The issues can be solved by bumping SDK version to 3.48

**Customer impact**
Customers trying full text search will experience errors for some scenarios - cryptic exception (Syntax error near '-' for hybrid, and invalid results for some ContainsAll queries). Workaround is to manually upgrade Cosmos SDK dependency.

**How found**
Internal testing by the partner team.

**Regression**
No

**Testing**
All current Cosmos tests pass. Performed smoke test to validate that breaking change added in the SDK (requiring explicit Newtonsoft.Json dependency) doesn't have impact on the customer app.

**Risk**
Low. This can only affect customers using EFCore.Cosmos, one breaking change introduced in the SDK is benign from the perspective of customers using EFCore to communicate with Cosmos (EFCore package absorbs the breaking change).