### PR TITLE
Cleanup around vector in Cosmos

### DIFF
--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -11,7 +11,6 @@
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>$(NoWarn);EF9101</NoWarn> <!-- Metrics is experimental -->
     <NoWarn>$(NoWarn);EF9102</NoWarn> <!-- Paging is experimental -->
-    <NoWarn>$(NoWarn);EF9103</NoWarn> <!-- Vector search is experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -104,13 +104,12 @@ public static class CosmosDbFunctionsExtensions
     /// <summary>
     ///     Returns the distance between two vectors, using the distance function and data type defined using
     ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
+    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
     ///     .
     /// </summary>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="vector1">The first vector.</param>
     /// <param name="vector2">The second vector.</param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<byte> vector1, ReadOnlyMemory<byte> vector2)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
 
@@ -125,7 +124,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<byte> vector1,
@@ -145,7 +143,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<byte> vector1,
@@ -157,13 +154,12 @@ public static class CosmosDbFunctionsExtensions
     /// <summary>
     ///     Returns the distance between two vectors, using the distance function and data type defined using
     ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
+    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
     ///     .
     /// </summary>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="vector1">The first vector.</param>
     /// <param name="vector2">The second vector.</param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<sbyte> vector1, ReadOnlyMemory<sbyte> vector2)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
 
