### PR TITLE
[rc2] Fix whitespace in Microsoft.EntityFrameworkCore.Tasks.props

### DIFF
--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -4,10 +4,7 @@
   <PropertyGroup>
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">net10.0</_TaskTargetFramework>
     <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_TaskTargetFramework>
-    <_EFCustomTasksAssembly>
-      $([MSBuild]::NormalizePath($(MSBuildThisFileDirectory),
-      '..\tasks\$(_TaskTargetFramework)\$(MSBuildThisFileName).dll'))
-    </_EFCustomTasksAssembly>
+    <_EFCustomTasksAssembly>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory),'..\tasks\$(_TaskTargetFramework)\$(MSBuildThisFileName).dll'))</_EFCustomTasksAssembly>
     <EFScaffoldModelStage Condition="'$(EFScaffoldModelStage)'==''">publish</EFScaffoldModelStage>
     <EFPrecompileQueriesStage Condition="'$(EFPrecompileQueriesStage)'==''">publish</EFPrecompileQueriesStage>
     <DbContextType Condition="'$(DbContextType)'==''">*</DbContextType>


### PR DESCRIPTION
Fixes #36605

**Description**
Code cleanup introduced invalid line breaks in an MSBuild property.

**Customer impact**
Build is broken for any project referencing `Microsoft.EntityFrameworkCore.Tasks`

**How found**
Customer reported on rc1

**Regression**
Yes, introduced by https://github.com/dotnet/efcore/pull/36565

**Testing**
Tested manually

**Risk**
Extremely low. The fix just reverts the changes.
