### PR TITLE
Complex json change tracking

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -484,6 +484,27 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
         return result;
     }
 
+    /// <summary>
+    ///     Called after a structural type is materialized, but before it's handed off to the change tracker.
+    ///     Here we inject the JSON shapers for any complex JSON properties the type has.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public override void AddStructuralTypeInitialization(
+        StructuralTypeShaperExpression shaper,
+        ParameterExpression instanceVariable,
+        List<ParameterExpression> variables,
+        List<Expression> expressions)
+    {
+        Check.DebugAssert(_currentShaperProcessor is not null);
+
+        _currentShaperProcessor.ProcessTopLevelComplexJsonProperties(shaper, instanceVariable, expressions);
+    }
+
     private Expression CreateRelationalCommandResolverExpression(Expression queryExpression)
     {
         // In the regular case, we generate code that accesses the RelationalCommandCache (which invokes the 2nd part of the

--- a/src/EFCore/Query/Internal/StructuralTypeMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/StructuralTypeMaterializerSource.cs
@@ -140,7 +140,7 @@ public class StructuralTypeMaterializerSource : IStructuralTypeMaterializerSourc
                 => serviceProperty.ParameterBinding.BindToParameter(bindingInfo),
 
             IComplexProperty { IsCollection: true } complexProperty
-                => Expression.Default(complexProperty.ClrType), // Initialize collections to null, they'll be populated separately
+                => Default(complexProperty.ClrType), // Initialize collections to null, they'll be populated separately
 
             IComplexProperty complexProperty
                 => CreateMaterializeExpression(

--- a/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
+++ b/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
@@ -150,7 +150,7 @@ public static class LiftableConstantExpressionHelpers
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildMemberAccessLambdaForEntityOrComplexType(
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildMemberAccessLambdaForStructuralType(
         ITypeBase type)
     {
         var prm = Parameter(typeof(MaterializerLiftableConstantContext));

--- a/test/EFCore.Relational.Specification.Tests/Update/ComplexCollectionJsonUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/ComplexCollectionJsonUpdateTestBase.cs
@@ -11,7 +11,7 @@ public abstract class ComplexCollectionJsonUpdateTestBase<TFixture>(TFixture fix
     protected ComplexCollectionJsonContext CreateContext()
         => (ComplexCollectionJsonContext)Fixture.CreateContext();
 
-    [ConditionalFact(Skip = "Issue #36433")]
+    [ConditionalFact]
     public virtual Task Add_element_to_complex_collection_mapped_to_json()
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext,
@@ -26,17 +26,10 @@ public abstract class ComplexCollectionJsonUpdateTestBase<TFixture>(TFixture fix
 
                 company.Contacts!.Add(new Contact { Name = "New Contact", PhoneNumbers = ["555-0000"] });
 
-                Assert.Equal("""
-CompanyWithComplexCollections {Id: 1} Unchanged
-    Id: 1 PK
-    Name: 'Test Company'
-    Contacts (Complex: List<Contact>)
-    Department (Complex: Department)
-      Budget: 10000.00
-      Name: 'Initial Department'
-    Employees (Complex: List<Employee>)
-
-""", context.ChangeTracker.DebugView.LongView);
+                Assert.Contains("Contacts (Complex: List<Contact>)", context.ChangeTracker.DebugView.LongView);
+                Assert.Contains("Department (Complex: Department)", context.ChangeTracker.DebugView.LongView);
+                Assert.Contains("Name: 'Initial Department'", context.ChangeTracker.DebugView.LongView);
+                Assert.Contains("Employees (Complex: List<Employee>)", context.ChangeTracker.DebugView.LongView);
 
                 ClearLog();
                 await context.SaveChangesAsync();
@@ -126,7 +119,7 @@ CompanyWithComplexCollections {Id: 1} Unchanged
                 }
             });
 
-    [ConditionalFact(Skip = "Issue #36433")]
+    [ConditionalFact]
     public virtual Task Change_complex_collection_mapped_to_json_to_null_and_to_empty()
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext,
@@ -354,7 +347,7 @@ CompanyWithComplexCollections {Id: 1} Unchanged
                 }
             });
 
