### PR TITLE
Pass DbContext to RelationalCommandParameterObject

### DIFF
--- a/src/EFCore.Relational/Query/Internal/GroupBySingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/GroupBySingleQueryingEnumerable.cs
@@ -145,7 +145,7 @@ public class GroupBySingleQueryingEnumerable<TKey, TElement>
                     _relationalQueryContext.Connection,
                     _relationalQueryContext.Parameters,
                     null,
-                    null,
+                    _relationalQueryContext.Context,
                     null, CommandSource.LinqQuery),
                 Guid.Empty,
                 (DbCommandMethod)(-1));

--- a/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
@@ -155,7 +155,7 @@ public class GroupBySplitQueryingEnumerable<TKey, TElement>
                     _relationalQueryContext.Connection,
                     _relationalQueryContext.Parameters,
                     null,
-                    null,
+                    _relationalQueryContext.Context,
                     null, CommandSource.LinqQuery),
                 Guid.Empty,
                 (DbCommandMethod)(-1));

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -129,7 +129,7 @@ public class SingleQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     _relationalQueryContext.Connection,
                     _relationalQueryContext.Parameters,
                     null,
-                    null,
+                    _relationalQueryContext.Context,
                     null, CommandSource.LinqQuery),
                 Guid.Empty,
                 (DbCommandMethod)(-1));

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
@@ -52,7 +52,7 @@ public class SqliteDatabaseCreator : RelationalDatabaseCreator
                     Dependencies.Connection,
                     null,
                     null,
-                    null,
+                    Dependencies.CurrentContext.Context,
                     Dependencies.CommandLogger, CommandSource.Migrations));
 
         Dependencies.Connection.Close();
@@ -101,7 +101,7 @@ public class SqliteDatabaseCreator : RelationalDatabaseCreator
                     Dependencies.Connection,
                     null,
                     null,
-                    null,
+                    Dependencies.CurrentContext.Context,
                     Dependencies.CommandLogger, CommandSource.Migrations))!;
 
         return count != 0;


### PR DESCRIPTION
Make `DbContext` available from `RelationalCommandParameterObject` for interception with SQLite and querying enumerables.

The functionality to add the context to the interception was added originally by #16162, but the context wasn't passed through for SQLite for some reason.

I found this by chance via some changes for OpenTelemetry in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2829 where an exception was being thrown internally due to an assumption that the context is always non-null [here](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/2fa2fdc84a1e1769263be2a54a7f7c0a2ed953da/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs#L84) and [here](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/2fa2fdc84a1e1769263be2a54a7f7c0a2ed953da/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs#L183).

It's used in `SqliteHistoryRepository` here, but not in the other two locations for SQLite, which this PR changes.

https://github.com/dotnet/efcore/blob/0e9f58b8163ee4c8cbc9117887f85a2c7096e620/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs#L225

While I was at it, I looked at all the other call sites for the constructor and changed any that had access to the DbContext but also just passed through null.

I haven't added any tests for this as it wasn't obvious to me where to add/edit existing tests for this. There wasn't any obvious SQLite-specific place to put tests based on reviewing the diff from #16162. I can add some if some guidance is provided on where they should go.

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo
