### PR TITLE
Implement support for SQL Server vector search 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,8 +41,8 @@
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.51.0" />
 
     <!-- SQL Server dependencies -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.0-preview2.25178.5" />
+    <PackageVersion Include="Microsoft.SqlServer.Types" Version="170.700.9-ctp2p0" />
 
     <!-- external dependencies -->
     <PackageVersion Include="Castle.Core" Version="5.2.1" />

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -50,6 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.SqlServer.Types" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -3,6 +3,8 @@
 
 // ReSharper disable once CheckNamespace
 
+using Microsoft.Data.SqlTypes;
+
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -2452,4 +2454,30 @@ public static class SqlServerDbFunctionsExtensions
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
 
     #endregion Population variance
+
+    #region Vector functions
+
+    /// <summary>
+    ///     Calculates the distance between two vectors using a specified distance metric.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="distanceMetric">
+    /// A string with the name of the distance metric to use to calculate the distance between the two given vectors. The following distance metrics are supported: <c>cosine</c>, <c>euclidean</c> or <c>dot</c>.
+    /// </param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <remarks>
+    ///     Vector distance is always exact and doesn't use any vector index, even if available.
+    /// </remarks>
+    /// <seealso href="https://learn.microsoft.com/sql/t-sql/functions/vector-distance-transact-sql">SQL Server documentation for <c>VECTOR_DISTANCE</c>.</seealso>
+    /// <seealso href="https://learn.microsoft.com/sql/relational-databases/vectors/vectors-sql-server">Vectors in the SQL Database Engine.</seealso>
+    public static double VectorDistance<T>(
+        this DbFunctions _,
+        [NotParameterized] string distanceMetric,
+        SqlVector<T> vector1,
+        SqlVector<T> vector2)
+        where T : unmanaged
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    #endregion Vector functions
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -417,6 +417,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         public static string TransientExceptionDetected
             => GetString("TransientExceptionDetected");
 
+        /// <summary>
+        ///     Vector properties require a positive size (number of dimensions).
+        /// </summary>
+        public static string VectorDimensionsInvalid
+            => GetString("VectorDimensionsInvalid");
+
+        /// <summary>
+        ///     Vector property '{structuralType}.{propertyName}' was not configured with the number of dimensions. Set the column type to 'vector(x)' with the desired number of dimensions, or use the 'MaxLength' APIs.
+        /// </summary>
+        public static string VectorDimensionsMissing(object? structuralType, object? propertyName)
+            => string.Format(
+                GetString("VectorDimensionsMissing", nameof(structuralType), nameof(propertyName)),
+                structuralType, propertyName);
+
+        /// <summary>
+        ///     Vector property '{propertyName}' is on '{structuralType}' which is mapped to JSON. Vector properties are not supported within JSON documents.
+        /// </summary>
+        public static string VectorPropertiesNotSupportedInJson(object? structuralType, object? propertyName)
+            => string.Format(
+                GetString("VectorPropertiesNotSupportedInJson", nameof(structuralType), nameof(propertyName)),
+                structuralType, propertyName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -369,4 +369,13 @@
   <data name="TransientExceptionDetected" xml:space="preserve">
     <value>An exception has been raised that is likely due to a transient failure. Consider enabling transient error resiliency by adding 'EnableRetryOnFailure' to the 'UseSqlServer' call.</value>
   </data>
+  <data name="VectorDimensionsInvalid" xml:space="preserve">
+    <value>Vector properties require a positive size (number of dimensions).</value>
+  </data>
+  <data name="VectorDimensionsMissing" xml:space="preserve">
+    <value>Vector property '{structuralType}.{propertyName}' was not configured with the number of dimensions. Set the column type to 'vector(x)' with the desired number of dimensions, or use the 'MaxLength' APIs.</value>
+  </data>
+  <data name="VectorPropertiesNotSupportedInJson" xml:space="preserve">
+    <value>Vector property '{propertyName}' is on '{structuralType}' which is mapped to JSON. Vector properties are not supported within JSON documents.</value>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMemberTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMemberTranslatorProvider.cs
@@ -30,7 +30,8 @@ public class SqlServerMemberTranslatorProvider : RelationalMemberTranslatorProvi
             new SqlServerDateTimeMemberTranslator(sqlExpressionFactory, typeMappingSource),
             new SqlServerStringMemberTranslator(sqlExpressionFactory),
             new SqlServerTimeSpanMemberTranslator(sqlExpressionFactory),
-            new SqlServerTimeOnlyMemberTranslator(sqlExpressionFactory)
+            new SqlServerTimeOnlyMemberTranslator(sqlExpressionFactory),
+            new SqlServerVectorTranslator(sqlExpressionFactory, typeMappingSource)
         ]);
     }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
