### PR TITLE
[RC2] Rename "relationship" to "structural property"

### DIFF
--- a/src/EFCore.Relational/Query/CollectionResultExpression.cs
+++ b/src/EFCore.Relational/Query/CollectionResultExpression.cs
@@ -14,11 +14,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     </para>
 /// </summary>
 /// <param name="queryExpression">Represents the server-side query expression for the collection.</param>
-/// <param name="relationship">A navigation associated with this collection, if any.</param>
-/// <param name="elementType">The clr type of individual elements in the collection.</param>
+/// <param name="structuralProperty">The navigation or complex property associated with the collection, if any.</param>
+/// <param name="elementType">The .NET type of individual elements in the collection.</param>
 public class CollectionResultExpression(
     Expression queryExpression,
-    IPropertyBase? relationship,
+    IPropertyBase? structuralProperty,
     Type elementType)
     : Expression, IPrintableExpression
 {
@@ -28,12 +28,12 @@ public class CollectionResultExpression(
     public virtual Expression QueryExpression { get; } = queryExpression;
 
     /// <summary>
-    ///     The relationship associated with the collection, if any.
+    ///     The navigation or complex property associated with the collection, if any.
     /// </summary>
-    public virtual IPropertyBase? Relationship { get; } = relationship;
+    public virtual IPropertyBase? StructuralProperty { get; } = structuralProperty;
 
     /// <summary>
-    ///     The clr type of elements of the collection.
+    ///     The .NET type of elements of the collection.
     /// </summary>
     public virtual Type ElementType { get; } = elementType;
 
@@ -58,7 +58,7 @@ public class CollectionResultExpression(
     public virtual CollectionResultExpression Update(Expression queryExpression)
         => queryExpression == QueryExpression
             ? this
-            : new CollectionResultExpression(queryExpression, Relationship, ElementType);
+            : new CollectionResultExpression(queryExpression, StructuralProperty, ElementType);
 
     /// <inheritdoc />
     public virtual void Print(ExpressionPrinter expressionPrinter)
@@ -70,9 +70,9 @@ public class CollectionResultExpression(
             expressionPrinter.Visit(QueryExpression);
             expressionPrinter.AppendLine();
 
-            if (Relationship is not null)
+            if (StructuralProperty is not null)
             {
-                expressionPrinter.Append("Relationship:").AppendLine(Relationship.ToString()!);
+                expressionPrinter.Append("Structural Property:").AppendLine(StructuralProperty.ToString()!);
             }
 
             expressionPrinter.Append("ElementType:").AppendLine(ElementType.ShortDisplayName());
@@ -88,6 +88,6 @@ public class CollectionResultExpression(
     /// <summary>
     ///     The navigation if associated with the collection.
     /// </summary>
-    [Obsolete("Use Relationship instead.", error: true)]
+    [Obsolete("Use StructuralProperty instead.", error: true)]
     public virtual INavigationBase? Navigation { get; }
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -198,7 +198,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                             // expression.Type here will be List<T>
                             return new CollectionResultExpression(
                                 new ProjectionBindingExpression(_selectExpression, _clientProjections.Count - 1, expression.Type),
-                                relationship: null,
+                                structuralProperty: null,
                                 methodCallExpression.Method.GetGenericArguments()[0]);
                         }
                     }
@@ -219,7 +219,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                                 _selectExpression, _clientProjections.Count - 1, type);
                             return subquery.ResultCardinality == ResultCardinality.Enumerable
                                 ? new CollectionResultExpression(
-                                    projectionBindingExpression, relationship: null, subquery.ShaperExpression.Type)
+                                    projectionBindingExpression, structuralProperty: null, subquery.ShaperExpression.Type)
                                 : projectionBindingExpression;
                         }
                     }

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -146,13 +146,13 @@ public class JsonQueryExpression : Expression, IPrintableExpression
     }
 
     /// <summary>
