### PR TITLE
fix: handle when WinRT APIs are unavailable

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -94,20 +94,29 @@ public partial class SqliteConnection : DbConnection
 
             if (currentAppData != null)
             {
-                var localFolder = appDataType?.GetRuntimeProperty("LocalFolder")?.GetValue(currentAppData);
-                var localFolderPath = (string?)storageFolderType?.GetRuntimeProperty("Path")?.GetValue(localFolder);
-                if (localFolderPath != null)
+                try
                 {
-                    var rc = sqlite3_win32_set_directory(SQLITE_WIN32_DATA_DIRECTORY_TYPE, localFolderPath);
-                    Debug.Assert(rc == SQLITE_OK);
+                    var localFolder = appDataType?.GetRuntimeProperty("LocalFolder")?.GetValue(currentAppData);
+                    var localFolderPath = (string?)storageFolderType?.GetRuntimeProperty("Path")?.GetValue(localFolder);
+                    if (localFolderPath != null)
+                    {
+                        var rc = sqlite3_win32_set_directory(SQLITE_WIN32_DATA_DIRECTORY_TYPE, localFolderPath);
+                        Debug.Assert(rc == SQLITE_OK);
+                    }
+            
+                    var tempFolder = appDataType?.GetRuntimeProperty("TemporaryFolder")?.GetValue(currentAppData);
+                    var tempFolderPath = (string?)storageFolderType?.GetRuntimeProperty("Path")?.GetValue(tempFolder);
+                    if (tempFolderPath != null)
+                    {
+                        var rc = sqlite3_win32_set_directory(SQLITE_WIN32_TEMP_DIRECTORY_TYPE, tempFolderPath);
+                        Debug.Assert(rc == SQLITE_OK);
+                    }
                 }
-
-                var tempFolder = appDataType?.GetRuntimeProperty("TemporaryFolder")?.GetValue(currentAppData);
-                var tempFolderPath = (string?)storageFolderType?.GetRuntimeProperty("Path")?.GetValue(tempFolder);
-                if (tempFolderPath != null)
+                catch (Exception ex) when (ex is TargetInvocationException 
+                                        or NotImplementedException 
+                                        or NotSupportedException)
                 {
-                    var rc = sqlite3_win32_set_directory(SQLITE_WIN32_TEMP_DIRECTORY_TYPE, tempFolderPath);
-                    Debug.Assert(rc == SQLITE_OK);
+                    // Ignore failures accessing LocalFolder/TemporaryFolder when WinRT isn't fully implemented.
                 }
             }
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -86,6 +86,11 @@ public partial class SqliteConnection : DbConnection
             {
                 // Ignore the unpackaged-app "no package identity" case; ApplicationData.Current is unavailable there.
             }
+            catch (Exception ex) when (ex is NotImplementedException or NotSupportedException)
+            {
+                // Ignore when WinRT APIs aren't implemented or supported (e.g., running under Wine)
+                // ApplicationData.Current is unavailable there.
+            }
 
             if (currentAppData != null)
             {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -86,7 +86,8 @@ public partial class SqliteConnection : DbConnection
             {
                 // Ignore the unpackaged-app "no package identity" case; ApplicationData.Current is unavailable there.
             }
-            catch (Exception ex) when (ex is NotImplementedException or NotSupportedException)
+            catch (Exception ex) when (ex is NotImplementedException or NotSupportedException
+                                           or TargetInvocationException { InnerException: NotImplementedException or NotSupportedException })
             {
                 // Ignore when WinRT APIs aren't implemented or supported (e.g., running under Wine)
                 // ApplicationData.Current is unavailable there.
@@ -103,7 +104,7 @@ public partial class SqliteConnection : DbConnection
                         var rc = sqlite3_win32_set_directory(SQLITE_WIN32_DATA_DIRECTORY_TYPE, localFolderPath);
                         Debug.Assert(rc == SQLITE_OK);
                     }
-            
+
                     var tempFolder = appDataType?.GetRuntimeProperty("TemporaryFolder")?.GetValue(currentAppData);
                     var tempFolderPath = (string?)storageFolderType?.GetRuntimeProperty("Path")?.GetValue(tempFolder);
                     if (tempFolderPath != null)
@@ -112,9 +113,8 @@ public partial class SqliteConnection : DbConnection
                         Debug.Assert(rc == SQLITE_OK);
                     }
                 }
-                catch (Exception ex) when (ex is TargetInvocationException 
-                                        or NotImplementedException 
-                                        or NotSupportedException)
+                catch (Exception ex) when (ex is NotImplementedException or NotSupportedException
+                                               or TargetInvocationException { InnerException: NotImplementedException or NotSupportedException })
                 {
                     // Ignore failures accessing LocalFolder/TemporaryFolder when WinRT isn't fully implemented.
                 }


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)

The change is a small addition to an existing exception filter and doesn't introduce new behavior that requires unit testing. The exceptions being added are already handled conceptually by the existing "feature unavailable" logic.

- [x] Code follows the same patterns and style as existing code in this repo


## Motivation

The existing code already catches exceptions from the initial WinRT call (e.g., `TargetInvocationException` and `InvalidOperationException` for unpackaged apps). However, Wine partially implements WinRT — it successfully returns a `ApplicationData` object from the first call, but then throws `NotImplementedException` when accessing the `LocalFolder` property. Since this exception isn't caught, the entire `SqliteConnection` type becomes unusable.

**Note:** `System.Data.SQLite` works fine under Wine because it doesn't attempt this WinRT trick. However, I love Microsoft.Data.Sqlite and I'm a programmer that daily drives Linux and want to test my application under Wine instead of an VM. It'd also fix [ShareX's latest versions under Wine](https://github.com/ShareX/ShareX/issues/6531#issuecomment-3234629414) too.

Fixes [#36343](https://github.com/dotnet/efcore/issues/36343)