### PR TITLE
[RC2] Fix structural Contains with JSON collections

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -578,7 +578,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             }
 
             // Otherwise, attempt to translate as Any since that passes through Where predicate translation. This will e.g. take care of
-            // entity , which e.g. does entity equality/containment for entities with composite keys.
+            // entity, which e.g. does entity equality/containment for entities with composite keys.
             var anyLambdaParameter = Expression.Parameter(item.Type, "p");
             var anyLambda = Expression.Lambda(
                 Infrastructure.ExpressionExtensions.CreateEqualsExpression(anyLambdaParameter, item),

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
@@ -333,66 +333,77 @@ public partial class RelationalSqlTranslatingExpressionVisitor
             // into complex properties to generate a flattened list of comparisons.
             // The moment we reach a a complex property that's mapped to JSON, we stop and generate a single comparison
             // for the whole complex type.
-            bool TryGenerateComparisons(IComplexType type, Expression left, Expression right, [NotNullWhen(true)] ref SqlExpression? comparisons, out bool exitImmediately)
+            bool TryGenerateComparisons(
+                IComplexType type,
+                Expression left,
+                Expression right,
+                [NotNullWhen(true)] ref SqlExpression? comparisons,
+                out bool exitImmediately)
             {
                 exitImmediately = false;
 
                 if (type.IsMappedToJson())
                 {
-                    var leftScalar = Process(left);
-                    var rightScalar = Process(right);
+                    // The fact that a type is mapped to JSON doesn't necessary mean that we simply compare its JSON column/value:
+                    // a JSON *collection* may have been converted to a relational representation via e.g. OPENJSON, at which point
+                    // it behaves just like a table-splitting complex type, where we have to compare column-by-column.
+                    // TryProcessJson() attempts to extract a single JSON column/value from both sides: if we succeed, we just compare
+                    // both sides. Otherwise, we flow down to the column-by-column flow.
+                    if (TryProcessJson(left, out var leftScalar) && TryProcessJson(right, out var rightScalar))
+                    {
+                        var comparison = _sqlExpressionFactory.MakeBinary(nodeType, leftScalar, rightScalar, boolTypeMapping)!;
 
-                    var comparison = _sqlExpressionFactory.MakeBinary(nodeType, leftScalar, rightScalar, boolTypeMapping)!;
+                        // A single JSON-mapped complex type requires only a single comparison for the JSON value/column on each side;
+                        // but the JSON-mapped complex type may be nested inside a non-JSON (table-split) complex type, in which
+                        // case this is just one comparison in several.
+                        comparisons = comparisons is null
+                            ? comparison
+                            : nodeType == ExpressionType.Equal
+                                ? _sqlExpressionFactory.AndAlso(comparisons, comparison)
+                                : _sqlExpressionFactory.OrElse(comparisons, comparison);
 
-                    // A single JSON-mapped complex type requires only a single comparison for the JSON value/column on each side;
-                    // but the JSON-mapped complex type may be nested inside a non-JSON (table-split) complex type, in which
-                    // case this is just one comparison in several.
-                    comparisons = comparisons is null
-                        ? comparison
-                        : nodeType == ExpressionType.Equal
-                            ? _sqlExpressionFactory.AndAlso(comparisons, comparison)
-                            : _sqlExpressionFactory.OrElse(comparisons, comparison);
+                        return true;
+                    }
 
-                    return true;
-
-                    SqlExpression Process(Expression expression)
-                        => expression switch
+                    bool TryProcessJson(Expression expression, [NotNullWhen(true)] out SqlExpression? result)
+                    {
+                        switch (expression)
                         {
                             // When a non-collection JSON column - or a nested complex property within a JSON column - is compared,
                             // we get a StructuralTypeReferenceExpression over a JsonQueryExpression. Convert this to a
                             // JsonScalarExpression, which is our current representation for a complex JSON in the SQL tree
                             // (as opposed to in the shaper) - see #36392.
-                            StructuralTypeReferenceExpression
-                                {
-                                    Parameter: { ValueBufferExpression: JsonQueryExpression jsonQuery }
-                                }
-                                => new JsonScalarExpression(
+                            case StructuralTypeReferenceExpression { Parameter.ValueBufferExpression: JsonQueryExpression jsonQuery }:
+                                result = new JsonScalarExpression(
                                     jsonQuery.JsonColumn,
                                     jsonQuery.Path,
                                     jsonQuery.Type.UnwrapNullableType(),
                                     jsonQuery.JsonColumn.TypeMapping,
-                                    jsonQuery.IsNullable),
+                                    jsonQuery.IsNullable);
+                                return true;
 
                             // As above, but for a complex JSON collection
-                            CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery }
-                                => new JsonScalarExpression(
+                            case CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery }:
+                                result = new JsonScalarExpression(
                                     jsonQuery.JsonColumn,
                                     jsonQuery.Path,
                                     jsonQuery.Type.UnwrapNullableType(),
                                     jsonQuery.JsonColumn.TypeMapping,
-                                    jsonQuery.IsNullable),
+                                    jsonQuery.IsNullable);
+                                return true;
 
                             // When an object is instantiated inline (e.g. Where(c => c.ShippingAddress == new Address { ... })), we get a SqlConstantExpression
                             // with the .NET instance. Serialize it to JSON and replace the constant (note that the type mapping will be inferred from the
                             // JSON column on other side above - important for e.g. nvarchar vs. json columns)
-                            SqlConstantExpression constant
-                                => new SqlConstantExpression(
+                            case SqlConstantExpression constant:
+                                result = new SqlConstantExpression(
                                     SerializeComplexTypeToJson(complexType, constant.Value, collection),
                                     typeof(string),
-                                    typeMapping: null),
+                                    typeMapping: null);
+                                return true;
 
-                            SqlParameterExpression parameter
-                                => (SqlParameterExpression)Visit(
+                            case SqlParameterExpression parameter:
+                                result = (SqlParameterExpression)Visit(
                                     _queryCompilationContext.RegisterRuntimeParameter(
                                         $"{RuntimeParameterPrefix}{parameter.Name}",
                                         Expression.Lambda(
@@ -405,13 +416,52 @@ public partial class RelationalSqlTranslatingExpressionVisitor
                                                     indexer: typeof(Dictionary<string, object>).GetProperty("Item", [typeof(string)]),
                                                     [Expression.Constant(parameter.Name, typeof(string))]),
                                                 Expression.Constant(collection)),
-                                            QueryCompilationContext.QueryContextParameter))),
+                                            QueryCompilationContext.QueryContextParameter)));
+                                return true;
 
