### PR TITLE
Discover the migrations-bundle DbContext out-of-process so publish doesn't lock the assembly

### DIFF
--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -138,6 +138,8 @@ internal class RootCommand : CommandBase
                 Resources.PlatformSpecificProject(startupProject.ProjectName, startupProject.TargetFramework));
         }
 
+        var additionalProbingPaths = new List<string>();
+
         var targetFramework = new FrameworkName(startupProject.TargetFrameworkMoniker!);
         if (targetFramework.Identifier == ".NETFramework")
         {
@@ -162,13 +164,16 @@ internal class RootCommand : CommandBase
                 using var file = File.OpenRead(projectAssetsFile);
                 using var reader = JsonDocument.Parse(file);
                 var projectAssets = reader.RootElement;
-                var packageFolders = projectAssets.GetProperty("packageFolders").EnumerateObject().Select(p => p.Name);
+                var packageFolders = projectAssets.GetProperty("packageFolders")
+                    .EnumerateObject().Select(p => p.Name.TrimEnd(Path.DirectorySeparatorChar)).ToList();
 
                 foreach (var packageFolder in packageFolders)
                 {
                     args.Add("--additionalprobingpath");
-                    args.Add(packageFolder.TrimEnd(Path.DirectorySeparatorChar));
+                    args.Add(packageFolder);
                 }
+
+                additionalProbingPaths = packageFolders;
             }
 
             if (File.Exists(runtimeConfig))
@@ -247,6 +252,31 @@ internal class RootCommand : CommandBase
         if (Reporter.PrefixOutput)
         {
             args.Add("--prefix-output");
+        }
+
+        if (File.Exists(depsFile))
+        {
+            args.Add("--deps-file");
+            args.Add(depsFile);
+        }
+
+        if (File.Exists(runtimeConfig))
+        {
+            args.Add("--runtime-config");
+            args.Add(runtimeConfig);
+        }
+        else if (startupProject.RuntimeFrameworkVersion!.Length != 0)
+        {
+            // Mirrors the host --fx-version above so a child discovery process (migrations bundle)
+            // can pin the same shared framework when there's no runtimeconfig.json.
+            args.Add("--runtime-framework-version");
+            args.Add(startupProject.RuntimeFrameworkVersion);
+        }
+
+        foreach (var additionalProbingPath in additionalProbingPaths)
+        {
+            args.Add("--additional-probing-path");
+            args.Add(additionalProbingPath);
         }
 
         if (_applicationArgs!.Any())

--- a/src/ef/Commands/MigrationsBundleCommand.Discovery.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.Discovery.cs
@@ -92,17 +92,47 @@ internal partial class MigrationsBundleCommand
 
     // Builds the failure for a non-zero discovery child. Under --prefix-output the child writes its
     // prefixed error lines to STDOUT (Reporter.WriteError -> WriteStdErr -> WriteLine -> stdout), so
-    // the actionable text is in the captured stdout, not stderr; scan stdout first and fall back to
-    // the raw stderr capture for unprefixed failures. See https://github.com/dotnet/efcore/issues/25555.
+    // the actionable text is in the captured stdout, not stderr; scan stdout first, then stderr for
+    // prefixed lines, and finally fall back to the raw stderr capture for unprefixed failures.
+    // See https://github.com/dotnet/efcore/issues/25555.
     internal static CommandException CreateDiscoveryFailure(string output, IEnumerable<string?> errorOutput)
     {
+        var errorLines = errorOutput as IReadOnlyCollection<string?> ?? errorOutput.ToList();
+
+        // Prefer prefixed error lines (actionable EF guidance like the multi-context "--context" hint):
+        // scan the child's stdout first (where --prefix-output routes its error: lines), then its stderr.
+        // As a last resort fall back to the raw stderr text, so host-level failures that carry no
+        // Reporter.ErrorPrefix (framework roll-forward, missing runtime, an unhandled exception) still
+        // reach the user instead of collapsing into the generic message.
         var detail = ExtractErrorMessage(output.Split('\n').Select(l => l.TrimEnd('\r')))
-            ?? ExtractErrorMessage(errorOutput);
+            ?? ExtractErrorMessage(errorLines)
+            ?? JoinRawErrorLines(errorLines);
 
         return new CommandException(
             detail != null
                 ? Resources.BundleContextDiscoveryFailedWithError(detail)
                 : Resources.BundleContextDiscoveryFailed);
+    }
+
+    // Joins the raw captured stderr lines verbatim, used as a last-resort fallback when the child
+    // produced no Reporter.ErrorPrefix-prefixed error text.
+    internal static string? JoinRawErrorLines(IEnumerable<string?> errorLines)
+    {
+        var builder = new StringBuilder();
+        foreach (var line in errorLines)
+        {
+            if (!string.IsNullOrEmpty(line))
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(Environment.NewLine);
+                }
+
+                builder.Append(line);
+            }
+        }
+
+        return builder.Length > 0 ? builder.ToString() : null;
     }
 
     // Pulls the human-readable error text out of prefixed output lines (those beginning with

