### PR TITLE
Refactor Execute{Update,Delete} to throw instead of return null

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
@@ -9,37 +9,35 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 {
     /// <inheritdoc />
-    protected override DeleteExpression? TranslateExecuteDelete(ShapedQueryExpression source)
+    protected override DeleteExpression TranslateExecuteDelete(ShapedQueryExpression source)
     {
         source = source.UpdateShaperExpression(new IncludePruner().Visit(source.ShaperExpression));
 
         if (source.ShaperExpression is not StructuralTypeShaperExpression { StructuralType: IEntityType entityType } shaper)
         {
-            AddTranslationErrorDetails(RelationalStrings.ExecuteDeleteOnNonEntityType);
-            return null;
+            throw new InvalidOperationException(RelationalStrings.ExecuteDeleteOnNonEntityType);
         }
 
         if (entityType.IsMappedToJson())
         {
-            AddTranslationErrorDetails(
+            throw new InvalidOperationException(
                 RelationalStrings.ExecuteOperationOnOwnedJsonIsNotSupported("ExecuteDelete", entityType.DisplayName()));
-            return null;
         }
 
         switch (entityType.GetMappingStrategy())
         {
             case RelationalAnnotationNames.TptMappingStrategy:
-                AddTranslationErrorDetails(
+                throw new InvalidOperationException(
                     RelationalStrings.ExecuteOperationOnTPT(
-                        nameof(EntityFrameworkQueryableExtensions.ExecuteDelete), entityType.DisplayName()));
-                return null;
+                        nameof(EntityFrameworkQueryableExtensions.ExecuteDelete),
+                        entityType.DisplayName()));
 
             // Note that we do allow TPC if the target is a leaf type
             case RelationalAnnotationNames.TpcMappingStrategy when entityType.GetDirectlyDerivedTypes().Any():
-                AddTranslationErrorDetails(
+                throw new InvalidOperationException(
                     RelationalStrings.ExecuteOperationOnTPC(
-                        nameof(EntityFrameworkQueryableExtensions.ExecuteDelete), entityType.DisplayName()));
-                return null;
+                        nameof(EntityFrameworkQueryableExtensions.ExecuteDelete),
+                        entityType.DisplayName()));
         }
 
         // Find the table model that maps to the entity type; there must be exactly one (e.g. no entity splitting).
@@ -55,10 +53,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 break;
 
             default:
-                AddTranslationErrorDetails(
+                throw new InvalidOperationException(
                     RelationalStrings.ExecuteOperationOnEntitySplitting(
                         nameof(EntityFrameworkQueryableExtensions.ExecuteDelete), entityType.DisplayName()));
-                return null;
         }
 
         var selectExpression = (SelectExpression)source.QueryExpression;
@@ -109,10 +106,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             {
                 if (AreOtherNonOwnedEntityTypesInTheTable(entityType.GetRootType(), targetTable))
                 {
-                    AddTranslationErrorDetails(
+                    throw new InvalidOperationException(
                         RelationalStrings.ExecuteDeleteOnTableSplitting(unwrappedTableExpression.Table.SchemaQualifiedName));
-
-                    return null;
                 }
 
                 selectExpression.ReplaceProjection(new List<Expression>());
@@ -128,11 +123,10 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         var pk = entityType.FindPrimaryKey();
         if (pk == null)
         {
-            AddTranslationErrorDetails(
+            throw new InvalidOperationException(
                 RelationalStrings.ExecuteOperationOnKeylessEntityTypeWithUnsupportedOperator(
                     nameof(EntityFrameworkQueryableExtensions.ExecuteDelete),
                     entityType.DisplayName()));
-            return null;
         }
 
         var clrType = entityType.ClrType;

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage.Json;
@@ -22,18 +21,13 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         typeof(RelationalQueryableMethodTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ParameterJsonSerializer))!;
 
     /// <inheritdoc />
-    protected override UpdateExpression? TranslateExecuteUpdate(ShapedQueryExpression source, IReadOnlyList<ExecuteUpdateSetter> setters)
+    protected override UpdateExpression TranslateExecuteUpdate(ShapedQueryExpression source, IReadOnlyList<ExecuteUpdateSetter> setters)
     {
         Check.DebugAssert(setters.Count > 0, "Empty setters list");
 
         // Our source may have IncludeExpressions because of owned entities or auto-include; unwrap these, as they're meaningless for
         // ExecuteUpdate's lambdas. Note that we don't currently support updates across tables.
         source = source.UpdateShaperExpression(new IncludePruner().Visit(source.ShaperExpression));
-
-        if (TranslationErrorDetails != null)
-        {
-            return null;
-        }
 
         var selectExpression = (SelectExpression)source.QueryExpression;
 
@@ -42,17 +36,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         // Note that if the query isn't natively supported, we'll do a pushdown (see PushdownWithPkInnerJoinPredicate below); if that
         // happens, we'll have to re-translate the setters over the new query (which includes a JOIN). However, we still translate here
         // since we need the target table in order to perform the check below.
-        if (!TryTranslateSetters(source, setters, out var translatedSetters, out var targetTable))
-        {
-            return null;
-        }
+        var translatedSetters = TranslateSetters(source, setters, out var targetTable);
 
         if (targetTable is TpcTablesExpression tpcTablesExpression)
         {
-            AddTranslationErrorDetails(
+            throw new InvalidOperationException(
                 RelationalStrings.ExecuteOperationOnTPC(
-                    nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate), tpcTablesExpression.EntityType.DisplayName()));
-            return null;
+                    nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate),
+                    tpcTablesExpression.EntityType.DisplayName()));
         }
 
         // Check if the provider has a native translation for the update represented by the select expression.
@@ -68,7 +59,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
         return PushdownWithPkInnerJoinPredicate();
 
-        UpdateExpression? PushdownWithPkInnerJoinPredicate()
+        UpdateExpression PushdownWithPkInnerJoinPredicate()
         {
             // The provider doesn't natively support the update.
             // As a fallback, we place the original query in a subquery and user an INNER JOIN on the primary key columns.
@@ -92,25 +83,22 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     out var baseExpression)
                 || _sqlTranslator.TranslateProjection(baseExpression) is not StructuralTypeShaperExpression shaper)
             {
-                AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(firstPropertySelector));
-                return null;
+                throw new InvalidOperationException(RelationalStrings.InvalidPropertyInSetProperty(firstPropertySelector));
             }
 
             // TODO: #36336
             if (shaper.StructuralType is not IEntityType entityType)
             {
-                AddTranslationErrorDetails(
+                throw new InvalidOperationException(
                     RelationalStrings.ExecuteUpdateSubqueryNotSupportedOverComplexTypes(shaper.StructuralType.DisplayName()));
-                return null;
             }
 
             if (entityType.FindPrimaryKey() is not { } pk)
             {
-                AddTranslationErrorDetails(
+                throw new InvalidOperationException(
                     RelationalStrings.ExecuteOperationOnKeylessEntityTypeWithUnsupportedOperator(
                         nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate),
                         entityType.DisplayName()));
-                return null;
             }
 
             // Generate the INNER JOIN around the original query, on the PK properties.
@@ -161,10 +149,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
             // Re-translate the property selectors to get column expressions pointing to the new outer select expression (the original one
             // has been pushed down into a subquery).
-            if (!TryTranslateSetters(outer, rewrittenSetters, out var translatedSetters, out _))
-            {
-                return null;
-            }
+            var translatedSetters = TranslateSetters(outer, rewrittenSetters, out _);
 
             outerSelectExpression.ReplaceProjection(new List<Expression>());
             outerSelectExpression.ApplyProjection();
@@ -251,18 +236,15 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    protected virtual bool TryTranslateSetters(
+    protected virtual IReadOnlyList<ColumnValueSetter> TranslateSetters(
         ShapedQueryExpression source,
         IReadOnlyList<ExecuteUpdateSetter> setters,
-        [NotNullWhen(true)] out IReadOnlyList<ColumnValueSetter>? columnSetters,
-        [NotNullWhen(true)] out TableExpressionBase? targetTable)
+        out TableExpressionBase targetTable)
     {
         var select = (SelectExpression)source.QueryExpression;
 
-        targetTable = null;
         string? targetTableAlias = null;
-        var mutableColumnSetters = new List<ColumnValueSetter>();
-        columnSetters = null;
+        var translatedSetters = new List<ColumnValueSetter>();
 
         Expression? targetTablePropertySelector = null;
 
@@ -310,8 +292,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     break;
 
                 default:
-                    AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
-                    return false;
+                    throw new InvalidOperationException(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
 
                 bool TryTranslateMemberAccess(
                     Expression expression,
@@ -334,8 +315,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
             if (targetProperty.DeclaringType is IEntityType entityType && entityType.IsMappedToJson())
             {
-                AddTranslationErrorDetails(RelationalStrings.ExecuteOperationOnOwnedJsonIsNotSupported("ExecuteUpdate", entityType.DisplayName()));
-                return false;
+                throw new InvalidOperationException(
+                    RelationalStrings.ExecuteOperationOnOwnedJsonIsNotSupported("ExecuteUpdate", entityType.DisplayName()));
             }
 
             // Hack: when returning a StructuralTypeShaperExpression, _sqlTranslator returns it wrapped by a
@@ -349,8 +330,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 }
                 else
                 {
-                    AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
-                    return false;
+                    throw new InvalidOperationException(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
                 }
             }
 
@@ -360,14 +340,11 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 {
                     Check.DebugAssert(column.TypeMapping is not null);
 
-                    if (!TryProcessColumn(column)
-                        || !TryTranslateScalarSetterValueSelector(
-                            source, valueSelector, column.Type, column.TypeMapping, out var translatedValue))
-                    {
-                        return false;
-                    }
+                    ProcessColumn(column);
 
-                    mutableColumnSetters.Add(new(column, translatedValue));
+                    var translatedValue = TranslateScalarSetterValueSelector(source, valueSelector, column.Type, column.TypeMapping);
+
+                    translatedSetters.Add(new(column, translatedValue));
                     break;
                 }
 
@@ -389,11 +366,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             RelationalStrings.ExecuteUpdateOverJsonIsNotSupported(complexType.DisplayName()));
                     }
 
-                    if (!TryTranslateSetterValueSelector(source, valueSelector, shaper.Type, out var translatedValue)
-                        || !TryProcessComplexType(shaper, translatedValue))
-                    {
-                        return false;
-                    }
+                    var translatedValue = TranslateSetterValueSelector(source, valueSelector, shaper.Type);
+                    ProcessComplexType(shaper, translatedValue);
 
                     break;
                 }
