### PR TITLE
Take lambda parameter names into account in lambda comparisons

### DIFF
--- a/src/EFCore/Query/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/ExpressionEqualityComparer.cs
@@ -405,7 +405,7 @@ public sealed class ExpressionEqualityComparer : IEqualityComparer<Expression?>
             {
                 var (p1, p2) = (a.Parameters[i], b.Parameters[i]);
 
-                if (p1.Type != p2.Type)
+                if (p1.Type != p2.Type || p1.Name != p2.Name)
                 {
                     for (var j = 0; j < i; j++)
                     {

--- a/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using JetBrains.Annotations;
+using static System.Linq.Expressions.Expression;
 
 // ReSharper disable AssignNullToNotNullAttribute
 
@@ -16,25 +17,21 @@ public class ExpressionEqualityComparerTest
 
         var addMethod = typeof(List<string>).GetTypeInfo().GetDeclaredMethod("Add");
 
-        var bindingMessages = Expression.ListBind(
+        var bindingMessages = ListBind(
             typeof(Node).GetProperty("Messages"),
-            Expression.ElementInit(addMethod, Expression.Constant("Constant1"))
-        );
+            ElementInit(addMethod, Constant("Constant1")));
 
-        var bindingDescriptions = Expression.ListBind(
+        var bindingDescriptions = ListBind(
             typeof(Node).GetProperty("Descriptions"),
-            Expression.ElementInit(addMethod, Expression.Constant("Constant2"))
-        );
+            ElementInit(addMethod, Constant("Constant2")));
 
-        Expression e1 = Expression.MemberInit(
-            Expression.New(typeof(Node)),
-            new List<MemberBinding> { bindingMessages }
-        );
+        Expression e1 = MemberInit(
+            New(typeof(Node)),
+            new List<MemberBinding> { bindingMessages });
 
-        Expression e2 = Expression.MemberInit(
-            Expression.New(typeof(Node)),
-            new List<MemberBinding> { bindingMessages, bindingDescriptions }
-        );
+        Expression e2 = MemberInit(
+            New(typeof(Node)),
+            new List<MemberBinding> { bindingMessages, bindingDescriptions });
 
         Assert.NotEqual(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e2));
         Assert.False(expressionComparer.Equals(e1, e2));
@@ -47,9 +44,9 @@ public class ExpressionEqualityComparerTest
     {
         var expressionComparer = ExpressionEqualityComparer.Instance;
 
-        Expression e1 = Expression.Default(typeof(int));
-        Expression e2 = Expression.Default(typeof(int));
-        Expression e3 = Expression.Default(typeof(string));
+        Expression e1 = Default(typeof(int));
+        Expression e2 = Default(typeof(int));
+        Expression e3 = Default(typeof(string));
 
         Assert.Equal(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e2));
         Assert.NotEqual(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e3));
@@ -64,11 +61,11 @@ public class ExpressionEqualityComparerTest
     {
         var expressionComparer = ExpressionEqualityComparer.Instance;
 
-        var param = Expression.Parameter(typeof(Indexable));
+        var param = Parameter(typeof(Indexable));
         var prop = typeof(Indexable).GetProperty("Item");
-        var e1 = Expression.MakeIndex(param, prop, new Expression[] { Expression.Constant(1) });
-        var e2 = Expression.MakeIndex(param, prop, new Expression[] { Expression.Constant(2) });
-        var e3 = Expression.MakeIndex(param, prop, new Expression[] { Expression.Constant(2) });
+        var e1 = MakeIndex(param, prop, [Constant(1)]);
+        var e2 = MakeIndex(param, prop, [Constant(2)]);
+        var e3 = MakeIndex(param, prop, [Constant(2)]);
 
         Assert.Equal(ExpressionType.Index, e1.NodeType);
         Assert.NotNull(e1.Indexer);
@@ -79,10 +76,10 @@ public class ExpressionEqualityComparerTest
         Assert.Equal(expressionComparer.GetHashCode(e2), expressionComparer.GetHashCode(e3));
         Assert.True(expressionComparer.Equals(e2, e3));
 
-        param = Expression.Parameter(typeof(int[]));
-        e1 = Expression.ArrayAccess(param, Expression.Constant(1));
-        e2 = Expression.ArrayAccess(param, Expression.Constant(2));
-        e3 = Expression.ArrayAccess(param, Expression.Constant(2));
+        param = Parameter(typeof(int[]));
+        e1 = ArrayAccess(param, Constant(1));
+        e2 = ArrayAccess(param, Constant(2));
+        e3 = ArrayAccess(param, Constant(2));
 
         Assert.Equal(ExpressionType.Index, e1.NodeType);
         Assert.Null(e1.Indexer);
@@ -99,15 +96,31 @@ public class ExpressionEqualityComparerTest
     {
         var expressionComparer = ExpressionEqualityComparer.Instance;
 
-        var e1 = Expression.Constant(new[] { 1, 2, 3 });
-        var e2 = Expression.Constant(new[] { 1, 2, 3 });
-        var e3 = Expression.Constant(new[] { 1, 2, 4 });
+        var e1 = Constant(new[] { 1, 2, 3 });
+        var e2 = Constant(new[] { 1, 2, 3 });
+        var e3 = Constant(new[] { 1, 2, 4 });
 
         Assert.True(expressionComparer.Equals(e1, e2));
         Assert.False(expressionComparer.Equals(e1, e3));
 
         Assert.Equal(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e2));
         Assert.NotEqual(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e3));
+    }
+
+    [ConditionalFact] // #30697
+    public void Lambda_parameters_names_are_taken_into_account()
+    {
+        var expressionComparer = ExpressionEqualityComparer.Instance;
+
+        Expression<Func<int, int>> lambda1 = x => 1;
+        Expression<Func<int, int>> lambda2 = x => 1;
+        Expression<Func<int, int>> lambda3 = y => 1;
+
+        Assert.True(expressionComparer.Equals(lambda1, lambda2));
+        Assert.False(expressionComparer.Equals(lambda1, lambda3));
+
+        Assert.Equal(expressionComparer.GetHashCode(lambda1), expressionComparer.GetHashCode(lambda2));
+        Assert.NotEqual(expressionComparer.GetHashCode(lambda1), expressionComparer.GetHashCode(lambda3));
     }
 
     private class Node


### PR DESCRIPTION
See previous alternative approach in #30755.

Closes #30697

/cc @aradalvand