### PR TITLE
[rc2] Enable the JSON data type for Azure SQL Database

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
@@ -70,11 +70,7 @@ public class SqlServerSingletonOptions : ISqlServerSingletonOptions
         => EngineType switch
         {
             SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 170,
-            // TODO: #36460
-            // At the time of writing, Azure SQL Database does not yet support OPENJSON over the JSON data type.
-            // This should get reenabled by the time we GA.
-            SqlServerEngineType.AzureSql => false,
-            // SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
+            SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
             SqlServerEngineType.AzureSynapse => false,
             SqlServerEngineType.Unknown => false, // TODO: We shouldn't observe Unknown here, #36477
             _ => throw new UnreachableException()

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -606,10 +606,7 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
         // 3. Can do JSON-specific decoding (e.g. base64 for varbinary)
         // Note that RETURNING is only (currently) supported over the json type (not nvarchar(max)).
         // Note that we don't need to check the compatibility level - if the json type is being used, then RETURNING is supported.
-        var useJsonValueReturningClause = !jsonQuery
-            && jsonScalarExpression.Json.TypeMapping?.StoreType is "json"
-            // Temporarily disabling for Azure SQL, which doesn't yet support RETURNING; this should get removed for 10 (see #36460).
-            && _sqlServerSingletonOptions.EngineType is not SqlServerEngineType.AzureSql;
+        var useJsonValueReturningClause = !jsonQuery && jsonScalarExpression.Json.TypeMapping?.StoreType is "json";
 
         // For JSON_VALUE(), if we can use the RETURNING clause, always do that.
         // Otherwise, JSON_VALUE always returns nvarchar(4000) (https://learn.microsoft.com/sql/t-sql/functions/json-value-transact-sql),

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -1588,13 +1588,8 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
     {
         var typeMappingSource = CreateTypeMappingSource(o => o.UseAzureSql());
 
-        // TODO: #36460
-        // At the time of writing, Azure SQL Database does not yet support OPENJSON over the JSON data type.
-        // This should get reenabled by the time we GA.
-        Assert.Equal("nvarchar(max)", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
-        Assert.Equal("nvarchar(max)", typeMappingSource.GetMapping(typeof(int[])).StoreType);
-        // Assert.Equal("json", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
-        // Assert.Equal("json", typeMappingSource.GetMapping(typeof(int[])).StoreType);
+        Assert.Equal("json", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
+        Assert.Equal("json", typeMappingSource.GetMapping(typeof(int[])).StoreType);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Closes #36460

**Description**
Support for the new SQL Server JSON data type was temporarily disabled for rc.1 as support for it wasn't yet fully rolled out to Azure SQL Database. Support has since been rolled out fully, and so this PR enables that support in EF for rc.2.

**Customer impact**
This allows using the new SQL Server JSON data type when targeting Azure SQL Database (as opposed to on-premise SQL Server 2025). This is a main feature of EF 10, and the reenabling was planned.

**How found**
User-reported

**Regression**
No

**Testing**
Already exists, manually validated against Azure SQL Database:

<details>
<summary>Validation checks performed on Azure SQL Database</summary>

```sql
-- OPENJSON over json data type works:
SELECT * FROM OPENJSON(CAST('[{ "a": 8 }, { "a": 9 }]' AS JSON)) WITH ([Foo] INT '$.a');

-- modify works:
CREATE TABLE foo (bar JSON);
INSERT INTO foo (bar) VALUES ('{ "a": 8 }');
UPDATE foo SET bar.modify('$.a', 10);
SELECT * FROM foo;

-- JSON_VALUE with RETURNING:
SELECT JSON_VALUE(CAST('{ "a": 8 }' AS JSON), '$.a' RETURNING int);
```

</details>

**Risk**
Extremely low, extremely targeted enabling of an already-existing feature for Azure SQL Database only.

/cc @uc-msft @yorek