--- a/src/ef/Commands/MigrationsBundleCommand.Discovery.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.Discovery.cs
@@ -1,0 +1,222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System.Text.Json;
+#endif
+using System.Text;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
+namespace Microsoft.EntityFrameworkCore.Tools.Commands;
+
+internal partial class MigrationsBundleCommand
+{
+    // Builds the `dotnet exec <host args> ef.dll dbcontext info --json <tool args>` command line for
+    // out-of-process DbContext discovery. The host args (consumed by the runtime host) precede ef.dll;
+    // the tool args follow it. See https://github.com/dotnet/efcore/issues/25555.
+    internal static IReadOnlyList<string> BuildDiscoveryArguments(
+        string efAssemblyPath,
+        string? depsFile,
+        string? runtimeConfig,
+        string? fxVersion,
+        IReadOnlyList<string> additionalProbingPaths,
+        IReadOnlyList<string> commonProjectArgs,
+        string? context,
+        bool verbose,
+        IReadOnlyList<string> applicationArgs)
+    {
+        var args = new List<string> { "exec" };
+
+        if (!string.IsNullOrEmpty(depsFile))
+        {
+            args.Add("--depsfile");
+            args.Add(depsFile!);
+        }
+
+        foreach (var path in additionalProbingPaths)
+        {
+            args.Add("--additionalprobingpath");
+            args.Add(path);
+        }
+
+        // Mirror how dotnet-ef launches the parent ef.dll (RootCommand): prefer the startup project's
+        // runtimeconfig.json, but when it has none, pin the shared framework with --fx-version so the
+        // child rolls forward to the same framework the app targets rather than ef.dll's own.
+        if (!string.IsNullOrEmpty(runtimeConfig))
+        {
+            args.Add("--runtimeconfig");
+            args.Add(runtimeConfig!);
+        }
+        else if (!string.IsNullOrEmpty(fxVersion))
+        {
+            args.Add("--fx-version");
+            args.Add(fxVersion!);
+        }
+
+        args.Add(efAssemblyPath);
+        args.Add("dbcontext");
+        args.Add("info");
+        args.Add("--json");
+
+        // The child invokes the user's application entry point to build design-time services, so the
+        // app may write to stdout. --prefix-output tags ef.dll's own output so we can isolate the JSON
+        // data lines from arbitrary app output; --no-color keeps those lines plain.
+        args.Add("--prefix-output");
+        args.Add("--no-color");
+
+        args.AddRange(commonProjectArgs);
+
+        if (!string.IsNullOrEmpty(context))
+        {
+            args.Add("--context");
+            args.Add(context!);
+        }
+
+        if (verbose)
+        {
+            args.Add("--verbose");
+        }
+
+        // Forward the application arguments (everything after "--") so the child's design-time
+        // discovery sees the same args the in-process path did — e.g. an IDesignTimeDbContextFactory
+        // or CreateHostBuilder that selects the context/connection from them. See
+        // https://github.com/dotnet/efcore/issues/25555.
+        if (applicationArgs.Count > 0)
+        {
+            args.Add("--");
+            args.AddRange(applicationArgs);
+        }
+
+        return args;
+    }
+
+    // Builds the failure for a non-zero discovery child. Under --prefix-output the child writes its
+    // prefixed error lines to STDOUT (Reporter.WriteError -> WriteStdErr -> WriteLine -> stdout), so
+    // the actionable text is in the captured stdout, not stderr; scan stdout first and fall back to
+    // the raw stderr capture for unprefixed failures. See https://github.com/dotnet/efcore/issues/25555.
+    internal static CommandException CreateDiscoveryFailure(string output, IEnumerable<string?> errorOutput)
+    {
+        var detail = ExtractErrorMessage(output.Split('\n').Select(l => l.TrimEnd('\r')))
+            ?? ExtractErrorMessage(errorOutput);
+
+        return new CommandException(
+            detail != null
+                ? Resources.BundleContextDiscoveryFailedWithError(detail)
+                : Resources.BundleContextDiscoveryFailed);
+    }
+
+    // Pulls the human-readable error text out of prefixed output lines (those beginning with
+    // Reporter.ErrorPrefix), so actionable discovery errors (e.g. the multi-context "--context"
+    // guidance) are surfaced instead of collapsed into a generic failure.
+    internal static string? ExtractErrorMessage(IEnumerable<string?> errorLines)
+    {
+        var builder = new StringBuilder();
+        foreach (var line in errorLines)
+        {
+            if (line != null
+                && line.StartsWith(Reporter.ErrorPrefix, StringComparison.Ordinal))
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(Environment.NewLine);
+                }
+
+                builder.Append(line.Substring(Reporter.ErrorPrefix.Length));
+            }
+        }
+
+        return builder.Length > 0 ? builder.ToString() : null;
+    }
+
+    private string DiscoverContextType(IReadOnlyList<string> applicationArgs)
+    {
+#if NET
+        var efAssemblyPath = typeof(Program).Assembly.Location;
+        var discoveryArgs = BuildDiscoveryArguments(
+            efAssemblyPath,
+            DepsFile!.Value(),
+            RuntimeConfig!.Value(),
+            FxVersion!.Value(),
+            AdditionalProbingPaths!.Values.Where(v => v != null).Cast<string>().ToList(),
+            GetCommonProjectArgs(),
+            Context!.Value(),
+            Reporter.IsVerbose,
+            applicationArgs);
+
+        var output = new StringBuilder();
+        var errorOutput = new List<string?>();
+        var exitCode = Exe.Run(
+            "dotnet",
+            discoveryArgs,
+            handleOutput: line =>
+            {
+                if (!string.IsNullOrEmpty(line))
+                {
+                    output.AppendLine(line);
+                }
+            },
+            handleError: line =>
+            {
+                if (!string.IsNullOrEmpty(line))
+                {
+                    errorOutput.Add(line);
+                    Reporter.WriteVerbose(line);
+                }
+            });
+
+        if (exitCode != 0)
+        {
+            throw CreateDiscoveryFailure(output.ToString(), errorOutput);
+        }
+
+        return ParseContextType(output.ToString());
+#else
+        // The .NET Framework build of ef.dll is a build-only reference (see ef.csproj) and is never
+        // executed by dotnet-ef, which always runs tools/net/ef.dll. Bundling is a .NET-only path.
+        throw new NotSupportedException();
+#endif
+    }
+
+    // Extracts the "type" field from the JSON emitted by `dbcontext info --json`. The child runs with
+    // --prefix-output, so its structured data lines start with Reporter.DataPrefix; only those lines
+    // are considered, so arbitrary stdout the user's app prints during discovery cannot corrupt the
+    // JSON. See https://github.com/dotnet/efcore/issues/25555.
+    internal static string ParseContextType(string output)
+    {
+#if NET
+        var builder = new StringBuilder();
+        foreach (var rawLine in output.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (line.StartsWith(Reporter.DataPrefix, StringComparison.Ordinal))
+            {
+                builder.Append(line.Substring(Reporter.DataPrefix.Length));
+            }
+        }
+
+        var json = builder.ToString();
+        var start = json.IndexOf('{');
+        var end = json.LastIndexOf('}');
+        if (start >= 0 && end > start)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(json.Substring(start, end - start + 1));
+                if (document.RootElement.TryGetProperty("type", out var type)
+                    && type.ValueKind == JsonValueKind.String
+                    && type.GetString() is { Length: > 0 } value)
+                {
+                    return value;
+                }
+            }
+            catch (JsonException)
+            {
+            }
+        }
+
+        throw new CommandException(Resources.BundleContextDiscoveryFailed);
+#else
+        throw new NotSupportedException();
+#endif
+    }
+}

