### PR TITLE
Add proper handling when a property’s backing field cannot be inferred or the unsafe accessor cannot be generated.

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -910,6 +910,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("WritingSnapshot", nameof(file)),
                 file);
 
+        /// <summary>
+        ///     Backing field for property could not be inferred.
+        /// </summary>
+        public static string CompiledModelBackingFieldNotFound(object? entityType, object? propertyName)
+            => string.Format(
+                GetString("CompiledModelBackingFieldNotFound", nameof(entityType)),
+                entityType,
+                propertyName);
+
+        /// <summary>
+        ///     Unsafe accessor for property could not be generated.
+        /// </summary>
+        public static string CompiledModelUnsafeAccessorNull(object? entityType, object? propertyName)
+            => string.Format(
+                GetString("CompiledModelUnsafeAccessorNull", nameof(entityType)),
+                entityType,
+                propertyName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -156,6 +156,9 @@
   <data name="CompilationMustBeLoaded" xml:space="preserve">
     <value>A compilation must be loaded.</value>
   </data>
+  <data name="CompiledModelBackingFieldNotFound" xml:space="preserve">
+    <value>Backing field for property '{entityType}.{propertyName}' could not be inferred. Use a matching field name or configure with HasField().</value>
+  </data>
   <data name="CompiledModelConstructorBinding" xml:space="preserve">
     <value>The entity type '{entityType}' has a custom constructor binding. Compiled model can't be generated, because custom constructor bindings are not supported. Configure the custom constructor binding in '{customize}' in a partial '{className}' class instead.</value>
   </data>
@@ -167,6 +170,9 @@
   </data>
   <data name="CompiledModelQueryFilter" xml:space="preserve">
     <value>The entity type '{entityType}' has a query filter configured. Compiled model can't be generated, because query filters are not supported.</value>
+  </data>
+  <data name="CompiledModelUnsafeAccessorNull" xml:space="preserve">
+    <value>Unsafe accessor for property '{entityType}.{propertyName}' could not be generated. Ensure the property can be accessed or has a matching backing field.</value>
   </data>
   <data name="CompiledModelValueGenerator" xml:space="preserve">
     <value>The property '{entityType}.{property}' has a value generator configured. Use '{method}' to configure the value generator factory type.</value>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1769,7 +1769,9 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         Dictionary<Type, HashSet<MemberInfo>> unsafeAccessorTypes,
         ref Dictionary<MemberInfo, QualifiedName>? memberAccessReplacements)
     {
-        var member = property.GetMemberInfo(forMaterialization, forSet);
+        var member = property.GetMemberInfo(forMaterialization, forSet) ?? throw new InvalidOperationException(
+                DesignStrings.CompiledModelBackingFieldNotFound(property.DeclaringType.ShortName(), property.Name));
+
         switch (member)
         {
             case FieldInfo field:
@@ -1799,7 +1801,9 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         }
 
         memberAccessReplacements ??= [];
-        var methodName = LinqToCSharpSyntaxTranslator.GetUnsafeAccessorName(member);
+
+        var methodName = LinqToCSharpSyntaxTranslator.GetUnsafeAccessorName(member) ?? throw new InvalidOperationException(
+                DesignStrings.CompiledModelUnsafeAccessorNull(property.DeclaringType.ShortName(), property.Name));
 
         var declaringType = member.DeclaringType!;
         if (declaringType.IsGenericType


### PR DESCRIPTION
My take on adding additional handling for the following issue: #35219

Throws InvalidOperationException with proper message as in DesignStrings (CompiledModelBackingFieldNotFound and CompiledModelUnsafeAccessorNull). Plus added additional exceptions specifically for this case.

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

