### PR TITLE
fix(CanConnectAsync): throw OperationCanceledException in case of cancellation

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -387,7 +387,6 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns><see langword="true" /> if the database is available; <see langword="false" /> otherwise.</returns>
-    /// <exception cref="Exception">Various exceptions might be thrown if the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual async Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
     {
         try

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -373,7 +373,8 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Any exceptions thrown when attempting to connect are caught and not propagated to the application.
+    ///         Any exceptions thrown when attempting to connect are caught and not propagated to the application,
+    ///         except for the ones indicating cancellation.
     ///     </para>
     ///     <para>
     ///         The configured connection string is used to create the connection in the normal way, so all
@@ -386,12 +387,16 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns><see langword="true" /> if the database is available; <see langword="false" /> otherwise.</returns>
-    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    /// <exception cref="Exception">Various exceptions might be thrown if the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual async Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
     {
         try
         {
             return await ExistsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (Dependencies.ExceptionDetector.IsCancellation(exception, cancellationToken))
+        {
+            throw;
         }
         catch
         {

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
@@ -54,7 +54,8 @@ public sealed record RelationalDatabaseCreatorDependencies
         IExecutionStrategy executionStrategy,
         ICurrentDbContext currentContext,
         IDbContextOptions contextOptions,
-        IRelationalCommandDiagnosticsLogger commandLogger)
+        IRelationalCommandDiagnosticsLogger commandLogger,
+        IExceptionDetector exceptionDetector)
     {
         Connection = connection;
         ModelDiffer = modelDiffer;
@@ -65,6 +66,7 @@ public sealed record RelationalDatabaseCreatorDependencies
         CurrentContext = currentContext;
         ContextOptions = contextOptions;
         CommandLogger = commandLogger;
+        ExceptionDetector = exceptionDetector;
     }
 
     /// <summary>
@@ -111,4 +113,9 @@ public sealed record RelationalDatabaseCreatorDependencies
     ///     Contains the <see cref="DbContext" /> currently in use.
     /// </summary>
     public ICurrentDbContext CurrentContext { get; init; }
+
+    /// <summary>
+    /// Gets the exception detector.
+    /// </summary>
+    public IExceptionDetector ExceptionDetector { get; init; }
 }


### PR DESCRIPTION
As already mentioned in the doc-string of the `CanConnectAsync` method, it should throw an `OperationCanceledException` in case the `CancellationToken` fired and the check method threw a corresponding exception.

This PR addresses this shortcoming and goes hand-in-hand with [this change to ASP.NET Core's `DbContextHealthCheck`](https://github.com/dotnet/aspnetcore/pull/61883) to propagate `OperationCanceledException`s.