### PR TITLE
[TINY] Add missing backslash in global.json error message

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
       ".dotnet",
       "$host$"
     ],
-    "errorMessage": "The required .NET SDK wasn't found. Please run ./restore.sh or .\restore.cmd to install it."
+    "errorMessage": "The required .NET SDK wasn't found. Please run ./restore.sh or .\\restore.cmd to install it."
   },
   "tools": {
     "dotnet": "10.0.100-preview.6.25272.112",


### PR DESCRIPTION
Without it the `\r` in `.\restore.cmd` gets interpreted as an escape sequence and we get a garbled error message. Fixup to #36121.