### PR TITLE
Specify some lambda parameters/return type explicitly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -281,3 +281,6 @@ dotnet_naming_rule.everything_else_naming.severity = suggestion
 
 # ReSharper properties
 resharper_local_function_body = expression_body
+
+# CS9236: Compiling requires binding the lambda expression at least 100 times
+dotnet_diagnostic.CS9236.severity = error

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -360,7 +360,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                 ss => from p in ss.Set<ProductForLinq>()
                       group p by p.Category
                       into g
-                      let minPrice = g.Min(p => p.UnitPrice)
+                      let minPrice = g.Min(decimal (ProductForLinq p) => p.UnitPrice)
                       select new { Category = g.Key, CheapestProducts = g.Where(p => p.UnitPrice == minPrice) }));
 
     [ConditionalTheory]
@@ -383,7 +383,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                 ss => from p in ss.Set<ProductForLinq>()
                       group p by p.Category
                       into g
-                      let minPrice = g.Max(p => p.UnitPrice)
+                      let minPrice = g.Max(decimal (ProductForLinq p) => p.UnitPrice)
                       select new { Category = g.Key, MostExpensiveProducts = g.Where(p => p.UnitPrice == minPrice) }));
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -139,7 +139,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertSum(
             async,
             ss => ss.Set<Customer>(),
-            selector: c => c.Orders.Sum(o => o.OrderID));
+            selector: c => c.Orders.Sum(int (Order o) => o.OrderID));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -147,7 +147,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertSum(
             async,
             ss => ss.Set<Customer>(),
-            selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
+            selector: c => c.Orders.Sum(int (Order o) => 5 + o.OrderDetails.Sum(int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -155,7 +155,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertSum(
             async,
             ss => ss.Set<Customer>(),
-            selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Min(od => od.ProductID)));
+            selector: c => c.Orders.Sum(int (Order o) => 5 + o.OrderDetails.Min(int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -270,7 +270,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertAverage(
             async,
             ss => ss.Set<Customer>(),
-            selector: c => c.Orders.Sum(o => o.OrderID));
+            selector: c => c.Orders.Sum(int (Order o) => o.OrderID));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -278,7 +278,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertAverage(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Average(od => od.ProductID)));
+            selector: c => (decimal)c.Orders.Average(double (Order o) => 5 + o.OrderDetails.Average(int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -286,7 +286,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertAverage(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
+            selector: c => (decimal)c.Orders.Average(int (Order o) => 5 + o.OrderDetails.Max(int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -447,7 +447,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMin(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.Min(o => 5 + Enumerable.Min(o.OrderDetails, od => od.ProductID)));
+            selector: c => c.Orders.Min(o => 5 + Enumerable.Min(o.OrderDetails, int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -455,7 +455,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMin(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
+            selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Max(int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -494,7 +494,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMax(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.Max(o => 5 + Enumerable.Max(o.OrderDetails, od => od.ProductID)));
+            selector: c => c.Orders.Max(o => 5 + Enumerable.Max(o.OrderDetails, int (OrderDetail od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -502,7 +502,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMax(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
+            selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Sum(int (od) => od.ProductID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -37,7 +37,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                     async,
                     ss => ss.Set<Order>().Where(o => o.Customer.City != "London")
                         .GroupBy(o => o.CustomerID, (k, es) => new { k, es })
-                        .Select(g => g.es.Average(o => o.OrderID))));
+                        .Select(g => g.es.Average(int (Order o) => o.OrderID))));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1580,7 +1580,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                   {
                       s.Month,
                       s.Total,
-                      Payment = ss.Set<Order>().Where(e => e.OrderDate.Value.Month == s.Month).Sum(e => e.OrderID)
+                      Payment = ss.Set<Order>().Where(e => e.OrderDate.Value.Month == s.Month).Sum(int (Order e) => e.OrderID)
                   },
             elementSorter: e => (e.Month, e.Total),
             elementAsserter: (e, a) =>
@@ -1775,7 +1775,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             ss => from c in ss.Set<Customer>()
                   from o in ss.Set<Order>().GroupBy(o => o.CustomerID)
                       .Where(g => g.Count() > 5)
-                      .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                      .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(int (Order o) => o.OrderID) })
                       .Where(c1 => c.CustomerID == c1.CustomerID)
                   select c);
 
@@ -1787,7 +1787,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             ss => from c in ss.Set<Customer>()
                   from o in ss.Set<Order>().GroupBy(o => o.CustomerID)
                       .Where(g => g.Count() > 5)
-                      .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                      .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(int (Order o) => o.OrderID) })
                       .Where(c1 => c.CustomerID == c1.CustomerID)
                       .DefaultIfEmpty()
                   select c);
@@ -2342,7 +2342,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                                   .Where(x => x.CustomerID == c.CustomerID).DefaultIfEmpty()
                               group new { c.CustomerID, oc1.Count } by c.CustomerID
                               into g
-                              select new { CustomerID = g.Key, Count = g.Sum(x => x.Count) }).Where(x => x.CustomerID == c1.CustomerID)
+                              select new { CustomerID = g.Key, Count = g.Sum(int? (x) => x.Count) }).Where(x => x.CustomerID == c1.CustomerID)
                       .DefaultIfEmpty()
                   select new
                   {
@@ -2357,7 +2357,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                                   .Where(x => x.CustomerID == c.CustomerID).DefaultIfEmpty()
                               group new { c.CustomerID, Count = oc1.MaybeScalar(e => e.Count) } by c.CustomerID
                               into g
-                              select new { CustomerID = g.Key, Count = g.Sum(x => x.Count) }).Where(x => x.CustomerID == c1.CustomerID)
+                              select new { CustomerID = g.Key, Count = g.Sum(int? (x) => x.Count) }).Where(x => x.CustomerID == c1.CustomerID)
                       .DefaultIfEmpty()
                   select new
                   {
@@ -3200,7 +3200,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                         Subquery = c.Orders
                             .Select(o => new { First = o.CustomerID, Second = o.OrderID })
                             .GroupBy(x => x.First)
-                            .Select(g => new { Sum = g.Sum(x => x.Second) }).ToList()
+                            .Select(g => new { Sum = g.Sum(int (x) => x.Second) }).ToList()
                     }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3222,7 +3222,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                         Subquery = c.Orders
                             .Select(o => new { First = o.CustomerID, Second = o.OrderID })
                             .GroupBy(x => x.First)
-                            .Select(g => new { Max = g.Max(x => x.First.Length), Sum = g.Sum(x => x.Second) }).ToList()
+                            .Select(g => new { Max = g.Max(int (x) => x.First.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
                     }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3244,7 +3244,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                         Subquery = ss.Set<Order>()
                             .Select(o => new { First = o.CustomerID, Second = o.OrderID })
                             .GroupBy(x => x.First)
-                            .Select(g => new { Max = g.Max(x => x.First.Length), Sum = g.Sum(x => x.Second) }).ToList()
+                            .Select(g => new { Max = g.Max(int (x) => x.First.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
                     }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3266,7 +3266,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                         Subquery = c.Orders
                             .Select(o => new { First = o.OrderID, Second = o.Customer.City + o.CustomerID })
                             .GroupBy(x => x.Second)
-                            .Select(g => new { Sum = g.Sum(x => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
+                            .Select(g => new { Sum = g.Sum(int (x) => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
                     }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3288,7 +3288,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                   {
                       Sum = grouping.Sum(x => x.ProductID + x.OrderID * 1000),
                       Subquery = (from c in ss.Set<Customer>()
-                                  where c.CustomerID.Length < grouping.Min(x => x.OrderID / 100)
+                                  where c.CustomerID.Length < grouping.Min(int (OrderDetail x) => x.OrderID / 100)
                                   orderby c.CustomerID
                                   select new { c.CustomerID, c.City }).ToList()
                   },
@@ -3381,7 +3381,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                     {
                         g.Key,
                         A = ss.Set<Employee>().Where(e => e.City == "Seattle").GroupBy(e => e.City)
-                            .Select(g2 => g2.Count() + g.Min(e => e.OrderID))
+                            .Select(g2 => g2.Count() + g.Min(int (Order e) => e.OrderID))
                             .OrderBy(e => 1)
                             .FirstOrDefault()
                     }),

--- a/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
@@ -721,7 +721,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                     ss.Set<Order>(),
                     x => new { x.CustomerID, Nested = new { x.City, Year = 1996 } },
                     x => new { x.CustomerID, Nested = new { City = "London", x.OrderDate.Value.Year } },
-                    (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID.Length) }),
+                    (c, g) => new { c.CustomerID, Sum = g.Sum(int (x) => x.CustomerID.Length) }),
                 elementSorter: e => e.CustomerID));
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -1833,6 +1833,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                       where c1.City == ss.Set<Customer>().OrderBy(c => c.CustomerID).First(c => c.IsLondon).City
                       select c1));
 
+#pragma warning disable CS9236 // Compiling requires binding the lambda expression at least 200 times
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_query_composition4(bool async)
@@ -1842,9 +1843,10 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 ss => from c1 in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
                       where c1.City
                           == (from c2 in ss.Set<Customer>().OrderBy(c => c.CustomerID)
-                              from c3 in ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CustomerID)
+                              from c3 in ss.Set<Customer>().OrderBy(bool (Customer c) => c.IsLondon).ThenBy(string (Customer c) => c.CustomerID)
                               select new { c3 }).First().c3.City
                       select c1));
+#pragma warning restore CS9236
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -3990,6 +3992,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                          where customers.Any()
                          select customers).Any()));
 
