### PR TITLE
[release/8.0] Remove OSX.13.Amd64 target from HelixTargetQueues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ extends:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
-                value: Windows.10.Amd64;OSX.13.Amd64;Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-sqlserver-amd64
+                value: Windows.10.Amd64;Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-sqlserver-amd64
               - name: _HelixAccessToken
               # Needed for internal queues
                 value: $(HelixApiAccessToken)


### PR DESCRIPTION
Tests on OSX.13.Amd64 started timing out now. Disabling to unblock the build
The public CI continues to use OSX.13.ARM64.Open and OSX.13.Amd64.Open