### PR TITLE
Work on inlined primitive collections (VALUES)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -420,8 +420,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             var sqlExpression = sqlExpressions[i];
             rowExpressions[i] =
                 new RowValueExpression(
-                    new[]
-                    {
+                    [
                         // Since VALUES may not guarantee row ordering, we add an _ord value by which we'll order.
                         _sqlExpressionFactory.Constant(i, intTypeMapping),
                         // If no type mapping was inferred (i.e. no column in the inline collection), it's left null, to allow it to get
@@ -431,11 +430,11 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                         sqlExpression.TypeMapping is null && inferredTypeMaping is not null
                             ? _sqlExpressionFactory.ApplyTypeMapping(sqlExpression, inferredTypeMaping)
                             : sqlExpression
-                    });
+                    ]);
         }
 
         var alias = _sqlAliasManager.GenerateTableAlias("values");
-        var valuesExpression = new ValuesExpression(alias, rowExpressions, new[] { ValuesOrderingColumnName, ValuesValueColumnName });
+        var valuesExpression = new ValuesExpression(alias, rowExpressions, [ValuesOrderingColumnName, ValuesValueColumnName]);
 
         return CreateShapedQueryExpressionForValuesExpression(
             valuesExpression,

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -74,8 +74,8 @@ public sealed class SqlParameterExpression : SqlExpression
     /// </summary>
     /// <param name="typeMapping">A relational type mapping to apply.</param>
     /// <returns>A new expression which has supplied type mapping.</returns>
-    public SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
-        => new SqlParameterExpression(InvariantName, Name, Type, IsNullable, TranslationMode, typeMapping);
+    public SqlParameterExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
+        => new(InvariantName, Name, Type, IsNullable, TranslationMode, typeMapping);
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -1020,6 +1020,13 @@ WHERE ([1, 2, 3][c["Int"]] = 1)
 """);
     }
 
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Inline_collection_index_Column_with_EF_Constant());
+
+        Assert.Equal(CoreStrings.EFConstantNotSupported, exception.Message);
+    }
+
     public override async Task Inline_collection_value_index_Column()
     {
         // Member indexer (c.Array[c.SomeMember]) isn't supported by Cosmos

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -681,6 +681,16 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Int <= 2 ? new[] { 1, 2, 3 }[c.Int] : -1) == 1));
 
     [ConditionalFact]
+    public virtual Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        int[] ints = [1, 2, 3];
+
+        return AssertQuery(
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => EF.Constant(ints)[c.Int] == 1),
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Int <= 2 ? ints[c.Int] : -1) == 1));
+    }
+
+    [ConditionalFact]
     public virtual Task Inline_collection_value_index_Column()
         => AssertQuery(
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 1, c.Int, 3 }[c.Int] == 1),

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -2604,7 +2604,7 @@ SELECT [t].[Id], [t].[Name]
 FROM [TestEntities] AS [t]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (?), (?), (?)) AS [i]([Value])
+    FROM (VALUES (CAST(? AS int)), (?), (?)) AS [i]([Value])
     WHERE [i].[Value] = [t].[Id])
 """,
                 //
@@ -2628,7 +2628,7 @@ SELECT [t].[Id], [t].[Name]
 FROM [TestEntities] AS [t]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (1), (2), (3)) AS [i]([Value])
+    FROM (VALUES (CAST(1 AS int)), (2), (3)) AS [i]([Value])
     WHERE [i].[Value] = [t].[Id])
 """,
             //

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -9194,7 +9194,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= ISNULL((
         SELECT [n].[Value]
-        FROM (VALUES (1, @numbers1), (2, @numbers2), (3, @numbers3)) AS [n]([_ord], [Value])
+        FROM (VALUES (@numbers1), (@numbers2), (@numbers3)) AS [n]([Value])
         ORDER BY [n].[Value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -799,7 +799,7 @@ SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (2), (999)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999)) AS [i]([Value])
     WHERE [i].[Value] > [t].[Id]) = 1
 """);
                 break;
@@ -905,7 +905,7 @@ SELECT [t].[Id]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (2), (999)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999)) AS [i]([Value])
     WHERE [i].[Value] > [t].[Id]) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -790,7 +790,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > 0)
 """);
     }
@@ -805,7 +805,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > [p].[Id]) = 2
 """);
     }