-    [ConditionalFact(Skip = "Issue #36433")]
+    [ConditionalFact]
     public virtual Task Set_complex_collection_to_null_mapped_to_json()
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext,
@@ -499,7 +492,7 @@ CompanyWithComplexCollections {Id: 1} Unchanged
                 }
             });
 
-    [ConditionalFact(Skip = "Issue #36433")]
+    [ConditionalFact]
     public virtual Task Set_complex_property_mapped_to_json_to_null()
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext,

--- a/test/EFCore.SqlServer.FunctionalTests/Update/ComplexCollectionJsonUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/ComplexCollectionJsonUpdateSqlServerTest.cs
@@ -33,15 +33,13 @@ WHERE [Id] = @p1;
         AssertSql(
             """
 @p0='[{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 66)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -52,15 +50,13 @@ WHERE [Id] = @p3;
         AssertSql(
             """
 @p0='[{"Name":"First Contact - Modified","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 141)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -71,15 +67,13 @@ WHERE [Id] = @p3;
         AssertSql(
             """
 @p0='[{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]},{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -117,16 +111,14 @@ WHERE [Id] = @p1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"John Doe","PhoneNumbers":["555-1234","555-5678"],"Address":{"City":"Seattle","Country":"USA","PostalCode":"98101","Street":"123 Main St"}},{"Name":"Jane Smith","PhoneNumbers":["555-9876"],"Address":{"City":"Portland","Country":"USA","PostalCode":"97201","Street":"456 Oak Ave"}}]' (Nullable = false) (Size = 289)
-@p3='1'
+@p0='[{"Name":"John Doe","PhoneNumbers":["555-1234","555-5678"],"Address":{"City":"Seattle","Country":"USA","PostalCode":"98101","Street":"123 Main St"}},{"Name":"Jane Smith","PhoneNumbers":["555-9876"],"Address":{"City":"Portland","Country":"USA","PostalCode":"97201","Street":"456 Oak Ave"}}]' (Nullable = false) (Size = 289)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Employees] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -138,14 +130,13 @@ WHERE [Id] = @p3;
             """
 @p0='[{"Name":"Contact 1","PhoneNumbers":["555-1111"]}]' (Nullable = false) (Size = 50)
 @p1='{"Budget":50000.00,"Name":"Department A"}' (Nullable = false) (Size = 41)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p2;
 """);
     }
 
@@ -156,15 +147,13 @@ WHERE [Id] = @p3;
         AssertSql(
             """
 @p0='[]' (Nullable = false) (Size = 2)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -175,15 +164,13 @@ WHERE [Id] = @p3;
         AssertSql(
             """
 @p0='[{"Name":"Replacement Contact 1","PhoneNumbers":["999-1111"]},{"Name":"Replacement Contact 2","PhoneNumbers":["999-2222","999-3333"]}]' (Nullable = false) (Size = 134)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Contacts] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -193,16 +180,14 @@ WHERE [Id] = @p3;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001","555-9999"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 163)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001","555-9999"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 163)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Employees] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -212,16 +197,14 @@ WHERE [Id] = @p3;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Modified City","Country":"USA","PostalCode":"99999","Street":"100 First St"}}]' (Nullable = false) (Size = 153)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Modified City","Country":"USA","PostalCode":"99999","Street":"100 First St"}}]' (Nullable = false) (Size = 153)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Employees] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -265,16 +248,14 @@ WHERE [Id] = @p1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Replacement Employee","PhoneNumbers":["555-7777","555-8888"],"Address":{"City":"Replace City","Country":"Canada","PostalCode":"54321","Street":"789 Replace St"}}]' (Nullable = false) (Size = 172)
-@p3='1'
+@p0='[{"Name":"Replacement Employee","PhoneNumbers":["555-7777","555-8888"],"Address":{"City":"Replace City","Country":"Canada","PostalCode":"54321","Street":"789 Replace St"}}]' (Nullable = false) (Size = 172)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Employees] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -284,16 +265,14 @@ WHERE [Id] = @p3;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":10000.00,"Name":"Initial Department"}' (Nullable = false) (Size = 47)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}},{"Name":"Employee No Phone","PhoneNumbers":[],"Address":{"City":"Quiet City","Country":"USA","PostalCode":"00000","Street":"456 No Phone St"}}]' (Nullable = false) (Size = 295)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}},{"Name":"Employee No Phone","PhoneNumbers":[],"Address":{"City":"Quiet City","Country":"USA","PostalCode":"00000","Street":"456 No Phone St"}}]' (Nullable = false) (Size = 295)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Employees] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 
@@ -337,16 +316,14 @@ WHERE [Id] = @p1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":99999.99,"Name":"Replacement Department"}' (Nullable = false) (Size = 51)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p0='{"Budget":99999.99,"Name":"Replacement Department"}' (Nullable = false) (Size = 51)
+@p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [Companies] SET [Contacts] = @p0, [Department] = @p1, [Employees] = @p2
+UPDATE [Companies] SET [Department] = @p0
 OUTPUT 1
-WHERE [Id] = @p3;
+WHERE [Id] = @p1;
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Update/ComplexCollectionJsonUpdateSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/ComplexCollectionJsonUpdateSqliteTest.cs
@@ -31,12 +31,10 @@ RETURNING 1;
         AssertSql(
             """
 @p0='[{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 66)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -48,12 +46,10 @@ RETURNING 1;
         AssertSql(
             """
 @p0='[{"Name":"First Contact - Modified","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 141)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -65,12 +61,10 @@ RETURNING 1;
         AssertSql(
             """
 @p0='[{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]},{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -105,13 +99,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"John Doe","PhoneNumbers":["555-1234","555-5678"],"Address":{"City":"Seattle","Country":"USA","PostalCode":"98101","Street":"123 Main St"}},{"Name":"Jane Smith","PhoneNumbers":["555-9876"],"Address":{"City":"Portland","Country":"USA","PostalCode":"97201","Street":"456 Oak Ave"}}]' (Nullable = false) (Size = 289)
-@p3='1'
+@p0='[{"Name":"John Doe","PhoneNumbers":["555-1234","555-5678"],"Address":{"City":"Seattle","Country":"USA","PostalCode":"98101","Street":"123 Main St"}},{"Name":"Jane Smith","PhoneNumbers":["555-9876"],"Address":{"City":"Portland","Country":"USA","PostalCode":"97201","Street":"456 Oak Ave"}}]' (Nullable = false) (Size = 289)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Employees" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -124,11 +116,10 @@ RETURNING 1;
             """
 @p0='[{"Name":"Contact 1","PhoneNumbers":["555-1111"]}]' (Nullable = false) (Size = 50)
 @p1='{"Budget":"50000.0","Name":"Department A"}' (Nullable = false) (Size = 42)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p2='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1
+WHERE "Id" = @p2
 RETURNING 1;
 """);
     }
@@ -140,12 +131,10 @@ RETURNING 1;
         AssertSql(
             """
 @p0='[]' (Nullable = false) (Size = 2)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -157,12 +146,10 @@ RETURNING 1;
         AssertSql(
             """
 @p0='[{"Name":"Replacement Contact 1","PhoneNumbers":["999-1111"]},{"Name":"Replacement Contact 2","PhoneNumbers":["999-2222","999-3333"]}]' (Nullable = false) (Size = 134)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Contacts" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -173,13 +160,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001","555-9999"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 163)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001","555-9999"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 163)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Employees" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -190,13 +175,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Modified City","Country":"USA","PostalCode":"99999","Street":"100 First St"}}]' (Nullable = false) (Size = 153)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Modified City","Country":"USA","PostalCode":"99999","Street":"100 First St"}}]' (Nullable = false) (Size = 153)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Employees" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -237,13 +220,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Replacement Employee","PhoneNumbers":["555-7777","555-8888"],"Address":{"City":"Replace City","Country":"Canada","PostalCode":"54321","Street":"789 Replace St"}}]' (Nullable = false) (Size = 172)