@@ -408,11 +382,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     // SQL Server datetime2), but contrived and unsupported.
                     Check.DebugAssert(jsonScalar.Path.Count > 0);
 
-                    if (!TryProcessColumn(jsonColumn)
-                        || !TryTranslateScalarSetterValueSelector(source, valueSelector, jsonScalar.Type, typeMapping, out var translatedValue))
-                    {
-                        return false;
-                    }
+                    ProcessColumn(jsonColumn);
+
+                    var translatedValue = TranslateScalarSetterValueSelector(source, valueSelector, jsonScalar.Type, typeMapping);
 
                     // We now have the relational scalar expression for the value; but we need the JSON representation to pass to the provider's JSON modification
                     // function (e.g. SQL Server JSON_MODIFY()).
@@ -432,31 +404,22 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 }
 
                 case StructuralTypeShaperExpression { ValueBufferExpression: JsonQueryExpression jsonQuery }:
-                    if (!TryProcessStructuralJsonSetter(jsonQuery))
-                    {
-                        return false;
-                    }
-
+                    ProcessStructuralJsonSetter(jsonQuery);
                     continue;
 
                 case CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery }:
-                    if (!TryProcessStructuralJsonSetter(jsonQuery))
-                    {
-                        return false;
-                    }
-
+                    ProcessStructuralJsonSetter(jsonQuery);
                     continue;
 
                 default:
