### PR TITLE
Use non-arch specific properties for shared framework versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -42,14 +42,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>0a01b394b186e190a80cb55740c13f6293cf5446</Sha>
     </Dependency>
-    <!--
-         Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-         All Runtime.$rid packages should have the same version.
-    -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.6.25278.103">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>0a01b394b186e190a80cb55740c13f6293cf5446</Sha>
-    </Dependency>
     <Dependency Name="System.Text.Json" Version="10.0.0-preview.6.25278.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>0a01b394b186e190a80cb55740c13f6293cf5446</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,6 @@
     <MicrosoftExtensionsHostFactoryResolverSourcesVersion>10.0.0-preview.6.25278.103</MicrosoftExtensionsHostFactoryResolverSourcesVersion>
     <MicrosoftExtensionsLoggingVersion>10.0.0-preview.6.25278.103</MicrosoftExtensionsLoggingVersion>
     <MicrosoftNETCoreAppRefVersion>10.0.0-preview.6.25278.103</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.6.25278.103</MicrosoftNETCoreAppRuntimewinx64Version>
     <SystemTextEncodingsWebVersion>10.0.0-preview.6.25278.103</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>10.0.0-preview.6.25278.103</SystemTextJsonVersion>
     <SystemFormatsAsn1Version>10.0.0-preview.6.25278.103</SystemFormatsAsn1Version>

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -30,7 +30,7 @@
       <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalReadSasToken'))</SasToken>
     </AdditionalDotNetPackageFeed>
 
-    <AdditionalDotNetPackage Include="$(MicrosoftNETCoreAppRuntimewinx64Version)">
+    <AdditionalDotNetPackage Include="$(MicrosoftNETCoreAppRefVersion)">
       <PackageType>runtime</PackageType>
     </AdditionalDotNetPackage>
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -13,7 +13,7 @@
     "dotnet": "10.0.100-preview.6.25272.112",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimewinx64Version)"
+        "$(MicrosoftNETCoreAppRefVersion)"
       ]
     }
   },

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <FrameworkReference Update="Microsoft.NETCore.App"
                         Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'"
-                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
                         TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This reduces issues when building verticals, which may not have built these dependencies.