@@ -178,7 +174,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<sbyte> vector1,
@@ -198,7 +193,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<sbyte> vector1,
@@ -210,13 +204,12 @@ public static class CosmosDbFunctionsExtensions
     /// <summary>
     ///     Returns the distance between two vectors, using the distance function and data type defined using
     ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVector(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
+    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
     ///     .
     /// </summary>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="vector1">The first vector.</param>
     /// <param name="vector2">The second vector.</param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<float> vector1, ReadOnlyMemory<float> vector2)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
 
@@ -231,7 +224,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<float> vector1,
@@ -251,7 +243,6 @@ public static class CosmosDbFunctionsExtensions
     ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
     ///     property is leveraged.
     /// </param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<float> vector1,

--- a/src/EFCore.Cosmos/Extensions/CosmosIndexBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosIndexBuilderExtensions.cs
@@ -27,8 +27,7 @@ public static class CosmosIndexBuilderExtensions
     /// <param name="indexBuilder">The builder for the index being configured.</param>
     /// <param name="indexType">The type of vector index to create.</param>
     /// <returns>A builder to further configure the index.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static IndexBuilder ForVectors(this IndexBuilder indexBuilder, VectorIndexType? indexType)
+    public static IndexBuilder IsVectorIndex(this IndexBuilder indexBuilder, VectorIndexType? indexType)
     {
         indexBuilder.Metadata.SetVectorIndexType(indexType);
 
@@ -46,11 +45,10 @@ public static class CosmosIndexBuilderExtensions
     /// <param name="indexBuilder">The builder for the index being configured.</param>
     /// <param name="indexType">The type of vector index to create.</param>
     /// <returns>A builder to further configure the index.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static IndexBuilder<TEntity> ForVectors<TEntity>(
+    public static IndexBuilder<TEntity> IsVectorIndex<TEntity>(
         this IndexBuilder<TEntity> indexBuilder,
         VectorIndexType? indexType)
-        => (IndexBuilder<TEntity>)ForVectors((IndexBuilder)indexBuilder, indexType);
+        => (IndexBuilder<TEntity>)IsVectorIndex((IndexBuilder)indexBuilder, indexType);
 
     /// <summary>
     ///     Configures whether the index as a vector index with the given vector index type, such as "flat", "diskANN", or "quantizedFlat".
@@ -67,8 +65,7 @@ public static class CosmosIndexBuilderExtensions
     ///     The same builder instance if the configuration was applied,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static IConventionIndexBuilder? ForVectors(
+    public static IConventionIndexBuilder? IsVectorIndex(
         this IConventionIndexBuilder indexBuilder,
         VectorIndexType? indexType,
         bool fromDataAnnotation = false)
@@ -93,7 +90,6 @@ public static class CosmosIndexBuilderExtensions
     /// <param name="indexType">The index type to use.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the index can be configured for vectors.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static bool CanSetVectorIndexType(
         this IConventionIndexBuilder indexBuilder,
         VectorIndexType? indexType,

--- a/src/EFCore.Cosmos/Extensions/CosmosIndexExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosIndexExtensions.cs
@@ -22,7 +22,6 @@ public static class CosmosIndexExtensions
     /// </summary>
     /// <param name="index">The index.</param>
     /// <returns>The index type to use, or <see langword="null" /> if none is set.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static VectorIndexType? GetVectorIndexType(this IReadOnlyIndex index)
         => (index is RuntimeIndex)
             ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
@@ -34,7 +33,6 @@ public static class CosmosIndexExtensions
     /// </summary>
     /// <param name="index">The index.</param>
     /// <param name="indexType">The index type to use.</param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static void SetVectorIndexType(this IMutableIndex index, VectorIndexType? indexType)
         => index.SetAnnotation(CosmosAnnotationNames.VectorIndexType, indexType);
 
@@ -46,7 +44,6 @@ public static class CosmosIndexExtensions
     /// <param name="index">The index.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static string? SetVectorIndexType(
         this IConventionIndex index,
         VectorIndexType? indexType,
@@ -61,7 +58,6 @@ public static class CosmosIndexExtensions
     /// </summary>
     /// <param name="property">The property.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for whether the index is clustered.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public static ConfigurationSource? GetVectorIndexTypeConfigurationSource(this IConventionIndex property)
         => property.FindAnnotation(CosmosAnnotationNames.VectorIndexType)?.GetConfigurationSource();
 

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -84,50 +84,88 @@ public static class CosmosPropertyExtensions
         => property.FindAnnotation(CosmosAnnotationNames.PropertyName)?.GetConfigurationSource();
 
     /// <summary>
-    ///     Returns the definition of the vector stored in this property.
+    ///     Returns the distance function of the vector stored in this property.
     /// </summary>
     /// <param name="property">The property.</param>
-    /// <returns>Returns the definition of the vector stored in this property.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static CosmosVectorType? GetVectorType(this IReadOnlyProperty property)
-        => (CosmosVectorType?)property[CosmosAnnotationNames.VectorType];
+    /// <returns>Returns the distance function of the vector stored in this property.</returns>
+    public static DistanceFunction? GetVectorDistanceFunction(this IReadOnlyProperty property)
+        => (DistanceFunction?)property[CosmosAnnotationNames.VectorDistanceFunction];
 
     /// <summary>
-    ///     Sets the definition of the vector stored in this property.
+    ///     Returns the dimensions of the vector stored in this property.
     /// </summary>
     /// <param name="property">The property.</param>
-    /// <param name="vectorType">The type of vector stored in the property.</param>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static void SetVectorType(this IMutableProperty property, CosmosVectorType? vectorType)
-        => property.SetOrRemoveAnnotation(CosmosAnnotationNames.VectorType, vectorType);
+    /// <returns>Returns the dimensions of the vector stored in this property.</returns>
+    public static int? GetVectorDimensions(this IReadOnlyProperty property)
+        => (int?)property[CosmosAnnotationNames.VectorDimensions];
 
     /// <summary>
-    ///     Sets the definition of the vector stored in this property.
+    ///     Sets the distance function of the vector stored in this property.
     /// </summary>
     /// <param name="property">The property.</param>
-    /// <param name="vectorType">The type of vector stored in the property.</param>
+    /// <param name="distanceFunction">The distance function of the vector stored in the property.</param>
+    public static void SetVectorDistanceFunction(this IMutableProperty property, DistanceFunction? distanceFunction)
+        => property.SetOrRemoveAnnotation(CosmosAnnotationNames.VectorDistanceFunction, distanceFunction);
+
+    /// <summary>
+    ///     Sets the dimensions of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="dimensions">The dimensions of the vector stored in the property.</param>
+    public static void SetVectorDimensions(this IMutableProperty property, int? dimensions)
+        => property.SetOrRemoveAnnotation(CosmosAnnotationNames.VectorDimensions, dimensions);
+
+    /// <summary>
+    ///     Sets the distance function of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="distanceFunction">The distance function of the vector stored in the property.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static CosmosVectorType? SetVectorType(
+    public static DistanceFunction? SetVectorDistanceFunction(
         this IConventionProperty property,
-        CosmosVectorType? vectorType,
+        DistanceFunction? distanceFunction,
         bool fromDataAnnotation = false)
-        => (CosmosVectorType?)property.SetOrRemoveAnnotation(
-            CosmosAnnotationNames.VectorType,
-            vectorType,
+        => (DistanceFunction?)property.SetOrRemoveAnnotation(
+            CosmosAnnotationNames.VectorDistanceFunction,
+            distanceFunction,
             fromDataAnnotation)?.Value;
 
     /// <summary>
-    ///     Gets the <see cref="ConfigurationSource" /> for the definition of the vector stored in this property.
+    ///     Sets the dimensions of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="dimensions">The dimensions of the vector stored in the property.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static int? SetVectorDimensions(
+        this IConventionProperty property,
+        int? dimensions,
+        bool fromDataAnnotation = false)
+        => (int?)property.SetOrRemoveAnnotation(
+            CosmosAnnotationNames.VectorDimensions,
+            dimensions,
+            fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Gets the <see cref="ConfigurationSource" /> for the distance function of the vector stored in this property.
     /// </summary>
     /// <param name="property">The property.</param>
     /// <returns>
-    ///     The <see cref="ConfigurationSource" /> for the definition of the vector stored in this property.
+    ///     The <see cref="ConfigurationSource" /> for the distance function of the vector stored in this property.
     /// </returns>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public static ConfigurationSource? GetVectorTypeConfigurationSource(this IConventionProperty property)
-        => property.FindAnnotation(CosmosAnnotationNames.VectorType)?.GetConfigurationSource();
+    public static ConfigurationSource? GetVectorDistanceFunctionConfigurationSource(this IConventionProperty property)
+        => property.FindAnnotation(CosmosAnnotationNames.VectorDistanceFunction)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Gets the <see cref="ConfigurationSource" /> for the dimensions of the vector stored in this property.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>
+    ///     The <see cref="ConfigurationSource" /> for the dimensions of the vector stored in this property.
+    /// </returns>
+    public static ConfigurationSource? GetVectorDimensionsConfigurationSource(this IConventionProperty property)
+        => property.FindAnnotation(CosmosAnnotationNames.VectorDimensions)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns the value indicating whether full-text search is enabled for this property.

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
@@ -83,7 +83,6 @@ public static class CosmosAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
     public const string VectorIndexType = Prefix + "VectorIndexType";
 
     /// <summary>
@@ -92,8 +91,15 @@ public static class CosmosAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
-    public const string VectorType = Prefix + "VectorType";
+    public const string VectorDistanceFunction = Prefix + "VectorDistanceFunction";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string VectorDimensions = Prefix + "VectorDimensions";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosVectorType.cs
@@ -12,7 +12,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
 public sealed record class CosmosVectorType(DistanceFunction DistanceFunction, int Dimensions)
 {
     /// <summary>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -106,9 +106,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         /// <summary>
         ///     Creating a container with full-text search or vector properties inside a collection navigation is currently not supported using EF Core; path: '{path}'. Create the container using other means (e.g. Microsoft.Azure.Cosmos SDK).
         /// </summary>
-        public static string CreatingContainerWithFullTextOnCollectionNotSupported(object? path)
+        public static string CreatingContainerWithFullTextOrVectorOnCollectionNotSupported(object? path)
             => string.Format(
-                GetString("CreatingContainerWithFullTextOnCollectionNotSupported", nameof(path)),
+                GetString("CreatingContainerWithFullTextOrVectorOnCollectionNotSupported", nameof(path)),
                 path);
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 itemId);
 
         /// <summary>
-        ///     A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.
+        ///     A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVectorProperty()' in 'OnModelCreating' to configure the property as a vector.
         /// </summary>
         public static string VectorIndexOnNonVector(object? entityType, object? property)
             => string.Format(
@@ -548,7 +548,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 entityType, property);
 
         /// <summary>
-        ///     The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.
+        ///     The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVectorProperty()' in 'OnModelCreating' to configure the property as a vector.
         /// </summary>
         public static string VectorSearchRequiresVector
             => GetString("VectorSearchRequiresVector");

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -150,7 +150,7 @@
   <data name="CosmosNotInUse" xml:space="preserve">
     <value>Cosmos-specific methods can only be used when the context is using the Cosmos provider.</value>
   </data>
-  <data name="CreatingContainerWithFullTextOnCollectionNotSupported" xml:space="preserve">
+  <data name="CreatingContainerWithFullTextOrVectorOnCollectionNotSupported" xml:space="preserve">
     <value>Creating a container with full-text search or vector properties inside a collection navigation is currently not supported using EF Core; path: '{path}'. Create the container using other means (e.g. Microsoft.Azure.Cosmos SDK).</value>
   </data>
   <data name="CrossDocumentJoinNotSupported" xml:space="preserve">
@@ -368,10 +368,10 @@
     <value>An error occurred while saving the item with id '{itemId}'. See the inner exception for details.</value>
   </data>
   <data name="VectorIndexOnNonVector" xml:space="preserve">
-    <value>A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.</value>
+    <value>A vector index is defined for `{entityType}.{property}`, but this property has not been configured as a vector. Use 'IsVectorProperty()' in 'OnModelCreating' to configure the property as a vector.</value>
   </data>
   <data name="VectorSearchRequiresVector" xml:space="preserve">
-    <value>The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVector()' in 'OnModelCreating' to configure the property as a vector.</value>
+    <value>The 'VectorDistance' function can only be used with a property mapped as a vector. Use 'IsVectorProperty()' in 'OnModelCreating' to configure the property as a vector.</value>
   </data>
   <data name="VisitChildrenMustBeOverridden" xml:space="preserve">
     <value>'VisitChildren' must be overridden in the class deriving from 'SqlExpression'.</value>

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -50,8 +50,9 @@ public class CosmosTypeMappingSource : TypeMappingSource
         // directly.
         => base.FindMapping(property) switch
         {
-            CosmosTypeMapping mapping when property.FindAnnotation(CosmosAnnotationNames.VectorType)?.Value is CosmosVectorType vectorType
-                => new CosmosVectorTypeMapping(mapping, vectorType),
+            CosmosTypeMapping mapping
+                when property.GetVectorDistanceFunction() is DistanceFunction distanceFunction && property.GetVectorDimensions() is int dimensions
+                => new CosmosVectorTypeMapping(mapping, new CosmosVectorType(distanceFunction, dimensions)),
             var other => other
         };
 

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosVectorTypeMapping.cs
@@ -14,7 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-[Experimental(EFDiagnostics.CosmosVectorSearchExperimental)]
 public class CosmosVectorTypeMapping : CosmosTypeMapping
 {
     /// <summary>

--- a/src/Shared/EFDiagnostics.cs
+++ b/src/Shared/EFDiagnostics.cs
@@ -18,5 +18,8 @@ internal static class EFDiagnostics
     public const string PrecompiledQueryExperimental = "EF9100";
     public const string MetricsExperimental = "EF9101";
     public const string PagingExperimental = "EF9102";
+
+    // These are no longer experimental but keeping the values so we won't re-purpose them
     public const string CosmosVectorSearchExperimental = "EF9103";
+    public const string CosmosFullTextSearchExperimental = "EF9104";
 }

--- a/test/EFCore.Cosmos.FunctionalTests/AddHocFullTextSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/AddHocFullTextSearchCosmosTest.cs
@@ -44,51 +44,12 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Entity>(b =>
-        {
-            b.ToContainer("Entities");
-            b.HasPartitionKey(x => x.PartitionKey);
-            b.Property(x => x.Name).EnableFullTextSearch();
-            b.Property(x => x.Number).EnableFullTextSearch();
-            b.HasIndex(x => new { x.Name, x.Number }).IsFullTextIndex();
-        });
-    }
-
-    #endregion
-
-    #region FullTextIndexWithoutProperty
-
-    [ConditionalFact]
-    public async Task Validate_full_text_index_without_property()
-    {
-        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-            () => InitializeAsync<ContextFullTextIndexWithoutProperty>())).Message;
-
-        Assert.Equal(
-            CosmosStrings.FullTextIndexOnNonFullTextProperty(
-                nameof(ContextFullTextIndexWithoutProperty.Entity),
-                nameof(ContextFullTextIndexWithoutProperty.Entity.Name),
-                nameof(CosmosPropertyBuilderExtensions.EnableFullTextSearch)),
-            message);
-    }
-
-    protected class ContextFullTextIndexWithoutProperty(DbContextOptions options) : DbContext(options)
-    {
-        public DbSet<Entity> Entities { get; set; } = null!;
-
-        public class Entity
-        {
-            public int Id { get; set; }
-            public string PartitionKey { get; set; } = null!;
-            public string Name { get; set; } = null!;
-            public int Number { get; set; }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<Entity>(b =>
             {
                 b.ToContainer("Entities");
                 b.HasPartitionKey(x => x.PartitionKey);
-                b.HasIndex(x => x.Name).IsFullTextIndex();
+                b.Property(x => x.Name).EnableFullTextSearch();
+                b.Property(x => x.Number).EnableFullTextSearch();
+                b.HasIndex(x => new { x.Name, x.Number }).IsFullTextIndex();
             });
     }
 
@@ -103,7 +64,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
             () => InitializeAsync<ContextFullTextPropertyOnCollectionNavigation>())).Message;
 
         Assert.Equal(
-            CosmosStrings.CreatingContainerWithFullTextOnCollectionNotSupported("/Collection"),
+            CosmosStrings.CreatingContainerWithFullTextOrVectorOnCollectionNotSupported("/Collection"),
             message);
     }
 