--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -32,22 +32,25 @@ internal partial class MigrationsBundleCommand
     protected override int Execute(string[] args)
     {
         string? version;
-        string context;
         using (var executor = CreateExecutor(args))
         {
+            // Reads the design assembly only (NuGet cache); does not load — or lock — the app assembly.
             version = executor.EFCoreVersion;
             if (new SemanticVersionComparer().Compare(version, "6.0.0") < 0)
             {
                 throw new CommandException(Resources.VersionRequired("6.0.0"));
             }
-
-            if (Context!.Value() == "*")
-            {
-                throw new CommandException(Resources.WildcardNotSupported);
-            }
-
-            context = (string)executor.GetContextInfo(Context!.Value())["Type"]!;
         }
+
+        if (Context!.Value() == "*")
+        {
+            throw new CommandException(Resources.WildcardNotSupported);
+        }
+
+        // Discover the DbContext type in a SEPARATE process so the target assembly is not loaded
+        // (and on Windows, not locked) by this process when it later runs `dotnet publish`.
+        // See https://github.com/dotnet/efcore/issues/25555.
+        var context = DiscoverContextType(args);
 
         Reporter.WriteInformation(Resources.BuildBundleStarted);
 

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -27,6 +27,10 @@ internal abstract class ProjectCommandBase : EFCommandBase
     protected CommandOption? WorkingDir { get; private set; }
     protected CommandOption? Framework { get; private set; }
     protected CommandOption? Configuration { get; private set; }
+    protected CommandOption? DepsFile { get; private set; }
+    protected CommandOption? RuntimeConfig { get; private set; }
+    protected CommandOption? FxVersion { get; private set; }
+    protected CommandOption? AdditionalProbingPaths { get; private set; }
 
     public override void Configure(CommandLineApplication command)
     {
@@ -45,8 +49,47 @@ internal abstract class ProjectCommandBase : EFCommandBase
         Framework = command.Option("--framework <FRAMEWORK>", Resources.FrameworkDescription);
         Configuration = command.Option("--configuration <CONFIGURATION>", Resources.ConfigurationDescription);
         _designAssembly = command.Option("--design-assembly <PATH>", Resources.DesignAssemblyDescription);
+        DepsFile = command.Option("--deps-file <PATH>", Resources.DepsFileDescription);
+        RuntimeConfig = command.Option("--runtime-config <PATH>", Resources.RuntimeConfigDescription);
+        FxVersion = command.Option("--runtime-framework-version <VERSION>", Resources.RuntimeFrameworkVersionDescription);
+        AdditionalProbingPaths = command.Option(
+            "--additional-probing-path <PATH>", Resources.AdditionalProbingPathDescription, CommandOptionType.MultipleValue);
 
         base.Configure(command);
+    }
+
+    protected IReadOnlyList<string> GetCommonProjectArgs()
+    {
+        var args = new List<string>();
+
+        void AddValue(CommandOption? option, string name)
+        {
+            if (option!.HasValue())
+            {
+                args.Add(name);
+                args.Add(option.Value()!);
+            }
+        }
+
+        AddValue(Assembly, "--assembly");
+        AddValue(StartupAssembly, "--startup-assembly");
+        AddValue(Project, "--project");
+        AddValue(StartupProject, "--startup-project");
+        AddValue(_dataDir, "--data-dir");
+        AddValue(_projectDir, "--project-dir");
+        AddValue(_rootNamespace, "--root-namespace");
+        AddValue(_language, "--language");
+        if (_nullable!.HasValue())
+        {
+            args.Add("--nullable");
+        }
+
+        AddValue(WorkingDir, "--working-dir");
+        AddValue(Framework, "--framework");
+        AddValue(Configuration, "--configuration");
+        AddValue(_designAssembly, "--design-assembly");
+
+        return args;
     }
 
     protected override void Validate()

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -52,6 +52,20 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 path);
 
         /// <summary>
