### PR TITLE
[release/8.0] Add missing parentheses for set operations

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.SqlExpressions.Internal;
 
@@ -14,6 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 /// </summary>
 public class SqliteQuerySqlGenerator : QuerySqlGenerator
 {
+    private static readonly bool UseOldBehavior36112 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue36112", out var enabled36112) && enabled36112;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -98,8 +102,63 @@ public class SqliteQuerySqlGenerator : QuerySqlGenerator
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override void GenerateSetOperationOperand(SetOperationBase setOperation, SelectExpression operand)
-        // Sqlite doesn't support parentheses around set operation operands
-        => Visit(operand);
+    {
+        // Most databases support parentheses around set operations to determine evaluation order, but SQLite does not;
+        // however, we can instead wrap the nested set operation in a SELECT * FROM () to achieve the same effect.
+        // The following is a copy-paste of the base implementation from QuerySqlGenerator, adding the SELECT.
+
+        // INTERSECT has higher precedence over UNION and EXCEPT, but otherwise evaluation is left-to-right.
+        // To preserve evaluation order, add parentheses whenever a set operation is nested within a different set operation
+        // - including different distinctness.
+        // In addition, EXCEPT is non-commutative (unlike UNION/INTERSECT), so add parentheses for that case too (see #36105).
+        if (!UseOldBehavior36112
+            && TryUnwrapBareSetOperation(operand, out var nestedSetOperation)
+            && (nestedSetOperation is ExceptExpression
+                || nestedSetOperation.GetType() != setOperation.GetType()
+                || nestedSetOperation.IsDistinct != setOperation.IsDistinct))
+        {
+            Sql.AppendLine("SELECT * FROM (");
+
+            using (Sql.Indent())
+            {
+                Visit(operand);
+            }
+
+            Sql.AppendLine().Append(")");
+        }
+        else
+        {
+            Visit(operand);
+        }
+
+        static bool TryUnwrapBareSetOperation(SelectExpression selectExpression, [NotNullWhen(true)] out SetOperationBase? setOperation)
+        {
+            if (selectExpression is
+                {
+                    Tables: [SetOperationBase s],
+                    Predicate: null,
+                    Orderings: [],
+                    Offset: null,
+                    Limit: null,
+                    IsDistinct: false,
+                    Having: null,
+                    GroupBy: []
+                }
+                && selectExpression.Projection.Count == s.Source1.Projection.Count
+                && selectExpression.Projection.Select(
+                        (pe, index) => pe.Expression is ColumnExpression column
+                            && column.TableAlias == s.Alias
+                            && column.Name == s.Source1.Projection[index].Alias)
+                    .All(e => e))
+            {
+                setOperation = s;
+                return true;
+            }
+
+            setOperation = null;
+            return false;
+        }
+    }
 
     private void GenerateGlob(GlobExpression globExpression, bool negated = false)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -201,6 +201,28 @@ WHERE [c1].[ContactName] LIKE N'%Thomas%'
 """);
     }
 
+    public override async Task Union_inside_Concat(bool async)
+    {
+        await base.Union_inside_Concat(async);
+
+AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'Berlin'
+UNION ALL
+(
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'London'
+    UNION
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] = N'Berlin'
+)
+""");
+    }
+
     public override async Task Union_Take_Union_Take(bool async)
     {
         await base.Union_Take_Union_Take(async);
@@ -1234,18 +1256,41 @@ FROM (
         await base.Except_nested(async);
 
         AssertSql(
-            """
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[ContactTitle] = N'Owner'
-EXCEPT
-SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM [Customers] AS [c0]
-WHERE [c0].[City] = N'México D.F.'
+"""
+(
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[ContactTitle] = N'Owner'
+    EXCEPT
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'México D.F.'
+)
 EXCEPT
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
 WHERE [c1].[City] = N'Seattle'
+""");
+    }
+
+    public override async Task Except_nested2(bool async)
+    {
+        await base.Except_nested2(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+EXCEPT
+(
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'Seattle'
+    EXCEPT
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] = N'Seattle'
+)
 """);
     }
 


### PR DESCRIPTION
Backports #36110 (see #36138 for identical 9.0 backport PR)
Fixes #36105
Fixes #36112

**Description**
When generating SQL for multiple set operators (UNION, INTERSECT, EXCEPT), EF omitted adding parentheses in certain combinations, leading to the LINQ evaluation order not being preserved in the generated SQL. In addition, the SQLite provider didn't generate parentheses at all, since the SQLite syntax is non-standard and we originally thought no form of parentheses was possible.

**Customer impact**
The missing parentheses could cause the SQL set operators to be evaluated in an incorrect order (compared to the user's specified evaluation order in the LINQ query). This could lead to incorrect results getting returned from the database (data corruption).

**How found**
Reported by a user.

**Regression**
No

**Testing**
Added.

**Risk**
Very low. This is a minimal, targeted fix which only adds parentheses to preserve the LINQ evaluation order. A quirk was added just in case.
