### PR TITLE
Discriminator support for optional complex types

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 complexProperty);
 
         /// <summary>
-        ///     The optional complex property '{type}.{property}' is mapped to columns by flattening the contained properties, but it only contains optional properties. Add a required property or discriminator or map this complex property to a JSON column.
+        ///     The optional complex property '{type}.{property}' is mapped to columns by flattening the contained properties into its container's table; this mapping requires at least one required property - to allow distinguishing between null and empty values - but type '{complexType}' contains only optional properties. Configure the property with a shadow discriminator by adding a call to 'HasDiscriminator()` on the complex property configuration, or map this complex property to a JSON column instead.
         /// </summary>
         public static string ComplexPropertyOptionalTableSharing(object? type, object? property)
             => string.Format(
@@ -2218,7 +2218,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -155,7 +155,7 @@
     <value>Complex property '{complexProperty}' cannot use 'HasJsonPropertyName()' because it is not contained within a JSON-mapped type. Use 'ToJson()' to map the complex property to a JSON column, or ensure it is contained within a type that is mapped to JSON.</value>
   </data>
   <data name="ComplexPropertyOptionalTableSharing" xml:space="preserve">
-    <value>The optional complex property '{type}.{property}' is mapped to columns by flattening the contained properties, but it only contains optional properties. Add a required property or discriminator or map this complex property to a JSON column.</value>
+    <value>The optional complex property '{type}.{property}' is mapped to columns by flattening the contained properties into its container's table; this mapping requires at least one required property - to allow distinguishing between null and empty values - but the complex type contains only optional properties. Configure the property with a shadow discriminator by adding a call to 'HasDiscriminator()` on the complex property configuration, or map this complex property to a JSON column instead.</value>
   </data>
   <data name="ComputedColumnSqlUnspecified" xml:space="preserve">
     <value>The computed column SQL has not been specified for the column '{table}.{column}'. Specify the SQL before using Entity Framework to create the database schema.</value>

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -170,8 +170,7 @@ public abstract class SnapshotFactoryFactory
                             structuralTypeVariable,
                             (IRuntimeTypeBase)propertyBases[0]!.DeclaringType switch
                             {
-                                IComplexType declaringComplexType when declaringComplexType.ComplexProperty.IsCollection
-                                    => PropertyAccessorsFactory.CreateComplexCollectionElementAccess(
+                                IComplexType { ComplexProperty.IsCollection: true } declaringComplexType => PropertyAccessorsFactory.CreateComplexCollectionElementAccess(
                                         declaringComplexType.ComplexProperty,
                                         Expression.Convert(
                                             Expression.Property(parameter!, nameof(IInternalEntry.Entity)),

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -94,8 +94,7 @@ public class ValueGenerationManager : IValueGenerationManager
         var hasNonStableValues = false;
         IProperty? propertyWithNoGenerator = null;
 
-        //TODO: Handle complex properties, #31633
-        foreach (var property in entry.EntityType.GetValueGeneratingProperties())
+        foreach (var property in entry.EntityType.GetFlattenedValueGeneratingProperties())
         {
             if (!TryFindValueGenerator(
                     entry, includePrimaryKey, property,
@@ -143,8 +142,7 @@ public class ValueGenerationManager : IValueGenerationManager
         var hasNonStableValues = false;
         IProperty? propertyWithNoGenerator = null;
 
-        //TODO: Handle complex properties
-        foreach (var property in entry.EntityType.GetValueGeneratingProperties())
+        foreach (var property in entry.EntityType.GetFlattenedValueGeneratingProperties())
         {
             if (!TryFindValueGenerator(
                     entry, includePrimaryKey, property,

--- a/src/EFCore/Metadata/IConventionTypeBase.cs
+++ b/src/EFCore/Metadata/IConventionTypeBase.cs
@@ -76,7 +76,7 @@ public interface IConventionTypeBase : IReadOnlyTypeBase, IConventionAnnotatable
     /// </summary>
     /// <returns>The property that will be used for storing a discriminator value.</returns>
     new IConventionProperty? FindDiscriminatorProperty()
-        => (IConventionProperty?)((IReadOnlyEntityType)this).FindDiscriminatorProperty();
+        => (IConventionProperty?)((IReadOnlyTypeBase)this).FindDiscriminatorProperty();
 
     /// <summary>
     ///     Sets the <see cref="IReadOnlyProperty" /> that will be used for storing a discriminator value.

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -540,7 +542,8 @@ public interface IEntityType : IReadOnlyEntityType, ITypeBase
     ///     <see cref="EntityState.Added" /> state.
     /// </summary>
     /// <returns>The properties that need a value to be generated on add.</returns>
-    IEnumerable<IProperty> GetValueGeneratingProperties();
+    IEnumerable<IProperty> GetValueGeneratingProperties()
+        => GetProperties().Where(p => p.RequiresValueGenerator());
 
     /// <summary>
     ///     Gets the service property with a given name.

--- a/src/EFCore/Metadata/ITypeBase.cs
+++ b/src/EFCore/Metadata/ITypeBase.cs
@@ -145,6 +145,13 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     new IEnumerable<IProperty> GetProperties();
 
     /// <summary>
+    ///     Returns the properties that need a value to be generated when the entity entry transitions to the
+    ///     <see cref="EntityState.Added" /> state, including properties defined on non-collection complex types.
+    /// </summary>
+    /// <returns>The properties that need a value to be generated on add.</returns>
+    IEnumerable<IProperty> GetFlattenedValueGeneratingProperties();
+
+    /// <summary>
     ///     Gets the complex property with a given name. Returns <see langword="null" /> if no property with the given name is defined.
     /// </summary>
     /// <remarks>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -53,7 +53,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     // Warning: Never access these fields directly as access needs to be thread-safe
     private PropertyCounts? _counts;
     private IProperty[]? _foreignKeyProperties;
-    private IProperty[]? _valueGeneratingProperties;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2288,22 +2287,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
                 return entityType.GetProperties().Where(p => p.IsForeignKey()).ToArray();
             });
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual IReadOnlyList<IProperty> ValueGeneratingProperties
-        => NonCapturingLazyInitializer.EnsureInitialized(
-            ref _valueGeneratingProperties, this,
-            static entityType =>
-            {
-                entityType.EnsureReadOnly();
-
-                return entityType.GetProperties().Where(p => p.RequiresValueGenerator()).ToArray();
-            });
-
     #endregion
 
     #region Service properties
@@ -4468,16 +4451,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     [DebuggerStepThrough]
     IEnumerable<IProperty> IEntityType.GetForeignKeyProperties()
         => ForeignKeyProperties;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [DebuggerStepThrough]
-    IEnumerable<IProperty> IEntityType.GetValueGeneratingProperties()
-        => ValueGeneratingProperties;
 
     #endregion
 

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -33,6 +33,7 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     private PropertyInfo? _indexerPropertyInfo;
     private SortedDictionary<string, PropertyInfo>? _runtimeProperties;
     private SortedDictionary<string, FieldInfo>? _runtimeFields;
+    private Property[]? _flattenedValueGeneratingProperties;
 
     // _serviceOnlyConstructorBinding needs to be set as well whenever _constructorBinding is set
     private InstantiationBinding? _constructorBinding;
@@ -875,6 +876,21 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
         => _baseType != null
             ? _baseType.GetProperties().Concat(_properties.Values)
             : _properties.Values;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IEnumerable<Property> GetFlattenedValueGeneratingProperties()
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _flattenedValueGeneratingProperties, this,
+            static typeBase =>
+            {
+                typeBase.EnsureReadOnly();
+                return [.. typeBase.GetFlattenedProperties().Where(p => p.RequiresValueGenerator())];
+            });
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2183,6 +2199,16 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     [DebuggerStepThrough]
     IEnumerable<IProperty> ITypeBase.GetProperties()
         => GetProperties();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> ITypeBase.GetFlattenedValueGeneratingProperties()
+        => GetFlattenedValueGeneratingProperties();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -44,8 +44,7 @@ public static class TypeBaseExtensions
 
         return !property.DeclaringType.IsAssignableFrom(structuralType)
             && (!((IRuntimeTypeBase)property.DeclaringType).ContainingEntryType.IsAssignableFrom(structuralType)
-                || (property.DeclaringType is IComplexType complexType
-                    && complexType.ComplexProperty.IsCollection))
+                || property.DeclaringType is IComplexType { ComplexProperty.IsCollection: true })
             && structuralType.ClrType != typeof(object) // For testing
                 ? throw new InvalidOperationException(
                     CoreStrings.PropertyDoesNotBelong(property.Name, property.DeclaringType.DisplayName(), structuralType.DisplayName()))

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -34,7 +34,6 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     private PropertyCounts? _counts;
     private Func<IInternalEntry, ISnapshot>? _relationshipSnapshotFactory;
     private IProperty[]? _foreignKeyProperties;
-    private IProperty[]? _valueGeneratingProperties;
     private Func<MaterializationContext, object>? _materializer;
     private Func<MaterializationContext, object>? _emptyMaterializer;
 
@@ -1315,13 +1314,6 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _foreignKeyProperties, this,
             static entityType => entityType.GetProperties().Where(p => ((IReadOnlyProperty)p).IsForeignKey()).ToArray());
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    IEnumerable<IProperty> IEntityType.GetValueGeneratingProperties()
-        => NonCapturingLazyInitializer.EnsureInitialized(
-            ref _valueGeneratingProperties, this,
-            static entityType => entityType.GetProperties().Where(p => p.RequiresValueGenerator()).ToArray());
 
     /// <inheritdoc />
     [DebuggerStepThrough]

--- a/src/EFCore/Metadata/RuntimeTypeBase.cs
+++ b/src/EFCore/Metadata/RuntimeTypeBase.cs
@@ -31,6 +31,7 @@ public abstract class RuntimeTypeBase : RuntimeAnnotatableBase, IRuntimeTypeBase
     private RuntimeProperty[]? _flattenedProperties;
     private RuntimeProperty[]? _flattenedDeclaredProperties;
     private RuntimeComplexProperty[]? _flattenedComplexProperties;
+    private RuntimeProperty[]? _flattenedValueGeneratingProperties;
     private RuntimePropertyBase[]? _snapshottableProperties;
     private Func<IInternalEntry, ISnapshot>? _originalValuesFactory;
     private Func<ISnapshot>? _storeGeneratedValuesFactory;
@@ -346,6 +347,18 @@ public abstract class RuntimeTypeBase : RuntimeAnnotatableBase, IRuntimeTypeBase
         => _baseType != null
             ? _baseType.GetProperties().Concat(_properties.Values)
             : _properties.Values;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual IEnumerable<RuntimeProperty> GetFlattenedValueGeneratingProperties()
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _flattenedValueGeneratingProperties, this,
+            static typeBase => [.. typeBase.GetFlattenedProperties().Where(p => p.RequiresValueGenerator())]);
 
     /// <inheritdoc />
     [DebuggerStepThrough]
@@ -952,6 +965,11 @@ public abstract class RuntimeTypeBase : RuntimeAnnotatableBase, IRuntimeTypeBase
     [DebuggerStepThrough]
     IEnumerable<IProperty> ITypeBase.GetProperties()
         => GetProperties();
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> ITypeBase.GetFlattenedValueGeneratingProperties()
+        => GetFlattenedValueGeneratingProperties();
 
     /// <inheritdoc />
     [DebuggerStepThrough]

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1035,6 +1035,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
+        ///     A discriminator property cannot be set for the type '{type}' because '{containingType}' is a complex collection.
+        /// </summary>
+        public static string DiscriminatorPropertyNotAllowedOnComplexCollection(object? type, object? containingType)
+            => string.Format(
+                GetString("DiscriminatorPropertyNotAllowedOnComplexCollection", nameof(type), nameof(containingType)),
+                type, containingType);
+
+        /// <summary>
         ///     Unable to set property '{property}' as a discriminator for entity type '{entityType}' because it is not a property of '{entityType}'.
         /// </summary>
         public static string DiscriminatorPropertyNotFound(object? property, object? entityType)
@@ -3748,7 +3756,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                         logger.Options,
                         CoreEventId.ComplexElementPropertyChangeDetected,
                         LogLevel.Debug,
-                        "CoreEventId.ComplexTypePropertyChangeDetected",
+                        "CoreEventId.ComplexElementPropertyChangeDetected",
                         level => LoggerMessage.Define<string, string>(
                             level,
                             CoreEventId.ComplexElementPropertyChangeDetected,
@@ -3773,7 +3781,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                         logger.Options,
                         CoreEventId.ComplexElementPropertyChangeDetected,
                         LogLevel.Debug,
-                        "CoreEventId.ComplexTypePropertyChangeDetected",
+                        "CoreEventId.ComplexElementPropertyChangeDetected",
                         level => LoggerMessage.Define<string, string, object?, object?, string>(
                             level,
                             CoreEventId.ComplexElementPropertyChangeDetected,

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -501,6 +501,9 @@
   <data name="DiscriminatorPropertyMustBeOnRoot" xml:space="preserve">
     <value>A discriminator property cannot be set for the entity type '{entityType}' because it is not the root of an inheritance hierarchy.</value>
   </data>
+  <data name="DiscriminatorPropertyNotAllowedOnComplexCollection" xml:space="preserve">
+    <value>A discriminator property cannot be set for the type '{type}' because '{containingType}' is a complex collection.</value>
+  </data>
   <data name="DiscriminatorPropertyNotFound" xml:space="preserve">
     <value>Unable to set property '{property}' as a discriminator for entity type '{entityType}' because it is not a property of '{entityType}'.</value>
   </data>
@@ -901,11 +904,11 @@
   </data>
   <data name="LogComplexElementPropertyChangeDetected" xml:space="preserve">
     <value>The unchanged property '{typePath}.{property}' was detected as changed and will be marked as modified. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see property values.</value>
-    <comment>Debug CoreEventId.ComplexTypePropertyChangeDetected string string</comment>
+    <comment>Debug CoreEventId.ComplexElementPropertyChangeDetected string string</comment>
   </data>
   <data name="LogComplexElementPropertyChangeDetectedSensitive" xml:space="preserve">
     <value>The unchanged property '{typePath}.{property}' was detected as changed from '{oldValue}' to '{newValue}' and will be marked as modified for entity with key '{keyValues}'.</value>
-    <comment>Debug CoreEventId.ComplexTypePropertyChangeDetected string string object? object? string</comment>
+    <comment>Debug CoreEventId.ComplexElementPropertyChangeDetected string string object? object? string</comment>
   </data>
   <data name="LogConflictingForeignKeyAttributesOnNavigationAndProperty" xml:space="preserve">
     <value>The relationship was separated into two relationships because the [ForeignKey] attribute specified on the navigation '{navigationEntityType}.{navigation}' doesn't match the [ForeignKey] attribute specified on the property '{propertyEntityType}.{property}'.</value>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -725,7 +725,6 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                     new StructuralTypeMaterializerSourceParameters(
                         concreteStructuralType, "instance", shaperIsNullable, queryTrackingBehavior), materializationContextVariable);
 
-            // TODO: Properly support shadow properties for complex types #35613
             if (_queryStateManager
                 && concreteStructuralType is IRuntimeEntityType { ShadowPropertyCount: > 0 } runtimeEntityType)
             {
@@ -738,17 +737,25 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                     .Where(n => n.IsShadowProperty())
                     .OrderBy(e => e.GetShadowIndex());
 
-                blockExpressions.Add(
-                    Assign(
-                        shadowValuesVariable,
-                        ShadowValuesFactoryFactory.Instance.CreateConstructorExpression(
-                            runtimeEntityType,
-                            NewArrayInit(
-                                typeof(object),
-                                shadowProperties.Select(p =>
-                                    Convert(
-                                        valueBufferExpression.CreateValueBufferReadValueExpression(
-                                            p.ClrType, p.GetIndex(), p), typeof(object)))))));
+                // When we have a discriminator on a (table splitting) complex type (for the null/empty distinction), the entity type
+                // has ShadowPropertyCount > 0 so end up here, but we don't actually support materializing shadow properties on
+                // complex types (the LINQ just above doesn't include them, #35613).
+                // So make sure there really are shadow properties to be materialized.
+                if (shadowProperties.Any())
+                {
+                    blockExpressions.Add(
+                        Assign(
+                            shadowValuesVariable,
+                            ShadowValuesFactoryFactory.Instance.CreateConstructorExpression(
+                                runtimeEntityType,
+                                NewArrayInit(
+                                    typeof(object),
+                                    shadowProperties.Select(
+                                        p =>
+                                            Convert(
+                                                valueBufferExpression.CreateValueBufferReadValueExpression(
+                                                    p.ClrType, p.GetIndex(), p), typeof(object)))))));
+                }
             }
 
             materializer = materializer.Type == returnType

--- a/src/EFCore/ValueGeneration/DiscriminatorValueGeneratorFactory.cs
+++ b/src/EFCore/ValueGeneration/DiscriminatorValueGeneratorFactory.cs
@@ -16,5 +16,5 @@ public class DiscriminatorValueGeneratorFactory : ValueGeneratorFactory
 {
     /// <inheritdoc />
     public override ValueGenerator Create(IProperty property, ITypeBase entityType)
-        => new DiscriminatorValueGenerator();
+        => new DiscriminatorValueGenerator(property);
 }

--- a/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class DiscriminatorValueGenerator : ValueGenerator
+public class DiscriminatorValueGenerator(IProperty property) : ValueGenerator
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -18,7 +18,9 @@ public class DiscriminatorValueGenerator : ValueGenerator
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override object NextValue(EntityEntry entry)
-        => entry.GetInfrastructure().EntityType.GetDiscriminatorValue()!;
+        => property.DeclaringType is IComplexType complexType
+            ? complexType.GetDiscriminatorValue()! // TODO: Support derived complex types #31250
+            : entry.GetInfrastructure().ContainingEntry.StructuralType.GetDiscriminatorValue()!;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -835,6 +835,9 @@ public class CosmosTestStore : TestStore
         public IEnumerable<IProperty> GetProperties()
             => throw new NotImplementedException();
 
+        public IEnumerable<IProperty> GetFlattenedValueGeneratingProperties()
+            => throw new NotImplementedException();
+
         public PropertyAccessMode GetPropertyAccessMode()
             => throw new NotImplementedException();
 
@@ -857,9 +860,6 @@ public class CosmosTestStore : TestStore
             => throw new NotImplementedException();
 
         public IEnumerable<ISkipNavigation> GetSkipNavigations()
-            => throw new NotImplementedException();
-
-        public IEnumerable<IProperty> GetValueGeneratingProperties()
             => throw new NotImplementedException();
 
         IEnumerable<IReadOnlyForeignKey> IReadOnlyEntityType.FindDeclaredForeignKeys(IReadOnlyList<IReadOnlyProperty> properties)

--- a/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
+++ b/test/EFCore.Relational.Specification.Tests/ModelBuilding/RelationalModelBuilderTest.cs
@@ -760,7 +760,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
                     b.ToJson("customer_data");
                     b.Ignore(c => c.Details);
                     b.Ignore(c => c.Orders);
-                    b.HasDiscriminator<string>("Title");
+                    b.HasDiscriminator<string>("CustomerType");
                     // Issue #31250
                     // .HasValue<Customer>("Customer")
                     // .HasValue<SpecialCustomer>("Special")
@@ -776,7 +776,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
             var discriminatorProperty = complexType.FindDiscriminatorProperty();
             Assert.NotNull(discriminatorProperty);
-            Assert.Equal("Title", discriminatorProperty.Name);
+            Assert.Equal("CustomerType", discriminatorProperty.Name);
             Assert.Equal("$type", discriminatorProperty.GetJsonPropertyName());
         }
 
@@ -899,7 +899,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
                         });
                     });
                 });
-                
+
             var model = modelBuilder.FinalizeModel();
             var entityType = model.FindEntityType(typeof(JsonEntityWithNesting))!;
 
@@ -907,7 +907,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
             Assert.True(complexProperty1.ComplexType.IsMappedToJson());
             Assert.Equal("CustomOwnedReference1", complexProperty1.ComplexType.GetContainerColumnName());
             Assert.Null(complexProperty1.GetJsonPropertyName());
-            
+
             var complexProperty2 = entityType.FindComplexProperty("OwnedReference2")!;
             Assert.True(complexProperty2.ComplexType.IsMappedToJson());
             Assert.Equal("CustomOwnedReference2", complexProperty2.ComplexType.GetContainerColumnName());
@@ -917,7 +917,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
             Assert.True(complexCollectionProperty1.ComplexType.IsMappedToJson());
             Assert.Equal("CustomOwnedCollection1", complexCollectionProperty1.ComplexType.GetContainerColumnName());
             Assert.Null(complexCollectionProperty1.GetJsonPropertyName());
-            
+
             var complexCollectionProperty2 = entityType.FindComplexProperty("OwnedCollection2")!;
             Assert.True(complexCollectionProperty2.ComplexType.IsMappedToJson());
             Assert.Equal("CustomOwnedCollection2", complexCollectionProperty2.ComplexType.GetContainerColumnName());
@@ -925,13 +925,13 @@ public class RelationalModelBuilderTest : ModelBuilderTest
 
             var nestedRef1 = complexProperty1.ComplexType.FindComplexProperty("Reference1")!;
             Assert.Equal("CustomNestedReference", nestedRef1.GetJsonPropertyName());
-            
+
             var nestedCol1 = complexProperty1.ComplexType.FindComplexProperty("Collection1")!;
             Assert.Equal("CustomNestedCollection", nestedCol1.GetJsonPropertyName());
-            
+
             var nestedRef3 = complexCollectionProperty1.ComplexType.FindComplexProperty("Reference1")!;
             Assert.Equal("CustomNestedReference3", nestedRef3.GetJsonPropertyName());
-            
+
             var nestedCol3 = complexCollectionProperty1.ComplexType.FindComplexProperty("Collection1")!;
             Assert.Equal("CustomNestedCollection3", nestedCol3.GetJsonPropertyName());
         }
@@ -1492,7 +1492,7 @@ public class RelationalModelBuilderTest : ModelBuilderTest
         public List<OwnedEntity>? OwnedCollection1 { get; set; }
         public List<OwnedEntity>? OwnedCollection2 { get; set; }
     }
-    
+
     protected class OwnedEntity
     {
         public DateTime Date { get; set; }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -109,6 +109,28 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
         Validate(modelBuilder);
     }
 
+    public override void Detects_discriminator_property_on_complex_collection()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder.Entity<SampleEntity>(eb =>
+        {
+            eb.ComplexCollection(e => e.OtherSamples, ccb =>
+            {
+                ccb.ToJson();
+                var complexType = ccb.Metadata.ComplexType;
+                var discriminatorProperty = complexType.AddProperty("Discriminator", typeof(string));
+                complexType.SetDiscriminatorProperty(discriminatorProperty);
+            });
+        });
+
+        VerifyError(
+            CoreStrings.DiscriminatorPropertyNotAllowedOnComplexCollection(
+                "SampleEntity.OtherSamples#SampleEntity",
+                "SampleEntity.OtherSamples#SampleEntity"),
+            modelBuilder);
+    }
+
     [ConditionalFact]
     public virtual void Ignores_bool_with_default_value_false()
     {

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -120,6 +120,60 @@ public abstract class AdHocComplexTypeQueryTestBase(NonSharedFixture fixture) : 
 
     #endregion
 
+    #region ShadowDiscriminator
+
+    [ConditionalFact]
+    public virtual async Task Optional_complex_type_with_discriminator()
+    {
+        var contextFactory = await InitializeAsync<ContextShadowDiscriminator>(
+            seed: context =>
+            {
+                context.AddRange(
+                    new ContextShadowDiscriminator.EntityType
+                    {
+                        AllOptionalsComplexType = new ContextShadowDiscriminator.AllOptionalsComplexType { OptionalProperty = "Non-null" }
+                    },
+                    new ContextShadowDiscriminator.EntityType
+                    {
+                        AllOptionalsComplexType = new ContextShadowDiscriminator.AllOptionalsComplexType { OptionalProperty = null }
+                    },
+                    new ContextShadowDiscriminator.EntityType
+                    {
+                        AllOptionalsComplexType = null
+                    }
+                    );
+                return context.SaveChangesAsync();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        var complexTypeNull = await context.Set<ContextShadowDiscriminator.EntityType>().SingleAsync(b => b.AllOptionalsComplexType == null);
+        Assert.Null(complexTypeNull.AllOptionalsComplexType);
+
+        complexTypeNull.AllOptionalsComplexType = new ContextShadowDiscriminator.AllOptionalsComplexType { OptionalProperty = "New thing" };
+        await context.SaveChangesAsync();
+    }
+
+    private class ContextShadowDiscriminator(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<EntityType>()
+                .ComplexProperty(b => b.AllOptionalsComplexType, x => x.HasDiscriminator());
+
+        public class EntityType
+        {
+            public int Id { get; set; }
+            public AllOptionalsComplexType? AllOptionalsComplexType { get; set; }
+        }
+
+        public class AllOptionalsComplexType
+        {
+            public string? OptionalProperty { get; set; }
+        }
+    }
+
+    #endregion ShadowDiscriminator
+
     protected override string StoreName
         => "AdHocComplexTypeQueryTest";
 }


### PR DESCRIPTION
@AndriySvyryd here's a WIP PR for end-to-end support for discriminators on optional (table splitting) complex types - see the AdHoc test.

There seems to be a problem in the update pipeline (or change tracking): after seeding the data, I can see that the discriminator is always null in the database (and so materialization fails as we think the complex type is missing). Are we missing the code to always set the discriminator property when the property is non-null?

In the interest of time, feel free to take over this PR and push any changes/merge it. The ad-hoc test is missing a few more checks we could probably add.

Note: we should still block discriminators on JSON-mapped complex types (at this point).