### PR TITLE
Remove wrong quotes from helix.cmd

### DIFF
--- a/helix.cmd
+++ b/helix.cmd
@@ -3,10 +3,10 @@
 :: This command sends helix test job from local machine
 
 SET DOTNET_ROOT=%~dp0.dotnet\
-SET BUILD_SOURCEBRANCH="main"
-SET BUILD_REPOSITORY_NAME="efcore"
-SET SYSTEM_TEAMPROJECT="public"
-SET BUILD_REASON="test"
+SET BUILD_SOURCEBRANCH=main
+SET BUILD_REPOSITORY_NAME=efcore
+SET SYSTEM_TEAMPROJECT=public
+SET BUILD_REASON=test
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
     call dotnet msbuild eng\helix.proj /restore /t:Test %*


### PR DESCRIPTION
When setting an env var in Windows .cmd it shouldn't be enclosed in quotes, otherwise the quotes will be part of the variable value.

