### PR TITLE
[release/8.0] Dispose related readers in GroupBySplitQueryingEnumerable (#36484)

### DIFF
--- a/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
@@ -330,6 +330,19 @@ public class GroupBySplitQueryingEnumerable<TKey, TElement>
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                 _dataReader.Dispose();
+
+                if (_resultCoordinator != null)
+                {
+                    foreach (var dataReader in _resultCoordinator.DataReaders)
+                    {
+                        dataReader?.DataReader.Dispose();
+                    }
+
+                    _resultCoordinator.DataReaders.Clear();
+
+                    _resultCoordinator = null;
+                }
+
                 _dataReader = null;
                 _dbDataReader = null;
             }
@@ -503,20 +516,30 @@ public class GroupBySplitQueryingEnumerable<TKey, TElement>
             return false;
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            if (_dataReader is not null)
+            if (_dataReader != null)
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
+                await _dataReader.DisposeAsync().ConfigureAwait(false);
 
-                var dataReader = _dataReader;
+                if (_resultCoordinator != null)
+                {
+                    foreach (var dataReader in _resultCoordinator.DataReaders)
+                    {
+                        if (dataReader != null)
+                        {
+                            await dataReader.DataReader.DisposeAsync().ConfigureAwait(false);
+                        }
+                    }
+
+                    _resultCoordinator.DataReaders.Clear();
+                    _resultCoordinator = null;
+                }
+
                 _dataReader = null;
                 _dbDataReader = null;
-
-                return dataReader.DisposeAsync();
             }
-
-            return default;
         }
     }
 }

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -251,6 +251,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                 _dataReader.Dispose();
+
                 if (_resultCoordinator != null)
                 {
                     foreach (var dataReader in _resultCoordinator.DataReaders)
@@ -407,6 +408,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
             {
                 _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                 await _dataReader.DisposeAsync().ConfigureAwait(false);
+
                 if (_resultCoordinator != null)
                 {
                     foreach (var dataReader in _resultCoordinator.DataReaders)


### PR DESCRIPTION
Port of #36484
Fixes #34280

**Description**
When a user executes a LINQ query that has a final GroupBy() (GroupBy as the very last operator), and executes as a split query, EF does not properly dispose the database reader(s) it uses to read back the results (these are IDisposable).

**Customer impact**
Depending on the provider, when executing a LINQ query that uses a final GroupBy() and is configured for split querying, the database connection may get leaked and never returned to the connection pool. This later leads to an exhausted connection pool and to an application failure in a way that's hard to track down and connect to the actual problematic EF LINQ query.

**How found**
Two users reported.

**Regression**
No - this bug was present when the final GroupBy feature was first introduced in EF 7.0 (in #19929)

**Testing**
Adding test coverage here is quite difficult/impractical - the bug is that a certain internal resource (DbDataReader) doesn't get disposed, which isn't something visible we can check. 

**Risk**
Extremely low. The fix is very targeted and simply does the as for very similar other code (e.g. non-GroupBy SplitQueryingEnumerable).
