### PR TITLE
[rc2] Fix ExecuteUpdate parameters for multiple properties with same name

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1628,6 +1628,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 sqlExpression);
 
         /// <summary>
+        ///     Required JSON property '{property}' cannot contain null.
+        /// </summary>
+        public static string NullValueInRequiredJsonProperty(object? property)
+            => string.Format(
+                GetString("NullValueInRequiredJsonProperty", nameof(property)),
+                property);
+
+        /// <summary>
         ///     Exactly one of '{param1}', '{param2}' or '{param3}' must be set.
         /// </summary>
         public static string OneOfThreeValuesMustBeSet(object? param1, object? param2, object? param3)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1069,6 +1069,9 @@
   <data name="NullTypeMappingInSqlTree" xml:space="preserve">
     <value>Expression '{sqlExpression}' in the SQL tree does not have a type mapping assigned.</value>
   </data>
+  <data name="NullValueInRequiredJsonProperty" xml:space="preserve">
+    <value>Required JSON property '{property}' cannot contain null.</value>
+  </data>
   <data name="OneOfThreeValuesMustBeSet" xml:space="preserve">
     <value>Exactly one of '{param1}', '{param2}' or '{param3}' must be set.</value>
   </data>

--- a/src/EFCore.Relational/Query/Internal/RelationalJsonUtilities.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalJsonUtilities.cs
@@ -92,6 +92,11 @@ public static class RelationalJsonUtilities
                 var propertyValue = property.GetGetter().GetClrValue(objectValue);
                 if (propertyValue is null)
                 {
+                    if (!property.IsNullable)
+                    {
+                        throw new InvalidOperationException(RelationalStrings.NullValueInRequiredJsonProperty(property.Name));
+                    }
+
                     writer.WriteNullValue();
                 }
                 else
@@ -109,6 +114,11 @@ public static class RelationalJsonUtilities
                 writer.WritePropertyName(jsonPropertyName);
 
                 var propertyValue = complexProperty.GetGetter().GetClrValue(objectValue);
+
+                if (propertyValue is null && !complexProperty.IsNullable)
+                {
+                    throw new InvalidOperationException(RelationalStrings.NullValueInRequiredJsonProperty(complexProperty.Name));
+                }
 
                 WriteJson(writer, complexProperty.ComplexType, propertyValue, complexProperty.IsCollection);
             }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -636,10 +637,17 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                                         Expression.Constant(property, typeof(IProperty))),
                                     QueryCompilationContext.QueryContextParameter);
 
-                                var newParameterName =
-                                    $"{ExecuteUpdateRuntimeParameterPrefix}{chainExpression.ParameterExpression.Name}_{property.Name}";
+                                var parameterNameBuilder = new StringBuilder(ExecuteUpdateRuntimeParameterPrefix)
+                                    .Append(chainExpression.ParameterExpression.Name);
 
-                                return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
+                                foreach (var complexProperty in chainExpression.ComplexPropertyChain)
+                                {
+                                    parameterNameBuilder.Append('_').Append(complexProperty.Name);
+                                }
+
+                                parameterNameBuilder.Append('_').Append(property.Name);
+
+                                return _queryCompilationContext.RegisterRuntimeParameter(parameterNameBuilder.ToString(), lambda);
                             }
 
                             case MemberInitExpression memberInitExpression

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonBulkUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonBulkUpdateSqlServerTest.cs
@@ -159,6 +159,13 @@ FROM [RootEntity] AS [r]
         AssertExecuteUpdateSql();
     }
 
+    public override async Task Update_association_with_null_required_property()
+    {
+        await base.Update_association_with_null_required_property();
+
+        AssertExecuteUpdateSql();
+    }
+
     #endregion Update properties
 
     #region Update association