+        ///     Could not determine the DbContext type for the bundle. Use --verbose to see errors.
+        /// </summary>
+        public static string BundleContextDiscoveryFailed
+            => GetString("BundleContextDiscoveryFailed");
+
+        /// <summary>
+        ///     Could not determine the DbContext type for the bundle. {error}
+        /// </summary>
+        public static string BundleContextDiscoveryFailedWithError(object? error)
+            => string.Format(
+                GetString("BundleContextDiscoveryFailedWithError", nameof(error)),
+                error);
+
+        /// <summary>
         ///     The configuration to use.
         /// </summary>
         public static string ConfigurationDescription
@@ -154,10 +168,22 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("DatabaseUpdateAddDescription");
 
         /// <summary>
+        ///     An additional assembly probing path. (Used internally.)
+        /// </summary>
+        public static string AdditionalProbingPathDescription
+            => GetString("AdditionalProbingPathDescription");
+
+        /// <summary>
         ///     The data directory.
         /// </summary>
         public static string DataDirDescription
             => GetString("DataDirDescription");
+
+        /// <summary>
+        ///     The dependencies file of the startup project. (Used internally.)
+        /// </summary>
+        public static string DepsFileDescription
+            => GetString("DepsFileDescription");
 
         /// <summary>
         ///     Data source: {dataSource}
@@ -578,6 +604,18 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => string.Format(
                 GetString("RemainingArguments", nameof(remainingArguments)),
                 remainingArguments);
+
+        /// <summary>
+        ///     The runtime config of the startup project. (Used internally.)
+        /// </summary>
+        public static string RuntimeConfigDescription
+            => GetString("RuntimeConfigDescription");
+
+        /// <summary>
+        ///     The shared-framework version of the startup project. (Used internally.)
+        /// </summary>
+        public static string RuntimeFrameworkVersionDescription
+            => GetString("RuntimeFrameworkVersionDescription");
 
         /// <summary>
         ///     The root namespace. Defaults to the target assembly name.

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AdditionalProbingPathDescription" xml:space="preserve">
+    <value>An additional assembly probing path. (Used internally.)</value>
+  </data>
   <data name="AppSettingsTip" xml:space="preserve">
     <value>Don't forget to copy appsettings.json alongside your bundle if you need it to apply migrations.</value>
   </data>
@@ -182,6 +185,9 @@
   </data>
   <data name="DataDirDescription" xml:space="preserve">
     <value>The data directory.</value>
+  </data>
+  <data name="DepsFileDescription" xml:space="preserve">
+    <value>The dependencies file of the startup project. (Used internally.)</value>
   </data>
   <data name="DataSource" xml:space="preserve">
     <value>Data source: {dataSource}</value>
