### PR TITLE
Fix bug in SQL baseline rewriting

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -137,6 +137,14 @@ public class TestSqlLoggerFactory : ListLoggerFactory
             var fileInfo = _queryBaselineRewritingFileInfos.GetOrAdd(fileName, _ => new QueryBaselineRewritingFileInfo());
             lock (fileInfo.Lock)
             {
+                // Check if we've already processed this line - if so no need to do it again
+                if (fileInfo.ProcessedLines.Contains(lineNumber))
+                {
+                    return;
+                }
+
+                fileInfo.ProcessedLines.Add(lineNumber);
+
                 // First, adjust our lineNumber to take into account any baseline rewriting that already occurred in this file
                 var origLineNumber = lineNumber;
                 foreach (var displacement in fileInfo.LineDisplacements)
@@ -255,13 +263,13 @@ public class TestSqlLoggerFactory : ListLoggerFactory
                         // Skip over the invocation on the read side, and write the new baseline invocation
                         var tempBuf = new char[Math.Max(1024, invocation.Span.Length)];
                         reader.ReadBlock(tempBuf, 0, invocation.Span.Length);
-                        var numNewlinesInOrigin = tempBuf.Count(c => c is '\n' or '\r');
+                        var numNewlinesInOrigin = tempBuf.Count(c => c is '\n');
 
                         indentBuilder.Append("    ");
                         var indent = indentBuilder.ToString();
                         var newBaseLine = $@"Assert{(forUpdate ? "ExecuteUpdate" : "")}Sql(
 {string.Join("," + Environment.NewLine + indent + "//" + Environment.NewLine, SqlStatements.Skip(offset).Take(count).Select(sql => indent + "\"\"\"" + Environment.NewLine + sql + Environment.NewLine + "\"\"\""))})";
-                        var numNewlinesInRewritten = newBaseLine.Count(c => c is '\n' or '\r');
+                        var numNewlinesInRewritten = newBaseLine.Count(c => c is '\n');
 
                         writer.Write(newBaseLine);
 
@@ -384,6 +392,12 @@ public class TestSqlLoggerFactory : ListLoggerFactory
         public QueryBaselineRewritingFileInfo() { }
 
         public object Lock { get; } = new();
+
+        /// <summary>
+        ///     Contains information on which lines in the file where we've already performed baseline rewriting; we use this to
+        ///     avoid processing the same line twice (e.g. when a test is a theory that's executed multiple times).
+        /// </summary>
+        public readonly HashSet<int> ProcessedLines = new();
 
         /// <summary>
         ///     Contains information on where previous baseline rewriting caused line numbers to shift; this is used in adjusting line


### PR DESCRIPTION
While work on some tests I managed to reproduce the problem where changing the number of lines caused the rewriter to fail. The rewriter has logic to count the number of newlines in the old and new baselines, and apply the diff to any additional rewrites that need to occur later in the same file. The newline counting looked at either \r or \n, which I think was the source of the problem: there seems to have been a \r\n (Windows - though I think we're supposed to normalize newlines on commit), so this was counted as two newlines, skewing the count.

I'm fixing this by simply not looking at \r at all, and just counting \n. The only problem this could cause is with very old MacOS versions, where \r alone was used as the newline - but that really should no longer be relevant any more.

Fixes #35823
