### PR TITLE
[rc2] Fix complex collection type in model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -565,11 +565,17 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
         var complexType = complexProperty.ComplexType;
         var complexTypeBuilderName = GenerateNestedBuilderName(builderName);
 
+        var propertyType = Code.Reference(Model.DefaultPropertyBagType);
+        if (complexProperty.IsCollection)
+        {
+            propertyType = $"List<{propertyType}>";
+        }
+
         stringBuilder
             .AppendLine()
             .Append(builderName)
             .Append(complexProperty.IsCollection ? ".ComplexCollection(" : ".ComplexProperty(")
-            .Append($"typeof({Code.Reference(Model.DefaultPropertyBagType)}), ")
+            .Append($"typeof({propertyType}), ")
             .Append($"{Code.Literal(complexProperty.Name)}, {Code.Literal(complexType.Name)}, ")
             .Append(complexTypeBuilderName)
             .AppendLine(" =>");

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -6201,7 +6201,7 @@ namespace RootNamespace
                                 {
                                     b2.Property<string>("Id");
 
-                                    b2.ComplexCollection(typeof(Dictionary<string, object>), "Properties", "Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithOneProperty.EntityWithTwoProperties#EntityWithTwoProperties.EntityWithStringKey#EntityWithStringKey.Properties#EntityWithStringProperty", b3 =>
+                                    b2.ComplexCollection(typeof(List<Dictionary<string, object>>), "Properties", "Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithOneProperty.EntityWithTwoProperties#EntityWithTwoProperties.EntityWithStringKey#EntityWithStringKey.Properties#EntityWithStringProperty", b3 =>
                                         {
                                             b3.Property<int>("Id");
 
@@ -6256,6 +6256,7 @@ namespace RootNamespace
                     entityWithStringKeyComplexType.FindComplexProperty(nameof(EntityWithStringKey.Properties));
                 Assert.True(propertiesComplexCollection.IsCollection);
                 Assert.Equal("JsonProps", propertiesComplexCollection.GetJsonPropertyName());
+                Assert.Equal(typeof(List<Dictionary<string, object>>), propertiesComplexCollection.ClrType);
             });
 
     #endregion


### PR DESCRIPTION
Fixes #36619

**Description**
The generated model snapshot that is used in migrations specifies an incorrect type for the complex collections (the element type is used instead of the collection type).

**Customer impact**
The incorrect snapshots cause redundant operations to be generated in every migration even when the model is not changed. This is usually just an annoyance, but would cause an exception if the user has "throw on warnings" enabled.

**How found**
RC1 validation

**Regression**
No, complex collections are a new feature in 10

**Testing**
Test added

**Risk**
Low, the code only affects the new feature