+#pragma warning disable CS9236 // Compiling requires binding the lambda expression at least 200 times
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool async)
@@ -4001,10 +4004,11 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                     outer =>
                         (from c in ss.Set<Customer>()
                          let customers = ss.Set<Customer>().Where(
-                                 cc => ss.Set<Customer>().OrderBy(inner => inner.CustomerID).Take(10).Distinct().Any())
+                                 cc => ss.Set<Customer>().OrderBy(string (Customer inner) => inner.CustomerID).Take(10).Distinct().Any())
                              .Select(cc => cc.CustomerID).ToList()
                          where customers.Any()
                          select customers).Any()));
+#pragma warning restore CS9236
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -950,7 +950,7 @@ OUTER APPLY (
         await AssertAverage(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Average(od => od.ProductID)),
+            selector: c => (decimal)c.Orders.Average(double (Order o) => 5 + o.OrderDetails.Average(int (OrderDetail od) => od.ProductID)),
             asserter: (e, a) => Assert.Equal(e, a, precision: 3));
 
         // #34256: rewrite query to avoid "Cannot perform an aggregate function on an expression containing an aggregate or a subquery"

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5844,18 +5844,19 @@ ORDER BY [c].[CustomerID]
                 () =>
                 {
                     using var context = CreateContext();
-                    using ((from c in context.Customers
-                            where c.City == "London"
-                            orderby c.CustomerID
-                            select (from o1 in context.Orders
-                                    where o1.CustomerID == c.CustomerID
-                                        && o1.OrderDate.Value.Year == 1997
-                                    orderby o1.OrderID
-                                    select (from o2 in context.Orders
-                                            where o1.CustomerID == c.CustomerID
-                                            orderby o2.OrderID
-                                            select o1.OrderID).ToList()).ToList())
-                           .GetEnumerator())
+                    using (context.Customers
+                        .Where(c => c.City == "London")
+                        .OrderBy(c => c.CustomerID)
+                        .Select(c => context.Orders
+                                .Where(o1 => o1.CustomerID == c.CustomerID && o1.OrderDate.Value.Year == 1997)
+                                .OrderBy(o1 => o1.OrderID)
+                                .Select(o1 => context.Orders
+                                    .Where(o2 => o1.CustomerID == c.CustomerID)
+                                    .OrderBy(o2 => o2.OrderID)
+                                    .Select(o2 => o1.OrderID)
+                                    .ToList())
+                                .ToList())
+                        .GetEnumerator())
                     {
                     }
                 });

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -867,17 +867,17 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), typeof(DateTimeOffset).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Min(e => e.TestNullableDateTimeOffset)).ToList()).Message);
+                () => query.Select(g => g.Min(DateTimeOffset? (BuiltInNullableDataTypes e) => e.TestNullableDateTimeOffset)).ToList()).Message);
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), typeof(TimeSpan).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Min(e => e.TestNullableTimeSpan)).ToList()).Message);
+                () => query.Select(g => g.Min(TimeSpan? (BuiltInNullableDataTypes e) => e.TestNullableTimeSpan)).ToList()).Message);
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), typeof(ulong).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Min(e => e.TestNullableUnsignedInt64)).ToList()).Message);
+                () => query.Select(g => g.Min(ulong? (BuiltInNullableDataTypes e) => e.TestNullableUnsignedInt64)).ToList()).Message);
     }
 
     [ConditionalFact]