@@ -900,6 +900,22 @@ WHERE (
 """);
     }
 
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        await base.Inline_collection_index_Column_with_EF_Constant();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT [i].[Value]
+    FROM (VALUES (0, CAST(1 AS int)), (1, 2), (2, 3)) AS [i]([_ord], [Value])
+    ORDER BY [i].[_ord]
+    OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
+""");
+    }
+
     public override async Task Inline_collection_value_index_Column()
     {
         await base.Inline_collection_value_index_Column();
@@ -946,7 +962,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT [i].[Value]
-    FROM (VALUES (1, @ints1), (2, @ints2), (3, @ints3)) AS [i]([_ord], [Value])
+    FROM (VALUES (0, @ints1), (1, @ints2), (2, @ints3)) AS [i]([_ord], [Value])
     ORDER BY [i].[_ord]
     OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = [p].[Int]
 """);
@@ -966,7 +982,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT [i].[Value]
-    FROM (VALUES (1, @ints1), (2, @ints2), (3, @ints3)) AS [i]([_ord], [Value])
+    FROM (VALUES (0, @ints1), (1, @ints2), (2, @ints3)) AS [i]([_ord], [Value])
     ORDER BY [i].[_ord]
     OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
 """);
@@ -1141,7 +1157,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [i].[Value] AS [Value0]
-        FROM (VALUES (1, @ints1), (2, @ints2)) AS [i]([_ord], [Value])
+        FROM (VALUES (0, @ints1), (1, @ints2)) AS [i]([_ord], [Value])
         ORDER BY [i].[_ord]
         OFFSET 1 ROWS
     ) AS [i0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
@@ -784,7 +784,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > 0)
 """);
     }
@@ -799,7 +799,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > [p].[Id]) = 2
 """);
     }
@@ -1063,6 +1063,18 @@ WHERE (
     FROM (VALUES (0, CAST(1 AS int)), (1, 2), (2, 3)) AS [v]([_ord], [Value])
     ORDER BY [v].[_ord]
     OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
+""");
+    }
+
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        await base.Inline_collection_index_Column_with_EF_Constant();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE CAST(JSON_VALUE(N'[1,2,3]', '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
 """);
     }
 
@@ -1664,7 +1676,7 @@ WHERE (
         SELECT [i1].[Value]
         FROM (
             SELECT [i].[Value]
-            FROM (VALUES (1, @ints1), (2, @ints2)) AS [i]([_ord], [Value])
+            FROM (VALUES (0, @ints1), (1, @ints2)) AS [i]([_ord], [Value])
             ORDER BY [i].[_ord]
             OFFSET 1 ROWS
         ) AS [i1]
@@ -1754,7 +1766,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [i].[Value] AS [Value0]
-        FROM (VALUES (1, @ints1), (2, @ints2)) AS [i]([_ord], [Value])
+        FROM (VALUES (0, @ints1), (1, @ints2)) AS [i]([_ord], [Value])
         ORDER BY [i].[_ord]
         OFFSET 1 ROWS
     ) AS [i0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
@@ -73,11 +73,11 @@ WHERE [p].[Id] IN (2, 999, 1000)
 
         AssertSql(
             """
-SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > 0)
 """);
     }
@@ -1091,6 +1091,22 @@ WHERE (
     SELECT [v].[Value]
     FROM (VALUES (0, CAST(1 AS int)), (1, 2), (2, 3)) AS [v]([_ord], [Value])
     ORDER BY [v].[_ord]
+    OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
+""");
+    }
+
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        await base.Inline_collection_index_Column_with_EF_Constant();
+
+        AssertSql(
+"""
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT [i].[Value]
+    FROM (VALUES (0, CAST(1 AS int)), (1, 2), (2, 3)) AS [i]([_ord], [Value])
+    ORDER BY [i].[_ord]
     OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -807,7 +807,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > 0)
 """);
     }
@@ -822,7 +822,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (2), (999), (1000)) AS [i]([Value])
+    FROM (VALUES (CAST(2 AS int)), (999), (1000)) AS [i]([Value])
     WHERE [i].[Value] > [p].[Id]) = 2
 """);
     }
