### PR TITLE
Add complex collection support to PropertyValues

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -83,6 +83,14 @@ public class CosmosModelValidator : ModelValidator
 
             foreach (var complexProperty in typeBase.GetDeclaredComplexProperties())
             {
+                if (complexProperty.IsCollection)
+                {
+                    throw new InvalidOperationException(
+                        CosmosStrings.ComplexTypeCollectionsNotSupported(
+                            complexProperty.ComplexType.ShortName(),
+                            complexProperty.Name));
+                }
+
                 ValidateType(complexProperty.ComplexType, logger);
             }
         }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -54,6 +54,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("CanConnectNotSupported");
 
         /// <summary>
+        ///     Complex projections in subqueries are currently unsupported.
+        /// </summary>
+        public static string ComplexProjectionInSubqueryNotSupported
+            => GetString("ComplexProjectionInSubqueryNotSupported");
+
+        /// <summary>
+        ///     Complex type collections are currently not supported in Cosmos. Consider using owned type collections. Complex type: '{complexType}', property: '{property}'. See https://github.com/dotnet/efcore/issues/31253 for more details.
+        /// </summary>
+        public static string ComplexTypeCollectionsNotSupported(object? complexType, object? property)
+            => string.Format(
+                GetString("ComplexTypeCollectionsNotSupported", nameof(complexType), nameof(property)),
+                complexType, property);
+
+        /// <summary>
         ///     A full-text index on '{entityType}' is defined over multiple properties (`{properties}`). A full-text index can only target a single property.
         /// </summary>
         public static string CompositeFullTextIndex(object? entityType, object? properties)
@@ -68,12 +82,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("CompositeVectorIndex", nameof(entityType), nameof(properties)),
                 entityType, properties);
-
-        /// <summary>
-        ///     Complex projections in subqueries are currently unsupported.
-        /// </summary>
-        public static string ComplexProjectionInSubqueryNotSupported
-            => GetString("ComplexProjectionInSubqueryNotSupported");
 
         /// <summary>
         ///     None of connection string, CredentialToken, account key or account endpoint were specified. Specify a set of connection details.
@@ -438,14 +446,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 propertyType, entityType, property, valueType);
 
         /// <summary>
-        ///     A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.
-        /// </summary>
-        public static string PartitionKeyNotOnRoot(object? entityType, object? baseEntityType)
-            => string.Format(
-                GetString("PartitionKeyNotOnRoot", nameof(entityType), nameof(baseEntityType)),
-                entityType, baseEntityType);
-
-        /// <summary>
         ///     Unable to execute a 'ReadItem' query since the partition key value is missing. Consider using the 'WithPartitionKey' method on the query to specify partition key to use.
         /// </summary>
         public static string PartitionKeyMissing
@@ -458,6 +458,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("PartitionKeyMissingProperty", nameof(entityType), nameof(property)),
                 entityType, property);
+
+        /// <summary>
+        ///     A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.
+        /// </summary>
+        public static string PartitionKeyNotOnRoot(object? entityType, object? baseEntityType)
+            => string.Format(
+                GetString("PartitionKeyNotOnRoot", nameof(entityType), nameof(baseEntityType)),
+                entityType, baseEntityType);
 
         /// <summary>
         ///     The partition key property '{property1}' on '{entityType1}' is mapped as '{storeName1}', but the partition key property '{property2}' on '{entityType2}' is mapped as '{storeName2}'. All partition key properties need to be mapped to the same store property for entity types mapped to the same container.
@@ -480,6 +488,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("ReverseAfterSkipTakeNotSupported");
 
         /// <summary>
+        ///     SingleOrDefault and FirstOrDefault cannot be used Cosmos SQL does not allow Offset without Limit. Consider specifying a 'Take' operation on the query.
+        /// </summary>
+        public static string SingleFirstOrDefaultNotSupportedOnNonNullableQueries
+            => GetString("SingleFirstOrDefaultNotSupportedOnNonNullableQueries");
+
+        /// <summary>
         ///     The provisioned throughput was configured to '{throughput1}' on '{entityType1}', but on '{entityType2}' it was configured to '{throughput2}'. All entity types mapped to the same container '{container}' must be configured with the same provisioned throughput.
         /// </summary>
         public static string ThroughputMismatch(object? throughput1, object? entityType1, object? entityType2, object? throughput2, object? container)
@@ -488,18 +502,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 throughput1, entityType1, entityType2, throughput2, container);
 
         /// <summary>
-        ///     'ToPageAsync' can only be used as the terminating operator of the top-level query.
-        /// </summary>
-        public static string ToPageAsyncAtTopLevelOnly
-            => GetString("ToPageAsyncAtTopLevelOnly");
-
-        /// <summary>
         ///     The provisioned throughput was configured as manual on '{manualEntityType}', but on '{autoscaleEntityType}' it was configured as autoscale. All entity types mapped to the same container '{container}' must be configured with the same provisioned throughput type.
         /// </summary>
         public static string ThroughputTypeMismatch(object? manualEntityType, object? autoscaleEntityType, object? container)
             => string.Format(
                 GetString("ThroughputTypeMismatch", nameof(manualEntityType), nameof(autoscaleEntityType), nameof(container)),
                 manualEntityType, autoscaleEntityType, container);
+
+        /// <summary>
+        ///     'ToPageAsync' can only be used as the terminating operator of the top-level query.
+        /// </summary>
+        public static string ToPageAsyncAtTopLevelOnly
+            => GetString("ToPageAsyncAtTopLevelOnly");
 
         /// <summary>
         ///     The Cosmos database provider does not support transactions.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -131,6 +131,9 @@
   </data>
   <data name="ComplexProjectionInSubqueryNotSupported" xml:space="preserve">
     <value>Complex projections in subqueries are currently unsupported.</value>
+  </data>
+  <data name="ComplexTypeCollectionsNotSupported" xml:space="preserve">
+    <value>Complex type collections are currently not supported in Cosmos. Consider using owned type collections. Complex type: '{complexType}', property: '{property}'. See https://github.com/dotnet/efcore/issues/31253 for more details.</value>
   </data>
   <data name="CompositeFullTextIndex" xml:space="preserve">
     <value>A full-text index on '{entityType}' is defined over multiple properties (`{properties}`). A full-text index can only target a single property.</value>
@@ -322,14 +325,14 @@
   <data name="PartitionKeyBadValueType" xml:space="preserve">
     <value>The partition key value supplied for '{propertyType}' property '{entityType}.{property}' is of type '{valueType}'. Partition key values must be of a type assignable to the property.</value>
   </data>
-  <data name="PartitionKeyNotOnRoot" xml:space="preserve">
-    <value>A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.</value>
-  </data>
   <data name="PartitionKeyMissing" xml:space="preserve">
     <value>Unable to execute a 'ReadItem' query since the partition key value is missing. Consider using the 'WithPartitionKey' method on the query to specify partition key to use.</value>
   </data>
   <data name="PartitionKeyMissingProperty" xml:space="preserve">
     <value>The partition key for entity type '{entityType}' is set to '{property}', but there is no property with that name.</value>
+  </data>
+  <data name="PartitionKeyNotOnRoot" xml:space="preserve">
+    <value>A partition key is defined on entity type '{entityType}', which inherits from '{baseEntityType}'. Partition keys must be defined on the root entity type of a hierarchy.</value>
   </data>
   <data name="PartitionKeyStoreNameMismatch" xml:space="preserve">
     <value>The partition key property '{property1}' on '{entityType1}' is mapped as '{storeName1}', but the partition key property '{property2}' on '{entityType2}' is mapped as '{storeName2}'. All partition key properties need to be mapped to the same store property for entity types mapped to the same container.</value>

--- a/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -15,6 +17,8 @@ public class ArrayPropertyValues : PropertyValues
 {
     private readonly object?[] _values;
     private IReadOnlyList<IProperty>? _properties;
+    private readonly List<ArrayPropertyValues?>?[] _complexCollectionValues;
+    private IReadOnlyList<IComplexProperty>? _complexCollectionProperties;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -22,9 +26,12 @@ public class ArrayPropertyValues : PropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public ArrayPropertyValues(InternalEntityEntry internalEntry, object?[] values)
+    public ArrayPropertyValues(InternalEntryBase internalEntry, object?[] values)
         : base(internalEntry)
-        => _values = values;
+    {
+        _values = values;
+        _complexCollectionValues = new List<ArrayPropertyValues?>?[ComplexCollectionProperties.Count];
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -33,10 +40,42 @@ public class ArrayPropertyValues : PropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override object ToObject()
-        => EntityType.GetOrCreateMaterializer(MaterializerSource)(
-            new MaterializationContext(
-                new ValueBuffer(_values),
-                InternalEntry.Context));
+    {
+        var structuralObject = StructuralType.GetOrCreateMaterializer(MaterializerSource)(
+            new MaterializationContext(new ValueBuffer(_values), InternalEntry.Context));
+
+        ComplexValuesToObject(structuralObject);
+
+        return structuralObject;
+    }
+
+    private object ComplexValuesToObject(object containingObject)
+    {
+        if (_complexCollectionValues == null)
+        {
+            return containingObject;
+        }
+
+        for (var i = 0; i < _complexCollectionValues.Length; i++)
+        {
+            var propertyValuesList = _complexCollectionValues[i];
+            if (propertyValuesList == null)
+            {
+                continue;
+            }
+
+            var complexProperty = ComplexCollectionProperties[i];
+            var list = (IList)((IRuntimeComplexProperty)complexProperty).GetIndexedCollectionAccessor().Create(propertyValuesList.Count);
+            containingObject = ((IRuntimeComplexProperty)complexProperty).GetSetter().SetClrValue(containingObject, list);
+
+            foreach (var propertyValues in propertyValuesList)
+            {
+                list.Add(propertyValues?.ToObject() ?? complexProperty.ComplexType.ClrType.GetDefaultValue());
+            }
+        }
+
+        return containingObject;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,7 +87,7 @@ public class ArrayPropertyValues : PropertyValues
     {
         Check.NotNull(obj);
 
-        if (obj.GetType() == EntityType.ClrType)
+        if (obj.GetType() == StructuralType.ClrType)
         {
             for (var i = 0; i < _values.Length; i++)
             {
@@ -56,6 +95,17 @@ public class ArrayPropertyValues : PropertyValues
                 {
                     SetValue(i, Properties[i].GetGetter().GetClrValueUsingContainingEntity(obj));
                 }
+            }
+
+            foreach (var complexProperty in ComplexCollectionProperties)
+            {
+                if (complexProperty.IsShadowProperty())
+                {
+                    continue;
+                }
+
+                var list = (IList?)complexProperty.GetGetter().GetClrValueUsingContainingEntity(obj);
+                _complexCollectionValues[complexProperty.GetIndex()] = GetComplexCollectionPropertyValues(complexProperty, list);
             }
         }
         else
@@ -66,6 +116,17 @@ public class ArrayPropertyValues : PropertyValues
                 if (getter != null)
                 {
                     SetValue(i, getter.GetValue(obj));
+                }
+            }
+
+            foreach (var complexProperty in ComplexCollectionProperties)
+            {
+                var getter = obj.GetType().GetAnyProperty(complexProperty.Name)?.FindGetterProperty();
+                if (getter != null)
+                {
+                    var complexCollection = (IList?)getter.GetValue(obj);
+                    var propertyValuesList = GetComplexCollectionPropertyValues(complexProperty, complexCollection);
+                    _complexCollectionValues[complexProperty.GetIndex()] = propertyValuesList;
                 }
             }
         }
@@ -82,7 +143,25 @@ public class ArrayPropertyValues : PropertyValues
         var copies = new object[_values.Length];
         Array.Copy(_values, copies, _values.Length);
 
-        return new ArrayPropertyValues(InternalEntry, copies);
+        var clone = new ArrayPropertyValues(InternalEntry, copies);
+        if (_complexCollectionValues != null)
+        {
+            for (var i = 0; i < _complexCollectionValues.Length; i++)
+            {
+                var list = _complexCollectionValues[i];
+                if (list != null)
+                {
+                    var clonedList = new List<ArrayPropertyValues?>();
+                    foreach (var propertyValues in list)
+                    {
+                        clonedList.Add((ArrayPropertyValues?)propertyValues?.Clone());
+                    }
+                    clone._complexCollectionValues[i] = clonedList;
+                }
+            }
+        }
+
+        return clone;
     }
 
     /// <summary>
@@ -99,6 +178,12 @@ public class ArrayPropertyValues : PropertyValues
         {
             SetValue(i, propertyValues[Properties[i]]);
         }
+
+        for (var i = 0; i < _complexCollectionValues.Length; i++)
+        {
+            var list = propertyValues[ComplexCollectionProperties[i]];
+            _complexCollectionValues[i] = GetComplexCollectionPropertyValues(ComplexCollectionProperties[i], list);
+        }
     }
 
     /// <summary>
@@ -108,7 +193,41 @@ public class ArrayPropertyValues : PropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override IReadOnlyList<IProperty> Properties
-        => _properties ??= EntityType.GetFlattenedProperties().ToList();
+    {
+        [DebuggerStepThrough]
+        get
+        {
+            if (_properties == null)
+            {
+                _properties = [.. StructuralType.GetFlattenedProperties()];
+                Check.DebugAssert(_properties.Select((p, i) => p.GetIndex() == i).All(e => e));
+            }
+
+            return _properties;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override IReadOnlyList<IComplexProperty> ComplexCollectionProperties
+    {
+        [DebuggerStepThrough]
+        get
+        {
+            if (_complexCollectionProperties == null)
+            {
+                _complexCollectionProperties = [.. StructuralType.GetFlattenedComplexProperties().Where(p => p.IsCollection)];
+                Check.DebugAssert(
+                    _complexCollectionProperties.Select((p, i) => p.GetIndex() == i).All(e => e),
+                    "Complex collection properties indices are not sequential.");
+            }
+            return _complexCollectionProperties;
+        }
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -118,8 +237,44 @@ public class ArrayPropertyValues : PropertyValues
     /// </summary>
     public override object? this[string propertyName]
     {
-        get => _values[EntityType.GetProperty(propertyName).GetIndex()];
-        set => SetValue(EntityType.GetProperty(propertyName).GetIndex(), value);
+        get
+        {
+            var property = StructuralType.FindProperty(propertyName);
+            if (property != null)
+            {
+                return _values[property.GetIndex()];
+            }
+
+            var complexProperty = StructuralType.FindComplexProperty(propertyName);
+            if (complexProperty != null)
+            {
+                return this[complexProperty];
+            }
+
+            // If neither found this will throw an appropriate exception
+            return _values[StructuralType.GetProperty(propertyName).GetIndex()];
+        }
+        set
+        {
+            var property = StructuralType.FindProperty(propertyName);
+            if (property != null)
+            {
+                SetValue(property.GetIndex(), value);
+                return;
+            }
+
+            var complexProperty = StructuralType.FindComplexProperty(propertyName);
+            if (complexProperty != null)
+            {
+                if (complexProperty.IsCollection && value is List<ArrayPropertyValues?> propertyValuesList)
+                {
+                    _complexCollectionValues[complexProperty.GetIndex()] = propertyValuesList;
+                }
+            }
+
+            // If neither found this will throw an appropriate exception
+            SetValue(StructuralType.GetProperty(propertyName).GetIndex(), value);
+        }
     }
 
     /// <summary>
@@ -130,8 +285,122 @@ public class ArrayPropertyValues : PropertyValues
     /// </summary>
     public override object? this[IProperty property]
     {
-        get => _values[EntityType.CheckContains(property).GetIndex()];
-        set => SetValue(EntityType.CheckContains(property).GetIndex(), value);
+        get => _values[StructuralType.CheckContains(property).GetIndex()];
+        set => SetValue(StructuralType.CheckContains(property).GetIndex(), value);
+    }
+
+    /// <summary>
+    ///     Gets or sets the value of the complex collection.
+    /// </summary>
+    /// <param name="complexProperty">The complex collection property.</param>
+    /// <returns>A list of complex objects, not PropertyValues.</returns>
+    public override IList? this[IComplexProperty complexProperty]
+    {
+        get
+        {
+            CheckCollection(complexProperty);
+
+            var propertyValuesList = _complexCollectionValues?[complexProperty.GetIndex()];
+            if (propertyValuesList == null)
+            {
+                return null;
+            }
+
+            var complexObjectsList = (IList)((IRuntimePropertyBase)complexProperty).GetIndexedCollectionAccessor().Create(propertyValuesList.Count);
+            foreach (var propertyValues in propertyValuesList)
+            {
+                complexObjectsList.Add(propertyValues?.ToObject());
+            }
+
+            return complexObjectsList;
+        }
+
+        set => SetComplexCollectionValue(CheckCollection(complexProperty), GetComplexCollectionPropertyValues(complexProperty, value));
+    }
+
+    /// <inheritdoc/>
+    public override void SetValues<TProperty>(IDictionary<string, TProperty> values)
+        => SetValuesFromDictionary((IRuntimeTypeBase)StructuralType, Check.NotNull(values));
+
+    private void SetValuesFromDictionary<TProperty>(IRuntimeTypeBase structuralType, IDictionary<string, TProperty> values)
+    {
+        foreach (var property in structuralType.GetProperties())
+        {
+            if (values.TryGetValue(property.Name, out var value))
+            {
+                this[property] = value;
+            }
+        }
+
+        foreach (var complexProperty in structuralType.GetComplexProperties())
+        {
+            if (!values.TryGetValue(complexProperty.Name, out var complexValue))
+            {
+                continue;
+            }
+
+            if (complexProperty.IsCollection)
+            {
+                var dictionaryList = complexValue as IList;
+                if (complexValue != null && dictionaryList == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexCollectionValueNotList(complexProperty.Name, complexValue.GetType().ShortDisplayName()));
+                }
+
+                SetComplexCollectionValue(complexProperty, CreatePropertyValuesFromDictionaryList<TProperty>(complexProperty, dictionaryList));
+            }
+            else
+            {
+                var complexDict = complexValue as IDictionary<string, TProperty>;
+                if (complexValue != null && complexDict == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexPropertyValueNotDictionary(complexProperty.Name, complexValue.GetType().ShortDisplayName()));
+                }
+
+                if (complexDict != null)
+                {
+                    SetValuesFromDictionary((IRuntimeTypeBase)complexProperty.ComplexType, complexDict);
+                }
+            }
+        }
+    }
+
+    private List<ArrayPropertyValues?>? CreatePropertyValuesFromDictionaryList<TProperty>(IComplexProperty complexProperty, IList? collection)
+    {
+        if (collection == null)
+        {
+            return null;
+        }
+
+        var propertyValuesList = new List<ArrayPropertyValues?>();
+        for (var i = 0; i < collection.Count; i++)
+        {
+            var item = collection[i];
+            if (item == null)
+            {
+                propertyValuesList.Add(null);
+            }
+            else
+            {
+                if (item is not IDictionary<string, TProperty> itemDict)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexCollectionValueNotList(complexProperty.Name, item.GetType().ShortDisplayName()));
+                }
+
+                var complexEntry = new InternalComplexEntry((IRuntimeComplexType)complexProperty.ComplexType, InternalEntry, i);
+                var complexType = complexEntry.StructuralType;
+                var values = new object?[complexType.GetFlattenedProperties().Count()];
+                var complexPropertyValues = new ArrayPropertyValues(complexEntry, values);
+                complexPropertyValues.SetValues(itemDict);
+
+                propertyValuesList.Add(complexPropertyValues);
+            }
+        }
+
+        return propertyValuesList;
     }
 
     /// <summary>