-@p3='1'
+@p0='[{"Name":"Replacement Employee","PhoneNumbers":["555-7777","555-8888"],"Address":{"City":"Replace City","Country":"Canada","PostalCode":"54321","Street":"789 Replace St"}}]' (Nullable = false) (Size = 172)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Employees" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -254,13 +235,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"10000.0","Name":"Initial Department"}' (Nullable = false) (Size = 48)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}},{"Name":"Employee No Phone","PhoneNumbers":[],"Address":{"City":"Quiet City","Country":"USA","PostalCode":"00000","Street":"456 No Phone St"}}]' (Nullable = false) (Size = 295)
-@p3='1'
+@p0='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}},{"Name":"Employee No Phone","PhoneNumbers":[],"Address":{"City":"Quiet City","Country":"USA","PostalCode":"00000","Street":"456 No Phone St"}}]' (Nullable = false) (Size = 295)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Employees" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }
@@ -301,13 +280,11 @@ RETURNING 1;
 
         AssertSql(
             """
-@p0='[{"Name":"First Contact","PhoneNumbers":["555-1234","555-5678"]},{"Name":"Second Contact","PhoneNumbers":["555-9876","555-5432"]}]' (Nullable = false) (Size = 130)
-@p1='{"Budget":"99999.99","Name":"Replacement Department"}' (Nullable = false) (Size = 53)
-@p2='[{"Name":"Initial Employee","PhoneNumbers":["555-0001"],"Address":{"City":"Initial City","Country":"USA","PostalCode":"00001","Street":"100 First St"}}]' (Nullable = false) (Size = 152)
-@p3='1'
+@p0='{"Budget":"99999.99","Name":"Replacement Department"}' (Nullable = false) (Size = 53)
+@p1='1'
 
-UPDATE "Companies" SET "Contacts" = @p0, "Department" = @p1, "Employees" = @p2
-WHERE "Id" = @p3
+UPDATE "Companies" SET "Department" = @p0
+WHERE "Id" = @p1
 RETURNING 1;
 """);
     }