-                            _ => throw new UnreachableException()
+                            case ParameterBasedComplexPropertyChainExpression chainExpression:
+                            {
+                                var lastComplexProperty = chainExpression.ComplexPropertyChain.Last();
+                                var extractComplexPropertyClrType = Expression.Call(
+                                    ParameterValueExtractorMethod.MakeGenericMethod(lastComplexProperty.ClrType.MakeNullable()),
+                                    QueryCompilationContext.QueryContextParameter,
+                                    Expression.Constant(chainExpression.ParameterExpression.Name, typeof(string)),
+                                    Expression.Constant(chainExpression.ComplexPropertyChain, typeof(List<IComplexProperty>)),
+                                    Expression.Constant(null, typeof(IProperty)));
+
+                                var lambda =
+                                    Expression.Lambda(
+                                        Expression.Call(
+                                            SerializeComplexTypeToJsonMethod,
+                                            Expression.Constant(lastComplexProperty.ComplexType),
+                                            extractComplexPropertyClrType,
+                                            Expression.Constant(lastComplexProperty.IsCollection)),
+                                        QueryCompilationContext.QueryContextParameter);
+
+                                var parameterNameBuilder = new StringBuilder(RuntimeParameterPrefix)
+                                    .Append(chainExpression.ParameterExpression.Name);
+
+                                foreach (var complexProperty in chainExpression.ComplexPropertyChain)
+                                {
+                                    parameterNameBuilder.Append('_').Append(complexProperty.Name);
+                                }
+
+                                result = (SqlParameterExpression)Visit(
+                                    _queryCompilationContext.RegisterRuntimeParameter(parameterNameBuilder.ToString(), lambda));
+
+                                return true;
+                            }
+
+                            default:
+                                result = null;
+                                return false;
                         };
+                    }
                 }
 
-                // We handled complex JSON above, from here we handle table splitting
+                // We handled JSON column comparison above.
+                // From here we handle table splitting and JSON types that have been converted to a relational table representation via
+                // e.g. OPENJSON.
                 foreach (var property in type.GetProperties())
                 {
                     if (TryTranslatePropertyAccess(left, property, out var leftTranslation)
@@ -586,7 +636,7 @@ public partial class RelationalSqlTranslatingExpressionVisitor
         QueryContext context,
         string baseParameterName,
         List<IComplexProperty>? complexPropertyChain,
-        IProperty property)
+        IProperty? property)
     {
         var baseValue = context.Parameters[baseParameterName];
 
@@ -603,7 +653,11 @@ public partial class RelationalSqlTranslatingExpressionVisitor
             }
         }
 