@@ -185,4 +454,67 @@ public class ArrayPropertyValues : PropertyValues
 
     private IEntityMaterializerSource MaterializerSource
         => InternalEntry.StateManager.EntityMaterializerSource;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    internal void SetComplexCollectionValue(IComplexProperty complexProperty, List<ArrayPropertyValues?>? propertyValuesList)
+    {
+        _complexCollectionValues[complexProperty.GetIndex()] = propertyValuesList;
+    }
+
+    private List<ArrayPropertyValues?>? GetComplexCollectionPropertyValues(IComplexProperty complexProperty, IList? collection)
+    {
+        if (collection == null)
+        {
+            return null;
+        }
+
+        var propertyValuesList = new List<ArrayPropertyValues?>();
+        for (var i = 0; i < collection.Count; i++)
+        {
+            var item = collection[i];
+            if (item == null)
+            {
+                propertyValuesList.Add(null);
+            }
+            else
+            {
+                var complexPropertyValues = CreateComplexPropertyValues(item,
+                    new InternalComplexEntry((IRuntimeComplexType)complexProperty.ComplexType, InternalEntry, i));
+                propertyValuesList.Add(complexPropertyValues);
+            }
+        }
+
+        return propertyValuesList;
+
+        ArrayPropertyValues CreateComplexPropertyValues(object complexObject, InternalComplexEntry entry)
+        {
+            var complexType = entry.StructuralType;
+            var properties = complexType.GetFlattenedProperties().ToList();
+            var values = new object?[properties.Count];
+
+            for (var i = 0; i < properties.Count; i++)
+            {
+                var property = properties[i];
+                var getter = property.GetGetter();
+                values[i] = getter.GetClrValue(complexObject);
+            }
+
+            var complexPropertyValues = new ArrayPropertyValues(entry, values);
+
+            foreach (var nestedComplexProperty in complexPropertyValues.ComplexCollectionProperties)
+            {
+                var nestedCollection = (IList?)nestedComplexProperty.GetGetter().GetClrValue(complexObject);
+                var propertyValuesList = GetComplexCollectionPropertyValues(nestedComplexProperty, nestedCollection);
+                complexPropertyValues.SetComplexCollectionValue(nestedComplexProperty, propertyValuesList);
+            }
+
+            return complexPropertyValues;
+        }
+    }
 }

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -324,6 +324,7 @@ public class ChangeDetector : IChangeDetector
         var changesFound = false;
         var originalEntries = new Dictionary<object, InternalComplexEntry>(ReferenceEqualityComparer.Instance);
         var currentCollection = (IList?)entry[complexProperty];
+        // The elements in the original collection might be the same instances as in the current collection, so their properties shouldn't be used for comparison.
         var originalCollection = (IList?)entry.GetOriginalValue(complexProperty);
 
         entry.EnsureComplexCollectionEntriesCapacity(complexProperty, currentCollection?.Count ?? 0, originalCollection?.Count ?? 0, trim: false);
@@ -347,7 +348,8 @@ public class ChangeDetector : IChangeDetector
                 var originalEntry = originalEntriesList[i];
                 if (originalEntry == null)
                 {
-                    continue;
+                    originalEntry = entry.GetComplexCollectionOriginalEntry(complexProperty, i);
+                    originalEntry.SetEntityState(EntityState.Deleted);
                 }
 
                 Check.DebugAssert(originalEntry.OriginalOrdinal == i, $"Expected original ordinal {originalEntry.OriginalOrdinal} to be equal to {i}.");
@@ -381,19 +383,31 @@ public class ChangeDetector : IChangeDetector
                         $"The OriginalOrdinal for entry of the element at original ordinal {originalOrdinal} is {originalEntry.OriginalOrdinal}.");
                     if (originalEntry.Ordinal != i)
                     {
-                        if (originalEntry.EntityState == EntityState.Detached)
+                        if (originalEntry.EntityState is EntityState.Detached or EntityState.Deleted)
                         {
-                            originalEntry.Ordinal = i;
-                            originalEntry.SetEntityState(EntityState.Unchanged);
+                            var currentEntry = entry.GetComplexCollectionEntry(complexProperty, i);
+                            if (currentEntry.EntityState is EntityState.Added)
+                            {
+                                // Prefer to use the current entry if possible
+                                currentEntry.OriginalOrdinal = originalEntry.OriginalOrdinal;
+                                originalEntry.SetEntityState(EntityState.Detached);
+                                currentEntry.SetEntityState(EntityState.Unchanged);
+                                originalEntry = currentEntry;
+                            }
+                            else
+                            {
+                                originalEntry.Ordinal = i;
+                                originalEntry.SetEntityState(EntityState.Unchanged);
+                            }
                         }
                         else
                         {
                             Check.DebugAssert(originalEntry.Ordinal > i || currentNulls.Contains(originalEntry.Ordinal),
                                 $"Expected the entry that was previously at {originalEntry.Ordinal} to have been encountered at an ordinal before {i}.");
                             entry.MoveComplexCollectionEntry(complexProperty, originalEntry.Ordinal, i);
-                        }
 
-                        changesFound = true;
+                            changesFound = true;
+                        }
                     }
 
                     if (LocalDetectChanges(originalEntry))
@@ -436,11 +450,19 @@ public class ChangeDetector : IChangeDetector
                         {
                             // If the element was newly added then there should be a null entry at some ordinal, otherwise it will be treated as a replacement.
                             var nullEntryOrdinal = -1;
-                            for (var j = i + 1; j < currentEntries.Count; j++)
+                            for (var j = originalCollection?.Count ?? i + 1; j < currentEntries.Count; j++)
                             {
-                                if (currentEntries[j] == null)
+                                var newEntry = currentEntries[j];
+                                if (newEntry == null)
                                 {
                                     nullEntryOrdinal = j;
+                                    break;
+                                }
+                                else if (newEntry.OriginalOrdinal >= (originalCollection?.Count ?? 0)
+                                    || newEntry.EntityState == EntityState.Detached)
+                                {
+                                    nullEntryOrdinal = j;
+                                    newEntry.SetEntityState(EntityState.Detached);
                                     break;
                                 }
                             }
@@ -461,41 +483,93 @@ public class ChangeDetector : IChangeDetector
             var currentEntry = entry.GetComplexCollectionEntry(complexProperty, addedOrdinal);
             if (currentEntry.EntityState is EntityState.Detached or EntityState.Added)
             {
+                var originalOrdinal = -1;
+                var originalWasNull = false;
                 if (originalNulls.Count > 0)
                 {
-                    var originalOrdinal = originalNulls.First();
+                    originalWasNull = true;
+                    originalOrdinal = originalNulls.First();
                     originalNulls.Remove(originalOrdinal);
-                    currentEntry.OriginalOrdinal = originalOrdinal;
-                    currentEntry.SetEntityState(EntityState.Modified);
                 }
                 else if (removed.Count > 0)
                 {
-                    var (removedElement, originalOrdinal) = removed.First();
+                    (var removedElement, originalOrdinal) = removed.First();
                     removed.Remove(removedElement);
-                    currentEntry.OriginalOrdinal = originalOrdinal;
-                    currentEntry.SetEntityState(EntityState.Modified);
                 }
                 else
                 {
                     currentEntry.SetEntityState(EntityState.Added);
                     continue;
                 }
+
+                if (originalOrdinal != -1)
+                {
+                    var originalEntry = entry.GetComplexCollectionOriginalEntry(complexProperty, originalOrdinal);
+                    if (originalEntry != currentEntry)
+                    {
+                        if (currentEntry.EntityState is EntityState.Detached)
+                        {
+                            currentEntry = originalEntry;
+                            if (currentEntry.Ordinal == -1)
+                            {
+                                currentEntry.Ordinal = addedOrdinal;
+                            }
+                            else
+                            {
+                                entry.MoveComplexCollectionEntry(complexProperty, currentEntry.Ordinal, addedOrdinal);
+                            }
+                        }
+                        else
+                        {
+                            originalEntry.SetEntityState(EntityState.Detached);
+                            if (currentEntry.OriginalOrdinal == -1)
+                            {
+                                currentEntry.OriginalOrdinal = originalOrdinal;
+                            }
+                            else
+                            {
+                                entry.MoveComplexCollectionEntry(complexProperty, currentEntry.OriginalOrdinal, originalOrdinal, original: true);
+                            }
+                        }
+                    }
+                    currentEntry.SetEntityState(originalWasNull ? EntityState.Modified : EntityState.Unchanged);
+                }
             }
             else if (!originalNulls.Remove(currentEntry.OriginalOrdinal))
             {
-                var removedElement = removed.FirstOrDefault(r => r.Value == currentEntry.OriginalOrdinal);
-                if (removedElement.Key != null)
+                var removedPair = removed.FirstOrDefault(r => r.Value == currentEntry.OriginalOrdinal);
+                if (removedPair.Key != null)
                 {
-                    removed.Remove(removedElement.Key);
+                    removed.Remove(removedPair.Key);
+                }
+                else if (removed.Count > 0)
+                {
+                    var (removedElement, originalOrdinal) = removed.First();
+                    removed.Remove(removedElement);
+
+                    if (currentEntry.OriginalOrdinal != originalOrdinal)
+                    {
+                        var movedEntry = entry.GetComplexCollectionOriginalEntry(complexProperty, currentEntry.OriginalOrdinal);
+                        var movedOrdinal = movedEntry.OriginalOrdinal;
+                        entry.MoveComplexCollectionEntry(complexProperty, movedEntry.Ordinal, addedOrdinal);
+                        movedEntry.SetEntityState(EntityState.Unchanged);
+                        entry.MoveComplexCollectionEntry(complexProperty, currentEntry.Ordinal, movedOrdinal);
+                    }
+                    else
+                    {
+                        currentEntry.SetEntityState(EntityState.Unchanged);
+                    }
                 }
                 else
                 {
                     Check.DebugAssert(false,
                         $"Expected the entry at {addedOrdinal} to have been removed or matched with a null entry. Current state: {currentEntry.EntityState}.");
+
+                    currentEntry.SetEntityState(EntityState.Added);
                 }
             }
 
-            if (currentEntry.EntityState == EntityState.Unchanged)
+            if (currentEntry.EntityState is EntityState.Unchanged or EntityState.Modified)
             {
                 if (LocalDetectChanges(currentEntry))
                 {
@@ -514,7 +588,7 @@ public class ChangeDetector : IChangeDetector
                 Check.DebugAssert(originalEntry.OriginalOrdinal == originalOrdinal,
                     $"The OriginalOrdinal for entry of the element at original ordinal {originalOrdinal} is {originalEntry.OriginalOrdinal}.");
                 var newCurrentOrdinal = originalEntry.Ordinal;
-                if (originalEntry.EntityState is EntityState.Unchanged or EntityState.Detached)
+                if (originalEntry.EntityState is EntityState.Unchanged or EntityState.Modified or EntityState.Detached)
                 {
                     // Try to match removed elements with nulls to mark the entry as modified
                     if (!currentNulls.Remove(newCurrentOrdinal))
@@ -570,9 +644,35 @@ public class ChangeDetector : IChangeDetector
             foreach (var originalNull in originalNulls)
             {
                 var nullEntry = entry.GetComplexCollectionOriginalEntry(complexProperty, originalNull);
+                if (currentNulls.Contains(nullEntry.Ordinal))
+                {
+                    currentNulls.Remove(nullEntry.Ordinal);
+                    nullEntry.SetEntityState(EntityState.Unchanged);
+                    changesFound |= nullEntry.Ordinal != nullEntry.OriginalOrdinal;
+                    continue;
+                }
 
-                Check.DebugAssert(nullEntry.EntityState is EntityState.Unchanged or EntityState.Detached,
-                    $"Expected null entry at {originalNull} to be unchanged or detached.");
+                if (currentNulls.Any())
+                {
+                    var currentNullOrdinal = currentNulls.First();
+                    currentNulls.Remove(currentNullOrdinal);
+                    if (nullEntry.Ordinal != -1)
+                    {
+                        entry.MoveComplexCollectionEntry(complexProperty, nullEntry.Ordinal, currentNullOrdinal);
+                        nullEntry.SetEntityState(EntityState.Unchanged);
+                    }
+                    else
+                    {
+                        entry.GetComplexCollectionEntry(complexProperty, currentNullOrdinal).SetEntityState(EntityState.Detached);
+                        nullEntry.Ordinal = currentNullOrdinal;
+                    }
+
+                    changesFound |= nullEntry.Ordinal != nullEntry.OriginalOrdinal;
+                    continue;
+                }
+
+                Check.DebugAssert(nullEntry.EntityState is EntityState.Deleted or EntityState.Detached,
+                    $"Expected null entry at {originalNull} to be deleted or detached, current state {nullEntry.EntityState}.");
                 nullEntry.SetEntityState(EntityState.Deleted);
                 changesFound = true;
             }
@@ -589,8 +689,8 @@ public class ChangeDetector : IChangeDetector
                     continue;
                 }
 
-                Check.DebugAssert(nullEntry.EntityState is EntityState.Unchanged or EntityState.Detached,
-                    $"Expected null entry at {currentNull} to be unchanged or detached.");
+                Check.DebugAssert(nullEntry.EntityState is EntityState.Added or EntityState.Detached,
+                    $"Expected null entry at {currentNull} to be added or detached, current state {nullEntry.EntityState}.");
                 nullEntry.SetEntityState(EntityState.Added);
                 changesFound = true;
             }

--- a/src/EFCore/ChangeTracking/Internal/CurrentPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/CurrentPropertyValues.cs
@@ -19,7 +19,7 @@ public class CurrentPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public CurrentPropertyValues(InternalEntityEntry internalEntry)
+    public CurrentPropertyValues(InternalEntryBase internalEntry)
         : base(internalEntry)
     {
     }
@@ -31,7 +31,7 @@ public class CurrentPropertyValues : EntryPropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override TValue GetValue<TValue>(string propertyName)
-        => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
+        => InternalEntry.GetCurrentValue<TValue>(InternalEntry.StructuralType.GetProperty(propertyName));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -40,7 +40,7 @@ public class CurrentPropertyValues : EntryPropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override TValue GetValue<TValue>(IProperty property)
-        => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.CheckContains(property));
+        => InternalEntry.GetCurrentValue<TValue>(InternalEntry.StructuralType.CheckContains(property));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,8 +48,8 @@ public class CurrentPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override void SetValueInternal(IProperty property, object? value)
-        => InternalEntry[property] = value;
+    protected override void SetValueInternal(IInternalEntry entry, IPropertyBase property, object? value)
+        => entry[property] = value;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -57,6 +57,15 @@ public class CurrentPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override object? GetValueInternal(IProperty property)
-        => InternalEntry[property];
+    protected override object? GetValueInternal(IInternalEntry entry, IPropertyBase property)
+        => entry[property];
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override InternalComplexEntry GetComplexCollectionEntry(InternalEntryBase entry, IComplexProperty complexProperty, int i)
+        => entry.GetComplexCollectionEntry(complexProperty, i);
 }