@@ -378,6 +384,12 @@
   <data name="RemainingArguments" xml:space="preserve">
     <value>Remaining arguments: {remainingArguments}.</value>
   </data>
+  <data name="RuntimeConfigDescription" xml:space="preserve">
+    <value>The runtime config of the startup project. (Used internally.)</value>
+  </data>
+  <data name="RuntimeFrameworkVersionDescription" xml:space="preserve">
+    <value>The shared-framework version of the startup project. (Used internally.)</value>
+  </data>
   <data name="RootNamespaceDescription" xml:space="preserve">
     <value>The root namespace. Defaults to the target assembly name.</value>
   </data>
@@ -443,5 +455,11 @@
   </data>
   <data name="WildcardNotSupported" xml:space="preserve">
     <value>The wildcard '*' is not supported for this command.</value>
+  </data>
+  <data name="BundleContextDiscoveryFailed" xml:space="preserve">
+    <value>Could not determine the DbContext type for the bundle. Use --verbose to see errors.</value>
+  </data>
+  <data name="BundleContextDiscoveryFailedWithError" xml:space="preserve">
+    <value>Could not determine the DbContext type for the bundle. {error}</value>
   </data>
 </root>

--- a/test/ef.Tests/MigrationsBundleDiscoveryTest.cs
+++ b/test/ef.Tests/MigrationsBundleDiscoveryTest.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Tools.Commands;
+
+namespace Microsoft.EntityFrameworkCore.Tools;
+
+public class MigrationsBundleDiscoveryTest
+{
+    private static string DataLines(params string[] jsonLines)
+        => string.Join("\n", jsonLines.Select(l => Reporter.DataPrefix + l));
+
+    [Fact]
+    public void BuildDiscoveryArguments_assembles_host_and_tool_args_in_order()
+    {
+        var args = MigrationsBundleCommand.BuildDiscoveryArguments(
+            efAssemblyPath: "/tools/ef.dll",
+            depsFile: "S.deps.json",
+            runtimeConfig: "S.runtimeconfig.json",
+            fxVersion: null,
+            additionalProbingPaths: new[] { "/n1", "/n2" },
+            commonProjectArgs: new[] { "--assembly", "A.dll", "--startup-assembly", "S.dll" },
+            context: "My.Context",
+            verbose: true,
+            applicationArgs: Array.Empty<string>());
+
+        Assert.Equal(
+            new[]
+            {
+                "exec",
+                "--depsfile", "S.deps.json",
+                "--additionalprobingpath", "/n1",
+                "--additionalprobingpath", "/n2",
+                "--runtimeconfig", "S.runtimeconfig.json",
+                "/tools/ef.dll",
+                "dbcontext", "info", "--json",
+                "--prefix-output", "--no-color",
+                "--assembly", "A.dll", "--startup-assembly", "S.dll",
+                "--context", "My.Context",
+                "--verbose"
+            },
+            args);
+    }
+
+    [Fact]
+    public void BuildDiscoveryArguments_forwards_application_args_after_separator()
+    {
+        var args = MigrationsBundleCommand.BuildDiscoveryArguments(
+            "/tools/ef.dll", depsFile: null, runtimeConfig: null, fxVersion: null,
+            additionalProbingPaths: Array.Empty<string>(),
+            commonProjectArgs: new[] { "--assembly", "A.dll" },
+            context: null, verbose: false,
+            applicationArgs: new[] { "--environment", "Staging", "--connection", "Server=." });
+
+        Assert.Equal(
+            new[]
+            {
+                "exec", "/tools/ef.dll", "dbcontext", "info", "--json", "--prefix-output", "--no-color",
+                "--assembly", "A.dll",
+                "--", "--environment", "Staging", "--connection", "Server=."
+            },
+            args);
+    }
+
+    [Fact]
+    public void BuildDiscoveryArguments_omits_optional_pieces_when_absent()
+    {
+        var args = MigrationsBundleCommand.BuildDiscoveryArguments(
+            "/tools/ef.dll", depsFile: null, runtimeConfig: null, fxVersion: null,
+            additionalProbingPaths: Array.Empty<string>(),
+            commonProjectArgs: new[] { "--assembly", "A.dll" },
+            context: null, verbose: false, applicationArgs: Array.Empty<string>());
+
+        Assert.Equal(
+            new[]
+            {
+                "exec", "/tools/ef.dll", "dbcontext", "info", "--json",
+                "--prefix-output", "--no-color", "--assembly", "A.dll"
+            },
+            args);
+    }
+
+    [Fact]
+    public void BuildDiscoveryArguments_uses_fx_version_when_no_runtimeconfig()
+    {
+        var args = MigrationsBundleCommand.BuildDiscoveryArguments(
+            "/tools/ef.dll", depsFile: null, runtimeConfig: null, fxVersion: "8.0.5",
+            additionalProbingPaths: Array.Empty<string>(),
+            commonProjectArgs: new[] { "--assembly", "A.dll" },
+            context: null, verbose: false, applicationArgs: Array.Empty<string>());
+
+        Assert.Equal(
+            new[]
+            {
+                "exec", "--fx-version", "8.0.5", "/tools/ef.dll", "dbcontext", "info", "--json",
+                "--prefix-output", "--no-color", "--assembly", "A.dll"
+            },
+            args);
+    }
+
+    [Fact]
+    public void BuildDiscoveryArguments_prefers_runtimeconfig_over_fx_version()
+    {
+        var args = MigrationsBundleCommand.BuildDiscoveryArguments(
+            "/tools/ef.dll", depsFile: null, runtimeConfig: "S.runtimeconfig.json", fxVersion: "8.0.5",
+            additionalProbingPaths: Array.Empty<string>(),
+            commonProjectArgs: new[] { "--assembly", "A.dll" },
+            context: null, verbose: false, applicationArgs: Array.Empty<string>());
+
+        Assert.Contains("--runtimeconfig", args);
+        Assert.DoesNotContain("--fx-version", args);
+    }
+
+    [Fact]
+    public void ParseContextType_reads_type_from_prefixed_data_lines()
+    {
+        var output = DataLines("{", "  \"type\": \"My.App.BlogContext\",", "  \"providerName\": \"x\"", "}");
+        Assert.Equal("My.App.BlogContext", MigrationsBundleCommand.ParseContextType(output));
+    }
+
+    [Fact]
+    public void ParseContextType_ignores_unprefixed_app_stdout_even_with_braces()
+    {
+        // The user's app/host writes to the same stdout during discovery. Lines without the data
+        // prefix — even ones containing braces — must not corrupt the parse. Regression test for #25555.
+        var output =
+            "Now listening on: http://localhost:5000 { not json }\n"
+            + DataLines("{", "  \"type\": \"My.App.BlogContext\",", "  \"providerName\": \"x\"", "}")
+            + "\n[12:00:00 INF] request finished }";
+        Assert.Equal("My.App.BlogContext", MigrationsBundleCommand.ParseContextType(output));
+    }
+
+    [Fact]
+    public void ParseContextType_throws_when_no_data_lines()
+        => Assert.Throws<CommandException>(
+            () => MigrationsBundleCommand.ParseContextType("startup banner { with braces }\nplain app output"));
+
+    [Fact]
+    public void ParseContextType_throws_when_type_missing()
+        => Assert.Throws<CommandException>(
+            () => MigrationsBundleCommand.ParseContextType(DataLines("{", "  \"providerName\": \"x\"", "}")));
+
+    [Fact]
+    public void ExtractErrorMessage_returns_error_prefixed_text()
+    {
+        var lines = new[]
+        {
+            Reporter.InfoPrefix + "Finding DbContext classes...",
+            Reporter.ErrorPrefix + "More than one DbContext was found. Use the '--context' option.",
+            null
+        };
+        Assert.Equal(
+            "More than one DbContext was found. Use the '--context' option.",
+            MigrationsBundleCommand.ExtractErrorMessage(lines));
+    }
+
+    [Fact]
+    public void ExtractErrorMessage_joins_multiple_error_lines()
+    {
+        var lines = new[]
+        {
+            Reporter.ErrorPrefix + "Unable to create a 'DbContext' of type 'X'.",
+            Reporter.ErrorPrefix + "See https://go.microsoft.com/fwlink/?linkid=851728 for details."
+        };
+        Assert.Equal(
+            "Unable to create a 'DbContext' of type 'X'." + Environment.NewLine
+            + "See https://go.microsoft.com/fwlink/?linkid=851728 for details.",
+            MigrationsBundleCommand.ExtractErrorMessage(lines));
+    }
+
+    [Fact]
+    public void ExtractErrorMessage_returns_null_when_no_error_lines()
+        => Assert.Null(MigrationsBundleCommand.ExtractErrorMessage(
+            new[] { Reporter.InfoPrefix + "info", Reporter.DataPrefix + "data" }));
+
+    [Fact]
+    public void CreateDiscoveryFailure_surfaces_error_from_stdout()
+    {
+        // Under --prefix-output the child's error lines arrive on STDOUT, interleaved with data/info.
+        // The failure must scan stdout (the captured output), not the stderr collection.
+        var stdout = string.Join(
+            "\n",
+            Reporter.InfoPrefix + "Finding DbContext classes...",
+            Reporter.ErrorPrefix + "More than one DbContext was found. Use the '--context' option.");
+
+        var ex = MigrationsBundleCommand.CreateDiscoveryFailure(stdout, Array.Empty<string?>());
+
+        Assert.Contains("More than one DbContext was found. Use the '--context' option.", ex.Message);
+    }
+
+    [Fact]
+    public void CreateDiscoveryFailure_falls_back_to_stderr_when_stdout_has_no_error()
+    {
+        var ex = MigrationsBundleCommand.CreateDiscoveryFailure(
+            Reporter.InfoPrefix + "no error here",
+            new[] { Reporter.ErrorPrefix + "Unhandled crash text." });
+
+        Assert.Contains("Unhandled crash text.", ex.Message);
+    }
+
+    [Fact]
+    public void CreateDiscoveryFailure_is_generic_when_no_error_lines_anywhere()
+    {
+        var ex = MigrationsBundleCommand.CreateDiscoveryFailure("plain noise\nmore noise", Array.Empty<string?>());
+
+        Assert.Equal(Properties.Resources.BundleContextDiscoveryFailed, ex.Message);
+    }
+}

