### PR TITLE
Use SQL Server 2025 JSON_VALUE() RETURNING clause 

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/ISqlServerSingletonOptions.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/ISqlServerSingletonOptions.cs
@@ -50,4 +50,12 @@ public interface ISqlServerSingletonOptions : ISingletonOptions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public bool SupportsJsonFunctions { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public bool SupportsJsonType { get; }
 }

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
@@ -56,6 +56,7 @@ public class SqlServerSingletonOptions : ISqlServerSingletonOptions
             SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 130,
             SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 130,
             SqlServerEngineType.AzureSynapse => true,
+            SqlServerEngineType.Unknown => false, // TODO: We shouldn't observe Unknown here, #36477
             _ => throw new UnreachableException()
         };
 
@@ -71,6 +72,7 @@ public class SqlServerSingletonOptions : ISqlServerSingletonOptions
             SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 170,
             SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
             SqlServerEngineType.AzureSynapse => false,
+            SqlServerEngineType.Unknown => false, // TODO: We shouldn't observe Unknown here, #36477
             _ => throw new UnreachableException()
         };
 

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
@@ -50,12 +50,29 @@ public class SqlServerSingletonOptions : ISqlServerSingletonOptions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool SupportsJsonFunctions =>
-        (EngineType == SqlServerEngineType.SqlServer && SqlServerCompatibilityLevel >= 130)
-        ||
-        (EngineType == SqlServerEngineType.AzureSql && AzureSqlCompatibilityLevel >= 130)
-        ||
-        (EngineType == SqlServerEngineType.AzureSynapse);
+    public virtual bool SupportsJsonFunctions
+        => EngineType switch
+        {
+            SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 130,
+            SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 130,
+            SqlServerEngineType.AzureSynapse => true,
+            _ => throw new UnreachableException()
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool SupportsJsonType
+        => EngineType switch
+        {
+            SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 170,
+            SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
+            SqlServerEngineType.AzureSynapse => false,
+            _ => throw new UnreachableException()
+        };
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerJsonPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerJsonPostprocessor.cs
@@ -218,6 +218,9 @@ public sealed class SqlServerJsonPostprocessor(
                     jsonScalarExpression.IsNullable);
             }
 
+            // TODO: With the new RETURNING clause the following should not longer be needed - but support for varbinary
+            // isn't there yet. See #36474.
+
             // Some SQL Server types cannot be reliably parsed with JSON_VALUE(): binary/varbinary are encoded in base64 in the JSON,
             // but JSON_VALUE() returns a string and there's no SQL Server function to parse base64. However, OPENJSON/WITH does do base64
             // decoding.

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -217,13 +217,7 @@ public class SqlServerTypeMappingSource(
         // ReSharper restore CoVariantArrayConversion
     }
 
-    private readonly bool _isJsonTypeSupported = sqlServerSingletonOptions.EngineType switch
-    {
-        SqlServerEngineType.SqlServer => sqlServerSingletonOptions.SqlServerCompatibilityLevel >= 170,
-        SqlServerEngineType.AzureSql => sqlServerSingletonOptions.AzureSqlCompatibilityLevel >= 170,
-        SqlServerEngineType.AzureSynapse => false,
-        _ => false
-    };
+    private readonly bool _isJsonTypeSupported = sqlServerSingletonOptions.SupportsJsonType;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
@@ -124,12 +124,24 @@ WHERE (
         // ElementAt (making a Select()), this interferes with our translation. See #36335.
         await Assert.ThrowsAsync<EqualException>(() => base.Index_constant());
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RelatedCollection], '$[0]' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[0]') AS int) = 8
 """);
+        }
     }
 
     public override async Task Index_parameter()
@@ -138,14 +150,28 @@ WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[0]') AS int) = 8
         // ElementAt (making a Select()), this interferes with our translation. See #36335.
         await Assert.ThrowsAsync<EqualException>(() => base.Index_parameter());
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                 """
+@i='?' (DbType = Int32)
+
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RelatedCollection], '$[' + CAST(@i AS nvarchar(max)) + ']' RETURNING int) = 8
+""");
+        }
+        else
+        {
+           AssertSql(
+               """
 @i='?' (DbType = Int32)
 
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[' + CAST(@i AS nvarchar(max)) + ']') AS int) = 8
 """);
+        }
     }
 
     public override async Task Index_column()
@@ -154,24 +180,48 @@ WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[' + CAST(@i AS nvarchar(max)) 
         // ElementAt (making a Select()), this interferes with our translation. See #36335.
         await Assert.ThrowsAsync<EqualException>(() => base.Index_column());
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RelatedCollection], '$[' + CAST([r].[Id] - 1 AS nvarchar(max)) + ']' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[' + CAST([r].[Id] - 1 AS nvarchar(max)) + ']') AS int) = 8
 """);