-        return baseValue == null ? (T?)(object?)null : (T?)property.GetGetter().GetClrValue(baseValue);
+        return baseValue == null
+            ? (T?)(object?)null
+            : property is null
+                ? (T?)baseValue
+                : (T?)property.GetGetter().GetClrValue(baseValue);
     }
 
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualityCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualityCosmosTest.cs
@@ -97,6 +97,39 @@ WHERE false
         AssertSql();
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_inline());
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await AssertTranslationFailed(base.Contains_with_parameter);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await AssertTranslationFailed(base.Contains_with_operators_composed_on_the_collection);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await AssertTranslationFailed(base.Contains_with_nested_and_composed_operators);
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/ComplexTableSplitting/ComplexTableSplittingStructuralEqualityRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/ComplexTableSplitting/ComplexTableSplittingStructuralEqualityRelationalTestBase.cs
@@ -28,6 +28,44 @@ public abstract class
     public override Task Two_nested_collections()
         => AssertTranslationFailed(() => base.Two_nested_collections());
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        // Collections are not supported with table splitting, only JSON
+        await AssertTranslationFailed(base.Contains_with_inline);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        // Collections are not supported with table splitting, only JSON
+        await AssertTranslationFailed(base.Contains_with_parameter);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        // Collections are not supported with table splitting, only JSON
+        // Note that the exception is correct, since the collections in the test data are null for table splitting
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_operators_composed_on_the_collection);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        // Collections are not supported with table splitting, only JSON
+        // Note that the exception is correct, since the collections in the test data are null for table splitting
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_nested_and_composed_operators);
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     protected void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualityRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualityRelationalTestBase.cs
@@ -20,6 +20,42 @@ public abstract class OwnedJsonStructuralEqualityRelationalTestBase<TFixture> : 
     public override Task Related_with_parameter_null()
         => Assert.ThrowsAsync<EqualException>(() => base.Related_with_parameter_null());
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        // The given key 'Property: RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.__synthesizedOrdinal (no field, int) Shadow Required PK AfterSave:Throw ValueGenerated.OnAdd' was not present in the dictionary.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_inline);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_parameter);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_operators_composed_on_the_collection);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_nested_and_composed_operators);
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     protected void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualityRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualityRelationalTestBase.cs
@@ -13,6 +13,42 @@ public abstract class OwnedNavigationsStructuralEqualityRelationalTestBase<TFixt
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        // The given key 'Property: RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.__synthesizedOrdinal (no field, int) Shadow Required PK AfterSave:Throw ValueGenerated.OnAdd' was not present in the dictionary.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_inline);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_parameter);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_operators_composed_on_the_collection);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        // No backing field could be found for property 'RootEntity.RelatedCollection#RelatedType.RootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_nested_and_composed_operators);
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     protected void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualityRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualityRelationalTestBase.cs
@@ -16,6 +16,42 @@ public abstract class
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_inline);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_parameter);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_operators_composed_on_the_collection);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_nested_and_composed_operators);
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     protected void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsData.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsData.cs
@@ -103,8 +103,8 @@ public class RelationshipsData : ISetSource
                     }
                 }),
 
-            // Entity where values are referentially identical to each other across required/optional, to test various equality sceanarios.
-            // Note that this gets overridden for owned navigations .
+            // Entity where values are referentially identical to each other across a given entity, to test various equality sceanarios.
+            // Note that this gets overridden for owned navigations.
             CreateRootEntity(
                 id++, description: "With_referential_identity", e =>
                 {
@@ -113,7 +113,7 @@ public class RelationshipsData : ISetSource
                     e.OptionalRelated.OptionalNested = e.RequiredRelated.RequiredNested;
 
                     e.RelatedCollection.Clear();
-                    e.RequiredRelated.NestedCollection.Clear();
+                    e.RequiredRelated.NestedCollection = [e.RequiredRelated.RequiredNested];
                     e.OptionalRelated.NestedCollection.Clear();
                 }),
 

--- a/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsStructuralEqualityTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Relationships/RelationshipsStructuralEqualityTestBase.cs
@@ -165,5 +165,55 @@ public abstract class RelationshipsStructuralEqualityTestBase<TFixture>(TFixture
                     nestedCollection))); // TODO: Rewrite equality to Equals for the entire test suite for complex
     }
 