-    ///     Binds a relationship with this JSON query expression to get the SQL representation.
+    ///     Binds a navigation or complex property with this JSON query expression to get the SQL representation.
     /// </summary>
-    /// <param name="relationship">The navigation or complex property to bind.</param>
+    /// <param name="structuralProperty">The navigation or complex property to bind.</param>
     /// <returns>An JSON query expression for the target entity or complex type.</returns>
-    public virtual JsonQueryExpression BindRelationship(IPropertyBase relationship)
+    public virtual JsonQueryExpression BindStructuralProperty(IPropertyBase structuralProperty)
     {
-        switch (relationship)
+        switch (structuralProperty)
         {
             case INavigation navigation:
             {

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1814,7 +1814,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
                 if (TryGetJsonQueryExpression(shaper, out var jsonQueryExpression))
                 {
-                    var newJsonQueryExpression = jsonQueryExpression.BindRelationship(navigation);
+                    var newJsonQueryExpression = jsonQueryExpression.BindStructuralProperty(navigation);
 
                     Debug.Assert(!navigation.IsOnDependent, "JSON navigations should always be from principal do dependent");
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -1055,7 +1055,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             QueryContext queryContext,
             object[]? keyPropertyValues,
             JsonReaderData? jsonReaderData,
-            IPropertyBase relationship,
+            IPropertyBase structuralProperty,
             Func<QueryContext, object[]?, JsonReaderData, TEntity> innerShaper)
             where TEntity : class
         {
@@ -1076,7 +1076,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     throw new InvalidOperationException(CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
-            var collectionAccessor = relationship.GetCollectionAccessor();
+            var collectionAccessor = structuralProperty.GetCollectionAccessor();
             var result = (TResult)collectionAccessor!.Create();
 
             object[]? newKeyPropertyValues = null;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
@@ -110,8 +110,8 @@ public partial class RelationalSqlTranslatingExpressionVisitor
             case (_, StructuralTypeReferenceExpression { StructuralType: IComplexType }):
                 return TryRewriteComplexTypeEquality(collection: false, out result);
 
-            case (CollectionResultExpression { Relationship: IComplexProperty }, _):
-            case (_, CollectionResultExpression { Relationship: IComplexProperty }):
+            case (CollectionResultExpression { StructuralProperty: IComplexProperty }, _):
+            case (_, CollectionResultExpression { StructuralProperty: IComplexProperty }):
                 return TryRewriteComplexTypeEquality(collection: true, out result);
 
             default:
@@ -281,14 +281,14 @@ public partial class RelationalSqlTranslatingExpressionVisitor
             var leftComplexType = left switch
             {
                 StructuralTypeReferenceExpression { StructuralType: IComplexType t } => t,
-                CollectionResultExpression { Relationship: IComplexProperty { ComplexType: var t } } => t,
+                CollectionResultExpression { StructuralProperty: IComplexProperty { ComplexType: var t } } => t,
                 _ => null
             };
 
             var rightComplexType = right switch
             {
                 StructuralTypeReferenceExpression { StructuralType: IComplexType t } => t,
-                CollectionResultExpression { Relationship: IComplexProperty { ComplexType: var t } } => t,
+                CollectionResultExpression { StructuralProperty: IComplexProperty { ComplexType: var t } } => t,
                 _ => null
             };
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1379,7 +1379,7 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
                         };
 
                     case JsonQueryExpression jsonQuery:
-                        var nestedJsonQuery = jsonQuery.BindRelationship(complexProperty);
+                        var nestedJsonQuery = jsonQuery.BindStructuralProperty(complexProperty);
 
                         return complexProperty.IsCollection
                             ? new CollectionResultExpression(

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -283,7 +283,7 @@ public sealed partial class SelectExpression
                     QueryExpression: ProjectionBindingExpression innerProjectionBindingExpression
                 } collectionResultExpression:
                 {
-                    var navigation = collectionResultExpression.Relationship switch
+                    var navigation = collectionResultExpression.StructuralProperty switch
                     {
                         INavigationBase n => n,
                         null => null,

--- a/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
+++ b/src/EFCore/Query/LiftableConstantExpressionHelpers.cs
@@ -200,19 +200,19 @@ public static class LiftableConstantExpressionHelpers
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static Expression BuildRelationshipAccess(IPropertyBase? relationship, ParameterExpression liftableConstantContextParameter)
+    public static Expression BuildStructuralPropertyAccess(IPropertyBase? structuralProperty, ParameterExpression liftableConstantContextParameter)
     {
-        if (relationship is null)
+        if (structuralProperty is null)
         {
             return Default(typeof(INavigationBase));
         }
 
-        var declaringType = relationship.DeclaringType;
+        var declaringType = structuralProperty.DeclaringType;
         var declaringTypeExpression = BuildMemberAccessForEntityOrComplexType(declaringType, liftableConstantContextParameter);
 
         var result = Call(
             declaringTypeExpression,
-            relationship switch
+            structuralProperty switch
             {
                 ISkipNavigation => EntityTypeFindSkipNavigationMethod,
                 INavigation => EntityTypeFindNavigationMethod,
@@ -220,7 +220,7 @@ public static class LiftableConstantExpressionHelpers
 
                 _ => throw new UnreachableException()
             },
-            Constant(relationship.Name));
+            Constant(structuralProperty.Name));
 
         return result;
     }
@@ -231,10 +231,10 @@ public static class LiftableConstantExpressionHelpers
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildRelationshipAccessLambda(IPropertyBase? relationship)
+    public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildStructuralPropertyAccessLambda(IPropertyBase? structuralProperty)
     {
         var prm = Parameter(typeof(MaterializerLiftableConstantContext));
-        var body = BuildRelationshipAccess(relationship, prm);
+        var body = BuildStructuralPropertyAccess(structuralProperty, prm);
 
         return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
     }
@@ -245,15 +245,15 @@ public static class LiftableConstantExpressionHelpers
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static Expression BuildClrCollectionAccessor(IPropertyBase? relationship, ParameterExpression liftableConstantContextParameter)
+    public static Expression BuildClrCollectionAccessor(IPropertyBase? structuralProperty, ParameterExpression liftableConstantContextParameter)
     {
-        if (relationship is null)
+        if (structuralProperty is null)
         {
             return Default(typeof(IClrCollectionAccessor));
         }
 
-        var relationshipAccessExpression = BuildRelationshipAccess(relationship, liftableConstantContextParameter);
-        var result = Call(relationshipAccessExpression, PropertyBaseClrCollectionAccessorMethod);
+        var structuralPropertyAccessExpression = BuildStructuralPropertyAccess(structuralProperty, liftableConstantContextParameter);
+        var result = Call(structuralPropertyAccessExpression, PropertyBaseClrCollectionAccessorMethod);
 
         return result;
     }
@@ -265,10 +265,10 @@ public static class LiftableConstantExpressionHelpers
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static Expression<Func<MaterializerLiftableConstantContext, object>> BuildClrCollectionAccessorLambda(
-        IPropertyBase? relationship)
+        IPropertyBase? structuralProperty)
     {
         var prm = Parameter(typeof(MaterializerLiftableConstantContext));
-        var body = BuildClrCollectionAccessor(relationship, prm);
+        var body = BuildClrCollectionAccessor(structuralProperty, prm);
 
         return Lambda<Func<MaterializerLiftableConstantContext, object>>(body, prm);
     }


### PR DESCRIPTION
As part of the recent complex type work, the term "relationship" has been introduced to refer to both navigations and complex properties; as per our design discussions, we'll rename these to "structural property" instead (as relationships are more tightly related to relational databases and foreign-key based relationships, etc.).

These are very light, mechanical renames - am submitting this in tell mode.

/cc @artl93 