--- a/test/ef.Tests/MigrationsBundleDiscoveryTest.cs
+++ b/test/ef.Tests/MigrationsBundleDiscoveryTest.cs
@@ -205,4 +205,29 @@ public class MigrationsBundleDiscoveryTest
 
         Assert.Equal(Properties.Resources.BundleContextDiscoveryFailed, ex.Message);
     }
+
+    [Fact]
+    public void CreateDiscoveryFailure_falls_back_to_raw_stderr_when_unprefixed()
+    {
+        // Host-level failures (framework roll-forward, missing runtime, unhandled exceptions) write
+        // unprefixed text to stderr. It must still reach the user rather than collapsing into the
+        // generic message.
+        var ex = MigrationsBundleCommand.CreateDiscoveryFailure(
+            Reporter.InfoPrefix + "no error here",
+            new[] { "A fatal error was encountered.", "The required framework was not found." });
+
+        Assert.Contains("A fatal error was encountered.", ex.Message);
+        Assert.Contains("The required framework was not found.", ex.Message);
+    }
+
+    [Fact]
+    public void CreateDiscoveryFailure_prefers_prefixed_stderr_over_raw()
+    {
+        var ex = MigrationsBundleCommand.CreateDiscoveryFailure(
+            Reporter.InfoPrefix + "no error here",
+            new[] { "noise line", Reporter.ErrorPrefix + "Actionable error." });
+
+        Assert.Contains("Actionable error.", ex.Message);
+        Assert.DoesNotContain("noise line", ex.Message);
+    }
 }

