### PR TITLE
[rc2] Revert migrator behavior to use a transaction for each migration (when possible)

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -182,7 +182,7 @@ public class Migrator : IMigrator
                 }
 
                 _migrationCommandExecutor.ExecuteNonQuery(
-                    getCommands(), _connection, state, commitTransaction: false, MigrationTransactionIsolationLevel);
+                    getCommands(), _connection, state, commitTransaction: useTransaction, MigrationTransactionIsolationLevel);
             }
 
             var coreOptionsExtension =
@@ -317,7 +317,7 @@ public class Migrator : IMigrator
                 }
 
                 await _migrationCommandExecutor.ExecuteNonQueryAsync(
-                        getCommands(), _connection, state, commitTransaction: false, MigrationTransactionIsolationLevel, cancellationToken)
+                        getCommands(), _connection, state, commitTransaction: useTransaction, MigrationTransactionIsolationLevel, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -595,7 +595,6 @@ public class Migrator : IMigrator
         var migrationsToApply = migratorData.AppliedMigrations;
         var migrationsToRevert = migratorData.RevertedMigrations;
         var actualTargetMigration = migratorData.TargetMigration;
-        var transactionStarted = false;
         for (var i = 0; i < migrationsToRevert.Count; i++)
         {
             var migration = migrationsToRevert[i];
@@ -611,7 +610,7 @@ public class Migrator : IMigrator
 
             GenerateSqlScript(
                 GenerateDownSql(migration, previousMigration, options),
-                builder, _sqlGenerationHelper, ref transactionStarted, noTransactions, idempotencyCondition, idempotencyEnd);
+                builder, _sqlGenerationHelper, noTransactions, idempotencyCondition, idempotencyEnd);
         }
 
         foreach (var migration in migrationsToApply)
@@ -624,14 +623,7 @@ public class Migrator : IMigrator
 
             GenerateSqlScript(
                 GenerateUpSql(migration, options),
-                builder, _sqlGenerationHelper, ref transactionStarted, noTransactions, idempotencyCondition, idempotencyEnd);
-        }
-
-        if (transactionStarted)
-        {
-            builder
-                .AppendLine(_sqlGenerationHelper.CommitTransactionStatement)
-                .Append(_sqlGenerationHelper.BatchTerminator);
+                builder, _sqlGenerationHelper, noTransactions, idempotencyCondition, idempotencyEnd);
         }
 
         return builder.ToString();
@@ -641,11 +633,11 @@ public class Migrator : IMigrator
         IEnumerable<MigrationCommand> commands,
         IndentedStringBuilder builder,
         ISqlGenerationHelper sqlGenerationHelper,
-        ref bool transactionStarted,
         bool noTransactions = false,
         string? idempotencyCondition = null,
         string? idempotencyEnd = null)
     {
+        var transactionStarted = false;
         foreach (var command in commands)
         {
             if (!noTransactions)
@@ -690,6 +682,13 @@ public class Migrator : IMigrator
             {
                 builder.Append(Environment.NewLine);
             }
+        }
+
+        if (transactionStarted)
+        {
+            builder
+                .AppendLine(sqlGenerationHelper.CommitTransactionStatement)
+                .Append(sqlGenerationHelper.BatchTerminator);
         }
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -100,6 +100,10 @@ CREATE TABLE [Table1] (
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000001_Migration1', N'7.0.0-test');
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 EXEC sp_rename N'[Table1].[Foo]', N'Bar', 'COLUMN';
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
@@ -158,6 +162,10 @@ Empty Lines')
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000005_Migration5', N'7.0.0-test');
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 INSERT INTO Table1 (Id, Bar, Description) VALUES (-2, 4, 'GO
 Value With
 
@@ -166,6 +174,10 @@ Empty Lines')
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000006_Migration6', N'7.0.0-test');
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 INSERT INTO Table1 (Id, Bar, Description) VALUES (-3, 5, '--Start
 GO
 Value With
@@ -186,23 +198,47 @@ BEGIN TRANSACTION;
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000007_Migration7';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000006_Migration6';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000005_Migration5';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000004_Migration4';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000003_Migration3';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 EXEC sp_rename N'[Table1].[Bar]', N'Foo', 'COLUMN';
 
 DELETE FROM [__EFMigrationsHistory]
 WHERE [MigrationId] = N'00000000000002_Migration2';
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 DROP TABLE [Table1];
 
 DELETE FROM [__EFMigrationsHistory]
@@ -467,6 +503,10 @@ BEGIN
     VALUES (N'00000000000001_Migration1', N'7.0.0-test');
 END;
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 IF NOT EXISTS (
     SELECT * FROM [__EFMigrationsHistory]
     WHERE [MigrationId] = N'00000000000002_Migration2'
@@ -505,6 +545,10 @@ BEGIN
     WHERE [MigrationId] = N'00000000000002_Migration2';
 END;
 
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
 IF EXISTS (
     SELECT * FROM [__EFMigrationsHistory]
     WHERE [MigrationId] = N'00000000000001_Migration1'

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -68,23 +68,41 @@ CREATE TABLE "Table1" (
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000001_Migration1', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 ALTER TABLE "Table1" RENAME COLUMN "Foo" TO "Bar";
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000002_Migration2', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000003_Migration3', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000004_Migration4', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000005_Migration5', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000006_Migration6', '7.0.0-test');
 
+COMMIT;
+
+BEGIN TRANSACTION;
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000007_Migration7', '7.0.0-test');
 
@@ -94,23 +112,41 @@ BEGIN TRANSACTION;
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000007_Migration7';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000006_Migration6';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000005_Migration5';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000004_Migration4';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000003_Migration3';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 ALTER TABLE "Table1" RENAME COLUMN "Bar" TO "Foo";
 
 DELETE FROM "__EFMigrationsHistory"
 WHERE "MigrationId" = '00000000000002_Migration2';
 
+COMMIT;
+
+BEGIN TRANSACTION;
 DROP TABLE "Table1";
 
 DELETE FROM "__EFMigrationsHistory"


### PR DESCRIPTION
Fixes #35096

**Description**
In EF9 we changed migration execution to use a single transaction across all migrations to rollback everything if there are any errors. However, many operations fail when executed in the same transaction. Also, a long-running transaction is more likely to fail due to transient errors.
So, this PR reverts the behavior to pre-EF9.

**Customer impact**
Certain operations now fail when several migrations are applied at once. A workaround is to apply one migration at a time.

**How found**
This was reported by several customers

**Regression**
Yes, from EF 8.0.x. Introduced in 972a50aed052de667463b2eb260d875171455cfc

**Testing**
Tested manually

**Risk**
Low. Targeted change that reverts to previous behavior.