### PR TITLE
Fix Cosmos tests on official CI by ignoring the ambient MI

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -34,7 +34,7 @@ public static class TestEnvironment
 
     public static bool UseTokenCredential { get; } = Config["UseTokenCredential"] == "true";
 
-    public static TokenCredential TokenCredential { get; } = new DefaultAzureCredential();
+    public static TokenCredential TokenCredential { get; } = new AzureCliCredential();
 
     public static string SubscriptionId { get; } = Config["SubscriptionId"];
 


### PR DESCRIPTION
Currently the tests are failing due to an authentication error.