@@ -917,17 +917,17 @@ public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTy
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), typeof(DateTimeOffset).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Max(e => e.TestNullableDateTimeOffset)).ToList()).Message);
+                () => query.Select(g => g.Max(DateTimeOffset? (BuiltInNullableDataTypes e) => e.TestNullableDateTimeOffset)).ToList()).Message);
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), typeof(TimeSpan).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Max(e => e.TestNullableTimeSpan)).ToList()).Message);
+                () => query.Select(g => g.Max(TimeSpan? (BuiltInNullableDataTypes e) => e.TestNullableTimeSpan)).ToList()).Message);
 
         Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), typeof(ulong).ShortDisplayName()),
             Assert.Throws<NotSupportedException>(
-                () => query.Select(g => g.Max(e => e.TestNullableUnsignedInt64)).ToList()).Message);
+                () => query.Select(g => g.Max(ulong? (BuiltInNullableDataTypes e) => e.TestNullableUnsignedInt64)).ToList()).Message);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
In the latest versions of the SDK I've noticed CS9236 being suggested on some test methods; this PR adds explicit typing information to the offending lambdas and makes CS9236 an error.

This knocks off ~3 seconds (~10%) from the compilation time of EFCore.Specification.Tests 🎉 :

```
Test commandline (in test/EFCore.Specification.Tests):

hyperfine --warmup 1 'touch EFCore.Specification.Tests.csproj && dotnet build-server shutdown && dotnet build'

BEFORE CHANGE:
Benchmark 1: touch EFCore.Specification.Tests.csproj && dotnet build-server shutdown && dotnet build
  Time (mean ± σ):     31.553 s ±  7.155 s    [User: 2.457 s, System: 0.612 s]
  Range (min … max):   26.723 s … 51.103 s    10 runs

AFTER CHANGE: 
Benchmark 1: touch EFCore.Specification.Tests.csproj && dotnet build-server shutdown && dotnet build
  Time (mean ± σ):     28.481 s ±  1.640 s    [User: 2.093 s, System: 0.591 s]
  Range (min … max):   26.138 s … 30.825 s    10 runs
```
/cc @artl93 

