### PR TITLE
Fix to #35983 - Cosmos/FTS: update translation of FullTextScore to use multiple keywords rather than keyword array

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
 
     <!-- Azure SDK for .NET dependencies -->
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.45.2" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.49.0" />
 
     <!-- SQL Server dependencies -->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />

--- a/src/EFCore.Cosmos/EFCore.Cosmos.csproj
+++ b/src/EFCore.Cosmos/EFCore.Cosmos.csproj
@@ -50,6 +50,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" />
+	<!-- Microsoft.Azure.Cosmos requires explicit reference to Newtonsoft.Json >= 10.0.2 -->
+    <PackageReference Include="Newtonsoft.Json" />		
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of #35984
Fixes #35983

Description
Reacting to Cosmos changing the signature of FullTextScore function to accept multiple parameters rather than parameter array.

Customer impact
TBD

How found
Partner team ask.

Regression
No

Testing
Extensively tested on EF 10, manual testing on EF9. End-to-end testing is not possible because we can't create containers programmatically (no support for it inside EF Core itself, and the Cosmos SDK which supports it is currently only available in beta, so we can't take dependency on it). Instead, we created containers and data using EF 10, ported all the query tests from EF 10 and ran them using the EF9 bits. Partner team will conduct additional testing on their end.

Risk
Low. Localized change to translation - method signature exposed by EF is already in place. New translation now resembles other FullText methods, so same techniques can be used for translation (essentially re-using code that has been in place for other methods and working). Full text search support is experimental on EF9. Added quirk just in case.