--- a/src/EFCore/ChangeTracking/Internal/EntryPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntryPropertyValues.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -14,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 public abstract class EntryPropertyValues : PropertyValues
 {
     private IReadOnlyList<IProperty>? _properties;
+    private IReadOnlyList<IComplexProperty>? _complexCollectionProperties;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -21,7 +24,7 @@ public abstract class EntryPropertyValues : PropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected EntryPropertyValues(InternalEntityEntry internalEntry)
+    protected EntryPropertyValues(InternalEntryBase internalEntry)
         : base(internalEntry)
     {
     }
@@ -44,25 +47,219 @@ public abstract class EntryPropertyValues : PropertyValues
     public override void SetValues(object obj)
     {
         Check.NotNull(obj);
-
-        if (obj.GetType() == EntityType.ClrType)
+        if (obj.GetType() == StructuralType.ClrType)
         {
-            foreach (var property in Properties.Where(p => !p.IsShadowProperty()))
-            {
-                SetValueInternal(property, property.GetGetter().GetClrValueUsingContainingEntity(obj));
-            }
+            SetValuesFromInstance(InternalEntry, (IRuntimeTypeBase)StructuralType, obj);
+        }
+        else if (obj is Dictionary<string, object> dictionary)
+        {
+            SetValues(dictionary);
         }
         else
         {
-            foreach (var property in Properties)
+            SetValuesFromDto(InternalEntry, InternalEntry.StructuralType, obj);
+        }
+    }
+
+    private void SetValuesFromInstance(InternalEntryBase entry, IRuntimeTypeBase structuralType, object obj)
+    {
+        foreach (var property in structuralType.GetProperties())
+        {
+            if (property.IsShadowProperty())
             {
-                var getter = obj.GetType().GetAnyProperty(property.Name)?.FindGetterProperty();
-                if (getter != null)
+                continue;
+            }
+
+            SetValueInternal(entry, property, property.GetGetter().GetClrValue(obj));
+        }
+
+        foreach (var complexProperty in structuralType.GetComplexProperties())
+        {
+            if (complexProperty.IsShadowProperty())
+            {
+                continue;
+            }
+
+            if (complexProperty.IsCollection)
+            {
+                var complexList = (IList?)complexProperty.GetGetter().GetClrValue(obj);
+                SetValueInternal(entry, complexProperty, complexList);
+
+                for (var i = 0; i < complexList?.Count; i++)
                 {
-                    SetValueInternal(property, getter.GetValue(obj));
+                    var complexObject = complexList[i];
+                    if (complexObject == null)
+                    {
+                        continue;
+                    }
+
+                    var complexEntry = GetComplexCollectionEntry(entry, complexProperty, i);
+                    SetValuesFromInstance(complexEntry, complexEntry.StructuralType, complexObject);
+                }
+            }
+            else
+            {
+                var complexObject = complexProperty.GetGetter().GetClrValue(obj);
+                if (complexObject != null)
+                {
+                    SetValuesFromInstance(entry, (IRuntimeTypeBase)complexProperty.ComplexType, complexObject);
                 }
             }
         }
+    }
+
+    private void SetValuesFromDto(InternalEntryBase entry, IRuntimeTypeBase structuralType, object obj)
+    {
+        foreach (var property in structuralType.GetProperties())
+        {
+            var getter = obj.GetType().GetAnyProperty(property.Name)?.FindGetterProperty();
+            if (getter != null)
+            {
+                SetValueInternal(entry, property, getter.GetValue(obj));
+            }
+        }
+
+        foreach (var complexProperty in structuralType.GetComplexProperties())
+        {
+            if (complexProperty.IsCollection)
+            {
+                var getter = obj.GetType().GetAnyProperty(complexProperty.Name)?.FindGetterProperty();
+                if (getter == null)
+                {
+                    continue;
+                }
+
+                var dtoList = (IList?)getter.GetValue(obj);
+                if (dtoList != null)
+                {
+                    var complexList = (IList)((IRuntimePropertyBase)complexProperty).GetIndexedCollectionAccessor().Create(dtoList.Count);
+                    for (var i = 0; i < dtoList.Count; i++)
+                    {
+                        var item = dtoList[i];
+                        if (item == null)
+                        {
+                            complexList.Add(null);
+                        }
+                        else
+                        {
+                            var complexObject = CreateComplexObjectFromDto((IRuntimeComplexType)complexProperty.ComplexType, item);
+                            complexList.Add(complexObject);
+                        }
+                    }
+
+                    SetValueInternal(entry, complexProperty, complexList);
+
+                    for (var i = 0; i < dtoList.Count; i++)
+                    {
+                        var item = dtoList[i];
+                        if (item != null)
+                        {
+                            SetValuesFromDto(GetComplexCollectionEntry(entry, complexProperty, i), (IRuntimeComplexType)complexProperty.ComplexType, item);
+                        }
+                    }
+                }
+                else
+                {
+                    SetValueInternal(entry, complexProperty, null);
+                }
+            }
+            else
+            {
+                var getter = obj.GetType().GetAnyProperty(complexProperty.Name)?.FindGetterProperty();
+                if (getter != null)
+                {
+                    var dtoComplexValue = getter.GetValue(obj);
+                    if (dtoComplexValue != null)
+                    {
+                        var complexObject = CreateComplexObjectFromDto((IRuntimeComplexType)complexProperty.ComplexType, dtoComplexValue);
+                        SetValueInternal(entry, complexProperty, complexObject);
+                        SetValuesFromDto(entry, (IRuntimeComplexType)complexProperty.ComplexType, dtoComplexValue);
+                    }
+                }
+            }
+        }
+    }
+
+    [return: NotNullIfNotNull(nameof(dto))]
+    private object? CreateComplexObjectFromDto(IRuntimeComplexType complexType, object? dto)
+    {
+        if (dto == null)
+        {
+            return null;
+        }
+
+        var values = new object?[complexType.PropertyCount];
+        foreach (var property in complexType.GetProperties())
+        {
+            if (!property.IsShadowProperty())
+            {
+                var dtoGetter = dto.GetType().GetAnyProperty(property.Name)?.FindGetterProperty();
+                if (dtoGetter != null && property.PropertyInfo != null && property.PropertyInfo.CanWrite)
+                {
+                    values[property.GetIndex()] = dtoGetter.GetValue(dto);
+                }
+            }
+        }
+
+        var complexObject = complexType.GetOrCreateMaterializer(MaterializerSource)(
+            new MaterializationContext(new ValueBuffer(values), InternalEntry.Context));
+
+        foreach (var nestedComplexProperty in complexType.GetComplexProperties())
+        {
+            if (nestedComplexProperty.IsCollection)
+            {
+                var dtoGetter = dto.GetType().GetAnyProperty(nestedComplexProperty.Name)?.FindGetterProperty();
+                if (dtoGetter != null)
+                {
+                    var nestedList = (IList?)dtoGetter.GetValue(dto);
+                    if (nestedList != null)
+                    {
+                        var nestedCollection = (IList)((IRuntimePropertyBase)nestedComplexProperty).GetIndexedCollectionAccessor().Create(nestedList.Count);
+                        for (var i = 0; i < nestedList.Count; i++)
+                        {
+                            var nestedDtoItem = nestedList[i];
+                            if (nestedDtoItem == null)
+                            {
+                                nestedCollection.Add(null);
+                            }
+                            else
+                            {
+                                var nestedComplexObject = CreateComplexObjectFromDto((IRuntimeComplexType)nestedComplexProperty.ComplexType, nestedDtoItem);
+                                nestedCollection.Add(nestedComplexObject);
+                            }
+                        }
+
+                        if (!nestedComplexProperty.IsShadowProperty())
+                        {
+                            var propertyInfo = nestedComplexProperty.PropertyInfo;
+                            if (propertyInfo != null && propertyInfo.CanWrite)
+                            {
+                                propertyInfo.SetValue(complexObject, nestedCollection);
+                            }
+                        }
+                    }
+                }
+            }
+            else if (!nestedComplexProperty.IsShadowProperty())
+            {
+                var dtoGetter = dto.GetType().GetAnyProperty(nestedComplexProperty.Name)?.FindGetterProperty();
+                if (dtoGetter != null)
+                {
+                    var nestedDto = dtoGetter.GetValue(dto);
+                    if (nestedDto != null)
+                    {
+                        var nestedComplexObject = CreateComplexObjectFromDto((IRuntimeComplexType)nestedComplexProperty.ComplexType, nestedDto);
+                        var propertyInfo = nestedComplexProperty.PropertyInfo;
+                        if (propertyInfo != null && propertyInfo.CanWrite)
+                        {
+                            propertyInfo.SetValue(complexObject, nestedComplexObject);
+                        }
+                    }
+                }
+            }
+        }
+
+        return complexObject;
     }
 
     /// <summary>
@@ -76,10 +273,20 @@ public abstract class EntryPropertyValues : PropertyValues
         var values = new object?[Properties.Count];
         for (var i = 0; i < values.Length; i++)
         {
-            values[i] = GetValueInternal(Properties[i]);
+            values[i] = GetValueInternal(InternalEntry, Properties[i]);
         }
 
-        return new ArrayPropertyValues(InternalEntry, values);
+        var cloned = new ArrayPropertyValues(InternalEntry, values);
+        foreach (var complexProperty in ComplexCollectionProperties)
+        {
+            var collection = (IList?)GetValueInternal(InternalEntry, complexProperty);
+            if (collection != null)
+            {
+                cloned[complexProperty] = collection;
+            }
+        }
+
+        return cloned;
     }
 
     /// <summary>
@@ -94,9 +301,103 @@ public abstract class EntryPropertyValues : PropertyValues
 
         foreach (var property in Properties)
         {
-            SetValueInternal(property, propertyValues[property]);
+            SetValueInternal(InternalEntry, property, propertyValues[property]);
+        }
+
+        foreach (var complexProperty in ComplexCollectionProperties)
+        {
+            SetValueInternal(InternalEntry, complexProperty, propertyValues[complexProperty]);
         }
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override void SetValues<TProperty>(IDictionary<string, TProperty> values)
+        => SetValuesFromDictionary(InternalEntry, (IRuntimeTypeBase)StructuralType, Check.NotNull(values));
+
+    private void SetValuesFromDictionary<TProperty>(InternalEntryBase entry, IRuntimeTypeBase structuralType, IDictionary<string, TProperty> values)
+    {
+        foreach (var property in structuralType.GetProperties())
+        {
+            if (values.TryGetValue(property.Name, out var value))
+            {
+                SetValueInternal(entry, property, value);
+            }
+        }
+
+        foreach (var complexProperty in structuralType.GetComplexProperties())
+        {
+            if (!values.TryGetValue(complexProperty.Name, out var complexValue))
+            {
+                continue;
+            }
+
+            if (complexProperty.IsCollection)
+            {
+                var dictionaryList = complexValue as IList;
+                if (complexValue != null && dictionaryList == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexCollectionValueNotList(complexProperty.Name, complexValue.GetType().ShortDisplayName()));
+                }
+
+                IList? complexList = null;
+                if (dictionaryList != null)
+                {
+                    complexList = (IList)((IRuntimePropertyBase)complexProperty).GetIndexedCollectionAccessor().Create(dictionaryList.Count);
+                    for (var i = 0; i < dictionaryList.Count; i++)
+                    {
+                        var item = dictionaryList[i];
+                        var itemDict = item as IDictionary<string, TProperty>;
+                        if (item != null && itemDict == null)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.ComplexCollectionValueNotList(complexProperty.Name, item.GetType().ShortDisplayName()));
+                        }
+                        complexList.Add(CreateComplexObjectFromDictionary((IRuntimeComplexType)complexProperty.ComplexType, itemDict));
+                    }
+                }
+
+                SetValueInternal(entry, complexProperty, complexList);
+
+                if (dictionaryList != null)
+                {
+                    for (var i = 0; i < dictionaryList.Count; i++)
+                    {
+                        if (dictionaryList[i] is IDictionary<string, TProperty> itemDict)
+                        {
+                            var complexEntry = GetComplexCollectionEntry(entry, complexProperty, i);
+                            SetValuesFromDictionary(complexEntry, complexEntry.StructuralType, itemDict);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var complexDict = complexValue as IDictionary<string, TProperty>;
+                if (complexValue != null && complexDict == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexPropertyValueNotDictionary(complexProperty.Name, complexValue.GetType().ShortDisplayName()));
+                }
+
+                var complexObject = CreateComplexObjectFromDictionary((IRuntimeComplexType)complexProperty.ComplexType, complexDict);
+                SetValueInternal(entry, complexProperty, complexObject);
+
+                if (complexDict != null)
+                {
+                    SetValuesFromDictionary(entry, (IRuntimeTypeBase)complexProperty.ComplexType, complexDict);
+                }
+            }
+        }
+    }
+
+    private IEntityMaterializerSource MaterializerSource
+        => InternalEntry.StateManager.EntityMaterializerSource;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -107,8 +408,48 @@ public abstract class EntryPropertyValues : PropertyValues
     public override IReadOnlyList<IProperty> Properties
     {
         [DebuggerStepThrough]
-        get => _properties ??= EntityType.GetFlattenedProperties().ToList();
+        get
+        {
+            if (_properties == null)
+            {
+                _properties = [.. StructuralType.GetFlattenedProperties()];
+                Check.DebugAssert(_properties.Select((p, i) => p.GetIndex() == i).All(e => e),
+                    "Properties indices are not sequential.");
+            }
+
+            return _properties;
+        }
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override IReadOnlyList<IComplexProperty> ComplexCollectionProperties
+    {
+        [DebuggerStepThrough]
+        get
+        {
+            if (_complexCollectionProperties == null)
+            {
+                _complexCollectionProperties = [.. StructuralType.GetFlattenedComplexProperties().Where(p => p.IsCollection)];
+                Check.DebugAssert(
+                    _complexCollectionProperties.Select((p, i) => p.GetIndex() == i).All(e => e),
+                    "Complex collection properties indices are not sequential.");
+            }
+            return _complexCollectionProperties;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected abstract InternalComplexEntry GetComplexCollectionEntry(InternalEntryBase entry, IComplexProperty complexProperty, int i);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -118,8 +459,42 @@ public abstract class EntryPropertyValues : PropertyValues
     /// </summary>
     public override object? this[string propertyName]
     {
-        get => GetValueInternal(EntityType.GetProperty(propertyName));
-        set => SetValueInternal(EntityType.GetProperty(propertyName), value);
+        get
+        {
+            var property = StructuralType.FindProperty(propertyName);
+            if (property != null)
+            {
+                return GetValueInternal(InternalEntry, property);
+            }
+
+            var complexProperty = StructuralType.FindComplexProperty(propertyName);
+            if (complexProperty != null)
+            {
+                return GetValueInternal(InternalEntry, complexProperty);
+            }
+
+            // If neither found, this will throw an appropriate exception
+            return GetValueInternal(InternalEntry, StructuralType.GetProperty(propertyName));
+        }
+        set
+        {
+            var property = StructuralType.FindProperty(propertyName);
+            if (property != null)
+            {
+                SetValueInternal(InternalEntry, property, value);
+                return;
+            }
+
+            var complexProperty = StructuralType.FindComplexProperty(propertyName);
+            if (complexProperty != null)
+            {
+                InternalEntry[complexProperty] = value;
+                return;
+            }
+
+            // If neither found, this will throw an appropriate exception
+            SetValueInternal(InternalEntry, StructuralType.GetProperty(propertyName), value);
+        }
     }
 
     /// <summary>
@@ -130,8 +505,19 @@ public abstract class EntryPropertyValues : PropertyValues
     /// </summary>
     public override object? this[IProperty property]
     {
-        get => GetValueInternal(EntityType.CheckContains(property));
-        set => SetValueInternal(EntityType.CheckContains(property), value);
+        get => GetValueInternal(InternalEntry, StructuralType.CheckContains(property));
+        set => SetValueInternal(InternalEntry, StructuralType.CheckContains(property), value);
+    }
+
+    /// <summary>
+    ///     Gets or sets the value of the complex collection.
+    /// </summary>
+    /// <param name="complexProperty">The complex collection property.</param>
+    /// <returns>A list of complex objects, not PropertyValues.</returns>
+    public override IList? this[IComplexProperty complexProperty]
+    {
+        get => (IList?)GetValueInternal(InternalEntry, CheckCollection(complexProperty));
+        set => SetValueInternal(InternalEntry, CheckCollection(complexProperty), value);
     }
 
     /// <summary>
@@ -140,7 +526,7 @@ public abstract class EntryPropertyValues : PropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract void SetValueInternal(IProperty property, object? value);
+    protected abstract void SetValueInternal(IInternalEntry entry, IPropertyBase property, object? value);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -148,5 +534,95 @@ public abstract class EntryPropertyValues : PropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected abstract object? GetValueInternal(IProperty property);
+    [EntityFrameworkInternal]
+    protected abstract object? GetValueInternal(IInternalEntry entry, IPropertyBase property);
+
+    /// <summary>
+    ///     Creates a complex object from a dictionary of property values using EF's property accessors.
+    /// </summary>
+    private object? CreateComplexObjectFromDictionary<TProperty>(IRuntimeComplexType complexType, IDictionary<string, TProperty>? dictionary)
+    {
+        if (dictionary == null)
+        {
+            return null;
+        }
+
+        var values = new object?[complexType.PropertyCount];
+        foreach (var property in complexType.GetProperties())
+        {
+            if (dictionary.TryGetValue(property.Name, out var value)
+                && !property.IsShadowProperty())
+            {
+                values[property.GetIndex()] = value;
+            }
+        }
+
+        var complexObject = complexType.GetOrCreateMaterializer(MaterializerSource)(
+            new MaterializationContext(new ValueBuffer(values), InternalEntry.Context));
+
+        foreach (var nestedComplexProperty in complexType.GetComplexProperties())
+        {
+            if (nestedComplexProperty.IsShadowProperty())
+            {
+                continue;
+            }
+
+            if (dictionary.TryGetValue(nestedComplexProperty.Name, out var nestedValue))
+            {
+                if (nestedComplexProperty.IsCollection && nestedValue is IList nestedList)
+                {
+                    var nestedCollection = (IList)((IRuntimePropertyBase)nestedComplexProperty).GetIndexedCollectionAccessor().Create(nestedList.Count);
+
+                    foreach (var nestedItem in nestedList)
+                    {
+                        if (nestedItem == null)
+                        {
+                            nestedCollection.Add(null);
+                        }
+                        else if (nestedItem is IDictionary<string, TProperty> nestedItemDict)
+                        {
+                            nestedCollection.Add(CreateComplexObjectFromDictionary((IRuntimeComplexType)nestedComplexProperty.ComplexType, nestedItemDict));
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.ComplexCollectionValueNotList(nestedComplexProperty.Name, nestedValue.GetType().ShortDisplayName()));
+                        }
+                    }
+
+                    var propertyInfo = nestedComplexProperty.PropertyInfo;
+                    if (propertyInfo != null && propertyInfo.CanWrite)
+                    {
+                        propertyInfo.SetValue(complexObject, nestedCollection);
+                    }
+                }
+                else if (nestedComplexProperty.IsCollection && nestedValue != null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexCollectionValueNotList(nestedComplexProperty.Name, nestedValue.GetType().ShortDisplayName()));
+                }
+                else if (!nestedComplexProperty.IsCollection)
+                {
+                    object? nestedComplexObject = null;
+                    if (nestedValue is IDictionary<string, TProperty> nestedDict)
+                    {
+                        nestedComplexObject = CreateComplexObjectFromDictionary((IRuntimeComplexType)nestedComplexProperty.ComplexType, nestedDict);
+                    }
+                    else if (nestedValue != null)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.ComplexPropertyValueNotDictionary(nestedComplexProperty.Name, nestedValue.GetType().ShortDisplayName()));
+                    }
+
+                    var propertyInfo = nestedComplexProperty.PropertyInfo;
+                    if (propertyInfo != null && propertyInfo.CanWrite)
+                    {
+                        propertyInfo.SetValue(complexObject, nestedComplexObject);
+                    }
+                }
+            }
+        }
+
+        return complexObject;
+    }
 }

