### PR TITLE
Slightly improve performance and maintainability in SequentialGuidValueGenerator

### DIFF
--- a/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration;
@@ -35,17 +36,29 @@ public class SequentialGuidValueGenerator : ValueGenerator<Guid>
     /// <returns>The value to be assigned to a property.</returns>
     public override Guid Next(EntityEntry entry)
     {
-        Span<byte> guidBytes = stackalloc byte[16];
-        var succeeded = Guid.NewGuid().TryWriteBytes(guidBytes);
-        Check.DebugAssert(succeeded, "Could not write Guid to Span");
-        var incrementedCounter = Interlocked.Increment(ref _counter);
-        Span<byte> counterBytes = stackalloc byte[sizeof(long)];
-        MemoryMarshal.Write(counterBytes, in incrementedCounter);
+        var guid = Guid.NewGuid();
 
-        if (!BitConverter.IsLittleEndian)
-        {
-            counterBytes.Reverse();
-        }
+        var counter = BitConverter.IsLittleEndian
+            ? Interlocked.Increment(ref _counter)
+            : BinaryPrimitives.ReverseEndianness(Interlocked.Increment(ref _counter));
+
+        var counterBytes = MemoryMarshal.AsBytes(
+            new ReadOnlySpan<long>(in counter));
+
+        // Guid uses a sequential layout where the first 8 bytes (_a, _b, _c)
+        // are subject to byte-swapping on big-endian systems when reading from
+        // or writing to a byte array (e.g., via MemoryMarshal or Guid constructors).
+        // The remaining 8 bytes (_d through _k) are interpreted as-is,
+        // regardless of endianness.
+        //
+        // Since we only modify the last 8 bytes of the Guid (bytes 8–15),
+        // byte order does not affect the result.
+        //
+        // This allows us to safely use MemoryMarshal.AsBytes to directly access
+        // and modify the Guid's underlying bytes without any extra conversions,
+        // which also slightly improves performance on big-endian architectures.
+        var guidBytes = MemoryMarshal.AsBytes(
+            new Span<Guid>(ref guid));
 
         guidBytes[08] = counterBytes[1];
         guidBytes[09] = counterBytes[0];
@@ -56,7 +69,7 @@ public class SequentialGuidValueGenerator : ValueGenerator<Guid>
         guidBytes[14] = counterBytes[3];
         guidBytes[15] = counterBytes[2];
 
-        return new Guid(guidBytes);
+        return guid;
     }
 
     /// <summary>


### PR DESCRIPTION
Replace unnecessary byte copying with direct in-place modification. 

Guid uses a sequential layout where the first 8 bytes require endianness handling on big-endian systems when reading from or writing to a byte array (e.g., via `MemoryMarshal` or `Guid` constructors). The remaining 8 bytes are interpreted as-is, regardless of endianness.

Since we only modify the last 8 bytes of the `Guid`, byte order does not affect the result, so we can:
* Eliminate intermediate copies
* Skip unnecessary byte order conversions
* Safely use `MemoryMarshal.AsBytes` for direct access

The optimization maintains identical behavior while being more efficient.