### PR TITLE
Uncomment tests using optional parameters in LINQ

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1442,32 +1442,29 @@ WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Contains_with_local_nullable_uint_array_closure(bool async)
-//         => Fixture.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Contains_with_local_nullable_uint_array_closure(a);
-//
-//                 AssertSql(
-//                     """
-// @ids='[0,1]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
-// """,
-//                     //
-//                     """
-// @ids='[0]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
-// """);
-//             });
+    public override Task Contains_with_local_nullable_uint_array_closure(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Contains_with_local_nullable_uint_array_closure(a);
+
+                AssertSql(
+                    """
+@ids='[0,1]'
+
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
+""",
+                    //
+                    """
+@ids='[0]'
+
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(@ids, c["EmployeeID"])
+""");
+            });
 
     public override Task Contains_with_local_array_inline(bool async)
         => Fixture.NoSyncTest(
@@ -2007,25 +2004,21 @@ SELECT VALUE EXISTS (
         }
     }
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    //
-    // public override async Task Contains_with_local_tuple_array_closure(bool async)
-    // {
-    //     // Contains over subquery. Issue #17246.
-    //     await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
-    //
-    //     AssertSql();
-    // }
-    //
-    // public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
-    // {
-    //     // Contains over subquery. Issue #17246.
-    //     await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
-    //
-    //     AssertSql();
-    // }
+    public override async Task Contains_with_local_tuple_array_closure(bool async)
+    {
+        // Contains over subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
+    {
+        // Contains over subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
+
+        AssertSql();
+    }
 
     public override async Task OfType_Select(bool async)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1627,16 +1627,13 @@ WHERE ((c["$type"] = "Product") AND (true ? false : true))
         AssertSql();
     }
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // public override async Task Where_collection_navigation_ToArray_Contains(bool async)
-    // {
-    //     // Cosmos client evaluation. Issue #17246.
-    //     await AssertTranslationFailed(() => base.Where_collection_navigation_ToArray_Contains(async));
-    //
-    //     AssertSql();
-    // }
+    public override async Task Where_collection_navigation_ToArray_Contains(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_collection_navigation_ToArray_Contains(async));
+
+        AssertSql();
+    }
 
     public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
     {
@@ -1694,24 +1691,21 @@ WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@orderIds, c["OrderID"]))
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Where_array_of_object_contains_over_value_type(bool async)
-//         => Fixture.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Where_array_of_object_contains_over_value_type(a);
-//
-//                 AssertSql(
-//                     """
-// @orderIds='[10248,10249]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@orderIds, c["OrderID"]))
-// """);
-//             });
+    public override Task Where_array_of_object_contains_over_value_type(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Where_array_of_object_contains_over_value_type(a);
+
+                AssertSql(
+                    """
+@orderIds='[10248,10249]'
+
+SELECT VALUE c
+FROM root c
+WHERE ((c["$type"] = "Order") AND ARRAY_CONTAINS(@orderIds, c["OrderID"]))
+""");
+            });
 
     public override Task Filter_with_EF_Property_using_closure_for_property_name(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -33,36 +33,33 @@ WHERE c["Int"] IN (10, 999)
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Inline_collection_of_nullable_ints_Contains(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Inline_collection_of_nullable_ints_Contains(a);
-//
-//                 AssertSql(
-//                     """
-// SELECT VALUE c
-// FROM root c
-// WHERE c["NullableInt"] IN (10, 999)
-// """);
-//             });
-//
-//     public override Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Inline_collection_of_nullable_ints_Contains_null(a);
-//
-//                 AssertSql(
-//                     """
-// SELECT VALUE c
-// FROM root c
-// WHERE c["NullableInt"] IN (null, 999)
-// """);
-//             });
+    public override Task Inline_collection_of_nullable_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_of_nullable_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+WHERE c["NullableInt"] IN (10, 999)
+""");
+            });
+
+    public override Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Inline_collection_of_nullable_ints_Contains_null(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+WHERE c["NullableInt"] IN (null, 999)
+""");
+            });
 
     public override Task Inline_collection_Count_with_zero_values(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -670,56 +667,53 @@ WHERE NOT(ARRAY_CONTAINS(@ints, c["NullableInt"]))
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Parameter_collection_of_nullable_ints_Contains_int(a);
-//
-//                 AssertSql(
-//                     """
-// @nullableInts='[10,999]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(@nullableInts, c["Int"])
-// """,
-//                     //
-//                     """
-// @nullableInts='[10,999]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["Int"]))
-// """);
-//             });
-//
-//     public override Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(a);
-//
-//                 AssertSql(
-//                     """
-// @nullableInts='[null,999]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(@nullableInts, c["NullableInt"])
-// """,
-//                     //
-//                     """
-// @nullableInts='[null,999]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["NullableInt"]))
-// """);
-//             });
+    public override Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_ints_Contains_int(a);
+
+                AssertSql(
+                    """
+@nullableInts='[10,999]'
+
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(@nullableInts, c["Int"])
+""",
+                    //
+                    """
+@nullableInts='[10,999]'
+
+SELECT VALUE c
+FROM root c
+WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["Int"]))
+""");
+            });
+
+    public override Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(a);
+
+                AssertSql(
+                    """
+@nullableInts='[null,999]'
+
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(@nullableInts, c["NullableInt"])
+""",
+                    //
+                    """
+@nullableInts='[null,999]'
+
+SELECT VALUE c
+FROM root c
+WHERE NOT(ARRAY_CONTAINS(@nullableInts, c["NullableInt"]))
+""");
+            });
 
     public override Task Parameter_collection_of_strings_Contains_string(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -849,24 +843,21 @@ WHERE ARRAY_CONTAINS(@bools, c["Bool"])
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Parameter_collection_of_enums_Contains(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Parameter_collection_of_enums_Contains(a);
-//
-//                 AssertSql(
-//                     """
-// @enums='[0,3]'
-//
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(@enums, c["Enum"])
-// """);
-//             });
+    public override Task Parameter_collection_of_enums_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Parameter_collection_of_enums_Contains(a);
+
+                AssertSql(
+                    """
+@enums='[0,3]'
+
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(@enums, c["Enum"])
+""");
+            });
 
     public override Task Parameter_collection_null_Contains(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
@@ -922,36 +913,33 @@ WHERE ARRAY_CONTAINS(c["Ints"], 10)
 """);
             });
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override Task Column_collection_of_nullable_ints_Contains(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Column_collection_of_nullable_ints_Contains(a);
-//
-//                 AssertSql(
-//                     """
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(c["NullableInts"], 10)
-// """);
-//             });
-//
-//     public override Task Column_collection_of_nullable_ints_Contains_null(bool async)
-//         => CosmosTestHelpers.Instance.NoSyncTest(
-//             async, async a =>
-//             {
-//                 await base.Column_collection_of_nullable_ints_Contains_null(a);
-//
-//                 AssertSql(
-//                     """
-// SELECT VALUE c
-// FROM root c
-// WHERE ARRAY_CONTAINS(c["NullableInts"], null)
-// """);
-//             });
+    public override Task Column_collection_of_nullable_ints_Contains(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_nullable_ints_Contains(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(c["NullableInts"], 10)
+""");
+            });
+
+    public override Task Column_collection_of_nullable_ints_Contains_null(bool async)
+        => CosmosTestHelpers.Instance.NoSyncTest(
+            async, async a =>
+            {
+                await base.Column_collection_of_nullable_ints_Contains_null(a);
+
+                AssertSql(
+                    """
+SELECT VALUE c
+FROM root c
+WHERE ARRAY_CONTAINS(c["NullableInts"], null)
+""");
+            });
 
     public override Task Column_collection_of_strings_contains_null(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1473,149 +1473,145 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
                 .Where(e => !new[] { 1, 2 }.Contains(e.IntA)).Select(e => e.Id));
     }
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new int?[] { 1, 2, null }.Contains(e.IntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new int?[] { 1, 2, null }.Contains(e.IntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new[] { 1, 2, e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new[] { 1, 2, e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new[] { 1, 2, e.NullableIntB, null }.Contains(e.IntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new[] { 1, 2, e.NullableIntB, null }.Contains(e.IntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new int?[] { 1, 2 }.Contains(e.NullableIntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new int?[] { 1, 2, null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new int?[] { 1, 2, null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new[] { 1, 2, e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new[] { 1, 2, e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new[] { 1, 2, e.NullableIntB, null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new[] { 1, 2, e.NullableIntB, null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_non_nullable_item_and_one_value(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => new[] { 1 }.Contains(e.IntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => !new[] { 1 }.Contains(e.IntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => new int?[] { null }.Contains(e.IntA)).Select(e => e.Id),
-    //         assertEmpty: true);
-    //
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => !new int?[] { null }.Contains(e.IntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => new[] { e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async,
-    //         ss => ss.Set<NullSemanticsEntity1>().Where(e => !new[] { e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Null_semantics_contains_with_nullable_item_and_one_value(bool async)
-    // {
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new int?[] { 1 }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new int?[] { 1 }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new int?[] { null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new int?[] { null }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => new[] { e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
-    //     await AssertQueryScalar(
-    //         async, ss => ss.Set<NullSemanticsEntity1>()
-    //             .Where(e => !new[] { e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new int?[] { 1, 2, null }.Contains(e.IntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new int?[] { 1, 2, null }.Contains(e.IntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new[] { 1, 2, e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new[] { 1, 2, e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new[] { 1, 2, e.NullableIntB, null }.Contains(e.IntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new[] { 1, 2, e.NullableIntB, null }.Contains(e.IntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new int?[] { 1, 2 }.Contains(e.NullableIntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new int?[] { 1, 2, null }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new int?[] { 1, 2, null }.Contains(e.NullableIntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new[] { 1, 2, e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new[] { 1, 2, e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new[] { 1, 2, e.NullableIntB, null }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new[] { 1, 2, e.NullableIntB, null }.Contains(e.NullableIntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_non_nullable_item_and_one_value(bool async)
+    {
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => new[] { 1 }.Contains(e.IntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => !new[] { 1 }.Contains(e.IntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => new int?[] { null }.Contains(e.IntA)).Select(e => e.Id),
+            assertEmpty: true);
+
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => !new int?[] { null }.Contains(e.IntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => new[] { e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Where(e => !new[] { e.NullableIntB }.Contains(e.IntA)).Select(e => e.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Null_semantics_contains_with_nullable_item_and_one_value(bool async)
+    {
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new int?[] { 1 }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new int?[] { 1 }.Contains(e.NullableIntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new int?[] { null }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new int?[] { null }.Contains(e.NullableIntA)).Select(e => e.Id));
+
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => new[] { e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
+        await AssertQueryScalar(
+            async, ss => ss.Set<NullSemanticsEntity1>()
+                .Where(e => !new[] { e.NullableIntB }.Contains(e.NullableIntA)).Select(e => e.Id));
+    }
 
     #endregion Contains with inline collection
 
@@ -2197,86 +2193,82 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
         Assert.Equal(expected.Count, result.Count);
     }
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
-    // {
-    //     var ctx = CreateContext(useRelationalNulls: true);
-    //
-    //     var expected = ctx.Entities1.AsEnumerable().Where(e => new int?[] { 1, 2, 3 }.Contains(e.NullableIntA)).ToList();
-    //
-    //     ClearLog();
-    //     var query = ctx.Entities1.Where(
-    //         e => new int?[] { 1, null }.Contains(e.NullableIntA)
-    //             || new int?[] { 2, null, 3 }.Contains(e.NullableIntA));
-    //
-    //     var result = async ? await query.ToListAsync() : query.ToList();
-    //     Assert.Equal(expected.Count, result.Count);
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
-    // {
-    //     var ctx = CreateContext(useRelationalNulls: true);
-    //     var query = ctx.Entities1.Where(
-    //         e => !(new int?[] { 1, null }.Contains(e.NullableIntA))
-    //             && !(new int?[] { 2, null, 3 }.Contains(e.NullableIntA)));
-    //
-    //     var result = async ? await query.ToListAsync() : query.ToList();
-    //     Assert.Empty(result);
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
-    // {
-    //     var ctx = CreateContext(useRelationalNulls: true);
-    //
-    //     var expected = ctx.Entities1.AsEnumerable().Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA) || e.NullableIntA == null)
-    //         .ToList();
-    //
-    //     ClearLog();
-    //     var query = ctx.Entities1.Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA) || e.NullableIntA == null);
-    //
-    //     var result = async ? await query.ToListAsync() : query.ToList();
-    //     Assert.Equal(expected.Count, result.Count);
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
-    // {
-    //     var ctx = CreateContext(useRelationalNulls: true);
-    //
-    //     var expected = ctx.Entities1.AsEnumerable()
-    //         .Where(e => !(new int?[] { 1, 2 }.Contains(e.NullableIntA)) && e.NullableIntA != null).ToList();
-    //
-    //     ClearLog();
-    //     var query = ctx.Entities1.Where(e => e.NullableIntA != null && !(new int?[] { 1, 2 }.Contains(e.NullableIntA)));
-    //
-    //     var result = async ? await query.ToListAsync() : query.ToList();
-    //     Assert.Equal(expected.Count, result.Count);
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(bool async)
-    // {
-    //     var ctx = CreateContext(useRelationalNulls: true);
-    //
-    //     var expected = ctx.Entities1.AsEnumerable().Where(e => !(new int?[] { 1, 2, 3, null }.Contains(e.NullableIntA))).ToList();
-    //
-    //     ClearLog();
-    //     var query = ctx.Entities1.Where(e => e.NullableIntA != 3 && !(new int?[] { 1, 2 }.Contains(e.NullableIntA)));
-    //
-    //     var result = async ? await query.ToListAsync() : query.ToList();
-    //     Assert.Equal(expected.Count, result.Count);
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
+    {
+        var ctx = CreateContext(useRelationalNulls: true);
+
+        var expected = ctx.Entities1.AsEnumerable().Where(e => new int?[] { 1, 2, 3 }.Contains(e.NullableIntA)).ToList();
+
+        ClearLog();
+        var query = ctx.Entities1.Where(
+            e => new int?[] { 1, null }.Contains(e.NullableIntA)
+                || new int?[] { 2, null, 3 }.Contains(e.NullableIntA));
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+        Assert.Equal(expected.Count, result.Count);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
+    {
+        var ctx = CreateContext(useRelationalNulls: true);
+        var query = ctx.Entities1.Where(
+            e => !(new int?[] { 1, null }.Contains(e.NullableIntA))
+                && !(new int?[] { 2, null, 3 }.Contains(e.NullableIntA)));
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+        Assert.Empty(result);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
+    {
+        var ctx = CreateContext(useRelationalNulls: true);
+
+        var expected = ctx.Entities1.AsEnumerable().Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA) || e.NullableIntA == null)
+            .ToList();
+
+        ClearLog();
+        var query = ctx.Entities1.Where(e => new int?[] { 1, 2 }.Contains(e.NullableIntA) || e.NullableIntA == null);
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+        Assert.Equal(expected.Count, result.Count);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
+    {
+        var ctx = CreateContext(useRelationalNulls: true);
+
+        var expected = ctx.Entities1.AsEnumerable()
+            .Where(e => !(new int?[] { 1, 2 }.Contains(e.NullableIntA)) && e.NullableIntA != null).ToList();
+
+        ClearLog();
+        var query = ctx.Entities1.Where(e => e.NullableIntA != null && !(new int?[] { 1, 2 }.Contains(e.NullableIntA)));
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+        Assert.Equal(expected.Count, result.Count);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(bool async)
+    {
+        var ctx = CreateContext(useRelationalNulls: true);
+
+        var expected = ctx.Entities1.AsEnumerable().Where(e => !(new int?[] { 1, 2, 3, null }.Contains(e.NullableIntA))).ToList();
+
+        ClearLog();
+        var query = ctx.Entities1.Where(e => e.NullableIntA != 3 && !(new int?[] { 1, 2 }.Contains(e.NullableIntA)));
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+        Assert.Equal(expected.Count, result.Count);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6028,20 +6028,17 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 .Take(1)
                 .Select(g => g.Rank & MilitaryRank.Private));
 
-    // TODO: The following no longer compiles since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Enum_array_contains(bool async)
-    // {
-    //     var types = new[] { (AmmunitionType?)null, AmmunitionType.Cartridge };
-    //
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<Weapon>()
-    //             .Where(w => w.SynergyWith != null && types.Contains(w.SynergyWith.AmmunitionType)));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Enum_array_contains(bool async)
+    {
+        var types = new[] { (AmmunitionType?)null, AmmunitionType.Cartridge };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Weapon>()
+                .Where(w => w.SynergyWith != null && types.Contains(w.SynergyWith.AmmunitionType)));
+    }
 
     [ConditionalTheory] // #35656
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -939,26 +939,23 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             assertEmpty: true);
     }
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Contains_with_local_nullable_uint_array_closure(bool async)
-    // {
-    //     var ids = new uint?[] { 0, 1 };
-    //
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<Employee>().Where(e => ids.Contains(e.EmployeeID)));
-    //
-    //     ids = [0];
-    //
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<Employee>().Where(e => ids.Contains(e.EmployeeID)),
-    //         assertEmpty: true);
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_nullable_uint_array_closure(bool async)
+    {
+        var ids = new uint?[] { 0, 1 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => ids.Contains(e.EmployeeID)));
+
+        ids = [0];
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => ids.Contains(e.EmployeeID)),
+            assertEmpty: true);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1342,30 +1339,27 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             syncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).Contains("ALFKI"),
             asyncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).ContainsAsync("ALFKI", default));
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Contains_with_local_tuple_array_closure(bool async)
-    // {
-    //     var ids = new[] { Tuple.Create(1, 2), Tuple.Create(10248, 11) };
-    //
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Contains_with_local_anonymous_type_array_closure(bool async)
-    // {
-    //     var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
-    //
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_tuple_array_closure(bool async)
+    {
+        var ids = new[] { Tuple.Create(1, 2), Tuple.Create(10248, 11) };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_anonymous_type_array_closure(bool async)
+    {
+        var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })));
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -1620,21 +1620,18 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
-    // TODO: The following no longer compiles since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Where_collection_navigation_ToArray_Contains(bool async)
-    // {
-    //     var order = new Order { OrderID = 10248 };
-    //
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<Customer>()
-    //             .Select(c => c.Orders.AsEnumerable().OrderBy(o => o.OrderID).ToArray())
-    //             .Where(e => e.Contains(order)));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_collection_navigation_ToArray_Contains(bool async)
+    {
+        var order = new Order { OrderID = 10248 };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .Select(c => c.Orders.AsEnumerable().OrderBy(o => o.OrderID).ToArray())
+                .Where(e => e.Contains(order)));
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1699,19 +1696,16 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
                 .Where(o => orderIds.Contains(o.OrderID)));
     }
 
-    // TODO: The following no longer compiles since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Where_array_of_object_contains_over_value_type(bool async)
-    // {
-    //     var orderIds = new object[] { 10248, 10249 };
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<Order>()
-    //             .Where(o => orderIds.Contains(o.OrderID)));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_array_of_object_contains_over_value_type(bool async)
+    {
+        var orderIds = new object[] { 10248, 10249 };
+        return AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .Where(o => orderIds.Contains(o.OrderID)));
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -15,22 +15,19 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 10, 999 }.Contains(c.Int)));
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Inline_collection_of_nullable_ints_Contains(bool async)
-    //     => AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int?[] { 10, 999 }.Contains(c.NullableInt)));
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-    //     => AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int?[] { null, 999 }.Contains(c.NullableInt)));
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Inline_collection_of_nullable_ints_Contains(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int?[] { 10, 999 }.Contains(c.NullableInt)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int?[] { null, 999 }.Contains(c.NullableInt)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -398,36 +395,33 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInt == null || !ints.Contains(c.NullableInt!.Value)));
     }
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-    // {
-    //     var nullableInts = new int?[] { 10, 999 };
-    //
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.Int)));
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.Int)));
-    // }
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-    // {
-    //     var nullableInts = new int?[] { null, 999 };
-    //
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.NullableInt)));
-    //     await AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.NullableInt)));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        var nullableInts = new int?[] { 10, 999 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.Int)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.Int)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        var nullableInts = new int?[] { null, 999 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.NullableInt)));
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => !nullableInts.Contains(c.NullableInt)));
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -620,19 +614,16 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => bools.Contains(c.Bool)));
     }
 
-    // TODO: The following no longer compiles since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Parameter_collection_of_enums_Contains(bool async)
-    // {
-    //     var enums = new[] { MyEnum.Value1, MyEnum.Value4 };
-    //
-    //     return AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => enums.Contains(c.Enum)));
-    // }
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        var enums = new[] { MyEnum.Value1, MyEnum.Value4 };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => enums.Contains(c.Enum)));
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -690,22 +681,19 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Contains(10)));
 
-    // TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-    // parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Column_collection_of_nullable_ints_Contains(bool async)
-    //     => AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(10)));
-    //
-    // [ConditionalTheory]
-    // [MemberData(nameof(IsAsyncData))]
-    // public virtual Task Column_collection_of_nullable_ints_Contains_null(bool async)
-    //     => AssertQuery(
-    //         async,
-    //         ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(null)));
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_of_nullable_ints_Contains(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(10)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_of_nullable_ints_Contains_null(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(null)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7413,26 +7413,23 @@ ORDER BY [g].[Nickname]
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Enum_array_contains(bool async)
-//     {
-//         await base.Enum_array_contains(async);
-//
-//         AssertSql(
-//             """
-// @types_without_nulls='[1]' (Size = 4000)
-//
-// SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-// FROM [Weapons] AS [w]
-// LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-// WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
-//     SELECT [t].[value]
-//     FROM OPENJSON(@types_without_nulls) AS [t]
-// ) OR [w0].[AmmunitionType] IS NULL)
-// """);
-//     }
+    public override async Task Enum_array_contains(bool async)
+    {
+        await base.Enum_array_contains(async);
+
+        AssertSql(
+            """
+@types_without_nulls='[1]' (Size = 4000)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@types_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
+""");
+    }
 
     public override async Task Coalesce_with_non_root_evaluatable_Convert(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -38,11 +38,8 @@ public class NorthwindAggregateOperatorsQuerySqlServerTest : NorthwindAggregateO
         AssertSql();
     }
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // public override async Task Contains_with_local_tuple_array_closure(bool async)
-    //     => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+    public override async Task Contains_with_local_tuple_array_closure(bool async)
+        => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
 
     public override async Task Array_cast_to_IEnumerable_Contains_with_constant(bool async)
     {
@@ -1716,36 +1713,33 @@ WHERE [e].[EmployeeID] IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Contains_with_local_nullable_uint_array_closure(bool async)
-//     {
-//         await base.Contains_with_local_nullable_uint_array_closure(async);
-//
-//         AssertSql(
-//             """
-// @ids='[0,1]' (Size = 4000)
-//
-// SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
-// FROM [Employees] AS [e]
-// WHERE [e].[EmployeeID] IN (
-//     SELECT [i].[value]
-//     FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
-// )
-// """,
-//             //
-//             """
-// @ids='[0]' (Size = 4000)
-//
-// SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
-// FROM [Employees] AS [e]
-// WHERE [e].[EmployeeID] IN (
-//     SELECT [i].[value]
-//     FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
-// )
-// """);
-//     }
+    public override async Task Contains_with_local_nullable_uint_array_closure(bool async)
+    {
+        await base.Contains_with_local_nullable_uint_array_closure(async);
+
+        AssertSql(
+            """
+@ids='[0,1]' (Size = 4000)
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[EmployeeID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
+)
+""",
+            //
+            """
+@ids='[0]' (Size = 4000)
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[EmployeeID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@ids) WITH ([value] int '$') AS [i]
+)
+""");
+    }
 
     public override async Task Contains_with_local_array_inline(bool async)
     {
@@ -2302,15 +2296,12 @@ END
 """);
     }
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
-    // {
-    //     await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
-    //
-    //     AssertSql();
-    // }
+    public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
+    {
+        await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
+
+        AssertSql();
+    }
 
     public override async Task OfType_Select(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1921,27 +1921,24 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Where_collection_navigation_ToArray_Contains(bool async)
-//     {
-//         await base.Where_collection_navigation_ToArray_Contains(async);
-//
-//         AssertSql(
-//             """
-// @entity_equality_order_OrderID='10248' (Nullable = true)
-//
-// SELECT [c].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-// FROM [Customers] AS [c]
-// LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-// WHERE EXISTS (
-//     SELECT 1
-//     FROM [Orders] AS [o]
-//     WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_order_OrderID)
-// ORDER BY [c].[CustomerID], [o0].[OrderID]
-// """);
-//     }
+    public override async Task Where_collection_navigation_ToArray_Contains(bool async)
+    {
+        await base.Where_collection_navigation_ToArray_Contains(async);
+
+        AssertSql(
+            """
+@entity_equality_order_OrderID='10248' (Nullable = true)
+
+SELECT [c].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] = @entity_equality_order_OrderID)
+ORDER BY [c].[CustomerID], [o0].[OrderID]
+""");
+    }
 
     public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
     {
@@ -2030,25 +2027,22 @@ WHERE [o].[OrderID] IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Where_array_of_object_contains_over_value_type(bool async)
-//     {
-//         await base.Where_array_of_object_contains_over_value_type(async);
-//
-//         AssertSql(
-//             """
-// @orderIds='[10248,10249]' (Size = 4000)
-//
-// SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-// FROM [Orders] AS [o]
-// WHERE [o].[OrderID] IN (
-//     SELECT [o0].[value]
-//     FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
-// )
-// """);
-//     }
+    public override async Task Where_array_of_object_contains_over_value_type(bool async)
+    {
+        await base.Where_array_of_object_contains_over_value_type(async);
+
+        AssertSql(
+            """
+@orderIds='[10248,10249]' (Size = 4000)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] IN (
+    SELECT [o0].[value]
+    FROM OPENJSON(@orderIds) WITH ([value] int '$') AS [o0]
+)
+""");
+    }
 
     public override async Task Multiple_OrElse_on_same_column_converted_to_in_with_overlap(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -3900,217 +3900,214 @@ WHERE [e].[IntA] NOT IN (1, 2)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
-//     {
-//         await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] IN (1, 2)
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] NOT IN (1, 2)
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
-//     {
-//         await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] IN (1, 2, [e].[NullableIntB])
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] NOT IN (1, 2) AND ([e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL)
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
-//     {
-//         await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] IN (1, 2, [e].[NullableIntB])
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] NOT IN (1, 2) AND ([e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL)
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(bool async)
-//     {
-//         await base.Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IN (1, 2)
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
-//     {
-//         await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
-//     {
-//         await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE ([e].[NullableIntA] IN (1, 2) AND [e].[NullableIntA] IS NOT NULL) OR [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE ([e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL) AND ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
-//     {
-//         await base.Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL OR [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL AND ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_non_nullable_item_and_one_value(bool async)
-//     {
-//         await base.Null_semantics_contains_with_non_nullable_item_and_one_value(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] = 1
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] <> 1
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE 0 = 1
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] = [e].[NullableIntB]
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL
-// """);
-//     }
-//
-//     public override async Task Null_semantics_contains_with_nullable_item_and_one_value(bool async)
-//     {
-//         await base.Null_semantics_contains_with_nullable_item_and_one_value(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] = 1
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] <> 1 OR [e].[NullableIntA] IS NULL
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IS NULL
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IS NOT NULL
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
-// """,
-//             //
-//             """
-// SELECT [e].[Id]
-// FROM [Entities1] AS [e]
-// WHERE ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
-// """);
-//     }
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(bool async)
+    {
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_null(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] IN (1, 2)
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] NOT IN (1, 2)
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(bool async)
+    {
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] IN (1, 2, [e].[NullableIntB])
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] NOT IN (1, 2) AND ([e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL)
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(bool async)
+    {
+        await base.Null_semantics_contains_with_non_nullable_item_and_inline_values_with_nullable_column_and_null(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] IN (1, 2, [e].[NullableIntB])
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] NOT IN (1, 2) AND ([e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL)
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(bool async)
+    {
+        await base.Null_semantics_contains_with_nullable_item_and_inline_non_nullable_values(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IN (1, 2)
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_null(bool async)
+    {
+        await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_null(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(bool async)
+    {
+        await base.Null_semantics_contains_with_nullable_item_and_inline_values_with_nullable_column(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableIntA] IN (1, 2) AND [e].[NullableIntA] IS NOT NULL) OR [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL) AND ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(bool async)
+    {
+        await base.Null_semantics_contains_with_nullable_item_and_values_with_nullable_column_and_null(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL OR [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL AND ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_non_nullable_item_and_one_value(bool async)
+    {
+        await base.Null_semantics_contains_with_non_nullable_item_and_one_value(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] = 1
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] <> 1
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE 0 = 1
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] = [e].[NullableIntB]
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[IntA] <> [e].[NullableIntB] OR [e].[NullableIntB] IS NULL
+""");
+    }
+
+    public override async Task Null_semantics_contains_with_nullable_item_and_one_value(bool async)
+    {
+        await base.Null_semantics_contains_with_nullable_item_and_one_value(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] = 1
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] <> 1 OR [e].[NullableIntA] IS NULL
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IS NULL
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IS NOT NULL
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] = [e].[NullableIntB] OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
+""",
+            //
+            """
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableIntA] <> [e].[NullableIntB] OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
+""");
+    }
 
     #endregion Contains with inline collection
 
@@ -4787,68 +4784,65 @@ WHERE [e].[NullableIntA] = 1 OR [e].[NullableIntA] IS NULL
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
-//     {
-//         await base.Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IN (1, NULL, 2, 3)
-// """);
-//     }
-//
-//     public override async Task Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
-//     {
-//         await base.Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] NOT IN (1, NULL, 2, 3)
-// """);
-//     }
-//
-//     public override async Task Contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
-//     {
-//         await base.Contains_with_comparison_dont_get_combined_for_relational_null_semantics(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL
-// """);
-//     }
-//
-//     public override async Task Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
-//     {
-//         await base.Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntA] NOT IN (1, 2)
-// """);
-//     }
-//
-//     public override async Task Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(bool async)
-//     {
-//         await base.Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(async);
-//
-//         AssertSql(
-//             """
-// SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
-// FROM [Entities1] AS [e]
-// WHERE [e].[NullableIntA] NOT IN (3, 1, 2)
-// """);
-//     }
+    public override async Task Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
+    {
+        await base.Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IN (1, NULL, 2, 3)
+""");
+    }
+
+    public override async Task Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
+    {
+        await base.Multiple_negated_contains_calls_get_combined_into_one_for_relational_null_semantics(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] NOT IN (1, NULL, 2, 3)
+""");
+    }
+
+    public override async Task Contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
+    {
+        await base.Contains_with_comparison_dont_get_combined_for_relational_null_semantics(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL
+""");
+    }
+
+    public override async Task Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
+    {
+        await base.Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntA] NOT IN (1, 2)
+""");
+    }
+
+    public override async Task Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(bool async)
+    {
+        await base.Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] NOT IN (3, 1, 2)
+""");
+    }
 
     public override async Task Bool_equal_nullable_bool_HasValue(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -37,32 +37,29 @@ WHERE [p].[Int] IN (10, 999)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
-// """);
-//     }
+    public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (10, 999)
+""");
+    }
+
+    public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""");
+    }
 
     public override async Task Inline_collection_Count_with_zero_values(bool async)
     {
@@ -537,44 +534,41 @@ WHERE [p].[NullableInt] NOT IN (10, 999) OR [p].[NullableInt] IS NULL
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_int(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] IN (10, 999)
-// """,
-//             //
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] NOT IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
-// """,
-//             //
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NOT NULL AND [p].[NullableInt] <> 999
-// """);
-//     }
+    public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_int(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (10, 999)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""",
+            //
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NOT NULL AND [p].[NullableInt] <> 999
+""");
+    }
 
     public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
@@ -672,20 +666,17 @@ WHERE [p].[Bool] = CAST(1 AS bit)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_enums_Contains(bool async)
-//     {
-//         await base.Parameter_collection_of_enums_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Enum] IN (0, 3)
-// """);
-//     }
+    public override async Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        await base.Parameter_collection_of_enums_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Enum] IN (0, 3)
+""");
+    }
 
     public override async Task Parameter_collection_null_Contains(bool async)
     {
@@ -744,14 +735,11 @@ WHERE (
     public override Task Column_collection_of_ints_Contains(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_of_ints_Contains(async));
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // public override Task Column_collection_of_nullable_ints_Contains(bool async)
-    //     => AssertCompatibilityLevelTooLow(() => base.Column_collection_of_nullable_ints_Contains(async));
-    //
-    // public override Task Column_collection_of_nullable_ints_Contains_null(bool async)
-    //     => AssertCompatibilityLevelTooLow(() => base.Column_collection_of_nullable_ints_Contains_null(async));
+    public override Task Column_collection_of_nullable_ints_Contains(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_of_nullable_ints_Contains(async));
+
+    public override Task Column_collection_of_nullable_ints_Contains_null(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Column_collection_of_nullable_ints_Contains_null(async));
 
     public override Task Column_collection_of_strings_contains_null(bool async)
         => AssertTranslationFailed(() => base.Column_collection_of_strings_contains_null(async));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
@@ -26,32 +26,29 @@ WHERE [p].[Int] IN (10, 999)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
-// """);
-//     }
+    public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (10, 999)
+""");
+    }
+
+    public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""");
+    }
 
     public override async Task Inline_collection_Count_with_zero_values(bool async)
     {
@@ -584,64 +581,61 @@ WHERE [p].[NullableInt] NOT IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """,
-//             //
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) OR [p].[NullableInt] IS NULL
-// """,
-//             //
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) AND [p].[NullableInt] IS NOT NULL
-// """);
-//     }
+    public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_int(async);
+
+        AssertSql(
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""",
+            //
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) OR [p].[NullableInt] IS NULL
+""",
+            //
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) AND [p].[NullableInt] IS NOT NULL
+""");
+    }
 
     public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
@@ -789,25 +783,22 @@ WHERE [p].[Bool] IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_enums_Contains(bool async)
-//     {
-//         await base.Parameter_collection_of_enums_Contains(async);
-//
-//         AssertSql(
-//             """
-// @enums='[0,3]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Enum] IN (
-//     SELECT [e].[value]
-//     FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
-// )
-// """);
-//     }
+    public override async Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        await base.Parameter_collection_of_enums_Contains(async);
+
+        AssertSql(
+            """
+@enums='[0,3]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Enum] IN (
+    SELECT [e].[value]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
+)
+""");
+    }
 
     public override async Task Parameter_collection_null_Contains(bool async)
     {
@@ -881,38 +872,35 @@ WHERE 10 IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE 10 IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE EXISTS (
-//     SELECT 1
-//     FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
-//     WHERE [n].[value] IS NULL)
-// """);
-//     }
+    public override async Task Column_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE 10 IN (
+    SELECT [n].[value]
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
+    WHERE [n].[value] IS NULL)
+""");
+    }
 
     public override async Task Column_collection_of_strings_contains_null(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
@@ -107,32 +107,29 @@ WHERE [p].[Int] IN (10, 999)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
-// """);
-//     }
+    public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (10, 999)
+""");
+    }
+
+    public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""");
+    }
 
     public override async Task Inline_collection_Count_with_zero_values(bool async)
     {
@@ -600,64 +597,61 @@ WHERE [p].[NullableInt] NOT IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """,
-//             //
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) OR [p].[NullableInt] IS NULL
-// """,
-//             //
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) AND [p].[NullableInt] IS NOT NULL
-// """);
-//     }
+    public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_int(async);
+
+        AssertSql(
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""",
+            //
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) OR [p].[NullableInt] IS NULL
+""",
+            //
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) AND [p].[NullableInt] IS NOT NULL
+""");
+    }
 
     public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
@@ -805,25 +799,22 @@ WHERE [p].[Bool] IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_enums_Contains(bool async)
-//     {
-//         await base.Parameter_collection_of_enums_Contains(async);
-//
-//         AssertSql(
-//             """
-// @enums='[0,3]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Enum] IN (
-//     SELECT [e].[value]
-//     FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
-// )
-// """);
-//     }
+    public override async Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        await base.Parameter_collection_of_enums_Contains(async);
+
+        AssertSql(
+            """
+@enums='[0,3]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Enum] IN (
+    SELECT [e].[value]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
+)
+""");
+    }
 
     public override async Task Parameter_collection_null_Contains(bool async)
     {
@@ -855,38 +846,35 @@ WHERE 10 IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE 10 IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(CAST([p].[NullableInts] AS nvarchar(max))) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE EXISTS (
-//     SELECT 1
-//     FROM OPENJSON(CAST([p].[NullableInts] AS nvarchar(max))) WITH ([value] int '$') AS [n]
-//     WHERE [n].[value] IS NULL)
-// """);
-//     }
+    public override async Task Column_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE 10 IN (
+    SELECT [n].[value]
+    FROM OPENJSON(CAST([p].[NullableInts] AS nvarchar(max))) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON(CAST([p].[NullableInts] AS nvarchar(max))) WITH ([value] int '$') AS [n]
+    WHERE [n].[value] IS NULL)
+""");
+    }
 
     public override async Task Column_collection_of_strings_contains_null(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -25,32 +25,29 @@ WHERE [p].[Int] IN (10, 999)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
-// """);
-//     }
+    public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (10, 999)
+""");
+    }
+
+    public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IS NULL OR [p].[NullableInt] = 999
+""");
+    }
 
     public override async Task Inline_collection_Count_with_zero_values(bool async)
     {
@@ -607,64 +604,61 @@ WHERE [p].[NullableInt] NOT IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """,
-//             //
-//             """
-// @nullableInts='[10,999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Int] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) OR [p].[NullableInt] IS NULL
-// """,
-//             //
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[NullableInt] NOT IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON(@nullableInts_without_nulls) AS [n]
-// ) AND [p].[NullableInt] IS NOT NULL
-// """);
-//     }
+    public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_int(async);
+
+        AssertSql(
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""",
+            //
+            """
+@nullableInts='[10,999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) OR [p].[NullableInt] IS NULL
+""",
+            //
+            """
+@nullableInts_without_nulls='[999]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[NullableInt] NOT IN (
+    SELECT [n].[value]
+    FROM OPENJSON(@nullableInts_without_nulls) AS [n]
+) AND [p].[NullableInt] IS NOT NULL
+""");
+    }
 
     public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
@@ -812,25 +806,22 @@ WHERE [p].[Bool] IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_enums_Contains(bool async)
-//     {
-//         await base.Parameter_collection_of_enums_Contains(async);
-//
-//         AssertSql(
-//             """
-// @enums='[0,3]' (Size = 4000)
-//
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE [p].[Enum] IN (
-//     SELECT [e].[value]
-//     FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
-// )
-// """);
-//     }
+    public override async Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        await base.Parameter_collection_of_enums_Contains(async);
+
+        AssertSql(
+            """
+@enums='[0,3]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Enum] IN (
+    SELECT [e].[value]
+    FROM OPENJSON(@enums) WITH ([value] int '$') AS [e]
+)
+""");
+    }
 
     public override async Task Parameter_collection_null_Contains(bool async)
     {
@@ -904,38 +895,35 @@ WHERE 10 IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE 10 IN (
-//     SELECT [n].[value]
-//     FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
-// )
-// """);
-//     }
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
-// FROM [PrimitiveCollectionsEntity] AS [p]
-// WHERE EXISTS (
-//     SELECT 1
-//     FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
-//     WHERE [n].[value] IS NULL)
-// """);
-//     }
+    public override async Task Column_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE 10 IN (
+    SELECT [n].[value]
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
+)
+""");
+    }
+
+    public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
+    WHERE [n].[value] IS NULL)
+""");
+    }
 
     public override async Task Column_collection_of_strings_contains_null(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -9959,26 +9959,23 @@ ORDER BY [u].[Nickname]
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Enum_array_contains(bool async)
-//     {
-//         await base.Enum_array_contains(async);
-//
-//         AssertSql(
-//             """
-// @types_without_nulls='[1]' (Size = 4000)
-//
-// SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-// FROM [Weapons] AS [w]
-// LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-// WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
-//     SELECT [t].[value]
-//     FROM OPENJSON(@types_without_nulls) AS [t]
-// ) OR [w0].[AmmunitionType] IS NULL)
-// """);
-//     }
+    public override async Task Enum_array_contains(bool async)
+    {
+        await base.Enum_array_contains(async);
+
+        AssertSql(
+            """
+@types_without_nulls='[1]' (Size = 4000)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@types_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
+""");
+    }
 
     public override async Task Coalesce_with_non_root_evaluatable_Convert(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -8412,26 +8412,23 @@ ORDER BY [g].[Nickname]
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Enum_array_contains(bool async)
-//     {
-//         await base.Enum_array_contains(async);
-//
-//         AssertSql(
-//             """
-// @types_without_nulls='[1]' (Size = 4000)
-//
-// SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-// FROM [Weapons] AS [w]
-// LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-// WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
-//     SELECT [t].[value]
-//     FROM OPENJSON(@types_without_nulls) AS [t]
-// ) OR [w0].[AmmunitionType] IS NULL)
-// """);
-//     }
+    public override async Task Enum_array_contains(bool async)
+    {
+        await base.Enum_array_contains(async);
+
+        AssertSql(
+            """
+@types_without_nulls='[1]' (Size = 4000)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@types_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
+""");
+    }
 
     public override async Task Coalesce_with_non_root_evaluatable_Convert(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -4958,26 +4958,23 @@ WHERE COALESCE([c].[Location], N'') + N'Added' LIKE N'%Add%'
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Enum_array_contains(bool async)
-//     {
-//         await base.Enum_array_contains(async);
-//
-//         AssertSql(
-//             """
-// @types_without_nulls='[1]' (Size = 4000)
-//
-// SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
-// FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
-// LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-// WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
-//     SELECT [t].[value]
-//     FROM OPENJSON(@types_without_nulls) AS [t]
-// ) OR [w0].[AmmunitionType] IS NULL)
-// """);
-//     }
+    public override async Task Enum_array_contains(bool async)
+    {
+        await base.Enum_array_contains(async);
+
+        AssertSql(
+            """
+@types_without_nulls='[1]' (Size = 4000)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[PeriodEnd], [w].[PeriodStart], [w].[SynergyWithId]
+FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
+LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (
+    SELECT [t].[value]
+    FROM OPENJSON(@types_without_nulls) AS [t]
+) OR [w0].[AmmunitionType] IS NULL)
+""");
+    }
 
     public override async Task Sum_with_optional_navigation_is_translated_to_sql(bool async)
     {

--- a/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
@@ -356,33 +356,30 @@ WHERE @isaac.IsDescendantOf([p].[Id]) = CAST(1 AS bit)
         Assert.Equal(new[] { HierarchyId.Parse("/") }, results);
     }
 
-// TODO: The following no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with optional
-// parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     [ConditionalFact]
-//     public void Contains_with_parameter_list_can_translate()
-//     {
-//         var ids = new[] { HierarchyId.Parse("/1/1/7/"), HierarchyId.Parse("/1/1/99/") };
-//         var result = (from p in _db.Patriarchy
-//                       where ids.Contains(p.Id)
-//                       select p.Name).Single();
-//
-//         Assert.Equal(
-//             """
-// @ids='?' (Size = 4000)
-//
-// SELECT TOP(2) [p].[Name]
-// FROM [Patriarchy] AS [p]
-// WHERE [p].[Id] IN (
-//     SELECT CAST([i].[value] AS hierarchyid) AS [value]
-//     FROM OPENJSON(@ids) AS [i]
-// )
-// """,
-//             _db.Sql,
-//             ignoreLineEndingDifferences: true);
-//
-//         Assert.Equal("Dan", result);
-//     }
+    [ConditionalFact]
+    public void Contains_with_parameter_list_can_translate()
+    {
+        var ids = new[] { HierarchyId.Parse("/1/1/7/"), HierarchyId.Parse("/1/1/99/") };
+        var result = (from p in _db.Patriarchy
+                      where ids.Contains(p.Id)
+                      select p.Name).Single();
+
+        Assert.Equal(
+            """
+@ids='?' (Size = 4000)
+
+SELECT TOP(2) [p].[Name]
+FROM [Patriarchy] AS [p]
+WHERE [p].[Id] IN (
+    SELECT CAST([i].[value] AS hierarchyid) AS [value]
+    FROM OPENJSON(@ids) AS [i]
+)
+""",
+            _db.Sql,
+            ignoreLineEndingDifferences: true);
+
+        Assert.Equal("Dan", result);
+    }
 
     public void Dispose()
         => _db.Dispose();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -2450,26 +2450,23 @@ WHERE "w"."Id" = 0
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Enum_array_contains(bool async)
-//     {
-//         await base.Enum_array_contains(async);
-//
-//         AssertSql(
-//             """
-// @types_without_nulls='[1]' (Size = 3)
-//
-// SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-// FROM "Weapons" AS "w"
-// LEFT JOIN "Weapons" AS "w0" ON "w"."SynergyWithId" = "w0"."Id"
-// WHERE "w0"."Id" IS NOT NULL AND ("w0"."AmmunitionType" IN (
-//     SELECT "t"."value"
-//     FROM json_each(@types_without_nulls) AS "t"
-// ) OR "w0"."AmmunitionType" IS NULL)
-// """);
-//     }
+    public override async Task Enum_array_contains(bool async)
+    {
+        await base.Enum_array_contains(async);
+
+        AssertSql(
+            """
+@types_without_nulls='[1]' (Size = 3)
+
+SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
+FROM "Weapons" AS "w"
+LEFT JOIN "Weapons" AS "w0" ON "w"."SynergyWithId" = "w0"."Id"
+WHERE "w0"."Id" IS NOT NULL AND ("w0"."AmmunitionType" IN (
+    SELECT "t"."value"
+    FROM json_each(@types_without_nulls) AS "t"
+) OR "w0"."AmmunitionType" IS NULL)
+""");
+    }
 
     public override async Task Include_multiple_one_to_one_optional_and_one_to_one_required(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -117,14 +117,11 @@ FROM (
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async))).Message);
 
-    // TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-    // optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-    //
-    // public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
-    //     => await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
-    //
-    // public override async Task Contains_with_local_tuple_array_closure(bool async)
-    //     => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+    public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
+        => await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
+
+    public override async Task Contains_with_local_tuple_array_closure(bool async)
+        => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
 
     public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -31,33 +31,29 @@ WHERE "p"."Int" IN (10, 999)
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."NullableInt" IN (10, 999)
-// """);
-//     }
-//
-//     public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Inline_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."NullableInt" IS NULL OR "p"."NullableInt" = 999
-// """);
-//     }
+    public override async Task Inline_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" IN (10, 999)
+""");
+    }
+
+    public override async Task Inline_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Inline_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" IS NULL OR "p"."NullableInt" = 999
+""");
+    }
 
     public override async Task Inline_collection_Count_with_zero_values(bool async)
     {
@@ -598,64 +594,61 @@ WHERE "p"."NullableInt" NOT IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts='[10,999]' (Size = 8)
-//
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."Int" IN (
-//     SELECT "n"."value"
-//     FROM json_each(@nullableInts) AS "n"
-// )
-// """,
-//             //
-//             """
-// @nullableInts='[10,999]' (Size = 8)
-//
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."Int" NOT IN (
-//     SELECT "n"."value"
-//     FROM json_each(@nullableInts) AS "n"
-// )
-// """);
-//     }
-//
-//     public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
-//     {
-//         await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
-//
-//         AssertSql(
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 5)
-//
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."NullableInt" IN (
-//     SELECT "n"."value"
-//     FROM json_each(@nullableInts_without_nulls) AS "n"
-// ) OR "p"."NullableInt" IS NULL
-// """,
-//             //
-//             """
-// @nullableInts_without_nulls='[999]' (Size = 5)
-//
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."NullableInt" NOT IN (
-//     SELECT "n"."value"
-//     FROM json_each(@nullableInts_without_nulls) AS "n"
-// ) AND "p"."NullableInt" IS NOT NULL
-// """);
-//     }
+    public override async Task Parameter_collection_of_nullable_ints_Contains_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_int(async);
+
+        AssertSql(
+            """
+@nullableInts='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" IN (
+    SELECT "n"."value"
+    FROM json_each(@nullableInts) AS "n"
+)
+""",
+            //
+            """
+@nullableInts='[10,999]' (Size = 8)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" NOT IN (
+    SELECT "n"."value"
+    FROM json_each(@nullableInts) AS "n"
+)
+""");
+    }
+
+    public override async Task Parameter_collection_of_nullable_ints_Contains_nullable_int(bool async)
+    {
+        await base.Parameter_collection_of_nullable_ints_Contains_nullable_int(async);
+
+        AssertSql(
+            """
+@nullableInts_without_nulls='[999]' (Size = 5)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" IN (
+    SELECT "n"."value"
+    FROM json_each(@nullableInts_without_nulls) AS "n"
+) OR "p"."NullableInt" IS NULL
+""",
+            //
+            """
+@nullableInts_without_nulls='[999]' (Size = 5)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."NullableInt" NOT IN (
+    SELECT "n"."value"
+    FROM json_each(@nullableInts_without_nulls) AS "n"
+) AND "p"."NullableInt" IS NOT NULL
+""");
+    }
 
     public override async Task Parameter_collection_of_strings_Contains_string(bool async)
     {
@@ -803,26 +796,22 @@ WHERE "p"."Bool" IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//
-//     public override async Task Parameter_collection_of_enums_Contains(bool async)
-//     {
-//         await base.Parameter_collection_of_enums_Contains(async);
-//
-//         AssertSql(
-//             """
-// @enums='[0,3]' (Size = 5)
-//
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE "p"."Enum" IN (
-//     SELECT "e"."value"
-//     FROM json_each(@enums) AS "e"
-// )
-// """);
-//     }
+    public override async Task Parameter_collection_of_enums_Contains(bool async)
+    {
+        await base.Parameter_collection_of_enums_Contains(async);
+
+        AssertSql(
+            """
+@enums='[0,3]' (Size = 5)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Enum" IN (
+    SELECT "e"."value"
+    FROM json_each(@enums) AS "e"
+)
+""");
+    }
 
     public override async Task Parameter_collection_null_Contains(bool async)
     {
@@ -896,39 +885,35 @@ WHERE 10 IN (
 """);
     }
 
-// TODO: The base implementations no longer compile since https://github.com/dotnet/runtime/pull/110197 (Contains overload added with
-// optional parameter, not supported in expression trees). #35547 is tracking on the EF side.
-//
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains(async);
-//
-//         AssertSql(
-//             """
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE 10 IN (
-//     SELECT "n"."value"
-//     FROM json_each("p"."NullableInts") AS "n"
-// )
-// """);
-//     }
-//
-//     public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
-//     {
-//         await base.Column_collection_of_nullable_ints_Contains_null(async);
-//
-//         AssertSql(
-//             """
-// SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
-// FROM "PrimitiveCollectionsEntity" AS "p"
-// WHERE EXISTS (
-//     SELECT 1
-//     FROM json_each("p"."NullableInts") AS "n"
-//     WHERE "n"."value" IS NULL)
-// """);
-//     }
+    public override async Task Column_collection_of_nullable_ints_Contains(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE 10 IN (
+    SELECT "n"."value"
+    FROM json_each("p"."NullableInts") AS "n"
+)
+""");
+    }
+
+    public override async Task Column_collection_of_nullable_ints_Contains_null(bool async)
+    {
+        await base.Column_collection_of_nullable_ints_Contains_null(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE EXISTS (
+    SELECT 1
+    FROM json_each("p"."NullableInts") AS "n"
+    WHERE "n"."value" IS NULL)
+""");
+    }
 
     public override async Task Column_collection_of_strings_contains_null(bool async)
     {


### PR DESCRIPTION
~Update to dotnet SDK 10.0.100-preview.5.25258.31~, which contains the fix for https://github.com/dotnet/csharplang/issues/9246.

This reverts commit 4f8ea72373f554a1189b5be5beaa5acdb96af7be.

Fixes #35547