### PR DESCRIPTION
With JSON owned entities, the root (non-JSON) entity is materialized and tracked, and then JSON shaper code materializes the JSON owned entity and tracks that separately; the change tracker does the fix-up etc. When originally implementing the shaper support for complex JSON, I also added JSON shaper code after materialization - similar to the owned flow - but that's too late, since StartTracking already gets called as part of materiailzation.

I considered separating StartTracking from materialization and pulling the former up, so that I can inject JSON shaper code in between - but that's quite a significant change would probably break external (non-relational) providers. Instead I opted for adding an extension hook during materialization, that gets called after the structural type is instantiated and its regular properties are populated, but before it's handed off to StartTracking().

Adding such a hook proved difficult - our shaper generation really isn't designed with extensibility in mind. The most problematic is that in relational, ShapedQueryCompilingExpressionVisitor immediately calls a separate private visitor - ShaperProcessingExpressionVisitor - which does most of the work, and occasionally calls into the "parent" ShaperProcessingExpressionVisitor. One of these calls is for structural type materialization, making it difficult to have the extension hook call back into ShaperProcessingExpressionVisitor, which is where the JSON shaper logic lives (and it relies on various global state inside that visitor, and so can't easily be moved out). So I ended up tracking the current ShaperProcessingExpressionVisitor on RelationalShapedQueryCompilingExpressionVisitor, so that the hook can call into it; and since ShaperProcessingExpressionVisitor instantiates and calls itself recursively, that also needs to be accounted for.

There's a lot of potential for simplifying and cleaning everything up here, I hope we get to it at some point.

/cc @artl93 