### PR TITLE
Stop moving pending selector after DefaultIfEmpty in nav expansion

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2378,20 +2378,25 @@ public sealed partial class SelectExpression : TableExpressionBase
         _tables.Add(dummySelectExpression);
         _tables.Add(joinTable);
 
+        // Go over all projected columns and make them nullable; for non-nullable value types, add a SQL COALESCE as well.
         var projectionMapping = new Dictionary<ProjectionMember, Expression>();
-        foreach (var projection in _projectionMapping)
+        foreach (var (projectionMember, projection) in _projectionMapping)
         {
-            var projectionToAdd = projection.Value;
-            if (projectionToAdd is StructuralTypeProjectionExpression typeProjection)
+            var newProjection = projection switch
             {
-                projectionToAdd = typeProjection.MakeNullable();
-            }
-            else if (projectionToAdd is ColumnExpression column)
+                StructuralTypeProjectionExpression p => p.MakeNullable(),
+                ColumnExpression column => column.MakeNullable(),
+                var p => p
+            };
+
+            if (newProjection is SqlExpression { Type: var type } newSqlProjection && !type.IsNullableType())
             {
-                projectionToAdd = column.MakeNullable();
+                newProjection = sqlExpressionFactory.Coalesce(
+                    newSqlProjection,
+                    sqlExpressionFactory.Constant(type.GetDefaultValue(), type));
             }
 
-            projectionMapping[projection.Key] = projectionToAdd;
+            projectionMapping[projectionMember] = newProjection;
         }
 
         // ChildIdentifiers shouldn't be required to be updated since during translation they should be empty.

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -2573,26 +2573,26 @@ FROM root c
         AssertSql();
     }
 
-    public override async Task Average_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Average_after_DefaultIfEmpty_does_not_throw(bool async)
     {
         // Contains over subquery. Issue #17246.
-        await AssertTranslationFailed(() => base.Average_after_default_if_empty_does_not_throw(async));
+        await AssertTranslationFailed(() => base.Average_after_DefaultIfEmpty_does_not_throw(async));
 
         AssertSql();
     }
 
-    public override async Task Max_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Max_after_DefaultIfEmpty_does_not_throw(bool async)
     {
         // Contains over subquery. Issue #17246.
-        await AssertTranslationFailed(() => base.Max_after_default_if_empty_does_not_throw(async));
+        await AssertTranslationFailed(() => base.Max_after_DefaultIfEmpty_does_not_throw(async));
 
         AssertSql();
     }
 
-    public override async Task Min_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Min_after_DefaultIfEmpty_does_not_throw(bool async)
     {
         // Contains over subquery. Issue #17246.
-        await AssertTranslationFailed(() => base.Min_after_default_if_empty_does_not_throw(async));
+        await AssertTranslationFailed(() => base.Min_after_DefaultIfEmpty_does_not_throw(async));
 
         AssertSql();
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -202,56 +202,64 @@ WHERE (c["id"] != null)
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level(bool async)
+    public override async Task DefaultIfEmpty_top_level(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Default_if_empty_top_level(async));
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level(async));
 
         AssertSql();
     }
 
-    public override async Task Join_with_default_if_empty_on_both_sources(bool async)
+    public override async Task Join_with_DefaultIfEmpty_on_both_sources(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Join_with_default_if_empty_on_both_sources(async));
+        await AssertTranslationFailed(() => base.Join_with_DefaultIfEmpty_on_both_sources(async));
 
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool async)
+    public override async Task DefaultIfEmpty_top_level_followed_by_constant_Select(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Default_if_empty_top_level_followed_by_projecting_constant(async));
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_followed_by_constant_Select(async));
 
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level_positive(bool async)
+    public override async Task DefaultIfEmpty_top_level_preceded_by_constant_Select(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Default_if_empty_top_level_positive(async));
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_preceded_by_constant_Select(async));
 
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level_arg(bool async)
-    {
-        await base.Default_if_empty_top_level_arg(async);
-
-        AssertSql();
-    }
-
-    public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
-    {
-        await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(async);
-
-        AssertSql();
-    }
-
-    public override async Task Default_if_empty_top_level_projection(bool async)
+    public override async Task DefaultIfEmpty_top_level_positive(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Default_if_empty_top_level_projection(async));
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_positive(async));
+
+        AssertSql();
+    }
+
+    public override async Task DefaultIfEmpty_top_level_arg(bool async)
+    {
+        await base.DefaultIfEmpty_top_level_arg(async);
+
+        AssertSql();
+    }
+
+    public override async Task DefaultIfEmpty_top_level_arg_followed_by_projecting_constant(bool async)
+    {
+        await base.DefaultIfEmpty_top_level_arg_followed_by_projecting_constant(async);
+
+        AssertSql();
+    }
+
+    public override async Task DefaultIfEmpty_top_level_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_projection(async));
 
         AssertSql();
     }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