+    #region Contains
+
+    [ConditionalFact]
+    public virtual Task Contains_with_inline()
+        => AssertQuery(ss => ss.Set<RootEntity>().Where(e =>
+            e.RequiredRelated.NestedCollection.Contains(
+                new NestedType
+                {
+                    Id = 1002,
+                    Name = "Root1_RequiredRelated_NestedCollection_1",
+                    Int = 8,
+                    String = "foo"
+                })));
+
+    [ConditionalFact]
+    public virtual async Task Contains_with_parameter()
+    {
+        var nested = new NestedType
+        {
+            Id = 1002,
+            Name = "Root1_RequiredRelated_NestedCollection_1",
+            Int = 8,
+            String = "foo"
+        };
+
+        await AssertQuery(ss => ss.Set<RootEntity>().Where(e => e.RequiredRelated.NestedCollection.Contains(nested)));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Contains_with_operators_composed_on_the_collection()
+    {
+        var collection = Fixture.Data.RootEntities.Single(e => e.Name == "Root3_With_different_values").RequiredRelated.NestedCollection;
+
+        await AssertQuery(
+            ss => ss.Set<RootEntity>().Where(
+                e => e.RequiredRelated.NestedCollection.Where(n => n.Int > collection[0].Int).Contains(collection[1])));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Contains_with_nested_and_composed_operators()
+    {
+        var collection = Fixture.Data.RootEntities.Single(e => e.Name == "Root3_With_different_values").RelatedCollection;
+
+        await AssertQuery(
+            ss => ss.Set<RootEntity>()
+                .Where(e => e.RelatedCollection.Where(r => r.Id > collection[0].Id).Contains(collection[1])));
+    }
+
+    #endregion Contains
+
     // TODO: Equality on subquery
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexTableSplitting/ComplexTableSplittingStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/ComplexTableSplitting/ComplexTableSplittingStructuralEqualitySqlServerTest.cs
@@ -130,6 +130,38 @@ WHERE [r].[RequiredRelated_RequiredNested_Id] = @entity_equality_nested_Id AND [
         AssertSql();
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     #region Value types
 
     public override async Task Nullable_value_type_with_null()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Navigations/NavigationsStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/Navigations/NavigationsStructuralEqualitySqlServerTest.cs
@@ -276,6 +276,142 @@ ORDER BY [r].[Id], [r0].[Id], [r1].[Id], [n].[Id], [n0].[Id], [n1].[Id], [n2].[I
         AssertSql();
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelatedId], [r].[RequiredRelatedId], [r1].[Id], [r1].[CollectionRootId], [r1].[Int], [r1].[Name], [r1].[OptionalNestedId], [r1].[RequiredNestedId], [r1].[String], [r0].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [n4].[CollectionRelatedId], [n4].[Int], [n4].[Name], [n4].[String], [n0].[CollectionRelatedId], [n0].[Int], [n0].[Name], [n0].[String], [n1].[CollectionRelatedId], [n1].[Int], [n1].[Name], [n1].[String], [s].[Id], [s].[CollectionRootId], [s].[Int], [s].[Name], [s].[OptionalNestedId], [s].[RequiredNestedId], [s].[String], [s].[Id0], [s].[Id1], [s].[Id2], [s].[CollectionRelatedId], [s].[Int0], [s].[Name0], [s].[String0], [s].[CollectionRelatedId0], [s].[Int1], [s].[Name1], [s].[String1], [s].[CollectionRelatedId1], [s].[Int2], [s].[Name2], [s].[String2], [r0].[CollectionRootId], [r0].[Int], [r0].[Name], [r0].[OptionalNestedId], [r0].[RequiredNestedId], [r0].[String], [n8].[Id], [n8].[CollectionRelatedId], [n8].[Int], [n8].[Name], [n8].[String], [n2].[CollectionRelatedId], [n2].[Int], [n2].[Name], [n2].[String], [n3].[CollectionRelatedId], [n3].[Int], [n3].[Name], [n3].[String]
+FROM [RootEntity] AS [r]
+INNER JOIN [RelatedType] AS [r0] ON [r].[RequiredRelatedId] = [r0].[Id]
+LEFT JOIN [RelatedType] AS [r1] ON [r].[OptionalRelatedId] = [r1].[Id]
+LEFT JOIN [NestedType] AS [n0] ON [r1].[OptionalNestedId] = [n0].[Id]
+LEFT JOIN [NestedType] AS [n1] ON [r1].[RequiredNestedId] = [n1].[Id]
+LEFT JOIN [NestedType] AS [n2] ON [r0].[OptionalNestedId] = [n2].[Id]
+INNER JOIN [NestedType] AS [n3] ON [r0].[RequiredNestedId] = [n3].[Id]
+LEFT JOIN [NestedType] AS [n4] ON [r1].[Id] = [n4].[CollectionRelatedId]
+LEFT JOIN (
+    SELECT [r2].[Id], [r2].[CollectionRootId], [r2].[Int], [r2].[Name], [r2].[OptionalNestedId], [r2].[RequiredNestedId], [r2].[String], [n5].[Id] AS [Id0], [n6].[Id] AS [Id1], [n7].[Id] AS [Id2], [n7].[CollectionRelatedId], [n7].[Int] AS [Int0], [n7].[Name] AS [Name0], [n7].[String] AS [String0], [n5].[CollectionRelatedId] AS [CollectionRelatedId0], [n5].[Int] AS [Int1], [n5].[Name] AS [Name1], [n5].[String] AS [String1], [n6].[CollectionRelatedId] AS [CollectionRelatedId1], [n6].[Int] AS [Int2], [n6].[Name] AS [Name2], [n6].[String] AS [String2]
+    FROM [RelatedType] AS [r2]
+    LEFT JOIN [NestedType] AS [n5] ON [r2].[OptionalNestedId] = [n5].[Id]
+    INNER JOIN [NestedType] AS [n6] ON [r2].[RequiredNestedId] = [n6].[Id]
+    LEFT JOIN [NestedType] AS [n7] ON [r2].[Id] = [n7].[CollectionRelatedId]
+) AS [s] ON [r].[Id] = [s].[CollectionRootId]
+LEFT JOIN [NestedType] AS [n8] ON [r0].[Id] = [n8].[CollectionRelatedId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [NestedType] AS [n]
+    WHERE [r0].[Id] = [n].[CollectionRelatedId] AND [n].[Id] = 1002)
+ORDER BY [r].[Id], [r0].[Id], [r1].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Id2]
+""");
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql(
+            """
+@entity_equality_nested_Id='1002' (Nullable = true)
+
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelatedId], [r].[RequiredRelatedId], [r1].[Id], [r1].[CollectionRootId], [r1].[Int], [r1].[Name], [r1].[OptionalNestedId], [r1].[RequiredNestedId], [r1].[String], [r0].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [n4].[CollectionRelatedId], [n4].[Int], [n4].[Name], [n4].[String], [n0].[CollectionRelatedId], [n0].[Int], [n0].[Name], [n0].[String], [n1].[CollectionRelatedId], [n1].[Int], [n1].[Name], [n1].[String], [s].[Id], [s].[CollectionRootId], [s].[Int], [s].[Name], [s].[OptionalNestedId], [s].[RequiredNestedId], [s].[String], [s].[Id0], [s].[Id1], [s].[Id2], [s].[CollectionRelatedId], [s].[Int0], [s].[Name0], [s].[String0], [s].[CollectionRelatedId0], [s].[Int1], [s].[Name1], [s].[String1], [s].[CollectionRelatedId1], [s].[Int2], [s].[Name2], [s].[String2], [r0].[CollectionRootId], [r0].[Int], [r0].[Name], [r0].[OptionalNestedId], [r0].[RequiredNestedId], [r0].[String], [n8].[Id], [n8].[CollectionRelatedId], [n8].[Int], [n8].[Name], [n8].[String], [n2].[CollectionRelatedId], [n2].[Int], [n2].[Name], [n2].[String], [n3].[CollectionRelatedId], [n3].[Int], [n3].[Name], [n3].[String]
+FROM [RootEntity] AS [r]
+INNER JOIN [RelatedType] AS [r0] ON [r].[RequiredRelatedId] = [r0].[Id]
+LEFT JOIN [RelatedType] AS [r1] ON [r].[OptionalRelatedId] = [r1].[Id]
+LEFT JOIN [NestedType] AS [n0] ON [r1].[OptionalNestedId] = [n0].[Id]
+LEFT JOIN [NestedType] AS [n1] ON [r1].[RequiredNestedId] = [n1].[Id]
+LEFT JOIN [NestedType] AS [n2] ON [r0].[OptionalNestedId] = [n2].[Id]
+INNER JOIN [NestedType] AS [n3] ON [r0].[RequiredNestedId] = [n3].[Id]
+LEFT JOIN [NestedType] AS [n4] ON [r1].[Id] = [n4].[CollectionRelatedId]
+LEFT JOIN (
+    SELECT [r2].[Id], [r2].[CollectionRootId], [r2].[Int], [r2].[Name], [r2].[OptionalNestedId], [r2].[RequiredNestedId], [r2].[String], [n5].[Id] AS [Id0], [n6].[Id] AS [Id1], [n7].[Id] AS [Id2], [n7].[CollectionRelatedId], [n7].[Int] AS [Int0], [n7].[Name] AS [Name0], [n7].[String] AS [String0], [n5].[CollectionRelatedId] AS [CollectionRelatedId0], [n5].[Int] AS [Int1], [n5].[Name] AS [Name1], [n5].[String] AS [String1], [n6].[CollectionRelatedId] AS [CollectionRelatedId1], [n6].[Int] AS [Int2], [n6].[Name] AS [Name2], [n6].[String] AS [String2]
+    FROM [RelatedType] AS [r2]
+    LEFT JOIN [NestedType] AS [n5] ON [r2].[OptionalNestedId] = [n5].[Id]
+    INNER JOIN [NestedType] AS [n6] ON [r2].[RequiredNestedId] = [n6].[Id]
+    LEFT JOIN [NestedType] AS [n7] ON [r2].[Id] = [n7].[CollectionRelatedId]
+) AS [s] ON [r].[Id] = [s].[CollectionRootId]
+LEFT JOIN [NestedType] AS [n8] ON [r0].[Id] = [n8].[CollectionRelatedId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [NestedType] AS [n]
+    WHERE [r0].[Id] = [n].[CollectionRelatedId] AND [n].[Id] = @entity_equality_nested_Id)
+ORDER BY [r].[Id], [r0].[Id], [r1].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Id2]
+""");
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql(
+            """
+@get_Item_Int='103'
+@entity_equality_get_Item_Id='3003' (Nullable = true)
+
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelatedId], [r].[RequiredRelatedId], [r1].[Id], [r1].[CollectionRootId], [r1].[Int], [r1].[Name], [r1].[OptionalNestedId], [r1].[RequiredNestedId], [r1].[String], [r0].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [n4].[CollectionRelatedId], [n4].[Int], [n4].[Name], [n4].[String], [n0].[CollectionRelatedId], [n0].[Int], [n0].[Name], [n0].[String], [n1].[CollectionRelatedId], [n1].[Int], [n1].[Name], [n1].[String], [s].[Id], [s].[CollectionRootId], [s].[Int], [s].[Name], [s].[OptionalNestedId], [s].[RequiredNestedId], [s].[String], [s].[Id0], [s].[Id1], [s].[Id2], [s].[CollectionRelatedId], [s].[Int0], [s].[Name0], [s].[String0], [s].[CollectionRelatedId0], [s].[Int1], [s].[Name1], [s].[String1], [s].[CollectionRelatedId1], [s].[Int2], [s].[Name2], [s].[String2], [r0].[CollectionRootId], [r0].[Int], [r0].[Name], [r0].[OptionalNestedId], [r0].[RequiredNestedId], [r0].[String], [n8].[Id], [n8].[CollectionRelatedId], [n8].[Int], [n8].[Name], [n8].[String], [n2].[CollectionRelatedId], [n2].[Int], [n2].[Name], [n2].[String], [n3].[CollectionRelatedId], [n3].[Int], [n3].[Name], [n3].[String]
+FROM [RootEntity] AS [r]
+INNER JOIN [RelatedType] AS [r0] ON [r].[RequiredRelatedId] = [r0].[Id]
+LEFT JOIN [RelatedType] AS [r1] ON [r].[OptionalRelatedId] = [r1].[Id]
+LEFT JOIN [NestedType] AS [n0] ON [r1].[OptionalNestedId] = [n0].[Id]
+LEFT JOIN [NestedType] AS [n1] ON [r1].[RequiredNestedId] = [n1].[Id]
+LEFT JOIN [NestedType] AS [n2] ON [r0].[OptionalNestedId] = [n2].[Id]
+INNER JOIN [NestedType] AS [n3] ON [r0].[RequiredNestedId] = [n3].[Id]
+LEFT JOIN [NestedType] AS [n4] ON [r1].[Id] = [n4].[CollectionRelatedId]
+LEFT JOIN (
+    SELECT [r2].[Id], [r2].[CollectionRootId], [r2].[Int], [r2].[Name], [r2].[OptionalNestedId], [r2].[RequiredNestedId], [r2].[String], [n5].[Id] AS [Id0], [n6].[Id] AS [Id1], [n7].[Id] AS [Id2], [n7].[CollectionRelatedId], [n7].[Int] AS [Int0], [n7].[Name] AS [Name0], [n7].[String] AS [String0], [n5].[CollectionRelatedId] AS [CollectionRelatedId0], [n5].[Int] AS [Int1], [n5].[Name] AS [Name1], [n5].[String] AS [String1], [n6].[CollectionRelatedId] AS [CollectionRelatedId1], [n6].[Int] AS [Int2], [n6].[Name] AS [Name2], [n6].[String] AS [String2]
+    FROM [RelatedType] AS [r2]
+    LEFT JOIN [NestedType] AS [n5] ON [r2].[OptionalNestedId] = [n5].[Id]
+    INNER JOIN [NestedType] AS [n6] ON [r2].[RequiredNestedId] = [n6].[Id]
+    LEFT JOIN [NestedType] AS [n7] ON [r2].[Id] = [n7].[CollectionRelatedId]
+) AS [s] ON [r].[Id] = [s].[CollectionRootId]
+LEFT JOIN [NestedType] AS [n8] ON [r0].[Id] = [n8].[CollectionRelatedId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [NestedType] AS [n]
+    WHERE [r0].[Id] = [n].[CollectionRelatedId] AND [n].[Int] > @get_Item_Int AND [n].[Id] = @entity_equality_get_Item_Id)
+ORDER BY [r].[Id], [r0].[Id], [r1].[Id], [n0].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n4].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Id2]
+""");
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql(
+            """
+@get_Item_Id='302'
+@entity_equality_get_Item_Id='303' (Nullable = true)
+
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelatedId], [r].[RequiredRelatedId], [r1].[Id], [r1].[CollectionRootId], [r1].[Int], [r1].[Name], [r1].[OptionalNestedId], [r1].[RequiredNestedId], [r1].[String], [n].[Id], [n0].[Id], [r2].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [n3].[CollectionRelatedId], [n3].[Int], [n3].[Name], [n3].[String], [n].[CollectionRelatedId], [n].[Int], [n].[Name], [n].[String], [n0].[CollectionRelatedId], [n0].[Int], [n0].[Name], [n0].[String], [s].[Id], [s].[CollectionRootId], [s].[Int], [s].[Name], [s].[OptionalNestedId], [s].[RequiredNestedId], [s].[String], [s].[Id0], [s].[Id1], [s].[Id2], [s].[CollectionRelatedId], [s].[Int0], [s].[Name0], [s].[String0], [s].[CollectionRelatedId0], [s].[Int1], [s].[Name1], [s].[String1], [s].[CollectionRelatedId1], [s].[Int2], [s].[Name2], [s].[String2], [r2].[CollectionRootId], [r2].[Int], [r2].[Name], [r2].[OptionalNestedId], [r2].[RequiredNestedId], [r2].[String], [n7].[Id], [n7].[CollectionRelatedId], [n7].[Int], [n7].[Name], [n7].[String], [n1].[CollectionRelatedId], [n1].[Int], [n1].[Name], [n1].[String], [n2].[CollectionRelatedId], [n2].[Int], [n2].[Name], [n2].[String]
+FROM [RootEntity] AS [r]
+LEFT JOIN [RelatedType] AS [r1] ON [r].[OptionalRelatedId] = [r1].[Id]
+LEFT JOIN [NestedType] AS [n] ON [r1].[OptionalNestedId] = [n].[Id]
+LEFT JOIN [NestedType] AS [n0] ON [r1].[RequiredNestedId] = [n0].[Id]
+INNER JOIN [RelatedType] AS [r2] ON [r].[RequiredRelatedId] = [r2].[Id]
+LEFT JOIN [NestedType] AS [n1] ON [r2].[OptionalNestedId] = [n1].[Id]
+INNER JOIN [NestedType] AS [n2] ON [r2].[RequiredNestedId] = [n2].[Id]
+LEFT JOIN [NestedType] AS [n3] ON [r1].[Id] = [n3].[CollectionRelatedId]
+LEFT JOIN (
+    SELECT [r3].[Id], [r3].[CollectionRootId], [r3].[Int], [r3].[Name], [r3].[OptionalNestedId], [r3].[RequiredNestedId], [r3].[String], [n4].[Id] AS [Id0], [n5].[Id] AS [Id1], [n6].[Id] AS [Id2], [n6].[CollectionRelatedId], [n6].[Int] AS [Int0], [n6].[Name] AS [Name0], [n6].[String] AS [String0], [n4].[CollectionRelatedId] AS [CollectionRelatedId0], [n4].[Int] AS [Int1], [n4].[Name] AS [Name1], [n4].[String] AS [String1], [n5].[CollectionRelatedId] AS [CollectionRelatedId1], [n5].[Int] AS [Int2], [n5].[Name] AS [Name2], [n5].[String] AS [String2]
+    FROM [RelatedType] AS [r3]
+    LEFT JOIN [NestedType] AS [n4] ON [r3].[OptionalNestedId] = [n4].[Id]
+    INNER JOIN [NestedType] AS [n5] ON [r3].[RequiredNestedId] = [n5].[Id]
+    LEFT JOIN [NestedType] AS [n6] ON [r3].[Id] = [n6].[CollectionRelatedId]
+) AS [s] ON [r].[Id] = [s].[CollectionRootId]
+LEFT JOIN [NestedType] AS [n7] ON [r2].[Id] = [n7].[CollectionRelatedId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [RelatedType] AS [r0]
+    WHERE [r].[Id] = [r0].[CollectionRootId] AND [r0].[Id] > @get_Item_Id AND [r0].[Id] = @entity_equality_get_Item_Id)
+ORDER BY [r].[Id], [r1].[Id], [n].[Id], [n0].[Id], [r2].[Id], [n1].[Id], [n2].[Id], [n3].[Id], [s].[Id], [s].[Id0], [s].[Id1], [s].[Id2]
+""");
+    }
+
+    #endregion Contains
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualitySqlServerTest.cs
@@ -124,6 +124,38 @@ WHERE 0 = 1
         );
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualitySqlServerTest.cs
@@ -234,6 +234,38 @@ ORDER BY [r].[Id], [o].[RootEntityId], [o0].[RelatedTypeRootEntityId], [o1].[Rel
         AssertSql();
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualitySqlServerTest.cs
@@ -194,6 +194,38 @@ ORDER BY [r].[Id], [o].[RelatedTypeRootEntityId], [o].[Id], [s].[RootEntityId], 
         AssertSql();
     }
 
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualitySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedJson/OwnedJsonStructuralEqualitySqliteTest.cs
@@ -112,17 +112,47 @@ WHERE 0
     {
         await base.Nested_collection_with_inline();
 
-        AssertSql(
-        );
+        AssertSql();
     }
 
     public override async Task Nested_collection_with_parameter()
     {
         await base.Nested_collection_with_parameter();
 
-        AssertSql(
-        );
+        AssertSql();
     }
+
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualitySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedNavigations/OwnedNavigationsStructuralEqualitySqliteTest.cs
@@ -224,17 +224,47 @@ ORDER BY "r"."Id", "o"."RootEntityId", "o0"."RelatedTypeRootEntityId", "o1"."Rel
     {
         await base.Nested_collection_with_inline();
 
-        AssertSql(
-        );
+        AssertSql();
     }
 
     public override async Task Nested_collection_with_parameter()
     {
         await base.Nested_collection_with_parameter();
 
-        AssertSql(
-        );
+        AssertSql();
     }
+
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualitySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Relationships/OwnedTableSplitting/OwnedTableSplittingStructuralEqualitySqliteTest.cs
@@ -184,17 +184,47 @@ ORDER BY "r"."Id", "o"."RelatedTypeRootEntityId", "o"."Id", "s"."RootEntityId", 
     {
         await base.Nested_collection_with_inline();
 
-        AssertSql(
-        );
+        AssertSql();
     }
 
     public override async Task Nested_collection_with_parameter()
     {
         await base.Nested_collection_with_parameter();
 
-        AssertSql(
-        );
+        AssertSql();
     }
+
+    #region Contains
+
+    public override async Task Contains_with_inline()
+    {
+        await base.Contains_with_inline();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_parameter()
+    {
+        await base.Contains_with_parameter();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_operators_composed_on_the_collection()
+    {
+        await base.Contains_with_operators_composed_on_the_collection();
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_nested_and_composed_operators()
+    {
+        await base.Contains_with_nested_and_composed_operators();
+
+        AssertSql();
+    }
+
+    #endregion Contains
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()


### PR DESCRIPTION
Part of #36296

### Description

This fixes queries which involve structural containment for complex JSON collections:

```c#
var post = ...;
var blogs = context.Blogs.Where(b => b.Posts.Contains(post)).ToListAsync();
```

This sort of query currently fails when b.Posts is mapped as complex JSON. Making this work properly is part of the complex type/JSON push in 10.

### Customer impact

All queries of the above form currently fail.

### How found
Testing.

### Regression

No

### Testing

Tests added

### Risk

Low, the fix almost exclusively touches new complex type/JSON code that was added in 10.