### PR TITLE
Support tracking queries for complex JSON queries

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -1092,7 +1092,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             TIncludingEntity entity,
             Func<QueryContext, object[]?, JsonReaderData, TIncludedEntity> innerShaper,
             Action<TIncludingEntity, TIncludedEntity> fixup,
-            bool trackingQuery)
+            bool performFixup)
             where TIncludingEntity : class
             where TIncludedEntity : class
         {
@@ -1116,7 +1116,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             var included = innerShaper(queryContext, keyPropertyValues, jsonReaderData);
 
-            if (!trackingQuery)
+            if (performFixup)
             {
                 fixup(entity, included);
             }
@@ -1137,7 +1137,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             Func<QueryContext, object[]?, JsonReaderData, TIncludedCollectionElement> innerShaper,
             Action<TIncludingEntity> getOrCreateCollectionObject,
             Action<TIncludingEntity, TIncludedCollectionElement> fixup,
-            bool trackingQuery)
+            bool performFixup)
             where TIncludingEntity : class
             where TIncludedCollectionElement : class
         {
@@ -1181,7 +1181,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     manager.CaptureState();
                     var resultElement = innerShaper(queryContext, newKeyPropertyValues, jsonReaderData);
 
-                    if (!trackingQuery)
+                    if (performFixup)
                     {
                         fixup(entity, resultElement);
                     }

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesCollectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesCollectionTestBase.cs
@@ -5,15 +5,4 @@ namespace Microsoft.EntityFrameworkCore.Query.Relationships.ComplexProperties;
 
 public abstract class ComplexPropertiesCollectionTestBase<TFixture>(TFixture fixture)
     : RelationshipsCollectionTestBase<TFixture>(fixture)
-    where TFixture : ComplexPropertiesFixtureBase, new()
-{
-    // TODO: the following is temporary until change tracking is implemented for complex JSON types (#35962)
-    private readonly TrackingRewriter _trackingRewriter = new(QueryTrackingBehavior.NoTracking);
-
-    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
-    {
-        var rewritten = _trackingRewriter.Visit(serverQueryExpression);
-
-        return rewritten;
-    }
-}
+    where TFixture : ComplexPropertiesFixtureBase, new();

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesMiscellaneousTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesMiscellaneousTestBase.cs
@@ -5,15 +5,4 @@ namespace Microsoft.EntityFrameworkCore.Query.Relationships.ComplexProperties;
 
 public abstract class ComplexPropertiesMiscellaneousTestBase<TFixture>(TFixture fixture)
     : RelationshipsMiscellaneousTestBase<TFixture>(fixture)
-        where TFixture : ComplexPropertiesFixtureBase, new()
-{
-    // TODO: the following is temporary until change tracking is implemented for complex JSON types (#35962)
-    private readonly TrackingRewriter _trackingRewriter = new(QueryTrackingBehavior.NoTracking);
-
-    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
-    {
-        var rewritten = _trackingRewriter.Visit(serverQueryExpression);
-
-        return rewritten;
-    }
-}
+        where TFixture : ComplexPropertiesFixtureBase, new();

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesProjectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesProjectionTestBase.cs
@@ -5,15 +5,4 @@ namespace Microsoft.EntityFrameworkCore.Query.Relationships.ComplexProperties;
 
 public abstract class ComplexPropertiesProjectionTestBase<TFixture>(TFixture fixture)
     : RelationshipsProjectionTestBase<TFixture>(fixture)
-        where TFixture : ComplexPropertiesFixtureBase, new()
-{
-    // TODO: the following is temporary until change tracking is implemented for complex JSON types (#35962)
-    private readonly TrackingRewriter _trackingRewriter = new(QueryTrackingBehavior.NoTracking);
-
-    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
-    {
-        var rewritten = _trackingRewriter.Visit(serverQueryExpression);
-
-        return rewritten;
-    }
-}
+        where TFixture : ComplexPropertiesFixtureBase, new();

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesSetOperationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesSetOperationsTestBase.cs
@@ -5,15 +5,4 @@ namespace Microsoft.EntityFrameworkCore.Query.Relationships.ComplexProperties;
 
 public abstract class ComplexPropertiesSetOperationsTestBase<TFixture>(TFixture fixture)
     : RelationshipsSetOperationsTestBase<TFixture>(fixture)
-    where TFixture : ComplexPropertiesFixtureBase, new()
-{
-    // TODO: the following is temporary until change tracking is implemented for complex JSON types (#35962)
-    private readonly TrackingRewriter _trackingRewriter = new(QueryTrackingBehavior.NoTracking);
-
-    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
-    {
-        var rewritten = _trackingRewriter.Visit(serverQueryExpression);
-
-        return rewritten;
-    }
-}
+    where TFixture : ComplexPropertiesFixtureBase, new();

--- a/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesStructuralEqualityTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/ComplexProperties/ComplexPropertiesStructuralEqualityTestBase.cs
@@ -74,14 +74,4 @@ public abstract class ComplexPropertiesStructuralEqualityTestBase<TFixture>(TFix
             ss => ss.Set<RootEntity>().Where(e => e.RequiredRelated.NestedCollection == nestedCollection),
             ss => ss.Set<RootEntity>().Where(e => e.RequiredRelated.NestedCollection.SequenceEqual(nestedCollection)));
     }
-
-    // TODO: the following is temporary until change tracking is implemented for complex JSON types (#35962)
-    private readonly TrackingRewriter _trackingRewriter = new(QueryTrackingBehavior.NoTracking);
-
-    protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
-    {
-        var rewritten = _trackingRewriter.Visit(serverQueryExpression);
-
-        return rewritten;
-    }
 }


### PR DESCRIPTION
In the query shaper, we have two general paths around fixup:

* For tracking queries, the change tracker is responsible for fixup
* For non-tracking queries, we generate extra code into the shaper to do the fixup

This PR applies the non-tracking approach to complex types: since they aren't tracked separately like (owned) entities, we need to connect all complex types to their entity root.

Did some smoke testing as well with basic scenarios, everything seems to be working well.

Part of https://github.com/dotnet/efcore/issues/36296

/cc @artl93 