-                    AddTranslationErrorDetails(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
-                    return false;
+                    throw new InvalidOperationException(RelationalStrings.InvalidPropertyInSetProperty(propertySelector.Print()));
             }
 
             void GenerateJsonPartialUpdateSetterWrapper(Expression target, ColumnExpression jsonColumn, SqlExpression value)
             {
-                var index = mutableColumnSetters.FindIndex(s => s.Column.Equals(jsonColumn));
-                var origExistingSetterValue = index == -1 ? null : mutableColumnSetters[index].Value;
-                var modifiedExistingSetterValue = index == -1 ? null : mutableColumnSetters[index].Value;
+                var index = translatedSetters.FindIndex(s => s.Column.Equals(jsonColumn));
+                var origExistingSetterValue = index == -1 ? null : translatedSetters[index].Value;
+                var modifiedExistingSetterValue = index == -1 ? null : translatedSetters[index].Value;
                 var newSetter = GenerateJsonPartialUpdateSetter(target, value, ref modifiedExistingSetterValue);
 
                 if (origExistingSetterValue is null ^ modifiedExistingSetterValue is null)
@@ -467,16 +430,16 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                 if (!ReferenceEquals(modifiedExistingSetterValue, origExistingSetterValue))
                 {
-                    mutableColumnSetters[index] = new(jsonColumn, modifiedExistingSetterValue!);
+                    translatedSetters[index] = new(jsonColumn, modifiedExistingSetterValue!);
                 }
 
                 if (newSetter is not null)
                 {
-                    mutableColumnSetters.Add(new(jsonColumn, newSetter));
+                    translatedSetters.Add(new(jsonColumn, newSetter));
                 }
             }
 
-            bool TryProcessColumn(ColumnExpression column)
+            void ProcessColumn(ColumnExpression column)
             {
                 var tableExpression = select.GetTable(column, out var tableIndex);
                 if (tableExpression.UnwrapJoin() is TableExpression { Table: not ITable } unwrappedTableExpression)
@@ -537,36 +500,31 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     select.SetTables(newTables);
                 }
 
-                return IsColumnOnSameTable(column, propertySelector);
+                CheckColumnOnSameTable(column, propertySelector);
             }
 
             // Recursively processes the complex types and all complex types referenced by it, adding setters fo all (non-complex)
             // properties.
-            // Note that this only supports table splitting (where all columns are flattened to the table), but not JSON complex types (#28766).
-            bool TryProcessComplexType(StructuralTypeShaperExpression shaperExpression, Expression valueExpression)
+            // Note that this only handles table splitting (where all columns are flattened to the table); JSON complex types are
+            // handled elsewhere.
+            void ProcessComplexType(StructuralTypeShaperExpression shaperExpression, Expression valueExpression)
             {
                 if (shaperExpression.StructuralType is not IComplexType complexType
                     || shaperExpression.ValueBufferExpression is not StructuralTypeProjectionExpression projection)
                 {
-                    return false;
+                    throw new UnreachableException();
                 }
 
                 foreach (var property in complexType.GetProperties())
                 {
                     var column = projection.BindProperty(property);
-                    if (!IsColumnOnSameTable(column, propertySelector))
-                    {
-                        return false;
-                    }
+                    CheckColumnOnSameTable(column, propertySelector);
 
                     var rewrittenValueSelector = CreatePropertyAccessExpression(valueExpression, property);
-                    if (!TryTranslateScalarSetterValueSelector(
-                        source, rewrittenValueSelector, column.Type, column.TypeMapping!, out var translatedValueSelector))
-                    {
-                        return false;
-                    }
+                    var translatedValueSelector = TranslateScalarSetterValueSelector(
+                        source, rewrittenValueSelector, column.Type, column.TypeMapping!);
 
-                    mutableColumnSetters.Add(new ColumnValueSetter(column, translatedValueSelector));
+                    translatedSetters.Add(new ColumnValueSetter(column, translatedValueSelector));
                 }
 
                 foreach (var complexProperty in complexType.GetComplexProperties())
@@ -584,13 +542,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                     var nestedShaperExpression = (StructuralTypeShaperExpression)projection.BindComplexProperty(complexProperty);
                     var nestedValueExpression = CreateComplexPropertyAccessExpression(valueExpression, complexProperty);
-                    if (!TryProcessComplexType(nestedShaperExpression, nestedValueExpression))
-                    {
-                        return false;
-                    }
+                    ProcessComplexType(nestedShaperExpression, nestedValueExpression);
                 }
-
-                return true;
 
                 Expression CreatePropertyAccessExpression(Expression target, IProperty property)
                 {
@@ -689,7 +642,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 }
             }
 
-            bool TryProcessStructuralJsonSetter(JsonQueryExpression jsonQuery)
+            void ProcessStructuralJsonSetter(JsonQueryExpression jsonQuery)
             {
                 var jsonColumn = jsonQuery.JsonColumn;
 
@@ -700,11 +653,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                 Check.DebugAssert(jsonColumn.TypeMapping is not null);
 
-                if (!TryProcessColumn(jsonColumn)
-                    || !TryTranslateSetterValueSelector(source, valueSelector, jsonQuery.Type, out var translatedValue))
-                {
-                    return false;
-                }
+                ProcessColumn(jsonColumn);
+
+                var translatedValue = TranslateSetterValueSelector(source, valueSelector, jsonQuery.Type);
 
                 SqlExpression? serializedValue;
 
@@ -761,41 +712,28 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 // Otherwise, call the TranslateJsonSetter hook to produce the provider-specific syntax for JSON partial update.
                 if (jsonQuery.Path is [])
                 {
-                    mutableColumnSetters.Add(new ColumnValueSetter(jsonColumn, serializedValue));
+                    translatedSetters.Add(new ColumnValueSetter(jsonColumn, serializedValue));
                 }
                 else
                 {
                     GenerateJsonPartialUpdateSetterWrapper(jsonQuery, jsonColumn, serializedValue);
                 }
-
-                return true;
             }
 
