### PR TITLE
Remove default constraint name annotation when removing the value annotations

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -829,6 +829,7 @@ public static class ScaffoldingModelExtensions
                 // Default value is CLR default for property, so exclude it from scaffolded model
                 annotations.Remove(RelationalAnnotationNames.DefaultValueSql);
                 annotations.Remove(RelationalAnnotationNames.DefaultValue);
+                annotations.Remove(RelationalAnnotationNames.DefaultConstraintName);
             }
             else
             {


### PR DESCRIPTION
Not sure we have good testing possibilities for this kind of bug; but as the fix is trivial and time is short, I verified manually.

Fixes #36567