--- a/src/EFCore/ChangeTracking/Internal/InternalComplexEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalComplexEntry.cs
@@ -255,7 +255,8 @@ public sealed class InternalComplexEntry : InternalEntryBase
     /// </summary>
     public override void AcceptChanges()
     {
-        if (EntityState == EntityState.Added)
+        if (EntityState == EntityState.Added
+            || ContainingEntry.GetComplexCollectionEntry(ComplexProperty, Ordinal) == this)
         {
             OriginalOrdinal = Ordinal;
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalEntryBase.OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntryBase.OriginalValues.cs
@@ -61,14 +61,8 @@ public partial class InternalEntryBase
                 return;
             }
 
-            foreach (var property in entry.StructuralType.GetFlattenedProperties())
-            {
-                var index = property.GetOriginalValueIndex();
-                if (index >= 0)
-                {
-                    entry[property] = SnapshotValue(property, _values[index]);
-                }
-            }
+            // This isn't efficient, but avoids duplicating the logic
+            new CurrentPropertyValues((InternalEntryBase)entry).SetValues(new OriginalPropertyValues((InternalEntryBase)entry));
         }
 
         public void AcceptChanges(IInternalEntry entry)
@@ -82,19 +76,13 @@ public partial class InternalEntryBase
         }
 
         private static object? SnapshotValue(IPropertyBase propertyBase, object? value)
-        {
-            if (propertyBase is IProperty property)
+            => propertyBase switch
             {
-                return property.GetValueComparer().Snapshot(value);
-            }
-
-            if (propertyBase is IComplexProperty complexProperty && complexProperty.IsCollection && value is IList list)
-            {
-                return SnapshotFactoryFactory.SnapshotComplexCollection(list, (IRuntimeComplexProperty)complexProperty);
-            }
-
-            return value;
-        }
+                IProperty property => property.GetValueComparer().Snapshot(value),
+                IComplexProperty complexProperty when complexProperty.IsCollection && value is IList list
+                    => SnapshotFactoryFactory.SnapshotComplexCollection(list, (IRuntimeComplexProperty)complexProperty),
+                _ => value
+            };
 
         public bool IsEmpty
             => _values == null;

--- a/src/EFCore/ChangeTracking/Internal/InternalEntryBase.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntryBase.cs
@@ -302,10 +302,20 @@ public abstract partial class InternalEntryBase : IInternalEntry
             if (acceptChanges)
             {
                 _originalValues.AcceptChanges(this);
+
+                foreach (var complexCollection in _complexCollectionEntries)
+                {
+                    complexCollection.AcceptChanges();
+                }
             }
             else
             {
                 _originalValues.RejectChanges(this);
+
+                foreach (var complexCollection in _complexCollectionEntries)
+                {
+                    complexCollection.RejectChanges();
+                }
             }
         }
 
@@ -955,17 +965,86 @@ public abstract partial class InternalEntryBase : IInternalEntry
 
         EnsureOriginalValues();
 
+        var complexProperty = propertyBase as IComplexProperty;
+        var isComplexCollection = complexProperty != null && complexProperty.IsCollection;
+        if (isComplexCollection)
+        {
+            ReorderOriginalComplexCollectionEntries(complexProperty!, (IList?)value);
+        }
+
         _originalValues.SetValue(propertyBase, value, index);
 
         if (propertyBase is IProperty property)
         {
-            // If setting the original value results in the current value being different from the
-            // original value, then mark the property as modified.
             if ((EntityState == EntityState.Unchanged
                     || (EntityState == EntityState.Modified && !IsModified(property)))
                 && !_stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Unknown))
             {
                 ((StateManager as StateManager)?.ChangeDetector as ChangeDetector)?.DetectValueChange(this, property);
+            }
+        }
+        else if (isComplexCollection
+            && EntityState is EntityState.Unchanged or EntityState.Modified)
+        {
+            ((StateManager as StateManager)?.ChangeDetector as ChangeDetector)?.DetectComplexCollectionChanges(this, complexProperty!);
+        }
+    }
+
+    private void ReorderOriginalComplexCollectionEntries(IComplexProperty complexProperty, IList? newOriginalCollection)
+    {
+        Check.DebugAssert(HasOriginalValuesSnapshot, "This should only be called when original values are present");
+
+        var oldOriginalCollection = (IList?)GetOriginalValue(complexProperty);
+        if (oldOriginalCollection == null
+            || newOriginalCollection == null)
+        {
+            return;
+        }
+
+        _complexCollectionEntries[complexProperty.GetIndex()].EnsureCapacity(newOriginalCollection.Count, original: true, trim: false);
+
+        var originalEntries = GetComplexCollectionOriginalEntries(complexProperty);
+        var elementToOriginalEntry = new Dictionary<object, InternalComplexEntry>(ReferenceEqualityComparer.Instance);
+        
+        // Build mapping of existing non-null elements to their entries
+        for (var i = 0; i < originalEntries.Count && i < oldOriginalCollection.Count; i++)
+        {
+            var originalEntry = originalEntries[i];
+            if (originalEntry != null)
+            {
+                var element = oldOriginalCollection[i];
+                if (element != null)
+                {
+                    elementToOriginalEntry[element] = originalEntry;
+                }
+            }
+        }
+
+        var newOrdinal = 0;
+        for (; newOrdinal < newOriginalCollection.Count; newOrdinal++)
+        {
+            var element = newOriginalCollection[newOrdinal];
+            if (element != null && elementToOriginalEntry.TryGetValue(element, out var originalEntry)
+                && originalEntry.OriginalOrdinal != newOrdinal)
+            {
+                if (originalEntry.EntityState is EntityState.Detached or EntityState.Added)
+                {
+                    originalEntry.OriginalOrdinal = newOrdinal;
+                }
+                else
+                {
+                    MoveComplexCollectionEntry(complexProperty, originalEntry.OriginalOrdinal, newOrdinal, original: true);
+                }
+            }
+        }
+
+        for (; newOrdinal < originalEntries.Count; newOrdinal++)
+        {
+            var entry = originalEntries[newOrdinal];
+            if (entry != null
+                && entry.EntityState is not EntityState.Detached)
+            {
+                entry.SetEntityState(EntityState.Detached);
             }
         }
     }
@@ -1343,7 +1422,16 @@ public abstract partial class InternalEntryBase : IInternalEntry
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected virtual void OnPropertyChanged(IPropertyBase propertyBase, object? value, bool setModified)
-        => StateManager.InternalEntityEntryNotifier.PropertyChanged(this, propertyBase, setModified);
+    {
+        StateManager.InternalEntityEntryNotifier.PropertyChanged(this, propertyBase, setModified);
+
+        if (propertyBase is IComplexProperty complexProperty && complexProperty.IsCollection)
+        {
+            // Trigger change detection for complex collections to ensure InternalComplexEntry states are updated
+            var changeDetector = (StateManager as StateManager)?.ChangeDetector;
+            changeDetector?.DetectComplexCollectionChanges(this, complexProperty);
+        }
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1421,21 +1509,10 @@ public abstract partial class InternalEntryBase : IInternalEntry
         {
             _originalValues.AcceptChanges(this);
 
-            foreach (var complexCollection in StructuralType.GetFlattenedComplexProperties())
+            foreach (var complexCollection in _complexCollectionEntries)
             {
-                if (!complexCollection.IsCollection)
-                {
-                    continue;
-                }
-
-                var originalCapacity = ((IList?)_originalValues.GetValue(this, complexCollection))?.Count ?? 0;
-                _complexCollectionEntries[complexCollection.GetIndex()].EnsureCapacity(originalCapacity, original: true);
+                complexCollection.AcceptChanges();
             }
-        }
-
-        foreach (var complexEntry in GetFlattenedComplexEntries())
-        {
-            complexEntry.AcceptChanges();
         }
 
         switch (currentState)

--- a/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -19,7 +20,7 @@ public class OriginalPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public OriginalPropertyValues(InternalEntityEntry internalEntry)
+    public OriginalPropertyValues(InternalEntryBase internalEntry)
         : base(internalEntry)
     {
     }
@@ -31,7 +32,7 @@ public class OriginalPropertyValues : EntryPropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override TValue GetValue<TValue>(string propertyName)
-        => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
+        => InternalEntry.GetOriginalValue<TValue>(InternalEntry.StructuralType.GetProperty(propertyName));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -40,7 +41,7 @@ public class OriginalPropertyValues : EntryPropertyValues
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override TValue GetValue<TValue>(IProperty property)
-        => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.CheckContains(property));
+        => InternalEntry.GetOriginalValue<TValue>(InternalEntry.StructuralType.CheckContains(property));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,8 +49,8 @@ public class OriginalPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override void SetValueInternal(IProperty property, object? value)
-        => InternalEntry.SetOriginalValue(property, value);
+    protected override void SetValueInternal(IInternalEntry entry, IPropertyBase property, object? value)
+        => entry.SetOriginalValue(property, value);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -57,6 +58,63 @@ public class OriginalPropertyValues : EntryPropertyValues
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override object? GetValueInternal(IProperty property)
-        => InternalEntry.GetOriginalValue(property);
+    protected override object? GetValueInternal(IInternalEntry entry, IPropertyBase property)
+    {
+        var originalValue = entry.GetOriginalValue(property);
+        if (property is IComplexProperty complexProperty && property.IsCollection)
+        {
+            var originalCollection = (IList?)originalValue;
+            if (originalCollection == null)
+            {
+                return null;
+            }
+
+            // The stored original collection might contain references to the current elements, so we need to recreate it using stored values.
+            var clonedCollection = (IList)((IRuntimePropertyBase)complexProperty).GetIndexedCollectionAccessor().Create(originalCollection.Count);
+            for (var i = 0; i < originalCollection.Count; i++)
+            {
+                clonedCollection.Add(
+                    originalCollection[i] == null
+                        ? null
+                        : GetPropertyValues(entry.GetComplexCollectionOriginalEntry(complexProperty, i)).ToObject());
+            }
+
+            return clonedCollection;
+        }
+
+        return originalValue;
+    }
+
+    private PropertyValues GetPropertyValues(InternalEntryBase entry)
+    {
+        var structuralType = entry.StructuralType;
+        var properties = structuralType.GetFlattenedProperties().ToList();
+        var values = new object?[properties.Count];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = entry.GetOriginalValue(properties[i]);
+        }
+
+        var cloned = new ArrayPropertyValues(entry, values);
+
+        foreach (var nestedComplexProperty in cloned.ComplexCollectionProperties)
+        {
+            var collection = (IList?)GetValueInternal(entry, nestedComplexProperty);
+            if (collection != null)
+            {
+                cloned[nestedComplexProperty] = collection;
+            }
+        }
+
+        return cloned;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override InternalComplexEntry GetComplexCollectionEntry(InternalEntryBase entry, IComplexProperty complexProperty, int i)
+        => entry.GetComplexCollectionOriginalEntry(complexProperty, i);
 }

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -366,6 +366,7 @@ public abstract class SnapshotFactoryFactory
         var snapshot = (IList)complexProperty.GetIndexedCollectionAccessor().Create(list.Count);
         foreach (var item in list)
         {
+            // We need to preserve the original reference, these are only used to find moved items, not modified properties on them
             snapshot.Add(item);
         }
         return snapshot;

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -644,24 +644,6 @@ public interface IReadOnlyEntityType : IReadOnlyTypeBase
     PropertyAccessMode GetNavigationAccessMode();
 
     /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source);
-
-    /// <summary>
     ///     <para>
     ///         Creates a human-readable representation of the given metadata.
     ///     </para>

--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -453,4 +453,22 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
     /// </summary>
     /// <returns>The <see cref="PropertyInfo" /> for the indexer on the associated CLR type if one exists.</returns>
     PropertyInfo? FindIndexerPropertyInfo();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source);
 }

--- a/src/EFCore/Metadata/Internal/ComplexType.cs
+++ b/src/EFCore/Metadata/Internal/ComplexType.cs
@@ -412,6 +412,26 @@ public class ComplexType : TypeBase, IMutableComplexType, IConventionComplexType
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [EntityFrameworkInternal]
+    public override Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+        => source.GetMaterializer(this);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public override Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
+        => source.GetEmptyMaterializer(this);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual DebugView DebugView
         => new(
             () => ((IReadOnlyComplexType)this).ToDebugString(),

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2892,7 +2892,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+    public override Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
         => source.GetMaterializer(this);
 
     /// <summary>
@@ -2902,7 +2902,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
+    public override Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
         => source.GetEmptyMaterializer(this);
 
     #endregion

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -371,25 +371,4 @@ public static class EntityTypeExtensions
         string navigationName)
         => entityType.GetDerivedTypes().Select(t => t.FindDeclaredNavigation(navigationName)!)
             .Where(n => n != null);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static IProperty CheckContains(
-        this IEntityType entityType,
-        IProperty property)
-    {
-        Check.NotNull(property);
-
-        if (!property.DeclaringType.ContainingType.IsAssignableFrom(entityType))
-        {
-            throw new InvalidOperationException(
-                CoreStrings.PropertyDoesNotBelong(property.Name, property.DeclaringType.DisplayName(), entityType.DisplayName()));
-        }
-
-        return property;
-    }
 }

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -1714,6 +1714,24 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [EntityFrameworkInternal]
+    public abstract Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public abstract Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     IReadOnlyModel IReadOnlyTypeBase.Model
     {
         [DebuggerStepThrough]

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -30,4 +30,21 @@ public static class TypeBaseExtensions
         => (structuralType is IReadOnlyComplexType complexType) && (complexType.ComplexProperty is IReadOnlyComplexProperty complexProperty)
             ? complexProperty.DeclaringType.ShortNameChain() + (complexProperty.IsCollection ? "[]" : ".") + structuralType.ShortName()
             : structuralType.ShortName();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static T CheckContains<T>(this IReadOnlyTypeBase structuralType, T property)
+        where T : IReadOnlyPropertyBase
+    {
+        Check.NotNull(property);
+
+        return !property.DeclaringType.IsAssignableFrom(structuralType) && !property.DeclaringType.ContainingType.IsAssignableFrom(structuralType)
+            ? throw new InvalidOperationException(
+                CoreStrings.PropertyDoesNotBelong(property.Name, property.DeclaringType.DisplayName(), structuralType.DisplayName()))
+            : property;
+    }
 }

--- a/src/EFCore/Metadata/RuntimeComplexType.cs
+++ b/src/EFCore/Metadata/RuntimeComplexType.cs
@@ -19,6 +19,8 @@ public class RuntimeComplexType : RuntimeTypeBase, IRuntimeComplexType
     private PropertyCounts? _counts;
     private InstantiationBinding? _constructorBinding;
     private InstantiationBinding? _serviceOnlyConstructorBinding;
+    private Func<MaterializationContext, object>? _materializer;
+    private Func<MaterializationContext, object>? _emptyMaterializer;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -176,6 +178,31 @@ public class RuntimeComplexType : RuntimeTypeBase, IRuntimeComplexType
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual void SetCounts(PropertyCounts value) => _counts = value;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    // TODO: Make this part of the compiled model to make it work with NativeAOT, Issue #32923
+    [EntityFrameworkInternal]
+    public override Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _materializer, this, source,
+            static (e, s) => s.GetMaterializer(e));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public override Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _emptyMaterializer, this, source,
+            static (e, s) => s.GetEmptyMaterializer(e));
 
     /// <summary>
     ///     Returns a string that represents the current object.

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -875,7 +875,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+    public override Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _materializer, this, source,
             static (e, s) => s.GetMaterializer(e));