--- a/test/ef.Tests/ProjectCommandBaseTest.cs
+++ b/test/ef.Tests/ProjectCommandBaseTest.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.EntityFrameworkCore.Tools.Commands;
+
+namespace Microsoft.EntityFrameworkCore.Tools;
+
+public class ProjectCommandBaseTest
+{
+    private sealed class TestCommand : ProjectCommandBase
+    {
+        public IReadOnlyList<string> CommonArgs() => GetCommonProjectArgs();
+        public string? Deps => DepsFile!.Value();
+        public string? RuntimeCfg => RuntimeConfig!.Value();
+        public IReadOnlyList<string?> Probing => AdditionalProbingPaths!.Values;
+        protected override void Validate() { } // skip file-existence checks for unit test
+        protected override int Execute(string[] args) => 0;
+    }
+
+    [Fact]
+    public void GetCommonProjectArgs_round_trips_supplied_options_and_receives_host_args()
+    {
+        var app = new CommandLineApplication { Name = "ef" };
+        var command = new TestCommand();
+        command.Configure(app);
+
+        app.Execute(
+            "--assembly", "A.dll", "--startup-assembly", "S.dll",
+            "--project", "A.csproj", "--language", "C#", "--nullable",
+            "--deps-file", "S.deps.json", "--runtime-config", "S.runtimeconfig.json",
+            "--additional-probing-path", "/n1", "--additional-probing-path", "/n2");
+
+        Assert.Equal("S.deps.json", command.Deps);
+        Assert.Equal("S.runtimeconfig.json", command.RuntimeCfg);
+        Assert.Equal(new[] { "/n1", "/n2" }, command.Probing);
+
+        var common = command.CommonArgs();
+        Assert.Equal(
+            new[] { "--assembly", "A.dll", "--startup-assembly", "S.dll", "--project", "A.csproj", "--language", "C#", "--nullable" },
+            common);
+        Assert.DoesNotContain("--deps-file", common);
+        Assert.DoesNotContain("--additional-probing-path", common);
+    }
+}


### PR DESCRIPTION
This is a new approach; see below for why the original approach didn't pan out.

Fixes #25555.

## Problem

`dotnet ef migrations bundle` failed intermittently on Windows with MSB3027/MSB3021 ("being used by another process").

The tool discovered the DbContext type in-process. It loaded the startup assembly. It then ran `dotnet publish` in the same process. On Windows the loaded assembly stayed locked. Publish overwrote that file and failed.

