### PR TITLE
Inject Application Name to SQL Server connection string when not set

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerConnection.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerConnection.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using Microsoft.Data.SqlClient;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -20,6 +21,15 @@ public class SqlServerConnection : RelationalConnection, ISqlServerConnection
     private static readonly ConcurrentDictionary<string, bool> MultipleActiveResultSetsEnabledMap = new();
 
     /// <summary>
+    ///     Maps a user-provided connection string to a possibly transformed connection string that will actually be used
+    ///     to connect. By default, if the user-provided connection string doesn't set Application Name, we set it to contain
+    ///     information about EF Core and the version being used.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, string> ConnectionStringMap = new();
+
+    private static string? _defaultApplicationName;
+
+    /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
@@ -28,6 +38,29 @@ public class SqlServerConnection : RelationalConnection, ISqlServerConnection
     public SqlServerConnection(RelationalConnectionDependencies dependencies)
         : base(dependencies)
     {
+        // If EF was configured with a connection string that doesn't contain Application Name, rewrite it to inject
+        // Application Name with EF and versioning info.
+        // Note that we don't do anything if EF was configured with a SqlConnection, as that could reset the
+        // password because of Persist Security Info=true
+        var relationalOptions = RelationalOptionsExtension.Extract(dependencies.ContextOptions);
+
+        if (!string.IsNullOrWhiteSpace(relationalOptions.ConnectionString))
+        {
+            Check.DebugAssert(relationalOptions.Connection is null);
+
+            // In the base constructor, the connection string is set by assigning directly to _connectionString
+            // (possibly first going through ConnectionStringResolver).
+            // Here we re-assign the same via the ConnectionString property, which does the rewriting.
+            var userProvidedConnectionString = ConnectionString;
+            ConnectionString = userProvidedConnectionString;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string? ConnectionString
+    {
+        get => base.ConnectionString;
+        set => base.ConnectionString = value is null ? null : ConnectionStringMap.GetOrAdd(value, ModifyConnectionString);
     }
 
     /// <summary>
@@ -120,4 +153,45 @@ public class SqlServerConnection : RelationalConnection, ISqlServerConnection
     /// </summary>
     protected override bool SupportsAmbientTransactions
         => true;
+
+    /// <summary>
+    ///     Modifies the user-provided connection string. By default, adds an Application Name to the connection
+    ///     string containing EF Core and versioning information.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    [EntityFrameworkInternal]
+    protected virtual string ModifyConnectionString(string userProvidedConnectionString)
+    {
+        try
+        {
+            var connectionStringBuilder = new SqlConnectionStringBuilder(userProvidedConnectionString);
+
+            // SqlClient sends "Core Microsoft SqlClient Data Provider" as the default Application Name when unset;
+            // detect that and overwrite.
+            if (connectionStringBuilder.ApplicationName is "Core Microsoft SqlClient Data Provider" or "" or null)
+            {
+                var efVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+
+                _defaultApplicationName ??=
+                    $"EFCore/{efVersion} ({RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture})";
+
+                connectionStringBuilder.ApplicationName = _defaultApplicationName;
+
+                return connectionStringBuilder.ToString();
+            }
+        }
+        catch
+        {
+            // If anything goes wrong, simply don't modify the connection string.
+            // There are some scenarios where an invalid string is provided and an exception isn't expected at this phase
+            // (see e.g. test GetContextInfo_does_not_throw_if_DbConnection_cannot_be_created)
+        }
+
+        return userProvidedConnectionString;
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TwoDatabasesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TwoDatabasesSqlServerTest.cs
@@ -10,6 +10,10 @@ public class TwoDatabasesSqlServerTest(SqlServerFixture fixture) : TwoDatabasesT
     protected new SqlServerFixture Fixture
         => (SqlServerFixture)base.Fixture;
 
+    [ConditionalTheory(Skip = "In SQL Server specifically, injection of Application Name into the connection string causes this test to fail (#36548)")]
+    public override void Can_set_connection_string_in_interceptor(bool withConnectionString, bool withNullConnectionString)
+        => base.Can_set_connection_string_in_interceptor(withConnectionString, withNullConnectionString);
+
     protected override DbContextOptionsBuilder CreateTestOptions(
         DbContextOptionsBuilder optionsBuilder,
         bool withConnectionString = false,
@@ -24,5 +28,5 @@ public class TwoDatabasesSqlServerTest(SqlServerFixture fixture) : TwoDatabasesT
         => new(Fixture.CreateOptions(SqlServerTestStore.Create(databaseName)));
 
     protected override string DummyConnectionString
-        => "Database=DoesNotExist";
+        => "Database=DoesNotExist;Application Name=foo";
 }

--- a/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerConnectionTest.cs
@@ -19,12 +19,14 @@ public class SqlServerConnectionTest
         Assert.IsType<SqlConnection>(connection.DbConnection);
     }
 
+    #region Master connection
+
     [ConditionalFact]
     public void Can_create_master_connection()
     {
         using var connection = new SqlServerConnection(CreateDependencies());
         using var master = connection.CreateMasterConnection();
-        Assert.Equal(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master", master.ConnectionString);
+        Assert.Equal(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master", StripApplicationName(master.ConnectionString));
         Assert.Equal(60, master.CommandTimeout);
     }
 
@@ -39,7 +41,7 @@ public class SqlServerConnectionTest
 
         using var connection = new SqlServerConnection(CreateDependencies(options));
         using var master = connection.CreateMasterConnection();
-        Assert.Equal(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master", master.ConnectionString);
+        Assert.Equal(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master", StripApplicationName(master.ConnectionString));
     }
 
     [ConditionalFact]
@@ -54,6 +56,61 @@ public class SqlServerConnectionTest
         using var connection = new SqlServerConnection(CreateDependencies(options));
         using var master = connection.CreateMasterConnection();
         Assert.Equal(55, master.CommandTimeout);
+    }
+
+    #endregion Master connection
+
+    #region Application Name
+
+    [ConditionalFact]
+    public void ApplicationName_is_injected_when_not_defined_with_connection_string()
+    {
+        var options = new DbContextOptionsBuilder()
+            .UseSqlServer("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest""")
+            .Options;
+
+        using var connection = new SqlServerConnection(CreateDependencies(options));
+        Assert.StartsWith("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest;Application Name="EFCore/""", connection.ConnectionString);
+
+        connection.ConnectionString = """Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase""";
+        Assert.StartsWith("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase;Application Name="EFCore/""", connection.ConnectionString);
+    }
+
+    [ConditionalFact]
+    public void ApplicationName_is_not_injected_when_user_defined_with_connection_string()
+    {
+        var options = new DbContextOptionsBuilder()
+            .UseSqlServer("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest;Application Name=foo""")
+            .Options;
+
+        using var connection = new SqlServerConnection(CreateDependencies(options));
+        Assert.Equal("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest;Application Name=foo""", connection.ConnectionString);
+
+        connection.ConnectionString = """Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase;Application Name=foo""";
+        Assert.Equal("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase;Application Name=foo""", connection.ConnectionString);
+    }
+
+    [ConditionalFact]
+    public void ApplicationName_is_not_injected_with_connection()
+    {
+        var dbConnection1 = new SqlConnection("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest""");
+        var options = new DbContextOptionsBuilder().UseSqlServer(dbConnection1).Options;
+
+        using var connection = new SqlServerConnection(CreateDependencies(options));
+        Assert.Equal("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SqlServerConnectionTest""", connection.ConnectionString);
+
+        var dbConnection2 = new SqlConnection("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase""");
+        connection.DbConnection = dbConnection2;
+        Assert.Equal("""Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=SomeOtherDatabase""", connection.ConnectionString);
+    }
+
+    #endregion Application Name
+
+    private static string StripApplicationName(string connectionString)
+    {
+        var builder = new SqlConnectionStringBuilder(connectionString);
+        builder.Remove("Application Name");
+        return builder.ToString();
     }
 
     public static RelationalConnectionDependencies CreateDependencies(DbContextOptions options = null)


### PR DESCRIPTION
Note: this support via the connection string is temporary and is likely to go away in EF 11 once SqlClient introduce a more first-class user-agent-like mechanism (see https://github.com/dotnet/efcore/issues/35730#issuecomment-3012092136).

Closes #35730