-            bool TryTranslateScalarSetterValueSelector(
+            SqlExpression TranslateScalarSetterValueSelector(
                 ShapedQueryExpression source,
                 Expression valueSelector,
                 Type type,
-                RelationalTypeMapping typeMapping,
-                [NotNullWhen(true)] out SqlExpression? result)
-            {
-                if (TryTranslateSetterValueSelector(source, valueSelector, type, out var tempResult)
-                    && tempResult is SqlExpression translatedSelector)
-                {
+                RelationalTypeMapping typeMapping)
+                => TranslateSetterValueSelector(source, valueSelector, type) is SqlExpression translatedSelector
                     // Apply the type mapping of the column (translated from the property selector above) to the value
-                    result = _sqlExpressionFactory.ApplyTypeMapping(translatedSelector, typeMapping);
-                    return true;
-                }
+                    ? _sqlExpressionFactory.ApplyTypeMapping(translatedSelector, typeMapping)
+                    : throw new InvalidOperationException(RelationalStrings.InvalidValueInSetProperty(valueSelector.Print()));
 
-                AddTranslationErrorDetails(RelationalStrings.InvalidValueInSetProperty(valueSelector.Print()));
-                result = null;
-                return false;
-            }
-
-            bool TryTranslateSetterValueSelector(
+            Expression TranslateSetterValueSelector(
                 ShapedQueryExpression source,
                 Expression valueSelector,
-                Type propertyType,
-                [NotNullWhen(true)] out Expression? result)
+                Type propertyType)
             {
                 var remappedValueSelector = valueSelector is LambdaExpression lambdaExpression
                     ? RemapLambdaBody(source, lambdaExpression)
@@ -806,18 +744,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     remappedValueSelector = Expression.Convert(remappedValueSelector, propertyType);
                 }
 
-                result = _sqlTranslator.TranslateProjection(remappedValueSelector, applyDefaultTypeMapping: false);
+                var result = _sqlTranslator.TranslateProjection(remappedValueSelector, applyDefaultTypeMapping: false);
 
-                if (result is null)
-                {
-                    AddTranslationErrorDetails(RelationalStrings.InvalidValueInSetProperty(valueSelector.Print()));
-                    return false;
-                }
-
-                return true;
+                return result is null
+                    ? throw new InvalidOperationException(RelationalStrings.InvalidValueInSetProperty(valueSelector.Print()))
+                    : result;
             }
 
-            bool IsColumnOnSameTable(ColumnExpression column, LambdaExpression propertySelector)
+            void CheckColumnOnSameTable(ColumnExpression column, LambdaExpression propertySelector)
             {
                 if (targetTableAlias is null)
                 {
@@ -826,12 +760,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 }
                 else if (column.TableAlias != targetTableAlias)
                 {
-                    AddTranslationErrorDetails(
+                    throw new InvalidOperationException(
                         RelationalStrings.MultipleTablesInExecuteUpdate(propertySelector.Print(), targetTablePropertySelector!.Print()));
-                    return false;
                 }
-
-                return true;
             }
 
             // If the entire JSON column is being referenced, remove the JsonQueryExpression altogether and just return
@@ -853,9 +784,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         Check.DebugAssert(targetTableAlias is not null, "Target table alias should have a value");
         var selectExpression = (SelectExpression)source.QueryExpression;
         targetTable = selectExpression.Tables.First(t => t.GetRequiredAlias() == targetTableAlias);
-        columnSetters = mutableColumnSetters;
-
-        return true;
+        return translatedSetters;
     }
 
     /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property, expectedType, actualType);
 
         /// <summary>
-        ///     The methods '{methodName}' and '{asyncMethodName}' are not supported by the current database provider. Please contact the publisher of the database provider for more information. 
+        ///     The methods '{methodName}' and '{asyncMethodName}' are not supported by the current database provider. Please contact the publisher of the database provider for more information.
         /// </summary>
         public static string ExecuteQueriesNotSupported(object? methodName, object? asyncMethodName)
             => string.Format(
@@ -2350,12 +2350,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, collectionType, changeTrackingStrategy);
 
         /// <summary>
-        ///     The LINQ expression '{expression}' could not be translated. Additional information: {details} See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
+        ///     The following 'ExecuteUpdate' or 'ExecuteDelete' expression could not be translated, see inner exception for more details: '{expression}'
         /// </summary>
-        public static string NonQueryTranslationFailedWithDetails(object? expression, object? details)
+        public static string NonQueryTranslationFailed(object? expression)
             => string.Format(
-                GetString("NonQueryTranslationFailedWithDetails", nameof(expression), nameof(details)),
-                expression, details);
+                GetString("NonQueryTranslationFailed", nameof(expression)),
+                expression);
 
         /// <summary>
         ///     The foreign key {foreignKeyProperties} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1352,8 +1352,8 @@
   <data name="NonNotifyingCollection" xml:space="preserve">
     <value>The collection type '{2_collectionType}' being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
   </data>
-  <data name="NonQueryTranslationFailedWithDetails" xml:space="preserve">
-    <value>The LINQ expression '{expression}' could not be translated. Additional information: {details} See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
+  <data name="NonQueryTranslationFailed" xml:space="preserve">
+    <value>The following 'ExecuteUpdate' or 'ExecuteDelete' expression could not be translated, see inner exception for more details: '{expression}'</value>
   </data>
   <data name="NonUniqueRequiredDependentForeignKey" xml:space="preserve">
     <value>The foreign key {foreignKeyProperties} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.</value>

--- a/test/EFCore.Cosmos.FunctionalTests/Types/CosmosMiscellaneousTypeTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Types/CosmosMiscellaneousTypeTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
-public class BoolTypeTest(BoolTypeTest.BoolTypeFixture fixture)
-    : TypeTestBase<bool, BoolTypeTest.BoolTypeFixture>(fixture)
+public class CosmosBoolTypeTest(CosmosBoolTypeTest.BoolTypeFixture fixture)
+    : TypeTestBase<bool, CosmosBoolTypeTest.BoolTypeFixture>(fixture)
 {
     public class BoolTypeFixture : CosmosTypeFixtureBase<bool>
     {
@@ -15,8 +15,8 @@ public class BoolTypeTest(BoolTypeTest.BoolTypeFixture fixture)
     }
 }
 
-public class StringTypeTest(StringTypeTest.StringTypeFixture fixture)
-    : TypeTestBase<string, StringTypeTest.StringTypeFixture>(fixture)
+public class CosmosStringTypeTest(CosmosStringTypeTest.StringTypeFixture fixture)
+    : TypeTestBase<string, CosmosStringTypeTest.StringTypeFixture>(fixture)
 {
     public class StringTypeFixture : CosmosTypeFixtureBase<string>
     {
@@ -27,8 +27,8 @@ public class StringTypeTest(StringTypeTest.StringTypeFixture fixture)
     }
 }
 
