### PR TITLE
[rc2] Update MSBuild and Roslyn dependencies to sim-ship versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,9 +22,9 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
 
     <!-- Roslyn dependencies-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildVersion)" />
 
     <!-- analyzer dependencies-->
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -24,6 +24,14 @@ This file should be imported by eng/Versions.props
     <SystemRuntimeCachingPackageVersion>10.0.0-rc.2.25427.104</SystemRuntimeCachingPackageVersion>
     <SystemTextEncodingsWebPackageVersion>10.0.0-rc.2.25427.104</SystemTextEncodingsWebPackageVersion>
     <SystemTextJsonPackageVersion>10.0.0-rc.2.25427.104</SystemTextJsonPackageVersion>
+    <!-- dotnet/msbuild dependencies -->
+    <MicrosoftBuildFrameworkPackageVersion>17.15.0-preview-25453-107</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>17.15.0-preview-25453-107</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildTasksCorePackageVersion>17.15.0-preview-25453-107</MicrosoftBuildTasksCorePackageVersion>
+    <!-- dotnet/roslyn dependencies -->
+    <MicrosoftCodeAnalysisCSharpPackageVersion>5.0.0-2.25453.107</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.0.0-2.25453.107</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.0.0-2.25453.107</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>
@@ -46,5 +54,13 @@ This file should be imported by eng/Versions.props
     <SystemRuntimeCachingVersion>$(SystemRuntimeCachingPackageVersion)</SystemRuntimeCachingVersion>
     <SystemTextEncodingsWebVersion>$(SystemTextEncodingsWebPackageVersion)</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>$(SystemTextJsonPackageVersion)</SystemTextJsonVersion>
+    <!-- dotnet/msbuild dependencies -->
+    <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildFrameworkPackageVersion)</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildUtilitiesCorePackageVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildTasksCorePackageVersion)</MicrosoftBuildTasksCoreVersion>
+    <!-- dotnet/roslyn dependencies -->
+    <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildVersion>$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)</MicrosoftCodeAnalysisWorkspacesMSBuildVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,6 +62,30 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>7ac1ca67bb1fb8a381c1c94a9f82a97725f0ccf3</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build.Framework" Version="17.15.0-preview-25453-107">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>53a2d6ba9edc932e724dc80a5a56eeb9943863cf</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.15.0-preview-25453-107">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>53a2d6ba9edc932e724dc80a5a56eeb9943863cf</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.15.0-preview-25453-107">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>53a2d6ba9edc932e724dc80a5a56eeb9943863cf</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.0.0-2.25453.107">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>e5924c0044a45b9b10ccde820a447adbb636f8be</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0-2.25453.107">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>e5924c0044a45b9b10ccde820a447adbb636f8be</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0-2.25453.107">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>e5924c0044a45b9b10ccde820a447adbb636f8be</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25427.104">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,11 +17,6 @@
     <UsingToolXliff>False</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
-    <MicrosoftBuildFrameworkVersion>17.14.8</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.14.8</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftBuildTasksCoreVersion>17.14.8</MicrosoftBuildTasksCoreVersion>
-    <!-- NB: This version affects Visual Studio compatibility. See https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md and https://learn.microsoft.com/visualstudio/extensibility/roslyn-version-support -->
-    <MicrosoftCodeAnalysisVersion>4.14.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.24423.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <MicrosoftCodeAnalysisCSharpTestingVersion>1.1.3-beta1.24352.1</MicrosoftCodeAnalysisCSharpTestingVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -965,7 +965,7 @@ Assert.Collection(blogs, b => Assert.Equal(8, b.Id));
         => Test(
             """
 int[] ids = [1, 2, 3];
-_ = await context.Blogs.Where(b => ids.Contains(b.Id)).ToListAsync();
+_ = await context.Blogs.Where(b => ((IEnumerable<int>)ids).Contains(b.Id)).ToListAsync();
 """);
 
     [ConditionalFact]

--- a/test/EFCore.Specification.Tests/Directory.Packages.props
+++ b/test/EFCore.Specification.Tests/Directory.Packages.props
@@ -1,9 +1,3 @@
 <Project>
   <Import Project="..\Directory.Packages.props" />
-  <ItemGroup>
-    <!-- Workaround for https://github.com/dotnet/roslyn-sdk/issues/1175 -->
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisVersion)" />
-  </ItemGroup>
 </Project>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -1800,13 +1800,13 @@ WHERE (
 
         AssertSql(
             """
-@ids1='1'
-@ids2='2'
-@ids3='3'
+@p1='1'
+@p2='2'
+@p3='3'
 
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
-WHERE [b].[Id] IN (@ids1, @ids2, @ids3)
+WHERE [b].[Id] IN (@p1, @p2, @p3)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledSqlPregenerationQuerySqlServerTest.cs
@@ -233,18 +233,18 @@ ORDER BY [b].[Name]
         await Test(
             """
 string[] names = ["foo", "bar"];
-var blogs = await context.Blogs.Where(b => names.Contains(b.Name)).ToListAsync();
+var blogs = await context.Blogs.Where(b => ((IEnumerable<string>)names).Contains(b.Name)).ToListAsync();
 """,
             interceptorCodeAsserter: code => Assert.Contains(nameof(RelationalCommandCache), code));
 
         AssertSql(
             """
-@names1='foo' (Size = 4000)
-@names2='bar' (Size = 4000)
+@p1='foo' (Size = 4000)
+@p2='bar' (Size = 4000)
 
 SELECT [b].[Id], [b].[Name]
 FROM [Blogs] AS [b]
-WHERE [b].[Name] IN (@names1, @names2)
+WHERE [b].[Name] IN (@p1, @p2)
 """);
     }
 


### PR DESCRIPTION
This is part of the effort to simplify our dependency versioning and support policies

cc @artl93 