@@ -887,7 +887,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public virtual Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
+    public override Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source)
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _emptyMaterializer, this, source,
             static (e, s) => s.GetEmptyMaterializer(e));

--- a/src/EFCore/Metadata/RuntimeTypeBase.cs
+++ b/src/EFCore/Metadata/RuntimeTypeBase.cs
@@ -788,8 +788,26 @@ public abstract class RuntimeTypeBase : RuntimeAnnotatableBase, IRuntimeTypeBase
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _emptyShadowValuesFactory, this,
             static structuralType => RuntimeFeature.IsDynamicCodeSupported
-                ? EmptyShadowValuesFactoryFactory.Instance.CreateEmpty((IRuntimeTypeBase)structuralType)
+                ? EmptyShadowValuesFactoryFactory.Instance.CreateEmpty(structuralType)
                 : throw new InvalidOperationException(CoreStrings.NativeAotNoCompiledModel));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public abstract Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public abstract Func<MaterializationContext, object> GetOrCreateEmptyMaterializer(IEntityMaterializerSource source);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -615,6 +615,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ordinal, declaringType, collection);
 
         /// <summary>
+        ///     The value for complex collection property '{property}' must be a 'List&lt;Dictionary&lt;string, object&gt;&gt;', but it was '{typeName}'.
+        /// </summary>
+        public static string ComplexCollectionValueNotList(object? property, object? typeName)
+            => string.Format(
+                GetString("ComplexCollectionValueNotList", nameof(property), nameof(typeName)),
+                property, typeName);
+
+        /// <summary>
         ///     The collection complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection complex property must implement IEnumerable&lt;&gt; of the complex type.
         /// </summary>
         public static string ComplexCollectionWrongClrType(object? property, object? type, object? clrType, object? targetType)
@@ -653,6 +661,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ComplexPropertyShadow", nameof(type), nameof(property)),
                 type, property);
+
+        /// <summary>
+        ///     The value for complex property '{property}' must be a 'Dictionary&lt;string, object&gt;', but it was '{typeName}'.
+        /// </summary>
+        public static string ComplexPropertyValueNotDictionary(object? property, object? typeName)
+            => string.Format(
+                GetString("ComplexPropertyValueNotDictionary", nameof(property), nameof(typeName)),
+                property, typeName);
 
         /// <summary>
         ///     The complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -339,6 +339,9 @@
   <data name="ComplexCollectionOriginalEntryAddedEntity" xml:space="preserve">
     <value>The complex entry at the original ordinal '{ordinal}' for the collection '{declaringType}.{collection}' cannot be accessed as the containing entry is in the added state.</value>
   </data>
+  <data name="ComplexCollectionValueNotList" xml:space="preserve">
+    <value>The value for complex collection property '{property}' must be a list of dictionaries, but it was '{typeName}'.</value>
+  </data>
   <data name="ComplexCollectionWrongClrType" xml:space="preserve">
     <value>The collection complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection complex property must implement IEnumerable&lt;&gt; of the complex type.</value>
   </data>
@@ -353,6 +356,9 @@
   </data>
   <data name="ComplexPropertyShadow" xml:space="preserve">
     <value>Configuring the complex property '{type}.{property}' in shadow state isn't supported.  See https://github.com/dotnet/efcore/issues/31243 for more information.</value>
+  </data>
+  <data name="ComplexPropertyValueNotDictionary" xml:space="preserve">
+    <value>The value for complex property '{property}' must be a 'Dictionary&lt;string, object&gt;', but it was '{typeName}'.</value>
   </data>
   <data name="ComplexPropertyWrongClrType" xml:space="preserve">
     <value>The complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>

--- a/src/EFCore/Query/IEntityMaterializerSource.cs
+++ b/src/EFCore/Query/IEntityMaterializerSource.cs
@@ -68,7 +68,7 @@ public interface IEntityMaterializerSource
 
     /// <summary>
     ///     <para>
-    ///         Returns a cached delegate that creates instances of the given entity type.
+    ///         Returns a delegate that creates an instance of the given entity type.
     ///     </para>
     ///     <para>
     ///         This method is typically used by database providers (and other extensions). It is generally
@@ -81,7 +81,20 @@ public interface IEntityMaterializerSource
 
     /// <summary>
     ///     <para>
-    ///         Returns a cached delegate that creates empty instances of the given entity type.
+    ///         Returns a delegate that creates an instance of the given complex type.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="complexType">The entity type being materialized.</param>
+    /// <returns>A delegate to create instances.</returns>
+    Func<MaterializationContext, object> GetMaterializer(IComplexType complexType);
+
+    /// <summary>
+    ///     <para>
+    ///         Returns a delegate that creates an empty instance of the given entity type.
     ///     </para>
     ///     <para>
     ///         This method is typically used by database providers (and other extensions). It is generally
@@ -91,4 +104,17 @@ public interface IEntityMaterializerSource
     /// <param name="entityType">The entity type being materialized.</param>
     /// <returns>A delegate to create instances.</returns>
     Func<MaterializationContext, object> GetEmptyMaterializer(IEntityType entityType);
+
+    /// <summary>
+    ///     <para>
+    ///         Returns a delegate that creates an empty instance of the given complex type.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="complexType">The entity type being materialized.</param>
+    /// <returns>A delegate to create instances.</returns>
+    Func<MaterializationContext, object> GetEmptyMaterializer(IComplexType complexType);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -795,15 +795,19 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
     public class CosmosGenericComplexCollection(CosmosModelBuilderFixture fixture)
         : ComplexCollectionTestBase(fixture), IClassFixture<CosmosModelBuilderFixture>
     {
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
         public override void Properties_can_have_custom_type_value_converter_type_set()
             => Properties_can_have_custom_type_value_converter_type_set<string>();
 
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
         public override void Properties_can_have_non_generic_value_converter_set()
             => Properties_can_have_non_generic_value_converter_set<string>();
 
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
         public override void Properties_can_have_provider_type_set()
             => Properties_can_have_provider_type_set<string>();
 
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
         public override void Can_set_complex_property_annotation()
         {
             var modelBuilder = CreateModelBuilder();
@@ -836,6 +840,176 @@ public class CosmosModelBuilderGenericTest : ModelBuilderTest
       Notes (List<string>) Element type: string Required", complexCollection.ToDebugString(), ignoreLineEndingDifferences: true);
         }
 
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_set_to_generate_values_on_Add()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Access_mode_can_be_overridden_at_entity_and_property_levels()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_unicode_for_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_property_annotation()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_set_row_version()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_property_annotation_by_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_ignored()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Value_converter_configured_on_non_nullable_type_is_applied()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_precision_and_scale_for_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_ignored_by_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Non_nullable_properties_cannot_be_made_optional()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_add_shadow_properties_when_they_have_been_ignored()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_have_field_set()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_unicode_for_property_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_custom_value_generator_for_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_made_optional()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_have_value_converter_set_inline()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_are_required_by_default_only_if_CLR_type_is_nullable()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_precision_and_scale_for_property_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_made_required()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_sentinel_for_property_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_property_annotation_when_no_clr_property()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_ignore_shadow_properties_when_they_have_been_added_explicitly()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_max_length_for_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_be_made_concurrency_tokens()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_sentinel_for_properties()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_max_length_for_property_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_have_provider_type_set_for_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_have_value_converter_set()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Value_converter_type_is_checked()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Value_converter_configured_on_nullable_type_overrides_non_nullable()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Can_set_unbounded_max_length_for_property_type()
+        {
+        }
+
+        [ConditionalFact(Skip = "Issue #31253: Complex type collections are not supported in Cosmos")]
+        public override void Properties_can_have_access_mode_set()
+        {
+        }
+        
         protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder>? configure = null)
             => new GenericTestModelBuilder(Fixture, configure);
     }

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/ComplexTypes/DbContextModelBuilder.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/ComplexTypes/DbContextModelBuilder.cs
@@ -11,19 +11,17 @@ namespace TestNamespace
     public partial class DbContextModel
     {
         private DbContextModel()
-            : base(skipDetectChanges: false, modelId: new Guid("00000000-0000-0000-0000-000000000000"), entityTypeCount: 2)
+            : base(skipDetectChanges: false, modelId: new Guid("00000000-0000-0000-0000-000000000000"), entityTypeCount: 1)
         {
         }
 
         partial void Initialize()
         {
             var principalBase = PrincipalBaseEntityType.Create(this);
-            var principalDerived = PrincipalDerivedEntityType.Create(this, principalBase);
 
             PrincipalBaseEntityType.CreateForeignKey1(principalBase, principalBase);
 
             PrincipalBaseEntityType.CreateAnnotations(principalBase);
-            PrincipalDerivedEntityType.CreateAnnotations(principalDerived);
 
             AddAnnotation("Cosmos:ContainerName", "DbContext");
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/ComplexTypes/PrincipalBaseEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/ComplexTypes/PrincipalBaseEntityType.cs
@@ -34,7 +34,6 @@ namespace TestNamespace
                 baseEntityType,
                 discriminatorProperty: "$type",
                 discriminatorValue: "PrincipalBase",
-                derivedTypesCount: 1,
                 propertyCount: 15,
                 complexPropertyCount: 1,
                 navigationCount: 1,

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/CompiledModelCosmosTest.cs
@@ -660,24 +660,27 @@ public class CompiledModelCosmosTest(NonSharedFixture fixture) : CompiledModelTe
                     });
             });
 
-        modelBuilder.Entity<PrincipalDerived<DependentBase<byte?>>>(
-            eb =>
-            {
-                eb.ComplexCollection<IList<OwnedType>, OwnedType>(
-                    "ManyOwned", "OwnedCollection", ob =>
-                    {
-                        ob.Ignore(e => e.RefTypeArray);
-                        ob.Ignore(e => e.RefTypeList);
-                        ob.ComplexProperty(
-                            o => o.Principal, cb =>
-                            {
-                                cb.Ignore(e => e.RefTypeList);
-                                cb.Ignore(e => e.RefTypeArray);
-                            });
-                    });
-                eb.Ignore(p => p.Dependent);
-                eb.Ignore(p => p.Principals);
-            });
+        // TODO: Complex collections not supported. Issue #31253
+        modelBuilder.Ignore<PrincipalDerived<DependentBase<byte?>>>();
+
+        //modelBuilder.Entity<PrincipalDerived<DependentBase<byte?>>>(
+        //    eb =>
+        //    {
+        //        eb.ComplexCollection<IList<OwnedType>, OwnedType>(
+        //            "ManyOwned", "OwnedCollection", ob =>
+        //            {
+        //                ob.Ignore(e => e.RefTypeArray);
+        //                ob.Ignore(e => e.RefTypeList);
+        //                ob.ComplexProperty(
+        //                    o => o.Principal, cb =>
+        //                    {
+        //                        cb.Ignore(e => e.RefTypeList);
+        //                        cb.Ignore(e => e.RefTypeArray);
+        //                    });
+        //            });
+        //        eb.Ignore(p => p.Dependent);
+        //        eb.Ignore(p => p.Principals);
+        //    });
     }
 
     protected override void AssertBigModel(IModel model, bool jsonColumns)

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -554,6 +554,33 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
                 typeof(Memory<float>[]).ShortDisplayName()), modelBuilder);
     }
 
+    [ConditionalFact]
+    public virtual void Detects_complex_type_collection()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithComplexTypeCollection>(
+            b =>
+            {
+                b.ComplexCollection(e => e.ComplexTypes);
+            });
+
+        VerifyError(
+            CosmosStrings.ComplexTypeCollectionsNotSupported(
+                nameof(ComplexTypeInCollection),
+                nameof(EntityWithComplexTypeCollection.ComplexTypes)), modelBuilder);
+    }
+
+    private class EntityWithComplexTypeCollection
+    {
+        public string Id { get; set; }
+        public List<ComplexTypeInCollection> ComplexTypes { get; set; }
+    }
+
+    private class ComplexTypeInCollection
+    {
+        public string Value { get; set; }
+    }
+
     private class RememberMyName<T>
     {
         public string Id { get; set; }

--- a/test/EFCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
@@ -26,11 +26,81 @@ public class PropertyValuesInMemoryTest(PropertyValuesInMemoryTest.PropertyValue
         => Assert.ThrowsAnyAsync<Exception>( // In-memory database cannot query complex types
             () => base.Values_can_be_reloaded_from_database_for_entity_in_any_state_with_inheritance(state, async));
 
+    // Complex collection tests - InMemory provider doesn't support complex collections yet
+    public override Task Complex_collection_current_values_can_be_accessed_as_a_property_dictionary()
+        => Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Complex_collection_current_values_can_be_accessed_as_a_property_dictionary());
+
+    public override Task Complex_collection_original_values_can_be_accessed_as_a_property_dictionary()
+        => Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Complex_collection_original_values_can_be_accessed_as_a_property_dictionary());
+
+    public override Task Complex_collection_store_values_can_be_accessed_as_a_property_dictionary()
+        => Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Complex_collection_store_values_can_be_accessed_as_a_property_dictionary());
+
+    public override Task Complex_collection_store_values_can_be_accessed_asynchronously_as_a_property_dictionary()
+        => Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Complex_collection_store_values_can_be_accessed_asynchronously_as_a_property_dictionary());
+
+    public override void Setting_complex_collection_values_from_object_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_values_from_object_works());
+
+    public override void Setting_complex_collection_original_values_from_object_with_nulls_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_original_values_from_object_with_nulls_works());
+
+    public override void Setting_complex_collection_original_values_from_dictionary_with_nulls_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_original_values_from_dictionary_with_nulls_works());
+
+    public override void Setting_complex_collection_current_values_from_dictionary_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_current_values_from_dictionary_works());
+
+    public override void SetValues_throws_for_nested_complex_collection_with_non_list_value()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.SetValues_throws_for_nested_complex_collection_with_non_list_value());
+
+    public override void SetValues_throws_for_complex_property_with_non_dictionary_value()
+        => Assert.Throws<Xunit.Sdk.ThrowsException>(
+            () => base.SetValues_throws_for_complex_property_with_non_dictionary_value());
+
+    public override void SetValues_throws_for_complex_collection_with_non_list_value()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.SetValues_throws_for_complex_collection_with_non_list_value());
+
+    public override void SetValues_throws_for_complex_collection_with_non_dictionary_item()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.SetValues_throws_for_complex_collection_with_non_dictionary_item());
+
+    public override void SetValues_throws_for_nested_complex_collection_with_non_dictionary_item()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.SetValues_throws_for_nested_complex_collection_with_non_dictionary_item());
+
+    public override void Setting_complex_collection_current_values_from_DTO_with_complex_metadata_access_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_current_values_from_DTO_with_complex_metadata_access_works());
+
+    public override void Setting_complex_collection_values_from_DTO_with_nulls_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_values_from_DTO_with_nulls_works());
+
+    public override void Setting_complex_collection_current_values_from_dictionary_with_nulls_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_current_values_from_dictionary_with_nulls_works());
+
+    public override void Setting_complex_collection_current_values_from_object_with_nulls_works()
+        => Assert.Throws<InvalidOperationException>(
+            () => base.Setting_complex_collection_current_values_from_object_with_nulls_works());
+
     public class PropertyValuesInMemoryFixture : PropertyValuesFixtureBase
     {
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder)
-                .ConfigureWarnings(w => w.Ignore(CoreEventId.MappedComplexPropertyIgnoredWarning))
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.MappedComplexPropertyIgnoredWarning)
+                    .Ignore(CoreEventId.MappedEntityTypeIgnoredWarning))
                 .EnableSensitiveDataLogging(false);
 
         protected override ITestStoreFactory TestStoreFactory
@@ -47,6 +117,9 @@ public class PropertyValuesInMemoryTest(PropertyValuesInMemoryTest.PropertyValue
                     b.Ignore(e => e.Culture);
                     b.Ignore(e => e.Milk);
                 });
+
+            // In-memory database doesn't support complex collections
+            modelBuilder.Ignore<School>();
         }
     }
 }

--- a/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -188,7 +188,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         bool expectOriginalValues)
     {
         using var context = CreateContext();
-        object building = context.Set<Building>().Single(b => b.Name == "Building One");
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
 
         context.Entry(building).Property("Name").CurrentValue = "Building One Prime";
         context.Entry(building).Property("Value").CurrentValue = 1500001m;
@@ -221,6 +221,10 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
             Assert.Equal(12, values.GetValue<int>("Shadow1"));
             Assert.Equal("Pine Walk", values.GetValue<string>("Shadow2"));
         }
+
+        Assert.True(building.CreatedCalled);
+        Assert.True(building.InitializingCalled);
+        Assert.True(building.InitializedCalled);
     }
 
     [ConditionalFact]