-public class GuidTypeTest(GuidTypeTest.GuidTypeFixture fixture)
-    : TypeTestBase<Guid, GuidTypeTest.GuidTypeFixture>(fixture)
+public class CosmosGuidTypeTest(CosmosGuidTypeTest.GuidTypeFixture fixture)
+    : TypeTestBase<Guid, CosmosGuidTypeTest.GuidTypeFixture>(fixture)
 {
     public class GuidTypeFixture : CosmosTypeFixtureBase<Guid>
     {
@@ -39,8 +39,8 @@ public class GuidTypeTest(GuidTypeTest.GuidTypeFixture fixture)
     }
 }
 
-public class ByteArrayTypeTest(ByteArrayTypeTest.ByteArrayTypeFixture fixture)
-    : TypeTestBase<byte[], ByteArrayTypeTest.ByteArrayTypeFixture>(fixture)
+public class CosmosByteArrayTypeTest(CosmosByteArrayTypeTest.ByteArrayTypeFixture fixture)
+    : TypeTestBase<byte[], CosmosByteArrayTypeTest.ByteArrayTypeFixture>(fixture)
 {
     public class ByteArrayTypeFixture : CosmosTypeFixtureBase<byte[]>
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Types/CosmosNumericTypeTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Types/CosmosNumericTypeTest.cs
@@ -3,7 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
-public class ByteTypeTest(ByteTypeTest.ByteTypeFixture fixture) : TypeTestBase<byte, ByteTypeTest.ByteTypeFixture>(fixture)
+public class CosmosByteTypeTest(CosmosByteTypeTest.ByteTypeFixture fixture)
+    : TypeTestBase<byte, CosmosByteTypeTest.ByteTypeFixture>(fixture)
 {
     public class ByteTypeFixture : CosmosTypeFixtureBase<byte>
     {
@@ -14,7 +15,8 @@ public class ByteTypeTest(ByteTypeTest.ByteTypeFixture fixture) : TypeTestBase<b
     }
 }
 
-public class ShortTypeTest(ShortTypeTest.ShortTypeFixture fixture) : TypeTestBase<short, ShortTypeTest.ShortTypeFixture>(fixture)
+public class CosmosShortTypeTest(CosmosShortTypeTest.ShortTypeFixture fixture)
+    : TypeTestBase<short, CosmosShortTypeTest.ShortTypeFixture>(fixture)
 {
     public class ShortTypeFixture : CosmosTypeFixtureBase<short>
     {
@@ -25,7 +27,7 @@ public class ShortTypeTest(ShortTypeTest.ShortTypeFixture fixture) : TypeTestBas
     }
 }
 
-public class IntTypeTest(IntTypeTest.IntTypeFixture fixture) : TypeTestBase<int, IntTypeTest.IntTypeFixture>(fixture)
+public class CosmosIntTypeTest(CosmosIntTypeTest.IntTypeFixture fixture) : TypeTestBase<int, CosmosIntTypeTest.IntTypeFixture>(fixture)
 {
     public class IntTypeFixture : CosmosTypeFixtureBase<int>
     {
@@ -36,7 +38,8 @@ public class IntTypeTest(IntTypeTest.IntTypeFixture fixture) : TypeTestBase<int,
     }
 }
 
-public class LongTypeTest(LongTypeTest.LongTypeFixture fixture) : TypeTestBase<long, LongTypeTest.LongTypeFixture>(fixture)
+public class CosmosLongTypeTest(CosmosLongTypeTest.LongTypeFixture fixture)
+    : TypeTestBase<long, CosmosLongTypeTest.LongTypeFixture>(fixture)
 {
     public class LongTypeFixture : CosmosTypeFixtureBase<long>
     {
@@ -47,7 +50,8 @@ public class LongTypeTest(LongTypeTest.LongTypeFixture fixture) : TypeTestBase<l
     }
 }
 
-public class DecimalTypeTest(DecimalTypeTest.DecimalTypeFixture fixture) : TypeTestBase<decimal, DecimalTypeTest.DecimalTypeFixture>(fixture)
+public class CosmosDecimalTypeTest(CosmosDecimalTypeTest.DecimalTypeFixture fixture)
+    : TypeTestBase<decimal, CosmosDecimalTypeTest.DecimalTypeFixture>(fixture)
 {
     public class DecimalTypeFixture : CosmosTypeFixtureBase<decimal>
     {
@@ -58,7 +62,8 @@ public class DecimalTypeTest(DecimalTypeTest.DecimalTypeFixture fixture) : TypeT
     }
 }
 
-public class DoubleTypeTest(DoubleTypeTest.DoubleTypeFixture fixture) : TypeTestBase<double, DoubleTypeTest.DoubleTypeFixture>(fixture)
+public class CosmosDoubleTypeTest(CosmosDoubleTypeTest.DoubleTypeFixture fixture)
+    : TypeTestBase<double, CosmosDoubleTypeTest.DoubleTypeFixture>(fixture)
 {
     public class DoubleTypeFixture : CosmosTypeFixtureBase<double>
     {
@@ -69,7 +74,8 @@ public class DoubleTypeTest(DoubleTypeTest.DoubleTypeFixture fixture) : TypeTest
     }
 }
 
-public class FloatTypeTest(FloatTypeTest.FloatTypeFixture fixture) : TypeTestBase<float, FloatTypeTest.FloatTypeFixture>(fixture)
+public class CosmosFloatTypeTest(CosmosFloatTypeTest.FloatTypeFixture fixture)
+    : TypeTestBase<float, CosmosFloatTypeTest.FloatTypeFixture>(fixture)
 {
     public class FloatTypeFixture : CosmosTypeFixtureBase<float>
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Types/CosmosTemporalTypeTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Types/CosmosTemporalTypeTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
-public class DateTimeTypeTest(DateTimeTypeTest.DateTimeTypeFixture fixture)
-    : TypeTestBase<DateTime, DateTimeTypeTest.DateTimeTypeFixture>(fixture)
+public class CosmosDateTimeTypeTest(CosmosDateTimeTypeTest.DateTimeTypeFixture fixture)
+    : TypeTestBase<DateTime, CosmosDateTimeTypeTest.DateTimeTypeFixture>(fixture)
 {
     public class DateTimeTypeFixture : CosmosTypeFixtureBase<DateTime>
     {
@@ -15,8 +15,8 @@ public class DateTimeTypeTest(DateTimeTypeTest.DateTimeTypeFixture fixture)
     }
 }
 
-public class DateTimeOffsetTypeTest(DateTimeOffsetTypeTest.DateTimeOffsetTypeFixture fixture)
-    : TypeTestBase<DateTimeOffset, DateTimeOffsetTypeTest.DateTimeOffsetTypeFixture>(fixture)
+public class CosmosDateTimeOffsetTypeTest(CosmosDateTimeOffsetTypeTest.DateTimeOffsetTypeFixture fixture)
+    : TypeTestBase<DateTimeOffset, CosmosDateTimeOffsetTypeTest.DateTimeOffsetTypeFixture>(fixture)
 {
     public class DateTimeOffsetTypeFixture : CosmosTypeFixtureBase<DateTimeOffset>
     {
@@ -27,7 +27,7 @@ public class DateTimeOffsetTypeTest(DateTimeOffsetTypeTest.DateTimeOffsetTypeFix
     }
 }
 
-public class DateOnlyTypeTest(DateOnlyTypeTest.DateOnlyTypeFixture fixture) : TypeTestBase<DateOnly, DateOnlyTypeTest.DateOnlyTypeFixture>(fixture)
+public class CosmosDateOnlyTypeTest(CosmosDateOnlyTypeTest.DateOnlyTypeFixture fixture) : TypeTestBase<DateOnly, CosmosDateOnlyTypeTest.DateOnlyTypeFixture>(fixture)
 {
     public class DateOnlyTypeFixture : CosmosTypeFixtureBase<DateOnly>
     {
@@ -38,8 +38,8 @@ public class DateOnlyTypeTest(DateOnlyTypeTest.DateOnlyTypeFixture fixture) : Ty
     }
 }
 
-public class TimeOnlyTypeTest(TimeOnlyTypeTest.TimeOnlyTypeFixture fixture)
-    : TypeTestBase<TimeOnly, TimeOnlyTypeTest.TimeOnlyTypeFixture>(fixture)
+public class CosmosTimeOnlyTypeTest(CosmosTimeOnlyTypeTest.TimeOnlyTypeFixture fixture)
+    : TypeTestBase<TimeOnly, CosmosTimeOnlyTypeTest.TimeOnlyTypeFixture>(fixture)
 {
     public class TimeOnlyTypeFixture : CosmosTypeFixtureBase<TimeOnly>
     {
@@ -50,7 +50,7 @@ public class TimeOnlyTypeTest(TimeOnlyTypeTest.TimeOnlyTypeFixture fixture)
     }
 }
 
-public class TimeSpanTypeTest(TimeSpanTypeTest.TimeSpanTypeFixture fixture) : TypeTestBase<TimeSpan, TimeSpanTypeTest.TimeSpanTypeFixture>(fixture)
+public class CosmosTimeSpanTypeTest(CosmosTimeSpanTypeTest.TimeSpanTypeFixture fixture) : TypeTestBase<TimeSpan, CosmosTimeSpanTypeTest.TimeSpanTypeFixture>(fixture)
 {
     public class TimeSpanTypeFixture : CosmosTypeFixtureBase<TimeSpan>
     {

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesRelationalTestBase.cs
@@ -38,9 +38,12 @@ public abstract class FiltersInheritanceBulkUpdatesRelationalTestBase<TFixture> 
                 rowsAffectedCount: 1));
 
     protected static async Task AssertTranslationFailed(string details, Func<Task> query)
-        => Assert.Contains(
-            CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..],
-            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(query);
+        Assert.StartsWith(CoreStrings.NonQueryTranslationFailed("")[0..^1], exception.Message);
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(details, innerException.Message);
+    }
 
     protected abstract void ClearLog();
 }

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesRelationalTestBase.cs
@@ -38,9 +38,12 @@ public abstract class InheritanceBulkUpdatesRelationalTestBase<TFixture> : Inher
                 rowsAffectedCount: 1));
 
     protected static async Task AssertTranslationFailed(string details, Func<Task> query)
