### PR TITLE
Dispose related readers in GroupBySplitQueryingEnumerable

### DIFF
--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -281,6 +281,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                 _dataReader.Dispose();
+
                 if (_resultCoordinator != null)
                 {
                     foreach (var dataReader in _resultCoordinator.DataReaders)
@@ -430,6 +431,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                 await _dataReader.DisposeAsync().ConfigureAwait(false);
+
                 if (_resultCoordinator != null)
                 {
                     foreach (var dataReader in _resultCoordinator.DataReaders)


### PR DESCRIPTION
Adding test coverage here is quite difficult/impractical - the bug is that a certain internal resource (DbDataReader) doesn't get disposed, which isn't something visible we can check. In any case, the fix is quite trivial and follows the same pattern as for the very similar SplitQueryingEnumerable (non-GroupBy).

Fixes #34280
