### PR TITLE
[rc2] Allow the build host to be copied from M.CA.Workspaces.MSBuild

### DIFF
--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -58,8 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
-    <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" PrivateAssets="analyzers;build" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.Extensions.HostFactoryResolver.Sources" PrivateAssets="All" />
     <PackageReference Include="Mono.TextTemplating" />

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -439,6 +439,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 assembly, migrationsAssembly);
 
         /// <summary>
+        ///     MSBuild Workspace diagnostics:{diagnostics}
+        /// </summary>
+        public static string MSBuildWorkspaceDiagnostics(object? diagnostics)
+            => string.Format(
+                GetString("MSBuildWorkspaceDiagnostics", nameof(diagnostics)),
+                diagnostics);
+
+        /// <summary>
+        ///     MSBuild Workspace failure: {kind} - {message}
+        /// </summary>
+        public static string MSBuildWorkspaceFailure(object? kind, object? message)
+            => string.Format(
+                GetString("MSBuildWorkspaceFailure", nameof(kind), nameof(message)),
+                kind, message);
+
+        /// <summary>
         ///     The annotation '{annotationName}' was specified twice with potentially different values. Specifying the same annotation multiple times for different providers is no longer supported. Review the generated Migration to ensure it is correct and, if necessary, edit the Migration to fix any issues.
         /// </summary>
         public static string MultipleAnnotationConflict(object? annotationName)
@@ -657,6 +673,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static string QueryPrecompilationErrors
             => GetString("QueryPrecompilationErrors");
+
+        /// <summary>
+        ///     Failed to load project for query precompilation. Project: {project}. Error: {error}
+        /// </summary>
+        public static string QueryPrecompilationProjectLoadFailed(object? project, object? error)
+            => string.Format(
+                GetString("QueryPrecompilationProjectLoadFailed", nameof(project), nameof(error)),
+                project, error);
 
         /// <summary>
         ///     No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist(s) and must be made writeable to continue: {readOnlyFiles}.

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -288,6 +288,12 @@ Consider changing your target project to the DbContext project by using the Pack
 Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}")). By default, the migrations assembly is the assembly containing the DbContext.
 Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list, or by executing "dotnet ef" from the directory containing the migrations project.</value>
   </data>
+  <data name="MSBuildWorkspaceDiagnostics" xml:space="preserve">
+    <value>MSBuild Workspace diagnostics:{diagnostics}</value>
+  </data>
+  <data name="MSBuildWorkspaceFailure" xml:space="preserve">
+    <value>MSBuild Workspace failure: {kind} - {message}</value>
+  </data>
   <data name="MultipleAnnotationConflict" xml:space="preserve">
     <value>The annotation '{annotationName}' was specified twice with potentially different values. Specifying the same annotation multiple times for different providers is no longer supported. Review the generated Migration to ensure it is correct and, if necessary, edit the Migration to fix any issues.</value>
   </data>
@@ -383,6 +389,9 @@ Change your target project to the migrations project by using the Package Manage
   </data>
   <data name="QueryPrecompilationErrors" xml:space="preserve">
     <value>Query precompilation failed with errors:</value>
+  </data>
+  <data name="QueryPrecompilationProjectLoadFailed" xml:space="preserve">
+    <value>Failed to load project for query precompilation. Project: {project}. Error: {error}</value>
   </data>
   <data name="ReadOnlyFiles" xml:space="preserve">
     <value>No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist(s) and must be made writeable to continue: {readOnlyFiles}.</value>

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.props
@@ -2,8 +2,8 @@
 
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">net10.0</_TaskTargetFramework>
-    <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_TaskTargetFramework>
+    <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">net10.0</_TaskTargetFramework>
+    <_TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_TaskTargetFramework>
     <_EFCustomTasksAssembly>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory),'..\tasks\$(_TaskTargetFramework)\$(MSBuildThisFileName).dll'))</_EFCustomTasksAssembly>
     <EFScaffoldModelStage Condition="'$(EFScaffoldModelStage)'==''">publish</EFScaffoldModelStage>
     <EFPrecompileQueriesStage Condition="'$(EFPrecompileQueriesStage)'==''">publish</EFPrecompileQueriesStage>

--- a/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
+++ b/src/EFCore.Tasks/buildTransitive/Microsoft.EntityFrameworkCore.Tasks.targets
@@ -5,10 +5,7 @@
   <PropertyGroup>
     <_FullOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(OutputPath)'))</_FullOutputPath>
     <_FullIntermediateOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
-    <_FullIntermediateOutputPath Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' And '$(RuntimeIdentifier)' != '' And '$(_UsingDefaultRuntimeIdentifier)' != 'true' And '$(UseArtifactsIntermediateOutput)' != 'true'">
-      $([MSBuild]::NormalizePath('$(_FullIntermediateOutputPath)',
-      '../'))
-    </_FullIntermediateOutputPath>
+    <_FullIntermediateOutputPath Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' And '$(RuntimeIdentifier)' != '' And '$(_UsingDefaultRuntimeIdentifier)' != 'true' And '$(UseArtifactsIntermediateOutput)' != 'true'">$([MSBuild]::NormalizePath('$(_FullIntermediateOutputPath)', '../'))</_FullIntermediateOutputPath>
     <EFGeneratedSourcesBuildFile Condition="'$(EFGeneratedSourcesBuildFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Build.txt</EFGeneratedSourcesBuildFile>
     <EFGeneratedSourcesPublishFile Condition="'$(EFGeneratedSourcesPublishFile)' == ''">$(_FullIntermediateOutputPath)$(AssemblyName).EFGeneratedSources.Publish.txt</EFGeneratedSourcesPublishFile>
     <_AssemblyFullName>$(_FullOutputPath)$(AssemblyName).dll</_AssemblyFullName>


### PR DESCRIPTION
Fixes #35638

**Description**
`Microsoft.CodeAnalysis.Workspaces.MSBuild` looks for the build host in the user's project, but it's not present as by default `content` is not transitively used from NuGet packages. This PR fixes that and adds more diagnostic information on MSBuild workspace failures. `MSBuildLocator` usage is also removed as it's no longer needed with the current version of `Microsoft.CodeAnalysis.Workspaces.MSBuild`.

**Customer impact**
Customers using `Microsoft.EntityFrameworkCore.Tasks` to precompile queries will get an exception on build/publish. The only workaround is to use other tools instead.

**How found**
Found during validation.

**Regression**
Yes, from EF 9.0.x

**Testing**
Tested manually.

**Risk**
Low, the code change only affects the broken scenario.