@@ -42,7 +42,8 @@ public class SqlServerMethodCallTranslatorProvider : RelationalMethodCallTransla
             new SqlServerNewGuidTranslator(sqlExpressionFactory),
             new SqlServerObjectToStringTranslator(sqlExpressionFactory, typeMappingSource),
             new SqlServerStringMethodTranslator(sqlExpressionFactory, sqlServerSingletonOptions),
-            new SqlServerTimeOnlyMethodTranslator(sqlExpressionFactory)
+            new SqlServerTimeOnlyMethodTranslator(sqlExpressionFactory),
+            new SqlServerVectorTranslator(sqlExpressionFactory, typeMappingSource)
         ]);
     }
 }

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerVectorTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerVectorTranslator.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Data.SqlTypes;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerVectorTranslator(
+    ISqlExpressionFactory sqlExpressionFactory,
+    IRelationalTypeMappingSource typeMappingSource)
+    : IMethodCallTranslator, IMemberTranslator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType == typeof(SqlServerDbFunctionsExtensions))
+        {
+            switch (method.Name)
+            {
+                case nameof(SqlServerDbFunctionsExtensions.VectorDistance)
+                    when arguments is [_, var distanceMetric, var vector1, var vector2]:
+                {
+                    var vectorTypeMapping = vector1.TypeMapping ?? vector2.TypeMapping
+                        ?? throw new InvalidOperationException(
+                            "One of the arguments to EF.Functions.VectorDistance must be a vector column.");
+
+                    return sqlExpressionFactory.Function(
+                        "VECTOR_DISTANCE",
+                        [
+                            sqlExpressionFactory.ApplyTypeMapping(distanceMetric, typeMappingSource.FindMapping("varchar(max)")),
+                            sqlExpressionFactory.ApplyTypeMapping(vector1, vectorTypeMapping),
+                            sqlExpressionFactory.ApplyTypeMapping(vector2, vectorTypeMapping)
+                        ],
+                        nullable: true,
+                        argumentsPropagateNullability: [true, true, true],
+                        typeof(double),
+                        typeMappingSource.FindMapping(typeof(double)));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (member.DeclaringType == typeof(SqlVector<float>))
+        {
+            switch (member.Name)
+            {
+                case nameof(SqlVector<>.Length) when instance is not null:
+                {
+                    return sqlExpressionFactory.Function(
+                        "VECTORPROPERTY",
+                        [
+                            instance,
+                            sqlExpressionFactory.Constant("Dimensions", typeMappingSource.FindMapping("varchar(max)"))
+                        ],
+                        nullable: true,
+                        argumentsPropagateNullability: [true, true],
+                        typeof(int),
+                        typeMappingSource.FindMapping(typeof(int)));
+                }
+            }
+        }
+
+        return null;
+    }
+}
+

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerVectorTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerVectorTypeMapping.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.Data.SqlTypes;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerVectorTypeMapping : RelationalTypeMapping
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static SqlServerVectorTypeMapping Default { get; } = new(dimensions: null);
+
+    private static readonly VectorComparer _comparerInstance = new();
+
+    // Note that dimensions is mandatory with SQL Server vector.
+    // However, our scaffolder looks up each type mapping without the facets, to find out whether the scaffolded
+    // facet happens to be the default (and therefore can be omitted). So we allow constructing a SqlServerVectorTypeMapping
+    // without dimensions, and validate against it in SqlServerModelValidator.
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlServerVectorTypeMapping(int? dimensions)
+        : this(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(SqlVector<float>), comparer: _comparerInstance),
+                "vector",
+                StoreTypePostfix.Size,
+                size: dimensions))
+    {
+        if (dimensions is <= 0)
+        {
+            throw new InvalidOperationException(SqlServerStrings.VectorDimensionsInvalid);
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected SqlServerVectorTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+        if (parameters.Size is <= 0)
+        {
+            throw new InvalidOperationException(SqlServerStrings.VectorDimensionsInvalid);
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new SqlServerVectorTypeMapping(parameters);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        Check.DebugAssert(Size is not null);
+
+        var sqlVector = (SqlVector<float>)value;
+
+        if (sqlVector.IsNull)
+        {
+            return "NULL";
+        }
+
+        // SQL Server has an implicit cast from JSON arrays (as strings or as the json type) to vector -
+        // that's the literal representation (though use-cases are probably mostly contrived/testing-only).
+        var builder = new StringBuilder();
+        var floats = sqlVector.Memory.Span;
+
+        builder.Append("CAST('[");
+
+        for (var i = 0; i < floats.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append(floats[i]);
+        }
+
+        builder
+            .Append("]' AS VECTOR(")
+            .Append(Size)
+            .Append("))");
+
+        return builder.ToString();
+    }
+
+    private sealed class VectorComparer() : ValueComparer<SqlVector<float>>(
+        (x, y) => CalculateEquality(x, y),
+        v => CalculateHashCode(v),
+        v => v)
+    {
+        // Note that we do not perform value comparison here, only checking that the SqlVector wraps the same memory.
+        // This is because vectors are basically immutable, and it's better to have more efficient change tracking
+        // equality checks.
+        private static bool CalculateEquality(SqlVector<float>? x, SqlVector<float>? y)
+            => x is null
+                ? y is null
+                : y is not null && (x.IsNull
+                    ? y.IsNull
+                    : !y.IsNull && x.Memory.Span == y.Memory.Span);
+
+        private static int CalculateHashCode(SqlVector<float> vector)
+        {
+            if (vector.IsNull)
+            {
+                return 0;
+            }
+
+            var hash = new HashCode();
+
+            foreach (var value in vector.Memory.Span)
+            {
+                hash.Add(value);
+            }
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.Data.SqlTypes;
+
+namespace Microsoft.EntityFrameworkCore.Query.Translations;
+
+[SqlServerCondition(SqlServerCondition.SupportsVectorType)]
+public class VectorTranslationsSqlServerTest : IClassFixture<VectorTranslationsSqlServerTest.VectorQueryFixture>
+{
+    private VectorQueryFixture Fixture { get; }
+
+    public VectorTranslationsSqlServerTest(VectorQueryFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        Fixture = fixture;
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [ConditionalFact]
+    public async Task VectorDistance_with_parameter()
+    {
+        using var ctx = CreateContext();
+
+        var vector = new SqlVector<float>(new float[] { 1, 2, 100 });
+        var results = await ctx.VectorEntities
+            .OrderBy(v => EF.Functions.VectorDistance("cosine", v.Vector, vector))
+            .Take(1)
+            .ToListAsync();
+
+        Assert.Equal(2, results.Single().Id);
+
+        AssertSql(
+            """
+@p='1'
+@vector='Microsoft.Data.SqlTypes.SqlVector`1[System.Single]' (Size = 20) (DbType = Binary)
+
+SELECT TOP(@p) [v].[Id], [v].[Vector]
+FROM [VectorEntities] AS [v]
+ORDER BY VECTOR_DISTANCE('cosine', [v].[Vector], @vector)
+""");
+    }
+
+    [ConditionalFact]
+    public async Task VectorDistance_with_constant()
+    {
+        using var ctx = CreateContext();
+
+        var results = await ctx.VectorEntities
+            .OrderBy(v => EF.Functions.VectorDistance("cosine", v.Vector, new SqlVector<float>(new float[] { 1, 2, 100 })))
+            .Take(1)
+            .ToListAsync();
+
+        Assert.Equal(2, results.Single().Id);
+
+        AssertSql(
+            """
+@p='1'
+
+SELECT TOP(@p) [v].[Id], [v].[Vector]
+FROM [VectorEntities] AS [v]
+ORDER BY VECTOR_DISTANCE('cosine', [v].[Vector], CAST('[1,2,100]' AS VECTOR(3)))
+""");
+    }
+
+    [ConditionalFact]
+    public async Task Length()
+    {
+        using var ctx = CreateContext();
+
+        var count = await ctx.VectorEntities
+            .Where(v => v.Vector.Length == 3)
+            .CountAsync();
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal(await ctx.VectorEntities.CountAsync(), count);
+        }
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM [VectorEntities] AS [v]
+WHERE VECTORPROPERTY([v].[Vector], 'Dimensions') = 3
+""");
+    }
+
+    protected VectorQueryContext CreateContext()
+        => Fixture.CreateContext();
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    public class VectorQueryContext(DbContextOptions options) : PoolableDbContext(options)
+    {
+        public DbSet<VectorEntity> VectorEntities { get; set; } = null!;
+
+        public static async Task SeedAsync(VectorQueryContext context)
+        {
+            var vectorEntities = new VectorEntity[]
+            {
+                new() { Id = 1, Vector = new(new float[] { 1, 2, 3 }) },
+                new() { Id = 2, Vector = new(new float[] { 1, 2, 100 }) },
+                new() { Id = 3, Vector = new(new float[] { 1, 2, 1000 }) }
+            };
+
+            context.VectorEntities.AddRange(vectorEntities);
+            await context.SaveChangesAsync();
+        }
+    }
+
+    public class VectorEntity
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public int Id { get; set; }
+
+        [Column(TypeName = "vector(3)")]
+        public SqlVector<float> Vector { get; set; } = null!;
+    }
+
+    public class VectorQueryFixture : SharedStoreFixtureBase<VectorQueryContext>
+    {
+        protected override string StoreName
+            => "VectorQueryTest";
+
+        protected override ITestStoreFactory TestStoreFactory
+            => SqlServerTestStoreFactory.Instance;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override Task SeedAsync(VectorQueryContext context)
+            => VectorQueryContext.SeedAsync(context);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
@@ -22,4 +22,5 @@ public enum SqlServerCondition
     SupportsFunctions2019 = 1 << 13,
     SupportsFunctions2022 = 1 << 14,
     SupportsJsonType = 1 << 15,
+    SupportsVectorType = 1 << 15,
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -97,6 +97,11 @@ public sealed class SqlServerConditionAttribute(SqlServerCondition conditions) :
             isMet &= TestEnvironment.IsJsonTypeSupported;
         }
 
+        if (Conditions.HasFlag(SqlServerCondition.SupportsVectorType))
+        {
+            isMet &= TestEnvironment.IsVectorTypeSupported;
+        }
+
         return ValueTask.FromResult(isMet);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -43,6 +43,8 @@ public static class TestEnvironment
 
     private static bool? _supportsJsonPathExpressions;
 
+    private static bool? _isVectorTypeSupported;
+
     private static bool? _supportsFunctions2017;
 
     private static bool? _supportsFunctions2019;
@@ -401,6 +403,33 @@ public static class TestEnvironment
     // TODO:SQLJSON Issue #34414
     public static bool IsJsonTypeSupported
         => false;
+
+    public static bool IsVectorTypeSupported
+    {
+        get
+        {
+            if (!IsConfigured)
+            {
+                return false;
+            }
+
+            if (_isVectorTypeSupported.HasValue)
+            {
+                return _isVectorTypeSupported.Value;
+            }
+
+            try
+            {
+                _isVectorTypeSupported = GetProductMajorVersion() >= 17 || IsSqlAzure;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                _isVectorTypeSupported = false;
+            }
+
+            return _isVectorTypeSupported.Value;
+        }
+    }
 
     public static byte SqlServerMajorVersion
         => GetProductMajorVersion();

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data;
+using Microsoft.Data.SqlTypes;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 
 // ReSharper disable InconsistentNaming
-namespace Microsoft.EntityFrameworkCore;
+namespace Microsoft.EntityFrameworkCore.Storage;
 
 public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBase
 {
@@ -1329,6 +1331,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
     [InlineData("varchar(333)", typeof(string), 333, false, false)]
     [InlineData("varchar(max)", typeof(string), -1, false, false)]
     [InlineData("VARCHAR(max)", typeof(string), -1, false, false, "VARCHAR(max)")]
+    [InlineData("vector(3)", typeof(SqlVector<float>), 3, false, false)]
     public void Can_map_by_store_type(string storeType, Type type, int? size, bool unicode, bool fixedLength, string expectedType = null)
     {
         var mapping = CreateRelationalTypeMappingSource(CreateModel()).FindMapping(storeType);
@@ -1346,6 +1349,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
     [InlineData(typeof(DateTime), "date")]
     [InlineData(typeof(TimeOnly), "time")]
     [InlineData(typeof(TimeSpan), "time")]
+    [InlineData(typeof(SqlVector<float>), "vector(3)")]
     public void Can_map_by_clr_and_store_types(Type clrType, string storeType)
     {
         var mapping = CreateRelationalTypeMappingSource(CreateModel()).FindMapping(clrType, storeType);
@@ -1762,6 +1766,37 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
             mapper.GetMapping(model.FindEntityType(typeof(MyRelatedType4)).FindProperty("Relationship2Id")).StoreType);
     }
 
+    #region Vector
+
+    [ConditionalFact]
+    public void Vector_is_properly_mapped()
+    {
+        var typeMapping = GetTypeMapping(typeof(SqlVector<float>), maxLength: 3);
+
+        Assert.Null(typeMapping.DbType);
+        Assert.Equal("vector(3)", typeMapping.StoreType);
+        Assert.Equal(3, typeMapping.Size);
+        Assert.Null(typeMapping.Precision);
+        Assert.Null(typeMapping.Scale);
+    }
+
+    [ConditionalFact]
+    public void Vector_requires_positive_dimensions()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(SqlVector<float>), maxLength: 0));
+        Assert.Equal(SqlServerStrings.VectorDimensionsInvalid, exception.Message);
+
+        exception = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(SqlVector<float>), maxLength: -1));
+        Assert.Equal(SqlServerStrings.VectorDimensionsInvalid, exception.Message);
+
+        // We do allow constructing a vector type mapping with no dimensions, since the scaffolder requires it
+        // (see comment in SqlServerVectorTypeMapping)
+        var typeMapping = GetTypeMapping(typeof(SqlVector<float>));
+        Assert.Null(typeMapping.Size);
+    }
+
+    #endregion Vector
+
     [ConditionalFact]
     public void Plugins_can_override_builtin_mappings()
     {
@@ -1769,7 +1804,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
             TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>() with
             {
-                Plugins = new[] { new FakeTypeMappingSourcePlugin() }
+                Plugins = [new FakeTypeMappingSourcePlugin()]
             });
 
         Assert.Equal("String", typeMappingSource.GetMapping("datetime2").ClrType.Name);

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data;
-using System.Globalization;
 using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlTypes;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 
@@ -408,6 +408,24 @@ public class SqlServerTypeMappingTest : RelationalTypeMappingTest
             "new TimeOnly(12, 30, 10, 500).Add(TimeSpan.FromTicks(10))");
     }
 
+    #region Vector
+
+    [ConditionalFact]
+    public virtual void Vector_comparer_compares_Memory()
+    {
+        var typeMapping = new SqlServerVectorTypeMapping(3);
+
+        float[] array = [1, 2, 3];
+        var vector1 = new SqlVector<float>(array);
+        var vector2 = new SqlVector<float>(array);
+        var vector3 = new SqlVector<float>(new float[] { 1, 2, 3 });
+
+        Assert.True(typeMapping.Comparer.Equals(vector1, vector2));
+        Assert.False(typeMapping.Comparer.Equals(vector1, vector3));
+    }
+
+    #endregion Vector
+
     public static RelationalTypeMapping GetMapping(string type)
         => GetTypeMappingSource().FindMapping(type);
 
@@ -428,146 +446,6 @@ public class SqlServerTypeMappingTest : RelationalTypeMappingTest
         var csharpHelper = new CSharpHelper(typeMappingSource);
 
         Assert.Equal(expectedCode, csharpHelper.UnknownLiteral(value));
-    }
-
-    private class FakeType(string fullName) : Type
-    {
-        public override object[] GetCustomAttributes(bool inherit)
-            => throw new NotImplementedException();
-
-        public override bool IsDefined(Type attributeType, bool inherit)
-            => throw new NotImplementedException();
-
-        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type GetInterface(string name, bool ignoreCase)
-            => throw new NotImplementedException();
-
-        public override Type[] GetInterfaces()
-            => throw new NotImplementedException();
-
-        public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override EventInfo[] GetEvents(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type[] GetNestedTypes(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type GetElementType()
-            => throw new NotImplementedException();
-
-        protected override bool HasElementTypeImpl()
-            => throw new NotImplementedException();
-
-        protected override PropertyInfo GetPropertyImpl(
-            string name,
-            BindingFlags bindingAttr,
-            Binder binder,
-            Type returnType,
-            Type[] types,
-            ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        protected override MethodInfo GetMethodImpl(
-            string name,
-            BindingFlags bindingAttr,
-            Binder binder,
-            CallingConventions callConvention,
-            Type[] types,
-            ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override FieldInfo[] GetFields(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override MemberInfo[] GetMembers(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        protected override TypeAttributes GetAttributeFlagsImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsArrayImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsByRefImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsPointerImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsPrimitiveImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsCOMObjectImpl()
-            => throw new NotImplementedException();
-
-        public override object InvokeMember(
-            string name,
-            BindingFlags invokeAttr,
-            Binder binder,
-            object target,
-            object[] args,
-            ParameterModifier[] modifiers,
-            CultureInfo culture,
-            string[] namedParameters)
-            => throw new NotImplementedException();
-
-        public override Type UnderlyingSystemType { get; }
-
-        protected override ConstructorInfo GetConstructorImpl(
-            BindingFlags bindingAttr,
-            Binder binder,
-            CallingConventions callConvention,
-            Type[] types,
-            ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        public override string Name
-            => throw new NotImplementedException();
-
-        public override Guid GUID
-            => throw new NotImplementedException();
-
-        public override Module Module
-            => throw new NotImplementedException();
-
-        public override Assembly Assembly
-            => throw new NotImplementedException();
-
-        public override string Namespace
-            => throw new NotImplementedException();
-
-        public override string AssemblyQualifiedName
-            => throw new NotImplementedException();
-
-        public override Type BaseType
-            => throw new NotImplementedException();
-
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
-            => throw new NotImplementedException();
-
-        public override string FullName { get; } = fullName;
-
-        public override int GetHashCode()
-            => FullName.GetHashCode();
-
-        public override bool Equals(object o)
-            => ReferenceEquals(this, o);
     }
 
     protected override DbContextOptions ContextOptions { get; }


### PR DESCRIPTION
Note: this does not include  [`VECTOR_SEARCH[]`](https://learn.microsoft.com/en-us/sql/t-sql/functions/vector-search-transact-sql?view=sql-server-ver17) translation support (as opposed to [`VECTOR_DISTANCE()`](https://learn.microsoft.com/en-us/sql/t-sql/functions/vector-distance-transact-sql?view=sql-server-ver17) which is included); this is tracked by #36384.

Closes #34659