@@ -1086,6 +1086,18 @@ WHERE (
     FROM (VALUES (0, CAST(1 AS int)), (1, 2), (2, 3)) AS [v]([_ord], [Value])
     ORDER BY [v].[_ord]
     OFFSET [p].[Int] ROWS FETCH NEXT 1 ROWS ONLY) = 1
+""");
+    }
+
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        await base.Inline_collection_index_Column_with_EF_Constant();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE CAST(JSON_VALUE(N'[1,2,3]', '$[' + CAST([p].[Int] AS nvarchar(max)) + ']') AS int) = 1
 """);
     }
 
@@ -1688,7 +1700,7 @@ WHERE (
         SELECT [i1].[Value]
         FROM (
             SELECT [i].[Value]
-            FROM (VALUES (1, @ints1), (2, @ints2)) AS [i]([_ord], [Value])
+            FROM (VALUES (0, @ints1), (1, @ints2)) AS [i]([_ord], [Value])
             ORDER BY [i].[_ord]
             OFFSET 1 ROWS
         ) AS [i1]
@@ -1778,7 +1790,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT [i].[Value] AS [Value0]
-        FROM (VALUES (1, @ints1), (2, @ints2)) AS [i]([_ord], [Value])
+        FROM (VALUES (0, @ints1), (1, @ints2)) AS [i]([_ord], [Value])
         ORDER BY [i].[_ord]
         OFFSET 1 ROWS
     ) AS [i0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -12271,7 +12271,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= ISNULL((
         SELECT [n].[Value]
-        FROM (VALUES (1, @numbers1), (2, @numbers2), (3, @numbers3)) AS [n]([_ord], [Value])
+        FROM (VALUES (@numbers1), (@numbers2), (@numbers3)) AS [n]([Value])
         ORDER BY [n].[Value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [u].[FullName] = [w1].[OwnerFullName]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -10412,7 +10412,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= ISNULL((
         SELECT [n].[Value]
-        FROM (VALUES (1, @numbers1), (2, @numbers2), (3, @numbers3)) AS [n]([_ord], [Value])
+        FROM (VALUES (@numbers1), (@numbers2), (@numbers3)) AS [n]([Value])
         ORDER BY [n].[Value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -9086,7 +9086,7 @@ LEFT JOIN (
     ) AS [w0]
     WHERE [w0].[row] <= ISNULL((
         SELECT [n].[Value]
-        FROM (VALUES (1, @numbers1), (2, @numbers2), (3, @numbers3)) AS [n]([_ord], [Value])
+        FROM (VALUES (@numbers1), (@numbers2), (@numbers3)) AS [n]([Value])
         ORDER BY [n].[Value]
         OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY), 0)
 ) AS [w1] ON [g].[FullName] = [w1].[OwnerFullName]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
@@ -108,7 +108,7 @@ SELECT "t"."Id", "t"."Name"
 FROM "TestEntities" AS "t"
 WHERE EXISTS (
     SELECT 1
-    FROM (SELECT ? AS "Value" UNION ALL VALUES (?), (?)) AS "i"
+    FROM (SELECT CAST(? AS INTEGER) AS "Value" UNION ALL VALUES (?), (?)) AS "i"
     WHERE "i"."Value" = "t"."Id")
 """,
                 //
@@ -132,7 +132,7 @@ SELECT "t"."Id", "t"."Name"
 FROM "TestEntities" AS "t"
 WHERE EXISTS (
     SELECT 1
-    FROM (SELECT 1 AS "Value" UNION ALL VALUES (2), (3)) AS "i"
+    FROM (SELECT CAST(1 AS INTEGER) AS "Value" UNION ALL VALUES (2), (3)) AS "i"
     WHERE "i"."Value" = "t"."Id")
 """,
                 //

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -8750,7 +8750,7 @@ LEFT JOIN (
     ) AS "w0"
     WHERE "w0"."row" <= COALESCE((
         SELECT "n"."Value"
-        FROM (SELECT 1 AS "_ord", @numbers1 AS "Value" UNION ALL VALUES (2, @numbers2), (3, @numbers3)) AS "n"
+        FROM (SELECT @numbers1 AS "Value" UNION ALL VALUES (@numbers2), (@numbers3)) AS "n"
         ORDER BY "n"."Value"
         LIMIT 1 OFFSET 1), 0)
 ) AS "w1" ON "g"."FullName" = "w1"."OwnerFullName"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqliteTest.cs
@@ -343,7 +343,7 @@ SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE (
     SELECT COUNT(*)
-    FROM (SELECT 2 AS "Value" UNION ALL VALUES (999)) AS "i"
+    FROM (SELECT CAST(2 AS INTEGER) AS "Value" UNION ALL VALUES (999)) AS "i"
     WHERE "i"."Value" > "t"."Id") = 1
 """);
                 break;
@@ -449,7 +449,7 @@ SELECT "t"."Id"
 FROM "TestEntity" AS "t"
 WHERE (
     SELECT COUNT(*)
-    FROM (SELECT 2 AS "Value" UNION ALL VALUES (999)) AS "i"
+    FROM (SELECT CAST(2 AS INTEGER) AS "Value" UNION ALL VALUES (999)) AS "i"
     WHERE "i"."Value" > "t"."Id") = 1
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -795,7 +795,7 @@ SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE EXISTS (
     SELECT 1
-    FROM (SELECT 2 AS "Value" UNION ALL VALUES (999), (1000)) AS "i"
+    FROM (SELECT CAST(2 AS INTEGER) AS "Value" UNION ALL VALUES (999), (1000)) AS "i"
     WHERE "i"."Value" > 0)
 """);
     }
@@ -810,7 +810,7 @@ SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
-    FROM (SELECT 2 AS "Value" UNION ALL VALUES (999), (1000)) AS "i"
+    FROM (SELECT CAST(2 AS INTEGER) AS "Value" UNION ALL VALUES (999), (1000)) AS "i"
     WHERE "i"."Value" > "p"."Id") = 2
 """);
     }
@@ -1051,6 +1051,18 @@ WHERE (
     FROM (SELECT 0 AS "_ord", CAST(1 AS INTEGER) AS "Value" UNION ALL VALUES (1, 2), (2, 3)) AS "v"
     ORDER BY "v"."_ord"
     LIMIT 1 OFFSET "p"."Int") = 1
+""");
+    }
+
+    public override async Task Inline_collection_index_Column_with_EF_Constant()
+    {
+        await base.Inline_collection_index_Column_with_EF_Constant();
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."NullableWrappedId", "p"."NullableWrappedIdWithNullableComparer", "p"."String", "p"."Strings", "p"."WrappedId"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE '[1,2,3]' ->> "p"."Int" = 1
 """);
     }
 
@@ -1639,7 +1651,7 @@ WHERE (
     SELECT COUNT(*)
     FROM (
         SELECT "i"."Value" AS "Value0"
-        FROM (SELECT 1 AS "_ord", @ints1 AS "Value" UNION ALL VALUES (2, @ints2)) AS "i"
+        FROM (SELECT 0 AS "_ord", @ints1 AS "Value" UNION ALL VALUES (1, @ints2)) AS "i"
         ORDER BY "i"."_ord"
         LIMIT -1 OFFSET 1
     ) AS "i0"
@@ -1671,7 +1683,7 @@ WHERE (
         SELECT "i1"."Value"
         FROM (
             SELECT "i"."Value"
-            FROM (SELECT 1 AS "_ord", @ints1 AS "Value" UNION ALL VALUES (2, @ints2)) AS "i"
+            FROM (SELECT 0 AS "_ord", @ints1 AS "Value" UNION ALL VALUES (1, @ints2)) AS "i"
             ORDER BY "i"."_ord"
             LIMIT -1 OFFSET 1
         ) AS "i1"


### PR DESCRIPTION
Work on inlined primitive collections (VALUES)

* Refactor and generalize the pruning of the VALUES _ord column,
  moving it from RelationalTypeMappingPostprocessor to SqlPruner.
* Ensure that inlined parameterized collections (EF.Constant)
  preserved ordering via _ord and specifies the type mapping.
* Properly visit JsonScalarExpression in SqlNullabilityProcessor.
* Add CAST() to VALUES generated in SqlNullabilityProcessor because
  of EF.Constant().
    
Fixes #36158
Fixes #36462
Fixes #36463

/cc @artl93 