@@ -258,6 +262,8 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         {
             Assert.Equal("Building One", values["Name"]);
             Assert.Equal(1500000m, values["Value"]);
+            Assert.Equal(11, values["Shadow1"]);
+            Assert.Equal("Meadow Drive", values["Shadow2"]);
 
             Assert.Equal("Building One", values.GetValue<string>(entry.Property("Name").Metadata));
             Assert.Equal(1500000m, values.GetValue<decimal>(entry.Property("Value").Metadata));
@@ -268,6 +274,8 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         {
             Assert.Equal("Building One Prime", values["Name"]);
             Assert.Equal(1500001m, values["Value"]);
+            Assert.Equal(12, values["Shadow1"]);
+            Assert.Equal("Pine Walk", values["Shadow2"]);
 
             Assert.Equal("Building One Prime", values.GetValue<string>(entry.Property("Name").Metadata));
             Assert.Equal(1500001m, values.GetValue<decimal>(entry.Property("Value").Metadata));
@@ -1012,7 +1020,6 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         context.Entry(building).Property("Shadow2").CurrentValue = "The Avenue";
 
         var buildingValues = await getPropertyValues(context.Entry(building));
-
         var clonedBuildingValues = buildingValues.Clone();
 
         if (expectOriginalValues)
@@ -1398,8 +1405,6 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
 
         buildingValues.SetValues(newBuilding);
 
-        // Check Values
-
         Assert.Equal("Values End", buildingValues["Name"]);
         Assert.Equal(1500000m, buildingValues["Value"]);
         Assert.Equal(11, buildingValues["Shadow1"]);
@@ -1505,8 +1510,6 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         };
 
         buildingValues.SetValues(dictionary);
-
-        // Check Values
 
         Assert.Equal("Values End", buildingValues["Name"]);
         Assert.Equal(1500000m, buildingValues["Value"]);
@@ -2237,6 +2240,1225 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         Assert.True(originalValues.InitializedCalled);
     }
 
