### PR TITLE
[release/9.0-staging] Fix performance degradation in converters because the instance was not reused

### DIFF
--- a/src/EFCore/Storage/Json/JsonConvertedValueReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonConvertedValueReaderWriter.cs
@@ -16,6 +16,9 @@ public class JsonConvertedValueReaderWriter<TModel, TProvider> :
     JsonValueReaderWriter<TModel>,
     IJsonConvertedValueReaderWriter
 {
+    private static readonly bool UseOldBehavior36856 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue36856", out var enabled) && enabled;
+
     private readonly JsonValueReaderWriter<TProvider> _providerReaderWriter;
     private readonly ValueConverter _converter;
 
@@ -52,8 +55,17 @@ public class JsonConvertedValueReaderWriter<TModel, TProvider> :
 
     /// <inheritdoc />
     public override Expression ConstructorExpression
-        => Expression.New(
-            _constructorInfo,
-            ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression,
-            ((IJsonConvertedValueReaderWriter)this).Converter.ConstructorExpression);
+        => UseOldBehavior36856
+            ? Expression.New(
+                _constructorInfo,
+                ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression,
+                ((IJsonConvertedValueReaderWriter)this).Converter.ConstructorExpression)
+            : Expression.New(
+                _constructorInfo,
+                ((ICompositeJsonValueReaderWriter)this).InnerReaderWriter.ConstructorExpression,
+                // We shouldn't quote converters, because it will create a new instance every time and
+                // it will have to compile the expression again and
+                // it will have a negative performance impact. See #36856 for more info.
+                // This means this is currently unsupported scenario for precompilation.
+                Expression.Constant(((IJsonConvertedValueReaderWriter)this).Converter));
 }


### PR DESCRIPTION
Backport of #36895.

### Description
Change to support NativeAOT in EF Core 9 (experimental feature) introduced new code path that resulted in new instances of value converters on primitive collections being recreated on every entity created and hence recompiling the expression on every call.

### Customer impact
Significant performance degradation when fetching primitive collections data with value converters from database.

### How found
Customer reported.

### Regression
Yes, from 8.

### Testing
Manual testing.

### Risk
Low. Feature flag added.