@@ -325,6 +332,13 @@ UPDATE [r]
 SET [r].[OptionalRelated] = NULL
 FROM [RootEntity] AS [r]
 """);
+    }
+
+    public override async Task Update_association_with_null_required_nested_association()
+    {
+        await base.Update_association_with_null_required_nested_association();
+
+        AssertExecuteUpdateSql();
     }
 
     #endregion Update association

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingBulkUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingBulkUpdateSqlServerTest.cs
@@ -104,6 +104,13 @@ FROM [RootEntity] AS [r]
         AssertExecuteUpdateSql();
     }
 
+    public override async Task Update_association_with_null_required_property()
+    {
+        await base.Update_association_with_null_required_property();
+
+        AssertExecuteUpdateSql();
+    }
+
     #endregion Update properties
 
     #region Update association
@@ -119,6 +126,11 @@ FROM [RootEntity] AS [r]
 @complex_type_p_Ints='?' (Size = 4000)
 @complex_type_p_Name='?' (Size = 4000)
 @complex_type_p_String='?' (Size = 4000)
+@complex_type_p_RequiredNested_Id='?' (DbType = Int32)
+@complex_type_p_RequiredNested_Int='?' (DbType = Int32)
+@complex_type_p_RequiredNested_Ints='?' (Size = 4000)
+@complex_type_p_RequiredNested_Name='?' (Size = 4000)
+@complex_type_p_RequiredNested_String='?' (Size = 4000)
 
 UPDATE [r]
 SET [r].[RequiredRelated_Id] = @complex_type_p_Id,
@@ -126,16 +138,16 @@ SET [r].[RequiredRelated_Id] = @complex_type_p_Id,
     [r].[RequiredRelated_Ints] = @complex_type_p_Ints,
     [r].[RequiredRelated_Name] = @complex_type_p_Name,
     [r].[RequiredRelated_String] = @complex_type_p_String,
-    [r].[RequiredRelated_OptionalNested_Id] = @complex_type_p_Id,
-    [r].[RequiredRelated_OptionalNested_Int] = @complex_type_p_Int,
-    [r].[RequiredRelated_OptionalNested_Ints] = @complex_type_p_Ints,
-    [r].[RequiredRelated_OptionalNested_Name] = @complex_type_p_Name,
-    [r].[RequiredRelated_OptionalNested_String] = @complex_type_p_String,
-    [r].[RequiredRelated_RequiredNested_Id] = @complex_type_p_Id,
-    [r].[RequiredRelated_RequiredNested_Int] = @complex_type_p_Int,
-    [r].[RequiredRelated_RequiredNested_Ints] = @complex_type_p_Ints,
-    [r].[RequiredRelated_RequiredNested_Name] = @complex_type_p_Name,
-    [r].[RequiredRelated_RequiredNested_String] = @complex_type_p_String
+    [r].[RequiredRelated_OptionalNested_Id] = NULL,
+    [r].[RequiredRelated_OptionalNested_Int] = NULL,
+    [r].[RequiredRelated_OptionalNested_Ints] = NULL,
+    [r].[RequiredRelated_OptionalNested_Name] = NULL,
+    [r].[RequiredRelated_OptionalNested_String] = NULL,
+    [r].[RequiredRelated_RequiredNested_Id] = @complex_type_p_RequiredNested_Id,
+    [r].[RequiredRelated_RequiredNested_Int] = @complex_type_p_RequiredNested_Int,
+    [r].[RequiredRelated_RequiredNested_Ints] = @complex_type_p_RequiredNested_Ints,
+    [r].[RequiredRelated_RequiredNested_Name] = @complex_type_p_RequiredNested_Name,
+    [r].[RequiredRelated_RequiredNested_String] = @complex_type_p_RequiredNested_String
 FROM [RootEntity] AS [r]
 """);
     }
@@ -215,6 +227,11 @@ FROM [RootEntity] AS [r]
 @complex_type_p_Ints='?' (Size = 4000)
 @complex_type_p_Name='?' (Size = 4000)
 @complex_type_p_String='?' (Size = 4000)
+@complex_type_p_RequiredNested_Id='?' (DbType = Int32)
+@complex_type_p_RequiredNested_Int='?' (DbType = Int32)
+@complex_type_p_RequiredNested_Ints='?' (Size = 4000)
+@complex_type_p_RequiredNested_Name='?' (Size = 4000)
+@complex_type_p_RequiredNested_String='?' (Size = 4000)
 
 UPDATE [r]
 SET [r].[RequiredRelated_Id] = @complex_type_p_Id,
