### PR TITLE
Implement DateOnly.DayNumber translations for SqlServer/Sqlite

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateOnlyMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateOnlyMemberTranslator.cs
@@ -12,28 +12,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlServerDateOnlyMemberTranslator : IMemberTranslator
+public class SqlServerDateOnlyMemberTranslator(ISqlExpressionFactory sqlExpressionFactory) : IMemberTranslator
 {
-    private static readonly Dictionary<string, string> DatePartMapping
-        = new()
-        {
-            { nameof(DateOnly.Year), "year" },
-            { nameof(DateOnly.Month), "month" },
-            { nameof(DateOnly.DayOfYear), "dayofyear" },
-            { nameof(DateOnly.Day), "day" }
-        };
-
-    private readonly ISqlExpressionFactory _sqlExpressionFactory;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public SqlServerDateOnlyMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
-        => _sqlExpressionFactory = sqlExpressionFactory;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -45,12 +25,39 @@ public class SqlServerDateOnlyMemberTranslator : IMemberTranslator
         MemberInfo member,
         Type returnType,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-        => member.DeclaringType == typeof(DateOnly) && DatePartMapping.TryGetValue(member.Name, out var datePart)
-            ? _sqlExpressionFactory.Function(
+    {
+        if (member.DeclaringType != typeof(DateOnly) || instance is null)
+        {
+            return null;
+        }
+
+        return member.Name switch
+        {
+            nameof(DateOnly.Year) => DatePart("year"),
+            nameof(DateOnly.Month) => DatePart("month"),
+            nameof(DateOnly.DayOfYear) => DatePart("dayofyear"),
+            nameof(DateOnly.Day) => DatePart("day"),
+
+            nameof(DateOnly.DayNumber) => sqlExpressionFactory.Function(
+                "DATEDIFF",
+                [
+                    sqlExpressionFactory.Fragment("day"),
+                    sqlExpressionFactory.Constant(new DateOnly(1, 1, 1)),
+                    instance
+                ],
+                nullable: true,
+                argumentsPropagateNullability: [false, true, true],
+                returnType),
+
+            _ => null
+        };
+
+        SqlExpression DatePart(string datePart)
+            => sqlExpressionFactory.Function(
                 "DATEPART",
-                new[] { _sqlExpressionFactory.Fragment(datePart), instance! },
+                [sqlExpressionFactory.Fragment(datePart), instance],
                 nullable: true,
                 argumentsPropagateNullability: Statics.FalseTrue,
-                returnType)
-            : null;
+                returnType);
+    }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsCosmosTest.cs
@@ -26,6 +26,10 @@ public class DateOnlyTranslationsCosmosTest : DateOnlyTranslationsTestBase<Basic
     public override Task DayOfWeek(bool async)
         => AssertTranslationFailed(() => base.DayOfWeek(async));
 
+    // Cosmos does not support DateTimeDiff with years under 1601
+    public override Task DayNumber(bool async)
+        => AssertTranslationFailed(() => base.DayNumber(async));
+
     public override Task AddYears(bool async)
         => AssertTranslationFailed(() => base.AddYears(async));
 
@@ -34,6 +38,10 @@ public class DateOnlyTranslationsCosmosTest : DateOnlyTranslationsTestBase<Basic
 
     public override Task AddDays(bool async)
         => AssertTranslationFailed(() => base.AddDays(async));
+
+    // Cosmos does not support DateTimeDiff with years under 1601
+    public override Task DayNumber_subtraction(bool async)
+        => AssertTranslationFailed(() => base.DayNumber_subtraction(async));
 
     public override Task FromDateTime(bool async)
         => AssertTranslationFailed(() => base.FromDateTime(async));

--- a/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateOnlyTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateOnlyTranslationsTestBase.cs
@@ -45,6 +45,13 @@ public abstract class DateOnlyTranslationsTestBase<TFixture>(TFixture fixture) :
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task DayNumber(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>().Where(b => b.DateOnly.DayNumber == 726780));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task AddYears(bool async)
         => AssertQuery(
             async,
@@ -63,6 +70,13 @@ public abstract class DateOnlyTranslationsTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(
             async,
             ss => ss.Set<BasicTypesEntity>().Where(b => b.DateOnly.AddDays(3) == new DateOnly(1990, 11, 13)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DayNumber_subtraction(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<BasicTypesEntity>().Where(b => b.DateOnly.DayNumber - new DateOnly(1990, 11, 5).DayNumber == 5));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsSqlServerTest.cs
@@ -67,6 +67,18 @@ WHERE DATEPART(dayofyear, [b].[DateOnly]) = 314
         AssertSql();
     }
 
+    public override async Task DayNumber(bool async)
+    {
+        await base.DayNumber(async);
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATEDIFF(day, '0001-01-01', [b].[DateOnly]) = 726780
+""");
+    }
+
     public override async Task AddYears(bool async)
     {
         await base.AddYears(async);
@@ -100,6 +112,20 @@ WHERE DATEADD(month, CAST(3 AS int), [b].[DateOnly]) = '1991-02-10'
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
 WHERE DATEADD(day, CAST(3 AS int), [b].[DateOnly]) = '1990-11-13'
+""");
+    }
+
+    public override async Task DayNumber_subtraction(bool async)
+    {
+        await base.DayNumber_subtraction(async);
+
+        AssertSql(
+            """
+@DayNumber='726775'
+
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATEDIFF(day, '0001-01-01', [b].[DateOnly]) - @DayNumber = 5
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsSqliteTest.cs
@@ -74,6 +74,18 @@ WHERE CAST(strftime('%w', "b"."DateOnly") AS INTEGER) = 6
 """);
     }
 
+    public override async Task DayNumber(bool async)
+    {
+        await base.DayNumber(async);
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST(julianday("b"."DateOnly") - julianday('0001-01-01') AS INTEGER) = 726780
+""");
+    }
+
     public override async Task AddYears(bool async)
     {
         await base.AddYears(async);
@@ -107,6 +119,20 @@ WHERE date("b"."DateOnly", CAST(3 AS TEXT) || ' months') = '1991-02-10'
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
 WHERE date("b"."DateOnly", CAST(3 AS TEXT) || ' days') = '1990-11-13'
+""");
+    }
+
+    public override async Task DayNumber_subtraction(bool async)
+    {
+        await base.DayNumber_subtraction(async);
+
+        AssertSql(
+            """
+@DayNumber='726775'
+
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST(julianday("b"."DateOnly") - julianday('0001-01-01') AS INTEGER) - @DayNumber = 5
 """);
     }
 


### PR DESCRIPTION
Tried to implement for Cosmos as well, but their [DateTimeDiff](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/datetimediff) function doesn't seem to work for timestamps before the year 1601 (and we need to calculate the number of days from `0001-01-01`.

Closes #36183