The lock needs a narrow conjunction, all at once:
- **C1** — the loaded path equals the publish target. Bundle's publish always injects a RID. The pre-invoke build only uses a RID with `--runtime`. Publish also defaults to Release; the pre-invoke build
defaults to Debug. So config and RID must both align.
- **C2** — the startup output is stale at publish time. Otherwise MSBuild's up-to-date check skips the recompile and nothing overwrites the file. `--no-build` is the deterministic trigger.
- **C3** — Windows. Unix does not lock loaded files.

This is why the bug is rare and went years unfixed.

## Change of direction

An earlier version of this PR took a different approach. It loaded the design assembly oadContext` and called `Unload()` before publish. **That approach is reverted.**

It was validated on real Windows and found ineffective. The file that locks is the targthe design assembly. `dotnet-ef` launches the tool with `--depsfile <app>.deps.json`. Sothe app assembly resolves onto the default ALC's TPA list. `Assembly.Load` loads it into the non-collectible default context before the collectible ALC ever sees it. Unloading the collectible ALC released nothing.

## Fix

Discover the DbContext type in a separate, short-lived process:

    dotnet exec <host args> ef.dll dbcontext info --json <tool args>

The child loads (and on Windows locks) the target assembly. It prints the context type parent runs `dotnet publish`. The assembly is no longer held when publish copies it.

Process exit releases all handles, managed and native. There is no async-unload timing

### Mechanics

- `dotnet-ef` (`RootCommand`) forwards the startup project's deps file, runtime config, to `ef.dll` as tool options. It pins the shared framework with`--runtime-framework-version` when the project has no `runtimeconfig.json`. This mirrors how it launches the parent host.
- `ef.dll` (`ProjectCommandBase`) accepts those options. `GetCommonProjectArgs` rebuild child. `MigrationsBundleCommand` assembles the `dotnet exec` command line and parses the result.
- The discovered type comes from `GetContextInfo(...)["Type"]` — the same source the int info --json` emits it; the parser reads it back. Behavior is unchanged.

### Hardening (parity with the in-process path)

The child runs the user's application entry point. So it behaves like a normal process.

1. **Output isolation.** The child runs with `--prefix-output`/`--no-color`. The parserlines. App output cannot corrupt the JSON.
2. **Error surfacing.** Under `--prefix-output` the child's `error:` text goes to stdout. Failures are read from stdout, falling back to stderr. Actionable guidance (the multi-context `--context` hint, "No
DbContext was found", "Unable to create a 'DbContext'") reaches the user without `--ver
3. **Framework roll-forward.** `--fx-version` is forwarded. The child rolls forward to the app's shared framework, not `ef.dll`'s own.
4. **Application args.** Everything after `--` is forwarded. An arg-dependent `IDesignTontext(args)` or `CreateHostBuilder(args)` selects the same context as before.

### Scope

The .NET Framework (net472) build of `ef.dll` is build-only and never executed. The dis#if NET` and throws `NotSupportedException` otherwise. `dotnet-ef` already rejects .NETFramework startup projects, so this path is unreachable in practice.

### Alternatives considered and rejected                                                                                                                                                               
- **Reflection-only (`MetadataLoadContext`).** Simpler and avoids the lock. Rejected. It cannot reproduce EF's real context selection (factories, DI registration, multi-context disambiguation). It cotarget a different context than `database update` would.
- **Orchestrate two `ef.dll` calls from `dotnet-ef`.** Avoids forwarding host args twice. Rejected. It pushes JSON parsing, error surfacing, and orchestration into the thin dual-target launcher, and special-cases one subcommand there. Bundle logic belongs in the bundle command.
                                                                                                                                                                                                       ## Tests
                                                                                                                                                                                                       Adds unit tests for the discovery arg builder, JSON/error parsing, application arg forwt-args round trip.
                                                                                                                                                                                                       Two notes before you paste it:
                                                                                                                                                                                                       - I asked you to keep sentences terse, so the body runs short and declarative. If a revtail trimmed, it's the most cuttable section.
- The "Tests" section claims unit-test coverage. The full Windows RED→GREEN validation (per the kit) is still pending on your end — I left that out of the PR body rather than claim it as done. Add a checkbox or a line once you've run it if you want it on record.



----

## Original description:

Fixes #25555

`dotnet ef migrations bundle` loads the target and startup assemblies into the tool process to discover the DbContext, then shells out to `dotnet publish`, which rebuilds and overwrites those same bin\...\*.dll files. On Windows a loaded assembly file is locked, so the copy fails with MSB3027/MSB3021 ("being used by another process"). The assemblies were loaded into the non-collectible default AssemblyLoadContext, so they could never be released while the tool process was alive.

Load them into a collectible AssemblyLoadContext instead and unload it when the executor is disposed (before publish runs), releasing the files.
