### PR TITLE
[rc2] Fix transformation from JsonQueryExpression to OPENJSON

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -22,8 +22,6 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
     private readonly ISqlServerSingletonOptions _sqlServerSingletonOptions;
 
-    private RelationalTypeMapping? _nvarcharMaxTypeMapping;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -239,6 +237,8 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     /// </summary>
     protected override ShapedQueryExpression TransformJsonQueryToTable(JsonQueryExpression jsonQueryExpression)
     {
+        var structuralType = jsonQueryExpression.StructuralType;
+
         // Calculate the table alias for the OPENJSON expression based on the last named path segment
         // (or the JSON column name if there are none)
         var lastNamedPathSegment = jsonQueryExpression.Path.LastOrDefault(ps => ps.PropertyName is not null);
@@ -251,7 +251,8 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         var columnInfos = new List<SqlServerOpenJsonExpression.ColumnInfo>();
 
         // We're only interested in properties which actually exist in the JSON, filter out uninteresting shadow keys
-        foreach (var property in jsonQueryExpression.StructuralType.GetPropertiesInHierarchy())
+        // (for owned JSON entities)
+        foreach (var property in structuralType.GetPropertiesInHierarchy())
         {
             if (property.GetJsonPropertyName() is { } jsonPropertyName)
             {
@@ -266,46 +267,45 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             }
         }
 
-        switch (jsonQueryExpression.StructuralType)
+        var containerColumnName = structuralType.GetContainerColumnName();
+        var containerColumnCandidates = structuralType.ContainingEntityType.GetTableMappings()
+            .SelectMany(m => m.Table.Columns)
+            .Where(c => c.Name == containerColumnName)
+            .ToList();
+
+        var containerColumn = containerColumnCandidates switch
         {
-            case IEntityType entityType:
-                // Navigations represent nested JSON owned entities, which we also add to the OPENJSON WITH clause, but with AS JSON.
-                foreach (var navigation in entityType.GetNavigationsInHierarchy()
-                             .Where(n => n.ForeignKey.IsOwnership
-                                 && n.TargetEntityType.IsMappedToJson()
-                                 && n.ForeignKey.PrincipalToDependent == n))
+            [var c] => c,
+            [] => throw new UnreachableException($"No container column found in relational model for {structuralType.DisplayName()}"),
+            _ => throw new InvalidOperationException(
+                $"Multiple columns with JSON container name '{containerColumnName}' on entity type '{structuralType.ContainingEntityType.DisplayName()}'")
+        };
+
+        var nestedJsonPropertyNames = jsonQueryExpression.StructuralType switch
+        {
+            IEntityType entityType
+                => entityType.GetNavigationsInHierarchy()
+                    .Where(n => n.ForeignKey.IsOwnership
+                        && n.TargetEntityType.IsMappedToJson()
+                        && n.ForeignKey.PrincipalToDependent == n)
+                    .Select(n => n.TargetEntityType.GetJsonPropertyName() ?? throw new UnreachableException()),
+
+            IComplexType complexType
+                => complexType.GetComplexProperties().Select(p => p.ComplexType.GetJsonPropertyName() ?? throw new UnreachableException()),
+
+            _ => throw new UnreachableException()
+        };
+
+        foreach (var jsonPropertyName in nestedJsonPropertyNames)
+        {
+            columnInfos.Add(
+                new SqlServerOpenJsonExpression.ColumnInfo
                 {
-                    var jsonPropertyName = navigation.TargetEntityType.GetJsonPropertyName();
-                    Check.DebugAssert(jsonPropertyName is not null, $"No JSON property name for navigation {navigation.Name}");
-
-                    AddStructuralColumnInfo(jsonPropertyName);
-                }
-
-                break;
-
-            case IComplexType complexType:
-                foreach (var complexProperty in complexType.GetComplexProperties())
-                {
-                    var jsonPropertyName = complexProperty.ComplexType.GetJsonPropertyName();
-                    Check.DebugAssert(jsonPropertyName is not null, $"No JSON property name for complex property {complexProperty.Name}");
-
-                    AddStructuralColumnInfo(jsonPropertyName);
-                }
-
-                break;
-
-            default:
-                throw new UnreachableException();
-
-                void AddStructuralColumnInfo(string jsonPropertyName)
-                    => columnInfos.Add(
-                        new SqlServerOpenJsonExpression.ColumnInfo
-                        {
-                            Name = jsonPropertyName,
-                            TypeMapping = _nvarcharMaxTypeMapping ??= _typeMappingSource.FindMapping("nvarchar(max)")!,
-                            Path = [new PathSegment(jsonPropertyName)],
-                            AsJson = true
-                        });
+                    Name = jsonPropertyName,
+                    TypeMapping = containerColumn.StoreTypeMapping,
+                    Path = [new PathSegment(jsonPropertyName)],
+                    AsJson = true
+                });
         }
 
         var openJsonExpression = new SqlServerOpenJsonExpression(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
@@ -233,8 +233,27 @@ ORDER BY [r].[Id]
     {
         await base.SelectMany_related_collection(queryTrackingBehavior);
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r0].[Id], [r0].[Int], [r0].[Name], [r0].[String], [r0].[NestedCollection], [r0].[OptionalNested], [r0].[RequiredNested]
+FROM [RootEntity] AS [r]
+CROSS APPLY OPENJSON([r].[RelatedCollection], '$') WITH (
+    [Id] int '$.Id',
+    [Int] int '$.Int',
+    [Name] nvarchar(max) '$.Name',
+    [String] nvarchar(max) '$.String',
+    [NestedCollection] json '$.NestedCollection' AS JSON,
+    [OptionalNested] json '$.OptionalNested' AS JSON,
+    [RequiredNested] json '$.RequiredNested' AS JSON
+) AS [r0]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 SELECT [r0].[Id], [r0].[Int], [r0].[Name], [r0].[String], [r0].[NestedCollection], [r0].[OptionalNested], [r0].[RequiredNested]
 FROM [RootEntity] AS [r]
 CROSS APPLY OPENJSON([r].[RelatedCollection], '$') WITH (
@@ -247,6 +266,7 @@ CROSS APPLY OPENJSON([r].[RelatedCollection], '$') WITH (
     [RequiredNested] nvarchar(max) '$.RequiredNested' AS JSON
 ) AS [r0]
 """);
+        }
     }
 
     public override async Task SelectMany_nested_collection_on_required_related(QueryTrackingBehavior queryTrackingBehavior)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonStructuralEqualitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonStructuralEqualitySqlServerTest.cs
@@ -341,8 +341,39 @@ WHERE EXISTS (
     {
         await base.Contains_with_nested_and_composed_operators();
 
-        AssertSql(
-            """
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+@get_Item_Id='?' (DbType = Int32)
+@entity_equality_get_Item_Id='?' (DbType = Int32)
+@entity_equality_get_Item_Int='?' (DbType = Int32)
+@entity_equality_get_Item_Name='?' (Size = 4000)
+@entity_equality_get_Item_String='?' (Size = 4000)
+@entity_equality_get_Item_NestedCollection='?' (Size = 195)
+@entity_equality_get_Item_OptionalNested='?' (Size = 89)
+@entity_equality_get_Item_RequiredNested='?' (Size = 89)
+
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON([r].[RelatedCollection], '$') WITH (
+        [Id] int '$.Id',
+        [Int] int '$.Int',
+        [Name] nvarchar(max) '$.Name',
+        [String] nvarchar(max) '$.String',
+        [NestedCollection] json '$.NestedCollection' AS JSON,
+        [OptionalNested] json '$.OptionalNested' AS JSON,
+        [RequiredNested] json '$.RequiredNested' AS JSON
+    ) AS [r0]
+    WHERE [r0].[Id] > @get_Item_Id AND [r0].[Id] = @entity_equality_get_Item_Id AND [r0].[Int] = @entity_equality_get_Item_Int AND [r0].[Name] = @entity_equality_get_Item_Name AND [r0].[String] = @entity_equality_get_Item_String AND CAST([r0].[NestedCollection] AS nvarchar(max)) = CAST(@entity_equality_get_Item_NestedCollection AS nvarchar(max)) AND CAST([r0].[OptionalNested] AS nvarchar(max)) = CAST(@entity_equality_get_Item_OptionalNested AS nvarchar(max)) AND CAST([r0].[RequiredNested] AS nvarchar(max)) = CAST(@entity_equality_get_Item_RequiredNested AS nvarchar(max)))
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
 @get_Item_Id='?' (DbType = Int32)
 @entity_equality_get_Item_Id='?' (DbType = Int32)
 @entity_equality_get_Item_Int='?' (DbType = Int32)
@@ -367,6 +398,7 @@ WHERE EXISTS (
     ) AS [r0]
     WHERE [r0].[Id] > @get_Item_Id AND [r0].[Id] = @entity_equality_get_Item_Id AND [r0].[Int] = @entity_equality_get_Item_Int AND [r0].[Name] = @entity_equality_get_Item_Name AND [r0].[String] = @entity_equality_get_Item_String AND [r0].[NestedCollection] = @entity_equality_get_Item_NestedCollection AND [r0].[OptionalNested] = @entity_equality_get_Item_OptionalNested AND [r0].[RequiredNested] = @entity_equality_get_Item_RequiredNested)
 """);
+        }
     }
 
     #endregion Contains


### PR DESCRIPTION
Fixes #36628

### Description

When transforming JsonQueryExpression to SqlServerOpenJsonExpression, nested JSON objects were always projected out of OPENJSON as `nvarchar(max)`, even if the containing column uses the new JSON data type; this caused subsequent JSON_VALUE() operations to fail, since the RETURNING clause which gets generated only works with the new JSON data type (regardless of this bug, nested JSON objects should always have the same type as the container JSON column).

This bug was missed since we don't test against SQL Server 2025 in CI (where the JSON data type can be exercised), only against SQL Server 2022.

### Customer impact

Various queries fail which involve LINQ operators on top of JSON collections (major EF 10 feature), where the collection element itself has nested JSON objects.

### How found

Testing by @AndriySvyryd in #36628.

### Regression

No

### Testing

Tests were already there, but are not currently being executed against SQL Server 2025 in CI.

### Risk

Low, the fix is very targeted and affects only this specific scenario.