+    [ConditionalFact]
+    public virtual Task Complex_collection_current_values_can_be_accessed_as_a_property_dictionary()
+        => TestComplexCollectionPropertyValues(e => Task.FromResult(e.CurrentValues), expectOriginalValues: false);
+
+    [ConditionalFact]
+    public virtual Task Complex_collection_original_values_can_be_accessed_as_a_property_dictionary()
+        => TestComplexCollectionPropertyValues(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
+
+    [ConditionalFact(Skip = "Complex collection query support. Issue #31411")]
+    public virtual Task Complex_collection_store_values_can_be_accessed_as_a_property_dictionary()
+        => TestComplexCollectionPropertyValues(e => Task.FromResult(e.GetDatabaseValues()!), expectOriginalValues: true);
+
+    [ConditionalFact(Skip = "Complex collection query support. Issue #31411")]
+    public virtual Task Complex_collection_store_values_can_be_accessed_asynchronously_as_a_property_dictionary()
+        => TestComplexCollectionPropertyValues(e => e.GetDatabaseValuesAsync()!, expectOriginalValues: true);
+
+    private async Task TestComplexCollectionPropertyValues(
+        Func<EntityEntry<School>, Task<PropertyValues>> getPropertyValues,
+        bool expectOriginalValues)
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var originalDepartments = school.Departments.ToList();
+        var originalFirstDepartmentCourses = school.Departments.First().Courses.ToList();
+
+        school.Departments.Clear();
+        school.Departments.Add(new Department
+        {
+            Name = "Modified Department",
+            Building = "Modified Building",
+            Courses =
+            [
+                new Course { Name = "Modified Course 1", Credits = 4 },
+                new Course { Name = "Modified Course 2", Credits = 5 }
+            ]
+        });
+
+        var entry = context.Entry(school);
+        var values = await getPropertyValues(entry);
+
+        Assert.Equal("Test School", values["Name"]);
+        Assert.Equal("Test School", values[entry.Property(e => e.Name).Metadata]);
+        Assert.Equal(1, values[entry.Property(e => e.Id).Metadata]);
+
+        var departmentsComplexProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        if (expectOriginalValues)
+        {
+            Assert.Equal("Test School", values["Name"]);
+            var departments = (IList<Department>)values["Departments"]!;
+            var departmentsViaComplexProperty = (IList<Department>)values[departmentsComplexProperty]!;
+            Assert.Equal(2, departments.Count);
+            Assert.Equal(2, departmentsViaComplexProperty.Count);
+
+            var dept1 = departments[0];
+            var dept1Object = departmentsViaComplexProperty[0];
+            Assert.Equal("Computer Science", dept1.Name);
+            Assert.Equal("Building A", dept1.Building);
+            Assert.Equal("Computer Science", dept1Object.Name);
+            Assert.Equal("Building A", dept1Object.Building);
+
+
+            var department1Courses = dept1.Courses;
+            Assert.Equal(2, department1Courses.Count);
+
+            Assert.Equal("Data Structures", department1Courses[0].Name);
+            Assert.Equal(3, department1Courses[0].Credits);
+            Assert.Equal("Data Structures", department1Courses[0].Name);
+            Assert.Equal(3, department1Courses[0].Credits);
+
+            Assert.Equal("Algorithms", department1Courses[1].Name);
+            Assert.Equal(4, department1Courses[1].Credits);
+            Assert.Equal("Algorithms", department1Courses[1].Name);
+            Assert.Equal(4, department1Courses[1].Credits);
+
+            var dept2 = departments[1];
+            Assert.Equal("Mathematics", dept2.Name);
+            Assert.Equal("Building B", dept2.Building);
+            Assert.Equal("Mathematics", dept2.Name);
+            Assert.Equal("Building B", dept2.Building);
+
+            var department2Courses = dept2.Courses;
+            Assert.Equal(2, department2Courses.Count);
+            Assert.Equal("Calculus I", department2Courses[0].Name);
+            Assert.Equal(4, department2Courses[0].Credits);
+            Assert.Equal("Linear Algebra", department2Courses[1].Name);
+            Assert.Equal(3, department2Courses[1].Credits);
+        }
+        else
+        {
+            Assert.Equal("Test School", values["Name"]);
+            var departments = (IList<Department>)values["Departments"]!;
+            var departmentsViaComplexProperty = (IList<Department>)values[departmentsComplexProperty]!;
+
+            Assert.Single(departments);
+            Assert.Single(departmentsViaComplexProperty);
+            var dept = departments[0];
+            var deptViaComplexProperty = departmentsViaComplexProperty[0];
+            Assert.Equal("Modified Department", dept.Name);
+            Assert.Equal("Modified Building", dept.Building);
+            Assert.Equal("Modified Department", deptViaComplexProperty.Name);
+            Assert.Equal("Modified Building", deptViaComplexProperty.Building);
+
+            Assert.Equal("Modified Department", dept.Name);
+            Assert.Equal("Modified Building", dept.Building);
+
+            var courses = dept.Courses;
+            Assert.Equal(2, courses.Count);
+
+            Assert.Equal("Modified Course 1", courses[0].Name);
+            Assert.Equal(4, courses[0].Credits);
+            Assert.Equal("Modified Course 1", courses[0].Name);
+            Assert.Equal(4, courses[0].Credits);
+
+            Assert.Equal("Modified Course 2", courses[1].Name);
+            Assert.Equal(5, courses[1].Credits);
+            Assert.Equal("Modified Course 2", courses[1].Name);
+            Assert.Equal(5, courses[1].Credits);
+        }
+
+        Assert.False(school.CreatedCalled);
+        Assert.False(school.InitializingCalled);
+        Assert.False(school.InitializedCalled);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_values_from_object_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var newSchool = new School
+        {
+            Id = school.Id,
+            Name = "Completely New School",
+            Departments =
+            [
+                new Department
+                {
+                    Name = "New Department",
+                    Building = "New Building",
+                    Courses =
+                    [
+                        new Course { Name = "New Course", Credits = 4 }
+                    ]
+                }
+            ]
+        };
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(newSchool);
+
+        Assert.Equal("Completely New School", school.Name);
+        Assert.Single(school.Departments);
+
+        var department = school.Departments[0];
+        Assert.Equal("New Department", department.Name);
+        Assert.Equal("New Building", department.Building);
+        Assert.Single(department.Courses);
+        var course = department.Courses[0];
+        Assert.Equal("New Course", course.Name);
+
+        Assert.Equal(4, course.Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentsProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        var departmentEntry = internalEntry.GetComplexCollectionEntry(departmentsProperty, 0);
+
+        Assert.Equal(EntityState.Modified, departmentEntry.EntityState);
+        Assert.Equal(EntityState.Deleted, internalEntry.GetComplexCollectionOriginalEntry(departmentsProperty, 1).EntityState);
+
+        var coursesProperty = departmentsProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+        var courseEntries = departmentEntry.GetComplexCollectionEntries(coursesProperty);
+
+        Assert.Single(courseEntries);
+        Assert.Equal(EntityState.Modified, courseEntries[0]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_current_values_from_object_with_nulls_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var newSchool = new School
+        {
+            Id = school.Id,
+            Name = "School with Nulls",
+            Departments =
+            [
+                new Department
+                {
+                    Name = "Department 1",
+                    Building = "Building 1",
+                    Courses = [null!, new Course { Name = "Course A", Credits = 3 }, null!]
+                },
+                null!,
+                new Department
+                {
+                    Name = "Department 2",
+                    Building = "Building 2",
+                    Courses = [new Course { Name = "Course B", Credits = 4 }]
+                }
+            ]
+        };
+
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(newSchool);
+
+        Assert.Equal("School with Nulls", school.Name);
+        Assert.Equal(3, school.Departments.Count);
+
+        Assert.Equal("Department 1", school.Departments[0]!.Name);
+        Assert.Equal("Building 1", school.Departments[0]!.Building);
+        Assert.Equal(3, school.Departments[0]!.Courses.Count);
+        Assert.Null(school.Departments[0]!.Courses[0]);
+        Assert.Equal("Course A", school.Departments[0]!.Courses[1]!.Name);
+        Assert.Equal(3, school.Departments[0]!.Courses[1]!.Credits);
+        Assert.Null(school.Departments[0]!.Courses[2]);
+        Assert.Null(school.Departments[1]);
+
+        Assert.Equal("Department 2", school.Departments[2]!.Name);
+        Assert.Equal("Building 2", school.Departments[2]!.Building);
+        Assert.Single(school.Departments[2]!.Courses);
+        Assert.Equal("Course B", school.Departments[2]!.Courses[0]!.Name);
+        Assert.Equal(4, school.Departments[2]!.Courses[0]!.Credits);
+
+        var currentValues = entry.CurrentValues;
+        var departments = (IList<Department>)currentValues["Departments"]!;
+        Assert.Equal(3, departments.Count);
+
+        Assert.Equal("Department 1", departments[0].Name);
+        Assert.Equal("Building 1", departments[0].Building);
+        var dept1Courses = departments[0].Courses;
+        Assert.Equal(3, dept1Courses.Count);
+        Assert.Null(dept1Courses[0]);
+        Assert.Equal("Course A", dept1Courses[1].Name);
+        Assert.Equal(3, dept1Courses[1].Credits);
+        Assert.Null(dept1Courses[2]);
+        Assert.Null(departments[1]);
+
+        Assert.Equal("Department 2", departments[2].Name);
+        Assert.Equal("Building 2", departments[2].Building);
+        var dept2Courses = departments[2].Courses;
+        Assert.Single(dept2Courses);
+        Assert.Equal("Course B", dept2Courses[0].Name);
+        Assert.Equal(4, dept2Courses[0].Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentsProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsProperty);
+
+        Assert.Equal(3, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Added, departmentEntries[1]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[2]!.EntityState);
+
+        var coursesProperty = departmentsProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Equal(3, dept1CourseEntries.Count);
+        if (dept1CourseEntries[0]!.EntityState == EntityState.Added)
+        {
+            Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+            Assert.Equal(EntityState.Modified, dept1CourseEntries[2]!.EntityState);
+        }
+        else
+        {
+            Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+            Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+            Assert.Equal(EntityState.Added, dept1CourseEntries[2]!.EntityState);
+        }
+
+        var dept2CourseEntries = departmentEntries[2]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Single(dept2CourseEntries);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[0]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_original_values_from_object_with_nulls_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var newSchool = new School
+        {
+            Id = school.Id,
+            Name = "Original School with Nulls",
+            Departments =
+            [
+                null!,
+                new Department
+                {
+                    Name = "Original Department",
+                    Building = "Original Building",
+                    Courses = [new Course { Name = "Original Course", Credits = 2 }, null!]
+                }
+            ]
+        };
+
+        var entry = context.Entry(school);
+        entry.OriginalValues.SetValues(newSchool);
+
+        Assert.Equal("Test School", school.Name);
+        Assert.Equal(2, school.Departments.Count);
+
+        var originalValues = entry.OriginalValues;
+        Assert.Equal("Original School with Nulls", originalValues["Name"]);
+        var originalDepartments = (IList<Department>)originalValues["Departments"]!;
+        Assert.Equal(2, originalDepartments.Count);
+
+        Assert.Null(originalDepartments[0]);
+        Assert.Equal("Original Department", originalDepartments[1].Name);
+        Assert.Equal("Original Building", originalDepartments[1].Building);
+
+        var originalCourses = originalDepartments[1].Courses;
+        Assert.Equal(2, originalCourses.Count);
+        Assert.Equal("Original Course", originalCourses[0].Name);
+        Assert.Equal(2, originalCourses[0].Credits);
+        Assert.Null(originalCourses[1]);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentsProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsProperty);
+
+        Assert.Equal(2, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[1]!.EntityState);
+
+        var coursesProperty = departmentsProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Equal(2, dept1CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+
+        var dept2CourseEntries = departmentEntries[1]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Equal(2, dept2CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[1]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_current_values_from_dictionary_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Id"] = school.Id,
+            ["Name"] = "Dictionary School",
+            ["Departments"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["Name"] = "Dict Department 1",
+                    ["Building"] = "Dict Building 1",
+                    ["Courses"] = new List<Dictionary<string, object>>
+                    {
+                        new() { ["Name"] = "Dict Course 1", ["Credits"] = 5 },
+                        new() { ["Name"] = "Dict Course 2", ["Credits"] = 6 }
+                    }
+                },
+                new()
+                {
+                    ["Name"] = "Dict Department 2",
+                    ["Building"] = "Dict Building 2",
+                    ["Courses"] = new List<Dictionary<string, object>>
+                    {
+                        new() { ["Name"] = "Dict Course 3", ["Credits"] = 7 }
+                    }
+                }
+            }
+        };
+
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(dictionary);
+
+        Assert.Equal("Dictionary School", school.Name);
+        Assert.Equal(2, school.Departments.Count);
+
+        Assert.Equal("Dict Department 1", school.Departments[0].Name);
+        Assert.Equal("Dict Building 1", school.Departments[0].Building);
+        Assert.Equal(2, school.Departments[0].Courses.Count);
+        Assert.Equal("Dict Course 1", school.Departments[0].Courses[0].Name);
+        Assert.Equal(5, school.Departments[0].Courses[0].Credits);
+        Assert.Equal("Dict Course 2", school.Departments[0].Courses[1].Name);
+        Assert.Equal(6, school.Departments[0].Courses[1].Credits);
+
+        Assert.Equal("Dict Department 2", school.Departments[1].Name);
+        Assert.Equal("Dict Building 2", school.Departments[1].Building);
+        Assert.Single(school.Departments[1].Courses);
+        Assert.Equal("Dict Course 3", school.Departments[1].Courses[0].Name);
+        Assert.Equal(7, school.Departments[1].Courses[0].Credits);
+
+        var currentValues = entry.CurrentValues;
+        var departments = (IList<Department>)currentValues["Departments"]!;
+        Assert.Equal(2, departments.Count);
+        Assert.Equal("Dict Department 1", departments[0].Name);
+        Assert.Equal("Dict Building 1", departments[0].Building);
+        var dept1Courses = departments[0].Courses;
+        Assert.Equal(2, dept1Courses.Count);
+        Assert.Equal("Dict Course 1", dept1Courses[0].Name);
+        Assert.Equal(5, dept1Courses[0].Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentsProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsProperty);
+
+        Assert.Equal(2, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[1]!.EntityState);
+
+        var coursesProperty = departmentsProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Equal(2, dept1CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+
+        var dept2CourseEntries = departmentEntries[1]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Single(dept2CourseEntries);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[0]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_values_from_DTO_with_nulls_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dto = new SchoolDto
+        {
+            Id = school.Id,
+            Name = "DTO School",
+            Departments = new List<DepartmentDto?>
+            {
+                new()
+                {
+                    Name = "DTO Department",
+                    Building = "DTO Building",
+                    Courses = new List<CourseDto?>
+                    {
+                        null,
+                        new() { Name = "DTO Course", Credits = 8 }
+                    }
+                },
+                null
+            }
+        };
+
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(dto);
+
+        Assert.Equal("DTO School", school.Name);
+        Assert.Equal(2, school.Departments.Count);
+
+        Assert.Equal("DTO Department", school.Departments[0]!.Name);
+        Assert.Equal("DTO Building", school.Departments[0]!.Building);
+        Assert.Equal(2, school.Departments[0]!.Courses.Count);
+        Assert.Null(school.Departments[0]!.Courses[0]);
+        Assert.Equal("DTO Course", school.Departments[0]!.Courses[1]!.Name);
+        Assert.Equal(8, school.Departments[0]!.Courses[1]!.Credits);
+
+        Assert.Null(school.Departments[1]);
+
+        var currentValues = entry.CurrentValues;
+        var departments = (IList<Department>)currentValues["Departments"]!;
+        Assert.Equal(2, departments.Count);
+        Assert.Equal("DTO Department", departments[0].Name);
+        var courses = departments[0].Courses;
+        Assert.Equal(2, courses.Count);
+        Assert.Null(courses[0]);
+        Assert.Equal("DTO Course", courses[1].Name);
+        Assert.Equal(8, courses[1].Credits);
+        Assert.Null(departments[1]);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentsProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsProperty);
+
+        Assert.Equal(2, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[1]!.EntityState);
+
+        var coursesProperty = departmentsProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesProperty);
+        Assert.Equal(2, dept1CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_current_values_from_dictionary_with_nulls_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Id"] = school.Id,
+            ["Name"] = "Dictionary School with Nulls",
+            ["Departments"] = new List<Dictionary<string, object>?>
+            {
+                null,
+                new()
+                {
+                    ["Name"] = "Dict Department",
+                    ["Building"] = "Dict Building",
+                    ["Courses"] = new List<Dictionary<string, object>?>
+                    {
+                        new() { ["Name"] = "Dict Course 1", ["Credits"] = 5 },
+                        null,
+                        new() { ["Name"] = "Dict Course 2", ["Credits"] = 6 }
+                    }
+                }
+            }
+        };
+
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(dictionary);
+
+        // Verify entity state
+        Assert.Equal("Dictionary School with Nulls", school.Name);
+        Assert.Equal(2, school.Departments.Count);
+        Assert.Null(school.Departments[0]);
+        Assert.Equal("Dict Department", school.Departments[1]!.Name);
+        Assert.Equal("Dict Building", school.Departments[1]!.Building);
+        Assert.Equal(3, school.Departments[1]!.Courses.Count);
+        Assert.Equal("Dict Course 1", school.Departments[1]!.Courses[0]!.Name);
+        Assert.Equal(5, school.Departments[1]!.Courses[0]!.Credits);
+        Assert.Null(school.Departments[1]!.Courses[1]);
+        Assert.Equal("Dict Course 2", school.Departments[1]!.Courses[2]!.Name);
+        Assert.Equal(6, school.Departments[1]!.Courses[2]!.Credits);
+
+        var currentValues = entry.CurrentValues;
+        var departmentsComplexProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+
+        var departments = (IList<Department>)currentValues["Departments"]!;
+        var departmentsViaComplexProperty = (IList<Department>)currentValues[departmentsComplexProperty]!;
+
+        Assert.Equal(2, departments.Count);
+        Assert.Equal(2, departmentsViaComplexProperty.Count);
+        Assert.Null(departments[0]);
+        Assert.Null(departmentsViaComplexProperty[0]);
+
+        var deptNameProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Name))!;
+        var deptBuildingProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Building))!;
+
+        Assert.Equal("Dict Department", departments[1].Name);
+        Assert.Equal("Dict Building", departments[1].Building);
+        Assert.Equal("Dict Department", departments[1].Name);
+        Assert.Equal("Dict Building", departments[1].Building);
+
+        var courses = departments[1].Courses;
+        var coursesComplexProperty = departmentsComplexProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+        var courseNameProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Name))!;
+        var courseCreditsProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Credits))!;
+
+        Assert.Equal(3, courses.Count);
+        Assert.Equal("Dict Course 1", courses[0].Name);
+        Assert.Equal(5, courses[0].Credits);
+        Assert.Equal("Dict Course 1", courses[0].Name);
+        Assert.Equal(5, courses[0].Credits);
+        Assert.Null(courses[1]);
+        Assert.Equal("Dict Course 2", courses[2].Name);
+        Assert.Equal(6, courses[2].Credits);
+        Assert.Equal("Dict Course 2", courses[2].Name);
+        Assert.Equal(6, courses[2].Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsComplexProperty);
+
+        Assert.Equal(2, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[1]!.EntityState);
+
+        var dept2CourseEntries = departmentEntries[1]!.GetComplexCollectionEntries(coursesComplexProperty);
+        Assert.Equal(3, dept2CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Added, dept2CourseEntries[1]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[2]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_original_values_from_dictionary_with_nulls_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Id"] = school.Id,
+            ["Name"] = "Original Dictionary School",
+            ["Departments"] = new List<Dictionary<string, object>?>
+            {
+                new()
+                {
+                    ["Name"] = "Original Dict Department",
+                    ["Building"] = "Original Dict Building",
+                    ["Courses"] = new List<Dictionary<string, object>?>
+                    {
+                        null,
+                        new() { ["Name"] = "Original Dict Course", ["Credits"] = 2 }
+                    }
+                },
+                null
+            }
+        };
+
+        var entry = context.Entry(school);
+        entry.OriginalValues.SetValues(dictionary);
+
+        Assert.Equal("Test School", school.Name);
+        Assert.Equal(2, school.Departments.Count);
+
+        var originalValues = entry.OriginalValues;
+        var departmentsComplexProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+
+        Assert.Equal("Original Dictionary School", originalValues["Name"]);
+        var originalDepartments = (IList<Department>)originalValues["Departments"]!;
+        var originalDepartmentsViaComplexProperty = (IList<Department>)originalValues[departmentsComplexProperty]!;
+
+        Assert.Equal(2, originalDepartments.Count);
+        Assert.Equal(2, originalDepartmentsViaComplexProperty.Count);
+
+        var deptNameProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Name))!;
+        var deptBuildingProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Building))!;
+
+        Assert.Equal("Original Dict Department", originalDepartments[0].Name);
+        Assert.Equal("Original Dict Building", originalDepartments[0].Building);
+        Assert.Equal("Original Dict Department", originalDepartments[0].Name);
+        Assert.Equal("Original Dict Building", originalDepartments[0].Building);
+        Assert.Null(originalDepartments[1]);
+        Assert.Null(originalDepartmentsViaComplexProperty[1]);
+
+        var originalCourses = originalDepartments[0].Courses;
+        var coursesComplexProperty = departmentsComplexProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+        var courseNameProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Name))!;
+        var courseCreditsProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Credits))!;
+
+        Assert.Equal(2, originalCourses.Count);
+        Assert.Null(originalCourses[0]);
+        Assert.Equal("Original Dict Course", originalCourses[1].Name);
+        Assert.Equal(2, originalCourses[1].Credits);
+        Assert.Equal("Original Dict Course", originalCourses[1].Name);
+        Assert.Equal(2, originalCourses[1].Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsComplexProperty);
+
+        Assert.Equal(2, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[1]!.EntityState);
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesComplexProperty);
+        Assert.Equal(2, dept1CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[1]!.EntityState);
+
+        var dept2CourseEntries = departmentEntries[1]!.GetComplexCollectionEntries(coursesComplexProperty);
+        Assert.Equal(2, dept2CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept2CourseEntries[1]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void Setting_complex_collection_current_values_from_DTO_with_complex_metadata_access_works()
+    {
+        using var context = CreateContext();
+        //var school = context.Set<School>().Single(s => s.Name == "Test School");
+
+        // Complex collection query support. Issue #31411
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dto = new SchoolDto
+        {
+            Id = school.Id,
+            Name = "Advanced DTO School",
+            Departments = new List<DepartmentDto?>
+            {
+                new()
+                {
+                    Name = "Advanced DTO Department 1",
+                    Building = "Advanced DTO Building 1",
+                    Courses = new List<CourseDto?>
+                    {
+                        new() { Name = "Advanced DTO Course 1", Credits = 10 },
+                        null,
+                        new() { Name = "Advanced DTO Course 2", Credits = 12 }
+                    }
+                },
+                null,
+                new()
+                {
+                    Name = "Advanced DTO Department 2",
+                    Building = "Advanced DTO Building 2",
+                    Courses = new List<CourseDto?>
+                    {
+                        new() { Name = "Advanced DTO Course 3", Credits = 15 }
+                    }
+                }
+            }
+        };
+
+        var entry = context.Entry(school);
+        entry.CurrentValues.SetValues(dto);
+
+        Assert.Equal("Advanced DTO School", school.Name);
+        Assert.Equal(3, school.Departments.Count);
+
+        var currentValues = entry.CurrentValues;
+        var departmentsComplexProperty = entry.Metadata.FindComplexProperty(nameof(School.Departments))!;
+
+        var departments = (IList<Department>)currentValues[departmentsComplexProperty]!;
+        Assert.Equal(3, departments.Count);
+
+        var deptNameProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Name))!;
+        var deptBuildingProperty = departmentsComplexProperty.ComplexType.FindProperty(nameof(Department.Building))!;
+
+        Assert.Equal("Advanced DTO Department 1", departments[0].Name);
+        Assert.Equal("Advanced DTO Building 1", departments[0].Building);
+
+        var dept1Courses = departments[0].Courses;
+        var coursesComplexProperty = departmentsComplexProperty.ComplexType.FindComplexProperty(nameof(Department.Courses))!;
+        var courseNameProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Name))!;
+        var courseCreditsProperty = coursesComplexProperty.ComplexType.FindProperty(nameof(Course.Credits))!;
+
+        Assert.Equal(3, dept1Courses.Count);
+        Assert.Equal("Advanced DTO Course 1", dept1Courses[0].Name);
+        Assert.Equal(10, dept1Courses[0].Credits);
+        Assert.Null(dept1Courses[1]);
+        Assert.Equal("Advanced DTO Course 2", dept1Courses[2].Name);
+        Assert.Equal(12, dept1Courses[2].Credits);
+
+        Assert.Null(departments[1]);
+
+        Assert.Equal("Advanced DTO Department 2", departments[2].Name);
+        Assert.Equal("Advanced DTO Building 2", departments[2].Building);
+
+        var dept2Courses = departments[2].Courses;
+        Assert.Single(dept2Courses);
+        Assert.Equal("Advanced DTO Course 3", dept2Courses[0].Name);
+        Assert.Equal(15, dept2Courses[0].Credits);
+
+        var internalEntry = entry.GetInfrastructure();
+        var departmentEntries = internalEntry.GetComplexCollectionEntries(departmentsComplexProperty);
+
+        Assert.Equal(3, departmentEntries.Count);
+        Assert.Equal(EntityState.Modified, departmentEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Added, departmentEntries[1]!.EntityState);
+        Assert.Equal(EntityState.Modified, departmentEntries[2]!.EntityState);
+
+        var dept1CourseEntries = departmentEntries[0]!.GetComplexCollectionEntries(coursesComplexProperty);
+        Assert.Equal(3, dept1CourseEntries.Count);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[0]!.EntityState);
+        Assert.Equal(EntityState.Added, dept1CourseEntries[1]!.EntityState);
+        Assert.Equal(EntityState.Modified, dept1CourseEntries[2]!.EntityState);
+
+        var dept3CourseEntries = departmentEntries[2]!.GetComplexCollectionEntries(coursesComplexProperty);
+        Assert.Single(dept3CourseEntries);
+        Assert.Equal(EntityState.Modified, dept3CourseEntries[0]!.EntityState);
+    }
+
+    [ConditionalFact]
+    public virtual void SetValues_throws_for_complex_collection_with_non_list_value()
+    {
+        using var context = CreateContext();
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Name"] = "Test School",
+            ["Departments"] = "Not a list"
+        };
+
+        var entry = context.Entry(school);
+        var exception = Assert.Throws<InvalidOperationException>(() => entry.OriginalValues.SetValues(dictionary));
+        Assert.Equal(CoreStrings.ComplexCollectionValueNotList("Departments", "string"), exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual void SetValues_throws_for_complex_collection_with_non_dictionary_item()
+    {
+        using var context = CreateContext();
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Name"] = "Test School",
+            ["Departments"] = new List<object?> { "Not a dictionary", null }
+        };
+
+        var entry = context.Entry(school);
+        var exception = Assert.Throws<InvalidOperationException>(() => entry.OriginalValues.SetValues(dictionary));
+        Assert.Equal(CoreStrings.ComplexCollectionValueNotList("Departments", "string"), exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual void SetValues_throws_for_nested_complex_collection_with_non_list_value()
+    {
+        using var context = CreateContext();
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Name"] = "Test School",
+            ["Departments"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["Name"] = "Department 1",
+                    ["Building"] = "Building 1",
+                    ["Courses"] = "Not a list"
+                }
+            }
+        };
+
+        var entry = context.Entry(school);
+        var exception = Assert.Throws<InvalidOperationException>(() => entry.OriginalValues.SetValues(dictionary));
+        Assert.Equal(CoreStrings.ComplexCollectionValueNotList("Courses", "string"), exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual void SetValues_throws_for_nested_complex_collection_with_non_dictionary_item()
+    {
+        using var context = CreateContext();
+        var school = CreateSchool();
+        context.Set<School>().Attach(school);
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Name"] = "Test School",
+            ["Departments"] = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["Name"] = "Department 1",
+                    ["Building"] = "Building 1",
+                    ["Courses"] = new List<object?> { "Not a dictionary" }
+                }
+            }
+        };
+
+        var entry = context.Entry(school);
+        var exception = Assert.Throws<InvalidOperationException>(() => entry.OriginalValues.SetValues(dictionary));
+        Assert.Equal(CoreStrings.ComplexCollectionValueNotList("Courses", "List<object>"), exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual void SetValues_throws_for_complex_property_with_non_dictionary_value()
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        var dictionary = new Dictionary<string, object>
+        {
+            ["Name"] = "Building",
+            ["Culture"] = "Not a dictionary"
+        };
+
+        var entry = context.Entry(building);
+        var exception = Assert.Throws<InvalidOperationException>(() => entry.OriginalValues.SetValues(dictionary));
+        Assert.Equal(CoreStrings.ComplexPropertyValueNotDictionary("Culture", "string"), exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual void Current_values_can_be_copied_to_object_using_ToObject()
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = context.Entry(building).CurrentValues;
+        var copy = (Building)values.ToObject();
+
+        Assert.Equal("Building One Prime", copy.Name);
+        Assert.Equal(1500001m, copy.Value);
+        Assert.Equal(building.BuildingId, copy.BuildingId);
+
+        Assert.True(copy.CreatedCalled);
+        Assert.True(copy.InitializingCalled);
+        Assert.True(copy.InitializedCalled);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = context.Entry(school).CurrentValues;
+            var schoolCopy = (School)schoolValues.ToObject();
+
+            Assert.Equal("Modified School", schoolCopy.Name);
+            Assert.Equal(school.Id, schoolCopy.Id);
+            Assert.Equal(school.Departments.Count, schoolCopy.Departments.Count);
+            Assert.Equal("Modified Department", schoolCopy.Departments[0].Name);
+            Assert.Equal(school.Departments[0].Courses.Count, schoolCopy.Departments[0].Courses.Count);
+            Assert.Equal("Modified Course", schoolCopy.Departments[0].Courses[0].Name);
+            Assert.Equal(999, schoolCopy.Departments[0].Courses[0].Credits);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual void Original_values_can_be_copied_to_object_using_ToObject()
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = context.Entry(building).OriginalValues;
+        var copy = (Building)values.ToObject();
+
+        Assert.Equal("Building One", copy.Name);
+        Assert.Equal(1500000m, copy.Value);
+        Assert.Equal(building.BuildingId, copy.BuildingId);
+
+        Assert.True(copy.CreatedCalled);
+        Assert.True(copy.InitializingCalled);
+        Assert.True(copy.InitializedCalled);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = context.Entry(school).OriginalValues;
+            var schoolCopy = (School)schoolValues.ToObject();
+
+            Assert.Equal("Test School", schoolCopy.Name);
+            Assert.Equal(school.Id, schoolCopy.Id);
+            Assert.Equal(2, schoolCopy.Departments.Count);
+            Assert.Equal("Computer Science", schoolCopy.Departments[0].Name);
+            Assert.Equal(2, schoolCopy.Departments[0].Courses.Count);
+            Assert.Equal("Data Structures", schoolCopy.Departments[0].Courses[0].Name);
+            Assert.Equal(3, schoolCopy.Departments[0].Courses[0].Credits);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual Task Store_values_can_be_copied_to_object_using_ToObject()
+        => Store_values_can_be_copied_to_object_using_ToObject_implementation(e => Task.FromResult(e.GetDatabaseValues()!));
+
+    [ConditionalFact]
+    public virtual Task Store_values_can_be_copied_to_object_using_ToObject_asynchronously()
+        => Store_values_can_be_copied_to_object_using_ToObject_implementation(e => e.GetDatabaseValuesAsync()!);
+
+    private async Task Store_values_can_be_copied_to_object_using_ToObject_implementation(
+        Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = await getPropertyValues(context.Entry(building));
+        var copy = (Building)values.ToObject();
+
+        Assert.Equal("Building One", copy.Name);
+        Assert.Equal(1500000m, copy.Value);
+        Assert.Equal(building.BuildingId, copy.BuildingId);
+
+        Assert.True(copy.CreatedCalled);
+        Assert.True(copy.InitializingCalled);
+        Assert.True(copy.InitializedCalled);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = await getPropertyValues(context.Entry(school));
+            if (schoolValues != null)
+            {
+                var schoolCopy = (School)schoolValues.ToObject();
+
+                Assert.Equal("Test School", schoolCopy.Name);
+                Assert.Equal(school.Id, schoolCopy.Id);
+                Assert.Equal(2, schoolCopy.Departments.Count);
+                Assert.Equal("Computer Science", schoolCopy.Departments[0].Name);
+                Assert.Equal(2, schoolCopy.Departments[0].Courses.Count);
+                Assert.Equal("Data Structures", schoolCopy.Departments[0].Courses[0].Name);
+                Assert.Equal(3, schoolCopy.Departments[0].Courses[0].Credits);
+            }
+        }
+    }
+
+    [ConditionalFact]
+    public virtual void Current_values_can_be_cloned()
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = context.Entry(building).CurrentValues;
+        var clone = values.Clone();
+
+        Assert.NotSame(values, clone);
+        Assert.Equal("Building One Prime", clone["Name"]);
+        Assert.Equal(1500001m, clone["Value"]);
+        Assert.Equal(12, clone["Shadow1"]);
+        Assert.Equal("Pine Walk", clone["Shadow2"]);
+
+        values["Name"] = "Modified";
+        Assert.Equal("Building One Prime", clone["Name"]);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = context.Entry(school).CurrentValues;
+            var schoolClone = schoolValues.Clone();
+
+            Assert.NotSame(schoolValues, schoolClone);
+            Assert.Equal("Modified School", schoolClone["Name"]);
+            Assert.Equal(school.Id, schoolClone["Id"]);
+
+            schoolValues["Name"] = "Further Modified";
+            Assert.Equal("Modified School", schoolClone["Name"]);
+
+            var departmentsProperty = schoolValues.ComplexCollectionProperties.Single(p => p.Name == "Departments");
+            var originalDepts = schoolValues[departmentsProperty];
+            var clonedDepts = schoolClone[departmentsProperty];
+            Assert.NotSame(originalDepts, clonedDepts);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual void Original_values_can_be_cloned()
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = context.Entry(building).OriginalValues;
+        var clone = values.Clone();
+
+        Assert.NotSame(values, clone);
+        Assert.Equal("Building One", clone["Name"]);
+        Assert.Equal(1500000m, clone["Value"]);
+        Assert.Equal(11, clone["Shadow1"]);
+        Assert.Equal("Meadow Drive", clone["Shadow2"]);
+
+        values["Name"] = "Modified";
+        Assert.Equal("Building One", clone["Name"]);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = context.Entry(school).OriginalValues;
+            var schoolClone = schoolValues.Clone();
+
+            Assert.NotSame(schoolValues, schoolClone);
+            Assert.Equal("Test School", schoolClone["Name"]);
+            Assert.Equal(school.Id, schoolClone["Id"]);
+
+            schoolValues["Name"] = "Further Modified";
+            Assert.Equal("Test School", schoolClone["Name"]);
+
+            var departmentsProperty = schoolValues.ComplexCollectionProperties.Single(p => p.Name == "Departments");
+            var originalDepts = schoolValues[departmentsProperty];
+            var clonedDepts = schoolClone[departmentsProperty];
+            Assert.NotSame(originalDepts, clonedDepts);
+        }
+    }
+
+    [ConditionalFact(Skip = "Complex collection query support. Issue #31411")]
+    public virtual Task Store_values_can_be_cloned()
+        => Store_values_can_be_cloned_implementation(e => Task.FromResult(e.GetDatabaseValues()!));
+
+    [ConditionalFact(Skip = "Complex collection query support. Issue #31411")]
+    public virtual Task Store_values_can_be_cloned_asynchronously()
+        => Store_values_can_be_cloned_implementation(e => e.GetDatabaseValuesAsync()!);
+
+    private async Task Store_values_can_be_cloned_implementation(
+        Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+    {
+        using var context = CreateContext();
+        var building = context.Set<Building>().Single(b => b.Name == "Building One");
+
+        building.Name = "Building One Prime";
+        building.Value = 1500001m;
+        context.Entry(building).Property("Shadow1").CurrentValue = 12;
+        context.Entry(building).Property("Shadow2").CurrentValue = "Pine Walk";
+
+        var values = await getPropertyValues(context.Entry(building));
+        var clone = values.Clone();
+
+        Assert.NotSame(values, clone);
+        Assert.Equal("Building One", clone["Name"]);
+        Assert.Equal(1500000m, clone["Value"]);
+        Assert.Equal(11, clone["Shadow1"]);
+        Assert.Equal("Meadow Drive", clone["Shadow2"]);
+
+        values["Name"] = "Modified";
+        Assert.Equal("Building One", clone["Name"]);
+
+        if (context.Model.FindEntityType(typeof(School)) != null)
+        {
+            //var school = context.Set<School>().First();
+
+            // Complex collection query support. Issue #31411
+            var school = CreateSchool();
+            context.Set<School>().Attach(school);
+            school.Name = "Modified School";
+            school.Departments[0].Name = "Modified Department";
+            school.Departments[0].Courses[0].Name = "Modified Course";
+            school.Departments[0].Courses[0].Credits = 999;
+
+            var schoolValues = await getPropertyValues(context.Entry(school));
+            var schoolClone = schoolValues.Clone();
+
+            Assert.NotSame(schoolValues, schoolClone);
+            Assert.Equal("Test School", schoolClone["Name"]);
+            Assert.Equal(school.Id, schoolClone["Id"]);
+
+            schoolValues["Name"] = "Further Modified";
+            Assert.Equal("Test School", schoolClone["Name"]);
+
+            var departmentsProperty = schoolValues.Properties.Single(p => p.Name == "Departments");
+            var originalDepts = schoolValues[departmentsProperty];
+            var clonedDepts = schoolClone[departmentsProperty];
+            Assert.NotSame(originalDepts, clonedDepts);
+        }
+    }
+
     protected abstract class PropertyValuesBase
     {
         [NotMapped]
@@ -2318,8 +3540,8 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         public Guid BuildingId { get; set; }
         public string? Name { get; set; }
         public decimal Value { get; set; }
-        public virtual ICollection<Office> Offices { get; } = new List<Office>();
-        public virtual IList<MailRoom> MailRooms { get; } = new List<MailRoom>();
+        public virtual ICollection<Office> Offices { get; } = [];
+        public virtual IList<MailRoom> MailRooms { get; } = [];
 
         public int? PrincipalMailRoomId { get; set; }
         public MailRoom? PrincipalMailRoom { get; set; }
@@ -2460,7 +3682,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
     {
         public Guid BuildingId { get; set; }
         public Building? Building { get; set; }
-        public IList<Whiteboard> WhiteBoards { get; } = new List<Whiteboard>();
+        public IList<Whiteboard> WhiteBoards { get; } = [];
     }
 
     protected abstract class UnMappedOfficeBase : PropertyValuesBase
@@ -2513,6 +3735,47 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
     {
         public DateTime TerminationDate { get; set; }
     }
+    protected class SchoolDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public List<DepartmentDto?> Departments { get; set; } = [];
+    }
+
+    protected class DepartmentDto
+    {
+        public string Name { get; set; } = null!;
+        public string Building { get; set; } = null!;
+        public List<CourseDto?> Courses { get; set; } = [];
+    }
+
+    protected class CourseDto
+    {
+        public string Name { get; set; } = null!;
+        public int Credits { get; set; }
+    }
+
+    protected class School : PropertyValuesBase
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public List<Department> Departments { get; set; } = [];
+    }
+
+    [ComplexType]
+    protected class Department
+    {
+        public string Name { get; set; } = null!;
+        public string Building { get; set; } = null!;
+        public List<Course> Courses { get; set; } = [];
+    }
+
+    [ComplexType]
+    protected class Course
+    {
+        public string Name { get; set; } = null!;
+        public int Credits { get; set; }
+    }
 
     protected DbContext CreateContext()
     {
@@ -2520,6 +3783,35 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         context.ChangeTracker.AutoDetectChangesEnabled = false;
         return context;
     }
