### PR TITLE
[rc2] Properly handle automatic rollbacks in SQLite in Commit.

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteTransaction.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteTransaction.cs
@@ -83,8 +83,11 @@ public class SqliteTransaction : DbTransaction
             throw new InvalidOperationException(Resources.TransactionCompleted);
         }
 
-        sqlite3_rollback_hook(_connection.Handle, null, null);
+        // Do commit first and then clear the rollback hook.
+        // Commit itself can fail (i.e. SQLITE_FULL) and then Dispose would throw
+        // confusing "SQLite Error 1: 'cannot rollback - no transaction is active'" exception.
         _connection.ExecuteNonQuery("COMMIT;");
+        sqlite3_rollback_hook(_connection.Handle, null, null);
         Complete();
     }
 


### PR DESCRIPTION
Fixes #36561.

### Description
Some SQLite errors can cause automatic rollback when errors (i.e. `SQLITE_FULL`) occur within a transaction. The way `SqliteTransaction` handles this case is incorrect.

### Customer impact
Using `using` blocks with `SqliteTransaction` is difficult, because different - confusing - exception is thrown, hiding the original one.

### How found
Customer reported on M.D.Sqlite 9.

### Regression
No.

### Testing
Manual testing.

### Risk
Low.