### PR TITLE
[TINY] Update Azure SQL compat level to 170

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/AzureSqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/AzureSqlDbContextOptionsBuilder.cs
@@ -107,7 +107,7 @@ public class AzureSqlDbContextOptionsBuilder
 
     /// <summary>
     ///     Sets the Azure SQL compatibility level that EF Core will use when interacting with the database. This allows configuring EF
-    ///     Core to work with older (or newer) versions of Azure SQL. Defaults to <c>160</c>.
+    ///     Core to work with older (or newer) versions of Azure SQL. Defaults to <c>170</c>.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -21,18 +21,21 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
     private int? _azureSynapseCompatibilityLevel;
     private bool _useRetryingStrategyByDefault;
 
+    // For the SQL Server/Azure SQL compatibility levels, see
+    // https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level
+    // SQL Server 2025 (17.x): compatibility level 170 (default for Azure SQL, currently preview for on-prem)
+    // SQL Server 2022 (16.x): compatibility level 160, start date 2022-11-16, mainstream end date 2028-01-11, extended end date 2033-01-11
+    // SQL Server 2019 (15.x): compatibility level 150, start date 2019-11-04, mainstream end date 2025-02-28, extended end date 2030-01-08
+    // SQL Server 2017 (14.x): compatibility level 140, start date 2017-09-29, mainstream end date 2022-10-11, extended end date 2027-10-12
+    // SQL Server 2016 (13.x): compatibility level 130, start date 2016-06-01, mainstream end date 2021-07-13, extended end date 2026-07-14
+    // SQL Server 2014 (12.x): compatibility level 120, start date 2014-06-05, mainstream end date 2019-07-09, extended end date 2024-07-09
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    // See https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level
-    // SQL Server 2022 (16.x): compatibility level 160, start date 2022-11-16, mainstream end date 2028-01-11, extended end date 2033-01-11
-    // SQL Server 2019 (15.x): compatibility level 150, start date 2019-11-04, mainstream end date 2025-02-28, extended end date 2030-01-08
-    // SQL Server 2017 (14.x): compatibility level 140, start date 2017-09-29, mainstream end date 2022-10-11, extended end date 2027-10-12
-    // SQL Server 2016 (13.x): compatibility level 130, start date 2016-06-01, mainstream end date 2021-07-13, extended end date 2026-07-14
-    // SQL Server 2014 (12.x): compatibility level 120, start date 2014-06-05, mainstream end date 2019-07-09, extended end date 2024-07-09
     public static readonly int SqlServerDefaultCompatibilityLevel = 150;
 
     /// <summary>
@@ -41,13 +44,8 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    // See https://learn.microsoft.com/sql/t-sql/statements/alter-database-transact-sql-compatibility-level
-    // SQL Server 2022 (16.x): compatibility level 160, start date 2022-11-16, mainstream end date 2028-01-11, extended end date 2033-01-11
-    // SQL Server 2019 (15.x): compatibility level 150, start date 2019-11-04, mainstream end date 2025-02-28, extended end date 2030-01-08
-    // SQL Server 2017 (14.x): compatibility level 140, start date 2017-09-29, mainstream end date 2022-10-11, extended end date 2027-10-12
-    // SQL Server 2016 (13.x): compatibility level 130, start date 2016-06-01, mainstream end date 2021-07-13, extended end date 2026-07-14
-    // SQL Server 2014 (12.x): compatibility level 120, start date 2014-06-05, mainstream end date 2019-07-09, extended end date 2024-07-09
-    public static readonly int AzureSqlDefaultCompatibilityLevel = 150;
+    // Azure SQL compatibility levels are the same as SQL Server compatibility levels, see table above
+    public static readonly int AzureSqlDefaultCompatibilityLevel = 170;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to


### PR DESCRIPTION
This allows detecting e.g. support for Azure SQL regex support (see https://github.com/efcore/EFCore.CheckConstraints/pull/164).

Note that we have the option of bumping the default compatibility level for on-prem SQL Server to 160 (SQL Server 2022), but it may be a bit early for that (released 2022-11).