+
+    private static School CreateSchool() => new School
+    {
+        Id = 1,
+        Name = "Test School",
+        Departments =
+            [
+                new Department
+                {
+                    Name = "Computer Science",
+                    Building = "Building A",
+                    Courses =
+                    [
+                        new Course { Name = "Data Structures", Credits = 3 },
+                        new Course { Name = "Algorithms", Credits = 4 }
+                    ]
+                },
+                new Department
+                {
+                    Name = "Mathematics",
+                    Building = "Building B",
+                    Courses =
+                    [
+                        new Course { Name = "Calculus I", Credits = 4 },
+                        new Course { Name = "Linear Algebra", Credits = 3 }
+                    ]
+                }
+            ]
+    };
 
     public abstract class PropertyValuesFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
     {
@@ -2626,6 +3918,10 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
             modelBuilder.Entity<Contact33307>();
             modelBuilder.Entity<Supplier33307>();
             modelBuilder.Entity<Customer33307>();
+
+            modelBuilder.Entity<School>(
+                b => b.ComplexCollection(
+                        e => e.Departments, b => b.ComplexCollection(e => e.Courses)));
         }
 
         protected override Task SeedAsync(PoolableDbContext context)
@@ -2676,7 +3972,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
                     LastName = "Miller",
                     LeaveBalance = 45,
                     Office = offices[0],
-                    VirtualTeams = new List<VirtualTeam> { teams[0], teams[1] }
+                    VirtualTeams = [teams[0], teams[1]]
                 },
                 new CurrentEmployee
                 {
@@ -2685,7 +3981,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
                     LastName = "Vickers",
                     LeaveBalance = 62,
                     Office = offices[1],
-                    VirtualTeams = new List<VirtualTeam> { teams[1], teams[2] }
+                    VirtualTeams = [teams[1], teams[2]]
                 },
                 new PastEmployee
                 {
@@ -2760,9 +4056,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
                         Number = 42,
                     },
                     Foo = "F"
-                });
-
-            context.Add(
+                }); context.Add(
                 new Customer33307
                 {
                     Name = "Bar",
@@ -2774,6 +4068,9 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
                     },
                     Bar = 11
                 });
+
+            // Complex collection query support. Issue #31411
+            //context.Add(CreateSchool());
 
             return context.SaveChangesAsync();
         }

--- a/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/Scaffolding/CompiledModelTestBase.cs
@@ -1166,14 +1166,25 @@ namespace TestNamespace
             AssertComplexTypes,
             async c =>
             {
-                c.Set<PrincipalDerived<DependentBase<byte?>>>().Add(
-                    new PrincipalDerived<DependentBase<byte?>>
+                c.Set<PrincipalBase>().Add(
+                    new PrincipalBase
                     {
                         Id = 1,
                         AlternateId = new Guid(),
-                        Dependent = new DependentBase<byte?>(1),
-                        Owned = new OwnedType(c) { Principal = new PrincipalBase() }
+                        Owned = new OwnedType(c) { Details = "details" }
                     });
+
+                if (c.Model.FindEntityType(typeof(PrincipalDerived<DependentBase<byte?>>)) != null)
+                {
+                    c.Set<PrincipalDerived<DependentBase<byte?>>>().Add(
+                        new PrincipalDerived<DependentBase<byte?>>
+                        {
+                            Id = 2,
+                            AlternateId = new Guid(),
+                            Dependent = new DependentBase<byte?>(1),
+                            Owned = new OwnedType(c)
+                        });
+                }
 
                 await c.SaveChangesAsync();
             },
@@ -1303,7 +1314,11 @@ namespace TestNamespace
 
         Assert.Equal(ExpectedComplexTypeProperties, nestedComplexType.GetProperties().Count());
 
-        var principalDerived = model.FindEntityType(typeof(PrincipalDerived<DependentBase<byte?>>))!;
+        var principalDerived = model.FindEntityType(typeof(PrincipalDerived<DependentBase<byte?>>));
+        if (principalDerived == null)
+        {
+            return;
+        }
         Assert.Equal(principalBase, principalDerived.BaseType);
 
         var complexCollection = principalDerived.GetDeclaredComplexProperties().Single();

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
@@ -117,7 +117,7 @@ public class InternalComplexEntryTest
         var originalTags = blog.Tags.ToList();
         originalTags.RemoveAt(1);
         entityEntry.SetOriginalValue(complexProperty, originalTags);
-        complexEntry.SetEntityState(EntityState.Added);
+        complexEntry = entityEntry.GetComplexCollectionEntry(complexProperty, 1);
 
         Assert.Equal(EntityState.Added, complexEntry.EntityState);
         Assert.Equal(entityState == EntityState.Unchanged ? EntityState.Modified : entityState, entityEntry.EntityState);
@@ -130,8 +130,6 @@ public class InternalComplexEntryTest
         Assert.True(entityEntry.IsModified(complexProperty));
 
         entityEntry.SetOriginalValue(complexProperty, blog.Tags.ToList());
-        complexEntry.OriginalOrdinal = 1;
-        complexEntry.SetEntityState(EntityState.Unchanged);
 
         Assert.Equal(EntityState.Unchanged, complexEntry.EntityState);
         Assert.Equal(entityState, entityEntry.EntityState);
@@ -220,29 +218,28 @@ public class InternalComplexEntryTest
 
         originalTags.RemoveAt(1);
         entityEntry.SetOriginalValue(complexProperty, originalTags);
-        entry1.SetEntityState(EntityState.Added);
 
         Assert.Equal([0, 1, 2, 3], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.Ordinal));
-        Assert.Equal([0, -1, 1, 3], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.OriginalOrdinal));
-        Assert.Equal([0, 2, -1, 3], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.Ordinal));
+        Assert.Equal([0, 2, 1, 3], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.OriginalOrdinal));
+        Assert.Equal([0, 2, 1, 3], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.Ordinal));
         Assert.Equal([0, 1, 2, 3], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.OriginalOrdinal));
-        Assert.Equal([EntityState.Unchanged, EntityState.Added, EntityState.Unchanged, EntityState.Unchanged],
+        Assert.Equal([EntityState.Unchanged, EntityState.Modified, EntityState.Unchanged, EntityState.Unchanged],
             entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e!.EntityState));
-        Assert.Equal([EntityState.Unchanged, EntityState.Unchanged, EntityState.Deleted, EntityState.Unchanged],
+        Assert.Equal([EntityState.Unchanged, EntityState.Unchanged, EntityState.Modified, EntityState.Unchanged],
             entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e!.EntityState));
         Assert.True(entityEntry.IsModified(complexProperty));
 
-        entry3.Ordinal = 3;
-        blog.Tags.Insert(3, tag3);
-        entry3.SetEntityState(EntityState.Unchanged);
+        entry1.Ordinal = 1;
+        blog.Tags.Insert(1, tag3);
+        entry1.SetEntityState(EntityState.Added);
 
         Assert.Equal([0, 1, 2, 3, 4], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.Ordinal));
-        Assert.Equal([0, -1, 1, 2, 3], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.OriginalOrdinal));
-        Assert.Equal([0, 2, 3, 4], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.Ordinal));
+        Assert.Equal([0, -1, 2, 1, 3], entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e?.OriginalOrdinal));
+        Assert.Equal([0, 3, 2, 4], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.Ordinal));
         Assert.Equal([0, 1, 2, 3], entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e?.OriginalOrdinal));
-        Assert.Equal([EntityState.Unchanged, EntityState.Added, EntityState.Unchanged, EntityState.Unchanged, EntityState.Unchanged],
+        Assert.Equal([EntityState.Unchanged, EntityState.Added, EntityState.Modified, EntityState.Unchanged, EntityState.Unchanged],
             entityEntry.GetComplexCollectionEntries(complexProperty).Select(e => e!.EntityState));
-        Assert.Equal([EntityState.Unchanged, EntityState.Unchanged, EntityState.Unchanged, EntityState.Unchanged],
+        Assert.Equal([EntityState.Unchanged, EntityState.Unchanged, EntityState.Modified, EntityState.Unchanged],
             entityEntry.GetComplexCollectionOriginalEntries(complexProperty).Select(e => e!.EntityState));
         Assert.True(entityEntry.IsModified(complexProperty));
     }
@@ -391,7 +388,7 @@ public class InternalComplexEntryTest
         var tag1 = new Tag { Name = "Tag1", Priority = 1 };
         var tag2 = new Tag { Name = "Tag2", Priority = 2 };
         var tag3 = new Tag { Name = "Tag3", Priority = 3 };
-        var tag4 = new Tag { Name = "Tag3", Priority = 3 };
+        var tag4 = new Tag { Name = "Tag4", Priority = 4 };
 
         var blog = new Blog
         {
@@ -541,7 +538,6 @@ public class InternalComplexEntryTest
         changeDetector.DetectChanges(entityEntry);
 
         var allEntries = entityEntry.GetComplexCollectionEntries(complexProperty);
-
         if (allEntries[0]!.EntityState == EntityState.Added)
         {
             Assert.Equal([-1, 0, 1], allEntries.Select(e => e!.OriginalOrdinal));

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -40,7 +40,10 @@ public class ClrPropertySetterFactoryTest
         IReadOnlyTypeBase IReadOnlyPropertyBase.DeclaringType
             => throw new NotImplementedException();
 
-        public void SetClrValueUsingContainingEntity(object instance, object value)
+        public void SetClrValueUsingContainingEntity(object instance, IReadOnlyList<int> indices, object value)
+            => throw new NotImplementedException();
+
+        public object SetClrValue(object instance, object value)
             => throw new NotImplementedException();
 
         public IEnumerable<IForeignKey> GetContainingForeignKeys()
@@ -133,10 +136,6 @@ public class ClrPropertySetterFactoryTest
 
         public PropertyAccessMode GetPropertyAccessMode()
             => throw new NotImplementedException();
-
-        public void SetClrValueUsingContainingEntity(object instance, IReadOnlyList<int> indices, object value)
-            => throw new NotImplementedException();
-        public object SetClrValue(object instance, object value) => throw new NotImplementedException();
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Part of #31237

This pull request extends `PropertyValues` and derived types to handle complex collection properties and adds an error message in the Cosmos provider strings. It also fixes some bugs in complex collection change detection.

### Enhancements to `PropertyValues`:

* `PropertyValues.cs`: Extended the class to support complex collection properties, including methods for cloning, setting values, and converting complex collections to objects. Introduced new properties like `ComplexCollectionProperties` for managing complex type collections.

### Validation for complex type collections:

* [`CosmosModelValidator.cs`](diffhunk://#diff-a38b470366374a2ca261dde604b3913a6535bb353ead6de880e32a3a60cf9f95R86-R93): Throw for complex type collections on Cosmos.