@@ -14,8 +14,4 @@ public class NorthwindSelectQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noop
             () => base
                 .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
                     async));
-
-    public override async Task SelectMany_correlated_with_outer_3(bool async)
-        // DefaultIfEmpty. Issue #17536.
-        => await Assert.ThrowsAsync<EqualException>(() => base.SelectMany_correlated_with_outer_3(async));
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1899,21 +1899,21 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Average_after_default_if_empty_does_not_throw(bool async)
+    public virtual Task Average_after_DefaultIfEmpty_does_not_throw(bool async)
         => AssertAverage(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Max_after_default_if_empty_does_not_throw(bool async)
+    public virtual Task Max_after_DefaultIfEmpty_does_not_throw(bool async)
         => AssertMax(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Min_after_default_if_empty_does_not_throw(bool async)
+    public virtual Task Min_after_DefaultIfEmpty_does_not_throw(bool async)
         => AssertMin(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -2232,60 +2232,69 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level(bool async)
+    public virtual Task DefaultIfEmpty_top_level(bool async)
         => AssertQuery(
             async,
-            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
-                  select e);
+            ss => ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Join_with_default_if_empty_on_both_sources(bool async)
+    public virtual Task Join_with_DefaultIfEmpty_on_both_sources(bool async)
         => AssertQuery(
             async,
-            ss => (from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
-                   select e).Join(
-                from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
-                select e, o => o, i => i, (o, i) => o),
+            ss => ss.Set<Employee>()
+                .Where(c => c.EmployeeID == NonExistentID)
+                .DefaultIfEmpty()
+                .Join(
+                    ss.Set<Employee>()
+                        .Where(c => c.EmployeeID == NonExistentID)
+                        .DefaultIfEmpty(),
+                    o => o, i => i, (o, i) => o),
             assertEmpty: true);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level_followed_by_projecting_constant(bool async)
+    public virtual Task DefaultIfEmpty_top_level_followed_by_constant_Select(bool async)
         => AssertQuery(
             async,
-            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
-                  select "Foo");
+            ss => ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty().Select(_ => "Foo"));
+
+    [ConditionalTheory] // #36208
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task DefaultIfEmpty_top_level_preceded_by_constant_Select(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Employee>().Where(e => e.EmployeeID == NonExistentID).Select(_ => "Foo").DefaultIfEmpty());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level_arg(bool async)
+    public virtual Task DefaultIfEmpty_top_level_arg(bool async)
         => AssertTranslationFailed(
             () => AssertQuery(
                 async,
-                ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
-                      select e));
+                ss => ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
+    public virtual Task DefaultIfEmpty_top_level_arg_followed_by_projecting_constant(bool async)
         => AssertTranslationFailed(
             () => AssertQueryScalar(
                 async,
-                ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
-                      select 42));
+                ss => ss.Set<Employee>()
+                    .Where(c => c.EmployeeID == NonExistentID)
+                    .DefaultIfEmpty(new Employee())
+                    .Select(_ => 42)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level_positive(bool async)
+    public virtual Task DefaultIfEmpty_top_level_positive(bool async)
         => AssertQuery(
             async,
-            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID > 0).DefaultIfEmpty()
-                  select e);
+            ss => ss.Set<Employee>().Where(c => c.EmployeeID > 0).DefaultIfEmpty());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Default_if_empty_top_level_projection(bool async)
+    public virtual Task DefaultIfEmpty_top_level_projection(bool async)
         => AssertQueryScalar(
             async,
             ss => from e in ss.Set<Employee>().Where(e => e.EmployeeID == NonExistentID).Select(e => e.EmployeeID).DefaultIfEmpty()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -152,9 +152,9 @@ WHERE [o].[OrderID] = 10248
 """);
     }
 
-    public override async Task Average_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Average_after_DefaultIfEmpty_does_not_throw(bool async)
     {
-        await base.Average_after_default_if_empty_does_not_throw(async);
+        await base.Average_after_DefaultIfEmpty_does_not_throw(async);
 
         AssertSql(
             """
@@ -170,9 +170,9 @@ LEFT JOIN (
 """);
     }
 
-    public override async Task Max_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Max_after_DefaultIfEmpty_does_not_throw(bool async)
     {
-        await base.Max_after_default_if_empty_does_not_throw(async);
+        await base.Max_after_DefaultIfEmpty_does_not_throw(async);
 
         AssertSql(
             """
@@ -188,9 +188,9 @@ LEFT JOIN (
 """);
     }
 
-    public override async Task Min_after_default_if_empty_does_not_throw(bool async)
+    public override async Task Min_after_DefaultIfEmpty_does_not_throw(bool async)
     {
-        await base.Min_after_default_if_empty_does_not_throw(async);
+        await base.Min_after_DefaultIfEmpty_does_not_throw(async);
 
         AssertSql(
             """

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -378,9 +378,9 @@ ORDER BY (
 """);
     }
 
-    public override async Task Default_if_empty_top_level(bool async)
+    public override async Task DefaultIfEmpty_top_level(bool async)
     {
-        await base.Default_if_empty_top_level(async);
+        await base.DefaultIfEmpty_top_level(async);
 
         AssertSql(
             """
@@ -396,9 +396,9 @@ LEFT JOIN (
 """);
     }
 
-    public override async Task Join_with_default_if_empty_on_both_sources(bool async)
+    public override async Task Join_with_DefaultIfEmpty_on_both_sources(bool async)
     {
-        await base.Join_with_default_if_empty_on_both_sources(async);
+        await base.Join_with_DefaultIfEmpty_on_both_sources(async);
 
         AssertSql(
             """
@@ -425,9 +425,9 @@ INNER JOIN (
 """);
     }
 
-    public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool async)
+    public override async Task DefaultIfEmpty_top_level_followed_by_constant_Select(bool async)
     {
-        await base.Default_if_empty_top_level_followed_by_projecting_constant(async);
+        await base.DefaultIfEmpty_top_level_followed_by_constant_Select(async);
 
         AssertSql(
             """
@@ -443,9 +443,27 @@ LEFT JOIN (
 """);
     }
 
-    public override async Task Default_if_empty_top_level_positive(bool async)
+    public override async Task DefaultIfEmpty_top_level_preceded_by_constant_Select(bool async)
     {
-        await base.Default_if_empty_top_level_positive(async);
+        await base.DefaultIfEmpty_top_level_preceded_by_constant_Select(async);
+
+        AssertSql(
+            """
+SELECT [e1].[c]
+FROM (
+    SELECT 1 AS empty
+) AS [e0]
+LEFT JOIN (
+    SELECT N'Foo' AS [c]
+    FROM [Employees] AS [e]
+    WHERE [e].[EmployeeID] = -1
+) AS [e1] ON 1 = 1
+""");
+    }
+
+    public override async Task DefaultIfEmpty_top_level_positive(bool async)
+    {
+        await base.DefaultIfEmpty_top_level_positive(async);
 
         AssertSql(
             """
@@ -461,9 +479,9 @@ LEFT JOIN (
 """);
     }
 
-    public override async Task Default_if_empty_top_level_projection(bool async)
+    public override async Task DefaultIfEmpty_top_level_projection(bool async)
     {
-        await base.Default_if_empty_top_level_projection(async);
+        await base.DefaultIfEmpty_top_level_projection(async);
 
         AssertSql(
             """
@@ -6794,16 +6812,16 @@ FROM [Orders] AS [o]
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level_arg(bool async)
+    public override async Task DefaultIfEmpty_top_level_arg(bool async)
     {
-        await base.Default_if_empty_top_level_arg(async);
+        await base.DefaultIfEmpty_top_level_arg(async);
 
         AssertSql();
     }
 
-    public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
+    public override async Task DefaultIfEmpty_top_level_arg_followed_by_projecting_constant(bool async)
     {
-        await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(async);
+        await base.DefaultIfEmpty_top_level_arg_followed_by_projecting_constant(async);
 
         AssertSql();
     }


### PR DESCRIPTION
This changes the NavigationExpandingExpressionVisitor around DefaultIfEmpty, applying any pending selector; this prevents any Select prior to the DIE from being moved after it.

This unfortunately caused some complications... Nav expansion was also previously responsible for adding a coalesce for value types, and relied on the fact that the Select gets moved after the DIE. Now that the Select stays before the DIE, the coalesce gets optimized away as it's not yet needed (the column hasn't yet been made nullable by DIE).

This logic doesn't strictly-speaking belong in nav expansion (or anywhere in preprocessing), and this PR moves it to the translation phase of DIE instead (translation was already handling making projected columns nullable, and is the right place for also applying a COALESCE when necessary).

Fixes #36208
