### PR TITLE
[release/9.0] Add missing parentheses for set operations

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -22,6 +22,9 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     private IRelationalCommandBuilder _relationalCommandBuilder;
     private Dictionary<string, int>? _repeatedParameterCounts;
 
+    private static readonly bool UseOldBehavior36105 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue36105", out var enabled36105) && enabled36105;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="QuerySqlGenerator" /> class.
     /// </summary>
@@ -1382,9 +1385,16 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     protected virtual void GenerateSetOperationOperand(SetOperationBase setOperation, SelectExpression operand)
     {
         // INTERSECT has higher precedence over UNION and EXCEPT, but otherwise evaluation is left-to-right.
-        // To preserve meaning, add parentheses whenever a set operation is nested within a different set operation.
+        // To preserve evaluation order, add parentheses whenever a set operation is nested within a different set operation
+        // - including different distinctness.
+        // In addition, EXCEPT is non-commutative (unlike UNION/INTERSECT), so add parentheses for that case too (see #36105).
         if (IsNonComposedSetOperation(operand)
-            && operand.Tables[0].GetType() != setOperation.GetType())
+            && ((UseOldBehavior36105 && operand.Tables[0].GetType() != setOperation.GetType())
+                || (!UseOldBehavior36105
+                    && operand.Tables[0] is SetOperationBase nestedSetOperation
+                    && (nestedSetOperation is ExceptExpression
+                        || nestedSetOperation.GetType() != setOperation.GetType()
+                        || nestedSetOperation.IsDistinct != setOperation.IsDistinct))))
         {
             _relationalCommandBuilder.AppendLine("(");
             using (_relationalCommandBuilder.Indent())

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -79,6 +79,19 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                 .Except(ss.Set<Customer>().Where(s => s.City == "México D.F."))
                 .Except(ss.Set<Customer>().Where(e => e.City == "Seattle")));
 
+    // EXCEPT is non-commutative, unlike UNION/INTERSECT. Therefore, parentheses are needed in the following query
+    // to ensure that the inner EXCEPT is evaluated first. See #36105.
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Except_nested2(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .Except(ss.Set<Customer>()
+                    .Where(s => s.City == "Seattle")
+                    .Except(ss.Set<Customer>()
+                        .Where(e => e.City == "Seattle"))));
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Except_non_entity(bool async)
@@ -217,6 +230,17 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                 .Where(c => c.City == "Berlin")
                 .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                 .Intersect(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))));
+
+    // The evaluation order of Concat and Union can matter: A UNION ALL (B UNION C) can be different from (A UNION ALL B) UNION C.
+    // Make sure parentheses are added.
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_inside_Concat(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.City == "Berlin")
+                .Concat(ss.Set<Customer>().Where(c => c.City == "London")
+                    .Union(ss.Set<Customer>().Where(c => c.City == "Berlin"))));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -200,6 +200,28 @@ WHERE [c1].[ContactName] LIKE N'%Thomas%'
 """);
     }
 
+    public override async Task Union_inside_Concat(bool async)
+    {
+        await base.Union_inside_Concat(async);
+
+AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'Berlin'
+UNION ALL
+(
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'London'
+    UNION
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] = N'Berlin'
+)
+""");
+    }
+
     public override async Task Union_Take_Union_Take(bool async)
     {
         await base.Union_Take_Union_Take(async);
@@ -1233,18 +1255,41 @@ FROM (
         await base.Except_nested(async);
 
         AssertSql(
-            """
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[ContactTitle] = N'Owner'
-EXCEPT
-SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM [Customers] AS [c0]
-WHERE [c0].[City] = N'México D.F.'
+"""
+(
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[ContactTitle] = N'Owner'
+    EXCEPT
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'México D.F.'
+)
 EXCEPT
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
 WHERE [c1].[City] = N'Seattle'
+""");
+    }
+
+    public override async Task Except_nested2(bool async)
+    {
+        await base.Except_nested2(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+EXCEPT
+(
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'Seattle'
+    EXCEPT
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] = N'Seattle'
+)
 """);
     }
 


### PR DESCRIPTION
Backports #36110 (see #36139 for identical 9.0 backport PR)
Fixes #36105
Fixes #36112

**Description**
When generating SQL for multiple set operators (UNION, INTERSECT, EXCEPT), EF omitted adding parentheses in certain combinations, leading to the LINQ evaluation order not being preserved in the generated SQL. In addition, the SQLite provider didn't generate parentheses at all, since the SQLite syntax is non-standard and we originally thought no form of parentheses was possible.

**Customer impact**
The missing parentheses could cause the SQL set operators to be evaluated in an incorrect order (compared to the user's specified evaluation order in the LINQ query). This could lead to incorrect results getting returned from the database (data corruption).

**How found**
Reported by a user.

**Regression**
No

**Testing**
Added.

**Risk**
Very low. This is a minimal, targeted fix which only adds parentheses to preserve the LINQ evaluation order. A quirk was added just in case.