-        => Assert.Contains(
-            CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..],
-            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(query);
+        Assert.StartsWith(CoreStrings.NonQueryTranslationFailed("")[0..^1], exception.Message);
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(details, innerException.Message);
+    }
 
     protected virtual void ClearLog()
         => Fixture.TestSqlLoggerFactory.Clear();

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
@@ -100,9 +100,12 @@ WHERE [CustomerID] LIKE 'A%'"));
             });
 
     protected static async Task AssertTranslationFailed(string details, Func<Task> query)
-        => Assert.Contains(
-            CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..],
-            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(query);
+        Assert.StartsWith(CoreStrings.NonQueryTranslationFailed("")[0..^1], exception.Message);
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(details, innerException.Message);
+    }
 
     protected string NormalizeDelimitersInRawString(string sql)
         => Fixture.TestStore.NormalizeDelimitersInRawString(sql);

--- a/test/EFCore.Relational.Specification.Tests/Query/Associations/OwnedJson/OwnedJsonBulkUpdateRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Associations/OwnedJson/OwnedJsonBulkUpdateRelationalTestBase.cs
@@ -62,7 +62,9 @@ public abstract class OwnedJsonBulkUpdateRelationalTestBase<TFixture> : BulkUpda
     protected static async Task AssertTranslationFailedWithDetails(string details, Func<Task> query)
     {
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(query);
-        Assert.Contains(CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..], exception.Message);
+        Assert.StartsWith(CoreStrings.NonQueryTranslationFailed("")[0..^1], exception.Message);
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(details, innerException.Message);
     }
 }
 

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsBulkUpdateTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsBulkUpdateTestBase.cs
@@ -531,7 +531,10 @@ public abstract class AssociationsBulkUpdateTestBase<TFixture>(TFixture fixture)
             .Message);
 
     protected static async Task AssertTranslationFailedWithDetails(string details, Func<Task> query)
