### PR TITLE
[rc2] SQL Server: Don't transform equality to bitwise operations in predicate contexts

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1101,9 +1101,12 @@ END <> @prm
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE [p].[Discontinued] = CASE
-    WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
+    WHEN CASE
+        WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END <> @prm THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END ^ @prm
+END
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2466,7 +2466,13 @@ WHERE ([e].[NullableBoolA] <> [e].[NullableBoolB] OR [e].[NullableBoolA] IS NULL
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] = CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] = [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CASE
+    WHEN [e].[IntA] = [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -2502,7 +2508,13 @@ END
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] <> CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] = [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END <> CASE
+    WHEN [e].[IntA] = [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -2538,7 +2550,13 @@ END
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] = ~CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] <> [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CASE
+    WHEN [e].[IntA] = [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -2574,7 +2592,13 @@ END
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] <> ~CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] <> [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END <> CASE
+    WHEN [e].[IntA] = [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -2610,7 +2634,13 @@ END
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] = CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] <> [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CASE
+    WHEN [e].[IntA] <> [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -2646,7 +2676,13 @@ END
             """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[BoolA] ^ [e].[BoolB] <> CAST([e].[IntA] ^ [e].[IntB] AS bit)
+WHERE CASE
+    WHEN [e].[BoolA] <> [e].[BoolB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END <> CASE
+    WHEN [e].[IntA] <> [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
 """,
             //
             """
@@ -4934,7 +4970,10 @@ WHERE [e].[BoolB] = CAST(1 AS bit) OR [e].[NullableBoolA] IS NOT NULL
             """
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ~CAST([e].[IntA] ^ [e].[IntB] AS bit) <> CASE
+WHERE CASE
+    WHEN [e].[IntA] = [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END <> CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -4943,7 +4982,10 @@ END
             """
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE CAST([e].[IntA] ^ [e].[IntB] AS bit) = CASE
+WHERE CASE
+    WHEN [e].[IntA] <> [e].[IntB] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CASE
     WHEN [e].[NullableBoolA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -5087,7 +5129,10 @@ END = CAST(1 AS bit)
 SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableBoolA] IS NULL THEN ~([e].[BoolA] ^ [e].[BoolB])
+    WHEN [e].[NullableBoolA] IS NULL THEN CASE
+        WHEN [e].[BoolA] = [e].[BoolB] THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
     WHEN [e].[NullableBoolC] IS NULL THEN CASE
         WHEN ([e].[NullableBoolA] <> [e].[NullableBoolC] OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolC] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolC] IS NOT NULL) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Operators/BitwiseOperatorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Operators/BitwiseOperatorTranslationsSqlServerTest.cs
@@ -123,7 +123,10 @@ FROM [BasicTypesEntities] AS [b]
             """
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE ~CAST([b].[Int] ^ [b].[Short] AS bit) ^ CASE
+WHERE CASE
+    WHEN [b].[Int] = [b].[Short] THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END ^ CASE
     WHEN [b].[String] = N'Seattle' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)


### PR DESCRIPTION
**Implementation note**: I suspect that this restores CASE in more scenarios than is absolutely necessary; for example, an alternative would be to very specifically pattern-match CASE within WHERE and perform the exemption for that only. However, despite the more complicated-looking SQL, there's probably no actual negative impact for having it (as opposed to the simpler-looking bitwise operation), and there seems to be more risk of regressing perf by keeping the bitwise operation (as happened in #36291) than there is by having CASE in more scenarios than needed.

Fixes #36291

/cc @ranma42 

**Description**
EF 9.0 brought some improvements to simplify SQL and fix bugs in the SQL Server profivider; these essentially involved replacing the more complex CASE expressions we previously generated for certain equality constructs into bitwise operators, using e.g. XOR to express inequality.

Unfortunately, after 9.0 it was reported that in some contexts this change caused a performance regression, as the new bitwise-based SQL caused SQL Server to no longer use indexes. This PR undoes that change, but only for predicate contexts which may benefit from index usage, while preserving the bitwise transformation for other contexts, where it fixes bugs.

**Customer impact**
Certain queries which should benefit from index usage on SQL Server do not, e.g. queries of the form:

```c#
var foo = await context.Blogs.Where(b => b.SomeBool ? b.SomeInt1 == b.SomeInt2 : b.SomeInt1 == b.SOmeInt3).ToListAsync();
```

Using a database index or not impacts query performance in decisive ways.

**How found**
User reported.

**Regression**
Yes (performance), in EF 9

**Testing**
Already there (tests already assert on specific SQL).

**Risk**
Low, very targeted fix, and the SQL produced is correct in any case, and so very unlikely to produce a regression.