@@ -185,7 +146,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         var exception = (await Assert.ThrowsAsync<CosmosException>(
             () => InitializeAsync<ContextSettingDefaultFullTextSearchLanguage>()));
 
-        Assert.Contains("The Full Text Policy contains an unsupported language pl-PL.", exception.Message);
+        Assert.Contains("The Full Text Policy contains an unsupported language xx-YY.", exception.Message);
     }
 
     protected class ContextSettingDefaultFullTextSearchLanguage(DbContextOptions options) : DbContext(options)
@@ -203,7 +164,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Entity>(b =>
             {
-                b.ToContainer("Entities").HasDefaultFullTextLanguage("pl-PL");
+                b.ToContainer("Entities").HasDefaultFullTextLanguage("xx-YY");
                 b.HasPartitionKey(x => x.PartitionKey);
                 b.Property(x => x.Name).EnableFullTextSearch();
                 b.HasIndex(x => x.Name).IsFullTextIndex();
@@ -280,7 +241,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         var exception = (await Assert.ThrowsAsync<CosmosException>(
             () => InitializeAsync<ContextDefaultFullTextSearchLanguageNoMismatchWhenNotSpecified>()));
 
-        Assert.Contains("The Full Text Policy contains an unsupported language pl-PL.", exception.Message);
+        Assert.Contains("The Full Text Policy contains an unsupported language xx-YY.", exception.Message);
     }
 
     protected class ContextDefaultFullTextSearchLanguageNoMismatchWhenNotSpecified(DbContextOptions options) : DbContext(options)
@@ -325,7 +286,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
 
             modelBuilder.Entity<Entity2>(b =>
             {
-                b.ToContainer("Entities").HasDefaultFullTextLanguage("pl-PL");
+                b.ToContainer("Entities").HasDefaultFullTextLanguage("xx-YY");
                 b.HasPartitionKey(x => x.PartitionKey);
                 b.Property(x => x.Name).EnableFullTextSearch();
                 b.HasIndex(x => x.Name).IsFullTextIndex();
@@ -351,7 +312,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         var exception = (await Assert.ThrowsAsync<CosmosException>(
             () => InitializeAsync<ContextDefaultFullTextSearchLanguageUsedWhenPropertyDoesntSpecifyOneExplicitly>()));
 
-        Assert.Contains("The Full Text Policy contains an unsupported language pl-PL.", exception.Message);
+        Assert.Contains("The Full Text Policy contains an unsupported language xx-YY.", exception.Message);
     }
 
     protected class ContextDefaultFullTextSearchLanguageUsedWhenPropertyDoesntSpecifyOneExplicitly(DbContextOptions options) : DbContext(options)
@@ -369,7 +330,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Entity>(b =>
         {
-            b.ToContainer("Entities").HasDefaultFullTextLanguage("pl-PL");
+            b.ToContainer("Entities").HasDefaultFullTextLanguage("xx-YY");
             b.HasPartitionKey(x => x.PartitionKey);
             b.Property(x => x.Name).EnableFullTextSearch();
             b.HasIndex(x => x.Name).IsFullTextIndex();
@@ -386,7 +347,7 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         var exception = (await Assert.ThrowsAsync<CosmosException>(
             () => InitializeAsync<ContextExplicitFullTextLanguageOverridesTheDefault>()));
 
-        Assert.Contains("The Full Text Policy contains an unsupported language pl-PL.", exception.Message);
+        Assert.Contains("The Full Text Policy contains an unsupported language xx-YY.", exception.Message);
     }
 
     protected class ContextExplicitFullTextLanguageOverridesTheDefault(DbContextOptions options) : DbContext(options)
@@ -404,9 +365,9 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Entity>(b =>
         {
-            b.ToContainer("Entities").HasDefaultFullTextLanguage("pl-PL");
+            b.ToContainer("Entities").HasDefaultFullTextLanguage("en-US");
             b.HasPartitionKey(x => x.PartitionKey);
-            b.Property(x => x.Name).EnableFullTextSearch("de-DE");
+            b.Property(x => x.Name).EnableFullTextSearch("xx-YY");
             b.HasIndex(x => x.Name).IsFullTextIndex();
         });
     }
@@ -423,8 +384,8 @@ public class AddHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShare
 
         Assert.Equal(
             CosmosStrings.FullTextIndexOnNonFullTextProperty(
-                nameof(ContextFullTextIndexWithoutProperty.Entity),
-                nameof(ContextFullTextIndexWithoutProperty.Entity.Name),
+                nameof(ContextEnableThenDisable.Entity),
+                nameof(ContextEnableThenDisable.Entity.Name),
                 nameof(CosmosPropertyBuilderExtensions.EnableFullTextSearch)),
             message);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/AddHocVectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/AddHocVectorSearchCosmosTest.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+
+namespace Microsoft.EntityFrameworkCore;
+
+[CosmosCondition(CosmosCondition.DoesNotUseTokenCredential)]
+public class AddHocVectorSearchCosmosTest(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
+{
+    protected override string StoreName
+        => "AdHocVectorSearchTests";
+
+    protected override ITestStoreFactory TestStoreFactory
+        => CosmosTestStoreFactory.Instance;
+
+    #region CompositeVectorIndex
+
+    [ConditionalFact]
+    public async Task Validate_composite_vector_index_throws()
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InitializeAsync<ContextCompositeVectorIndex>())).Message;
+
+        Assert.Equal(
+            CosmosStrings.CompositeVectorIndex(
+                nameof(ContextCompositeVectorIndex.Entity),
+                "MyVector1,MyVector2"),
+            message);
+    }
+
+    protected class ContextCompositeVectorIndex(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Entity> Entities { get; set; } = null!;
+
+        public class Entity
+        {
+            public int Id { get; set; }
+            public string PartitionKey { get; set; } = null!;
+            public ReadOnlyMemory<float> MyVector1 { get; set; } = null!;
+            public byte[] MyVector2 { get; set; } = null!;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Entity>(b =>
+            {
+                b.ToContainer("Entities");
+                b.HasPartitionKey(x => x.PartitionKey);
+                b.Property(x => x.MyVector1).IsVectorProperty(DistanceFunction.Cosine, 5);
+                b.Property(x => x.MyVector2).IsVectorProperty(DistanceFunction.Euclidean, 7);
+                b.HasIndex(x => new { x.MyVector1, x.MyVector2 }).IsVectorIndex(VectorIndexType.Flat);
+            });
+    }
+
+    #endregion
+
+    #region VectorPropertyOnCollectionNavigation
+
+    [ConditionalFact]
+    public async Task Validate_vector_property_on_collection_navigation_container_creation()
+    {
+        var message = (await Assert.ThrowsAsync<NotSupportedException>(
+            () => InitializeAsync<ContextVectorPropertyOnCollectionNavigation>())).Message;
+
+        Assert.Equal(
+            CosmosStrings.CreatingContainerWithFullTextOrVectorOnCollectionNotSupported("/Collection"),
+            message);
+    }
+
+    protected class ContextVectorPropertyOnCollectionNavigation(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Entity> Entities { get; set; } = null!;
+
+        public class Entity
+        {
+            public int Id { get; set; }
+            public string PartitionKey { get; set; } = null!;
+            public List<Json> Collection { get; set; } = null!;
+        }
+
+        public class Json
+        {
+            public byte[] Vector { get; set; } = null!;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Entity>(b =>
+            {
+                b.ToContainer("Entities");
+                b.HasPartitionKey(x => x.PartitionKey);
+                b.OwnsMany(x => x.Collection, bb =>
+                {
+                    bb.Property(x => x.Vector).IsVectorProperty(DistanceFunction.Cosine, 5);
+                    bb.HasIndex(x => x.Vector).IsVectorIndex(VectorIndexType.QuantizedFlat);
+                });
+            });
+    }
+
+    #endregion
+}

--- a/test/EFCore.Cosmos.FunctionalTests/HybridSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/HybridSearchCosmosTest.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#pragma warning disable EF9103
 [CosmosCondition(CosmosCondition.DoesNotUseTokenCredential)]
 public class HybridSearchCosmosTest : IClassFixture<HybridSearchCosmosTest.HybridSearchFixture>
 {
@@ -162,20 +161,20 @@ ORDER BY RANK RRF(VectorDistance(c["Owned"]["Singles"], @inputVector, false, {'d
                 b.Property(x => x.Description).EnableFullTextSearch();
                 b.HasIndex(x => x.Description).IsFullTextIndex();
 
-                b.HasIndex(e => e.Bytes).ForVectors(VectorIndexType.Flat);
-                b.HasIndex(e => e.SBytes).ForVectors(VectorIndexType.Flat);
-                b.HasIndex(e => e.BytesArray).ForVectors(VectorIndexType.Flat);
-                b.HasIndex(e => e.SinglesArray).ForVectors(VectorIndexType.Flat);
+                b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
 
-                b.Property(e => e.Bytes).IsVector(DistanceFunction.Cosine, 10);
-                b.Property(e => e.SBytes).IsVector(DistanceFunction.DotProduct, 10);
-                b.Property(e => e.BytesArray).IsVector(DistanceFunction.Cosine, 10);
-                b.Property(e => e.SinglesArray).IsVector(DistanceFunction.Cosine, 10);
+                b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+                b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
 
                 b.OwnsOne(x => x.Owned, bb =>
                 {
-                    bb.HasIndex(e => e.Singles).ForVectors(VectorIndexType.Flat);
-                    bb.Property(e => e.Singles).IsVector(DistanceFunction.Cosine, 10);
+                    bb.HasIndex(e => e.Singles).IsVectorIndex(VectorIndexType.Flat);
+                    bb.Property(e => e.Singles).IsVectorProperty(DistanceFunction.Cosine, 10);
 
                     bb.Property(x => x.AnotherDescription).EnableFullTextSearch();
                     bb.HasIndex(x => x.AnotherDescription).IsFullTextIndex();
@@ -256,4 +255,3 @@ ORDER BY RANK RRF(VectorDistance(c["Owned"]["Singles"], @inputVector, false, {'d
             => CosmosTestStoreFactory.Instance;
     }
 }
-#pragma warning restore EF9103

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -435,7 +435,6 @@ public class CosmosTestStore : TestStore
             mappedTypes.Add(entityType);
         }
 
-#pragma warning disable EF9103
         foreach (var (containerName, mappedTypes) in containers)
         {
             IReadOnlyList<string> partitionKeyStoreNames = Array.Empty<string>();
@@ -502,7 +501,6 @@ public class CosmosTestStore : TestStore
                 ProcessEntityType(ownedType, indexes, vectors, fullTextProperties);
             }
         }
-#pragma warning restore EF9103
     }
 
     private static IReadOnlyList<string> GetPartitionKeyStoreNames(IEntityType entityType)

--- a/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/VectorSearchCosmosTest.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#pragma warning disable EF9103
 public class VectorSearchCosmosTest : IClassFixture<VectorSearchCosmosTest.VectorSearchFixture>
 {
     public VectorSearchCosmosTest(VectorSearchFixture fixture, ITestOutputHelper testOutputHelper)
@@ -394,22 +393,22 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p, false, {'distanceFunction'
                     b.HasKey(e => e.Id);
                     b.HasPartitionKey(e => e.Publisher);
 
-                    b.HasIndex(e => e.Bytes).ForVectors(VectorIndexType.Flat);
-                    b.HasIndex(e => e.SBytes).ForVectors(VectorIndexType.Flat);
-                    b.HasIndex(e => e.BytesArray).ForVectors(VectorIndexType.Flat);
-                    b.HasIndex(e => e.SinglesArray).ForVectors(VectorIndexType.Flat);
+                    b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
+                    b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
+                    b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
+                    b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
 
-                    b.Property(e => e.Bytes).IsVector(DistanceFunction.Cosine, 10);
-                    b.Property(e => e.SBytes).IsVector(DistanceFunction.DotProduct, 10);
-                    b.Property(e => e.BytesArray).IsVector(DistanceFunction.Cosine, 10);
-                    b.Property(e => e.SinglesArray).IsVector(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                    b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
 
                     b.OwnsOne(x => x.OwnedReference, bb =>
                     {
                         bb.OwnsOne(x => x.NestedOwned, bbb =>
                         {
-                            bbb.HasIndex(x => x.NestedSingles).ForVectors(VectorIndexType.Flat);
-                            bbb.Property(x => x.NestedSingles).IsVector(DistanceFunction.Cosine, 10);
+                            bbb.HasIndex(x => x.NestedSingles).IsVectorIndex(VectorIndexType.Flat);
+                            bbb.Property(x => x.NestedSingles).IsVectorProperty(DistanceFunction.Cosine, 10);
                         });
 
                         bb.OwnsMany(x => x.NestedOwnedCollection, bbb => bbb.Ignore(x => x.NestedSingles));
@@ -505,4 +504,3 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p, false, {'distanceFunction'
             => CosmosTestStoreFactory.Instance;
     }
 }
-#pragma warning restore EF9103

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -478,18 +478,22 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
         VerifyError(CosmosStrings.ETagNonStringStoreType("_etag", nameof(Customer), "int"), modelBuilder);
     }
 
-#pragma warning disable EF9103
     [ConditionalFact]
-    public virtual void Detects_multi_property_vector_index()
+    public virtual void Detects_full_text_index_without_full_text_property()
     {
         var modelBuilder = CreateConventionModelBuilder();
         modelBuilder.Entity<Customer>(
             b =>
             {
-                b.HasIndex(e => new { e.Name, e.OtherName }).ForVectors(VectorIndexType.Flat);
+                b.HasIndex(e => e.Name).IsFullTextIndex();
             });
 
-        VerifyError(CosmosStrings.CompositeVectorIndex(nameof(Customer), "Name,OtherName"), modelBuilder);
+        VerifyError(
+            CosmosStrings.FullTextIndexOnNonFullTextProperty(
+                nameof(Customer),
+                nameof(Customer.Name),
+                nameof(CosmosPropertyBuilderExtensions.EnableFullTextSearch)),
+            modelBuilder);
     }
 
     [ConditionalFact]
@@ -499,12 +503,11 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<Customer>(
             b =>
             {
-                b.HasIndex(e => new { e.Name }).ForVectors(VectorIndexType.Flat);
+                b.HasIndex(e => e.Name).IsVectorIndex(VectorIndexType.Flat);
             });
 
         VerifyError(CosmosStrings.VectorIndexOnNonVector(nameof(Customer), "Name"), modelBuilder);
     }
-#pragma warning restore EF9103
 
     [ConditionalFact]
     public virtual void Detects_vector_property_with_unknown_data_type()
@@ -513,9 +516,7 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<NonVector>(
             b =>
             {
-#pragma warning disable EF9103
-                b.Property(e => e.Vector).IsVector(DistanceFunction.Cosine, dimensions: 10);
-#pragma warning restore EF9103
+                b.Property(e => e.Vector).IsVectorProperty(DistanceFunction.Cosine, dimensions: 10);
             });
 
         VerifyError(CosmosStrings.BadVectorDataType("double[]"), modelBuilder);


### PR DESCRIPTION
- remove experimental from vector APIs,
- renamed vector index model builder method from ForVector to IsVectorIndex,
- renamed vector property model builder method from IsVector to IsVectorProperty,
- use helper methods rather than extracting annotations directly in validation,
- move some validation to container creation, so that queries are not blocked when Cosmos starts supporting new things (e.g. composite indexes)
- split CosmosVectorType into two annotations (distance function and dimensions) so that we can keep CVT pubternal

Fixes #35895
Fixes #35886
Fixes #35897
Fixes #35903
Fixes #35965