-        => Assert.Contains(
-            CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..],
-            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(query);
+        Assert.StartsWith(CoreStrings.NonQueryTranslationFailed("")[0..^1], exception.Message);
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal(details, innerException.Message);
+    }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Types/SqliteMiscellaneousTypeTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Types/SqliteMiscellaneousTypeTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
-public class BoolTypeTest(BoolTypeTest.BoolTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<bool, BoolTypeTest.BoolTypeFixture>(fixture, testOutputHelper)
+public class SqliteBoolTypeTest(SqliteBoolTypeTest.BoolTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<bool, SqliteBoolTypeTest.BoolTypeFixture>(fixture, testOutputHelper)
 {
     public class BoolTypeFixture : RelationalTypeFixtureBase<bool>
     {
@@ -15,8 +15,8 @@ public class BoolTypeTest(BoolTypeTest.BoolTypeFixture fixture, ITestOutputHelpe
     }
 }
 
-public class StringTypeTest(StringTypeTest.StringTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<string, StringTypeTest.StringTypeFixture>(fixture, testOutputHelper)
+public class SqliteStringTypeTest(SqliteStringTypeTest.StringTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<string, SqliteStringTypeTest.StringTypeFixture>(fixture, testOutputHelper)
 {
     public class StringTypeFixture : RelationalTypeFixtureBase<string>
     {
@@ -27,14 +27,14 @@ public class StringTypeTest(StringTypeTest.StringTypeFixture fixture, ITestOutpu
     }
 }
 
-public class GuidTypeTest(GuidTypeTest.GuidTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<Guid, GuidTypeTest.GuidTypeFixture>(fixture, testOutputHelper)
+public class SqliteGuidTypeTest(SqliteGuidTypeTest.GuidTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<Guid, SqliteGuidTypeTest.GuidTypeFixture>(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class GuidTypeFixture : RelationalTypeFixtureBase<Guid>
@@ -46,8 +46,8 @@ public class GuidTypeTest(GuidTypeTest.GuidTypeFixture fixture, ITestOutputHelpe
     }
 }
 
-public class ByteArrayTypeTest(ByteArrayTypeTest.ByteArrayTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<byte[], ByteArrayTypeTest.ByteArrayTypeFixture>(fixture, testOutputHelper)
+public class SqliteByteArrayTypeTest(SqliteByteArrayTypeTest.ByteArrayTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<byte[], SqliteByteArrayTypeTest.ByteArrayTypeFixture>(fixture, testOutputHelper)
 {
     // TODO: string representation discrepancy between our JSON and M.D.SQLite's string representation, see #36749.
     public override Task Query_property_within_json()
@@ -57,7 +57,7 @@ public class ByteArrayTypeTest(ByteArrayTypeTest.ByteArrayTypeFixture fixture, I
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class ByteArrayTypeFixture : RelationalTypeFixtureBase<byte[]>

--- a/test/EFCore.Sqlite.FunctionalTests/Types/SqliteNumericTypeTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Types/SqliteNumericTypeTest.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
-public class ByteTypeTest(ByteTypeTest.ByteTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<byte, ByteTypeTest.ByteTypeFixture>(fixture, testOutputHelper)
+public class SqliteByteTypeTest(SqliteByteTypeTest.ByteTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<byte, SqliteByteTypeTest.ByteTypeFixture>(fixture, testOutputHelper)
 {
     public class ByteTypeFixture : RelationalTypeFixtureBase<byte>
     {
@@ -15,8 +15,8 @@ public class ByteTypeTest(ByteTypeTest.ByteTypeFixture fixture, ITestOutputHelpe
     }
 }
 
-public class ShortTypeTest(ShortTypeTest.ShortTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<short, ShortTypeTest.ShortTypeFixture>(fixture, testOutputHelper)
+public class SqliteShortTypeTest(SqliteShortTypeTest.ShortTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<short, SqliteShortTypeTest.ShortTypeFixture>(fixture, testOutputHelper)
 {
     public class ShortTypeFixture : RelationalTypeFixtureBase<short>
     {
@@ -27,8 +27,8 @@ public class ShortTypeTest(ShortTypeTest.ShortTypeFixture fixture, ITestOutputHe
     }
 }
 
-public class IntTypeTest(IntTypeTest.IntTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<int, IntTypeTest.IntTypeFixture>(fixture, testOutputHelper)
+public class SqliteIntTypeTest(SqliteIntTypeTest.IntTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<int, SqliteIntTypeTest.IntTypeFixture>(fixture, testOutputHelper)
 {
     public class IntTypeFixture : RelationalTypeFixtureBase<int>
     {
@@ -39,8 +39,8 @@ public class IntTypeTest(IntTypeTest.IntTypeFixture fixture, ITestOutputHelper t
     }
 }
 
-public class LongTypeTest(LongTypeTest.LongTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<long, LongTypeTest.LongTypeFixture>(fixture, testOutputHelper)
+public class SqliteLongTypeTest(SqliteLongTypeTest.LongTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<long, SqliteLongTypeTest.LongTypeFixture>(fixture, testOutputHelper)
 {
     public class LongTypeFixture : RelationalTypeFixtureBase<long>
     {
@@ -51,8 +51,8 @@ public class LongTypeTest(LongTypeTest.LongTypeFixture fixture, ITestOutputHelpe
     }
 }
 
-public class DecimalTypeTest(DecimalTypeTest.DecimalTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<decimal, DecimalTypeTest.DecimalTypeFixture>(fixture, testOutputHelper)
+public class SqliteDecimalTypeTest(SqliteDecimalTypeTest.DecimalTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<decimal, SqliteDecimalTypeTest.DecimalTypeFixture>(fixture, testOutputHelper)
 {
     public class DecimalTypeFixture : RelationalTypeFixtureBase<decimal>
     {
@@ -63,8 +63,8 @@ public class DecimalTypeTest(DecimalTypeTest.DecimalTypeFixture fixture, ITestOu
     }
 }
 
-public class DoubleTypeTest(DoubleTypeTest.DoubleTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<double, DoubleTypeTest.DoubleTypeFixture>(fixture, testOutputHelper)
+public class SqliteDoubleTypeTest(SqliteDoubleTypeTest.DoubleTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<double, SqliteDoubleTypeTest.DoubleTypeFixture>(fixture, testOutputHelper)
 {
     public class DoubleTypeFixture : RelationalTypeFixtureBase<double>
     {
@@ -75,8 +75,8 @@ public class DoubleTypeTest(DoubleTypeTest.DoubleTypeFixture fixture, ITestOutpu
     }
 }
 
-public class FloatTypeTest(FloatTypeTest.FloatTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<float, FloatTypeTest.FloatTypeFixture>(fixture, testOutputHelper)
+public class SqliteFloatTypeTest(SqliteFloatTypeTest.FloatTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<float, SqliteFloatTypeTest.FloatTypeFixture>(fixture, testOutputHelper)
 {
     public class FloatTypeFixture : RelationalTypeFixtureBase<float>
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Types/SqliteTemporalTypeTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Types/SqliteTemporalTypeTest.cs
@@ -3,14 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
-public class DateTimeTypeTest(DateTimeTypeTest.DateTimeTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<DateTime, DateTimeTypeTest.DateTimeTypeFixture>(fixture, testOutputHelper)
+public class SqliteDateTimeTypeTest(SqliteDateTimeTypeTest.DateTimeTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<DateTime, SqliteDateTimeTypeTest.DateTimeTypeFixture>(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class DateTimeTypeFixture : RelationalTypeFixtureBase<DateTime>
@@ -22,14 +22,14 @@ public class DateTimeTypeTest(DateTimeTypeTest.DateTimeTypeFixture fixture, ITes
     }
 }
 
-public class DateTimeOffsetTypeTest(DateTimeOffsetTypeTest.DateTimeOffsetTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<DateTimeOffset, DateTimeOffsetTypeTest.DateTimeOffsetTypeFixture>(fixture, testOutputHelper)
+public class SqliteDateTimeOffsetTypeTest(SqliteDateTimeOffsetTypeTest.DateTimeOffsetTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<DateTimeOffset, SqliteDateTimeOffsetTypeTest.DateTimeOffsetTypeFixture>(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class DateTimeOffsetTypeFixture : RelationalTypeFixtureBase<DateTimeOffset>
@@ -41,14 +41,14 @@ public class DateTimeOffsetTypeTest(DateTimeOffsetTypeTest.DateTimeOffsetTypeFix
     }
 }
 
-public class DateOnlyTypeTest(DateOnlyTypeTest.DateTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<DateOnly, DateOnlyTypeTest.DateTypeFixture>(fixture, testOutputHelper)
+public class SqliteDateOnlyTypeTest(SqliteDateOnlyTypeTest.DateTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<DateOnly, SqliteDateOnlyTypeTest.DateTypeFixture>(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class DateTypeFixture : RelationalTypeFixtureBase<DateOnly>
@@ -60,8 +60,8 @@ public class DateOnlyTypeTest(DateOnlyTypeTest.DateTypeFixture fixture, ITestOut
     }
 }
 
-public class TimeOnlyTypeTest(TimeOnlyTypeTest.TimeTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<TimeOnly, TimeOnlyTypeTest.TimeTypeFixture>(fixture, testOutputHelper)
+public class SqliteTimeOnlyTypeTest(SqliteTimeOnlyTypeTest.TimeTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<TimeOnly, SqliteTimeOnlyTypeTest.TimeTypeFixture>(fixture, testOutputHelper)
 {
     // TODO: string representation discrepancy between our JSON and M.D.SQLite's string representation, see #36749.
     public override Task Query_property_within_json()
@@ -71,7 +71,7 @@ public class TimeOnlyTypeTest(TimeOnlyTypeTest.TimeTypeFixture fixture, ITestOut
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class TimeTypeFixture : RelationalTypeFixtureBase<TimeOnly>
@@ -83,14 +83,14 @@ public class TimeOnlyTypeTest(TimeOnlyTypeTest.TimeTypeFixture fixture, ITestOut
     }
 }
 
-public class TimeSpanTypeTest(TimeSpanTypeTest.TimeSpanTypeFixture fixture, ITestOutputHelper testOutputHelper)
-    : RelationalTypeTestBase<TimeSpan, TimeSpanTypeTest.TimeSpanTypeFixture>(fixture, testOutputHelper)
+public class SqliteTimeSpanTypeTest(SqliteTimeSpanTypeTest.TimeSpanTypeFixture fixture, ITestOutputHelper testOutputHelper)
+    : RelationalTypeTestBase<TimeSpan, SqliteTimeSpanTypeTest.TimeSpanTypeFixture>(fixture, testOutputHelper)
 {
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
         // See #36688 for supporting this for Sqlite types other than string/numeric/bool
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.ExecuteUpdate_within_json_to_nonjson_column());
-        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.Message);
+        Assert.Equal(RelationalStrings.ExecuteUpdateCannotSetJsonPropertyToNonJsonColumn, exception.InnerException!.Message);
     }
 
     public class TimeSpanTypeFixture : RelationalTypeFixtureBase<TimeSpan>

--- a/test/EFCore.Tests/Query/QueryProviderTest.cs
+++ b/test/EFCore.Tests/Query/QueryProviderTest.cs
@@ -13,19 +13,19 @@ public class QueryProviderTest
 
         Assert.Equal(
             CoreStrings.ExecuteQueriesNotSupported("ExecuteUpdate", "ExecuteUpdateAsync"),
-            Assert.Throws<InvalidOperationException>(() => set.ExecuteUpdate(s => s.SetProperty(e => e.Id, 1))).Message);
+            Assert.Throws<InvalidOperationException>(() => set.ExecuteUpdate(s => s.SetProperty(e => e.Id, 1))).InnerException!.Message);
 
         Assert.Equal(
             CoreStrings.ExecuteQueriesNotSupported("ExecuteUpdate", "ExecuteUpdateAsync"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => set.ExecuteUpdateAsync(s => s.SetProperty(e => e.Id, 1)))).Message);
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => set.ExecuteUpdateAsync(s => s.SetProperty(e => e.Id, 1)))).InnerException!.Message);
 
         Assert.Equal(
             CoreStrings.ExecuteQueriesNotSupported("ExecuteDelete", "ExecuteDeleteAsync"),
-            Assert.Throws<InvalidOperationException>(() => set.ExecuteDelete()).Message);
+            Assert.Throws<InvalidOperationException>(() => set.ExecuteDelete()).InnerException!.Message);
 
         Assert.Equal(
             CoreStrings.ExecuteQueriesNotSupported("ExecuteDelete", "ExecuteDeleteAsync"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => set.ExecuteDeleteAsync())).Message);
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => set.ExecuteDeleteAsync())).InnerException!.Message);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
This simplifies error handling in Execute{Update,Delete} codepaths. Like everywhere else within query, the code there would return null for "not translatable", and setting state for passing additional details. However, that mechanism is there to allow for client evaluation, which isn't relevant for the update/delete APIs. So changed the APIs to no longer return nullable types, and to simply throw exceptions directly when encountering errors.