+        }
     }
 
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RelatedCollection], '$[9999]' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RelatedCollection], '$[9999]') AS int) = 8
 """);
+        }
     }
 
     #endregion Index

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonMiscellaneousSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonMiscellaneousSqlServerTest.cs
@@ -12,36 +12,72 @@ public class ComplexJsonMiscellaneousSqlServerTest(ComplexJsonSqlServerFixture f
     {
         await base.Where_related_property();
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredRelated], '$.Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+           AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RequiredRelated], '$.Int') AS int) = 8
 """);
+        }
     }
 
     public override async Task Where_optional_related_property()
     {
         await base.Where_optional_related_property();
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[OptionalRelated], '$.Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[OptionalRelated], '$.Int') AS int) = 8
 """);
+        }
     }
 
     public override async Task Where_nested_related_property()
     {
         await base.Where_nested_related_property();
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredRelated], '$.RequiredNested.Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
 FROM [RootEntity] AS [r]
 WHERE CAST(JSON_VALUE([r].[RequiredRelated], '$.RequiredNested.Int') AS int) = 8
 """);
+        }
     }
 
     #endregion Simple filters

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
@@ -23,44 +23,88 @@ FROM [RootEntity] AS [r]
     {
         await base.Select_property_on_required_related(queryTrackingBehavior);
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[RequiredRelated], '$.String' RETURNING nvarchar(max))
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT JSON_VALUE([r].[RequiredRelated], '$.String')
 FROM [RootEntity] AS [r]
 """);
+        }
     }
 
     public override async Task Select_property_on_optional_related(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_property_on_optional_related(queryTrackingBehavior);
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[OptionalRelated], '$.String' RETURNING nvarchar(max))
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT JSON_VALUE([r].[OptionalRelated], '$.String')
 FROM [RootEntity] AS [r]
 """);
+        }
     }
 
     public override async Task Select_value_type_property_on_null_related_throws(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_value_type_property_on_null_related_throws(queryTrackingBehavior);
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[OptionalRelated], '$.Int' RETURNING int)
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT CAST(JSON_VALUE([r].[OptionalRelated], '$.Int') AS int)
 FROM [RootEntity] AS [r]
 """);
+        }
     }
 
     public override async Task Select_nullable_value_type_property_on_null_related(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_nullable_value_type_property_on_null_related(queryTrackingBehavior);
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[OptionalRelated], '$.Int' RETURNING int)
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT CAST(JSON_VALUE([r].[OptionalRelated], '$.Int') AS int)
 FROM [RootEntity] AS [r]
 """);
+        }
     }
 
     #endregion Simple properties

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexJson/ComplexJsonSqlServerFixture.cs
@@ -10,7 +10,7 @@ public class ComplexJsonSqlServerFixture : ComplexJsonRelationalFixtureBase
 
     // When testing against SQL Server 2025 or later, set the compatibility level to 170 to use the json type instead of nvarchar(max).
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-        => UsingJsonType
+        => TestEnvironment.SqlServerMajorVersion >= 17
             ? builder.UseSqlServer(o => o.UseCompatibilityLevel(170))
             : builder;
 


### PR DESCRIPTION
Based on top of #36442, review last commit only.

Note: disabling this specifically when UseAzureSql() is used, as RETURNING isn't supported there yet (but should be supported very soon).

Closes #35729