@@ -222,16 +239,16 @@ SET [r].[RequiredRelated_Id] = @complex_type_p_Id,
     [r].[RequiredRelated_Ints] = @complex_type_p_Ints,
     [r].[RequiredRelated_Name] = @complex_type_p_Name,
     [r].[RequiredRelated_String] = @complex_type_p_String,
-    [r].[RequiredRelated_OptionalNested_Id] = @complex_type_p_Id,
-    [r].[RequiredRelated_OptionalNested_Int] = @complex_type_p_Int,
-    [r].[RequiredRelated_OptionalNested_Ints] = @complex_type_p_Ints,
-    [r].[RequiredRelated_OptionalNested_Name] = @complex_type_p_Name,
-    [r].[RequiredRelated_OptionalNested_String] = @complex_type_p_String,
-    [r].[RequiredRelated_RequiredNested_Id] = @complex_type_p_Id,
-    [r].[RequiredRelated_RequiredNested_Int] = @complex_type_p_Int,
-    [r].[RequiredRelated_RequiredNested_Ints] = @complex_type_p_Ints,
-    [r].[RequiredRelated_RequiredNested_Name] = @complex_type_p_Name,
-    [r].[RequiredRelated_RequiredNested_String] = @complex_type_p_String
+    [r].[RequiredRelated_OptionalNested_Id] = NULL,
+    [r].[RequiredRelated_OptionalNested_Int] = NULL,
+    [r].[RequiredRelated_OptionalNested_Ints] = NULL,
+    [r].[RequiredRelated_OptionalNested_Name] = NULL,
+    [r].[RequiredRelated_OptionalNested_String] = NULL,
+    [r].[RequiredRelated_RequiredNested_Id] = @complex_type_p_RequiredNested_Id,
+    [r].[RequiredRelated_RequiredNested_Int] = @complex_type_p_RequiredNested_Int,
+    [r].[RequiredRelated_RequiredNested_Ints] = @complex_type_p_RequiredNested_Ints,
+    [r].[RequiredRelated_RequiredNested_Name] = @complex_type_p_RequiredNested_Name,
+    [r].[RequiredRelated_RequiredNested_String] = @complex_type_p_RequiredNested_String
 FROM [RootEntity] AS [r]
 """);
     }
@@ -354,6 +371,13 @@ SET [r].[OptionalRelated_Id] = NULL,
     [r].[OptionalRelated_RequiredNested_String] = NULL
 FROM [RootEntity] AS [r]
 """);
+    }
+
+    public override async Task Update_association_with_null_required_nested_association()
+    {
+        await base.Update_association_with_null_required_nested_association();
+
+        AssertExecuteUpdateSql();
     }
 
     #endregion Update association


### PR DESCRIPTION
Fixes #36714

In addition to the below, also adds validation against required JSON properties being null (both complex and scalar).

**Description**
When using ExecuteUpdate to set an entire table-split complex type (as opposed to a single scalar property), if there were two (nested) properties with the same name, 

When using ExecuteUpdate to set an entire table-split complex type (as opposed to a single scalar property), EF generates SQL to set every property of the complex type; when one of these complex type is a client-side parameter, EF constructs a new, synthetic parameter for each such property - recursively. However, the synthetic parameter names contained the name of the parameter and the name of the final (non-complex property), but did not contain the names of intermediate nested complex types containing the property. As a result, if a complex type contains two properties with the same name within different nested complex types, the same parameter name is generated and the old parameter is overridden.

**Customer impact**
When setting table-split complex type to a parameter, where multiple nested properties have the same name, an incorrect query is generated, leading either to an error or two data corruption (incorrect data being set in the database).

**How found**
During unrelated work on JSON property validation.

**Regression**
No

**Testing**
Test added

**Risk**
Very low, very targeted fix.
