### PR TITLE
Fix UpdateExpression.VisitChildren() to retain Tags

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
@@ -117,7 +117,7 @@ public sealed class UpdateExpression : Expression, IRelationalQuotableExpression
 
         return selectExpression == SelectExpression && table == Table && columnValueSetters is null
             ? this
-            : new UpdateExpression(table, selectExpression, columnValueSetters ?? ColumnValueSetters);
+            : new UpdateExpression(table, selectExpression, columnValueSetters ?? ColumnValueSetters, Tags);
     }
 
     /// <summary>

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -363,6 +363,16 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_set_constant_TagWith_null(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().TagWith("MyUpdate"),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, (string)null),
+            rowsAffectedCount: 91,
+            (b, a) => Assert.All(a, c => Assert.Equal(null, c.ContactName)));
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Update_Where_set_constant(bool async)
         => AssertUpdate(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -666,6 +666,20 @@ WHERE [c].[CustomerID] LIKE N'F%'
 """);
     }
 
+    public override async Task Update_set_constant_TagWith_null(bool async)
+    {
+        await base.Update_set_constant_TagWith_null(async);
+
+        AssertExecuteUpdateSql(
+            """
+-- MyUpdate
+
+UPDATE [c]
+SET [c].[ContactName] = NULL
+FROM [Customers] AS [c]
+""");
+    }
+
     public override async Task Update_Where_set_constant(bool async)
     {
         await base.Update_Where_set_constant(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -648,6 +648,19 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
 
+    public override async Task Update_set_constant_TagWith_null(bool async)
+    {
+        await base.Update_set_constant_TagWith_null(async);
+
+        AssertExecuteUpdateSql(
+            """
+-- MyUpdate
+
+UPDATE "Customers" AS "c"
+SET "ContactName" = NULL
+""");
+    }
+
     public override async Task Update_Where_set_constant(bool async)
     {
         await base.Update_Where_set_constant(async);


### PR DESCRIPTION
Fixes #36908
