### PR TITLE
Fold single-table filter subqueries into joins on SQLite

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
@@ -39,6 +39,10 @@ public class SqliteQueryTranslationPostprocessor : RelationalQueryTranslationPos
     public override Expression Process(Expression query)
     {
         var result = base.Process(query);
+
+        // Fold single-table filter subqueries in LEFT/INNER joins back into the join condition, removing needless subqueries.
+        result = new SqliteSubqueryToJoinRewriter(RelationalDependencies.SqlExpressionFactory).Visit(result);
+
         _applyValidator.Visit(result);
 
         return result;

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSubqueryToJoinRewriter.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSubqueryToJoinRewriter.cs
@@ -1,0 +1,218 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     Rewrites a LEFT/INNER JOIN over a single-table subquery whose only content is a WHERE filter into a join over the table
+///     itself, folding the filter into the join condition. This removes an unnecessary subquery for queries such as
+///     <c>from b in Bars.Where(x =&gt; x.FooId == foo.Id &amp;&amp; x.State == "Blah").DefaultIfEmpty()</c>, which EF otherwise
+///     translates to a <c>LEFT JOIN (SELECT ... WHERE State = 'Blah')</c>.
+/// </summary>
+/// <remarks>
+///     A subquery is only unwrapped when no other join in the same SELECT references its alias in a join condition. Such a
+///     dependency (e.g. a nested collection include whose join keys off the previous subquery) relies on the subquery having
+///     already filtered its rows, so folding the filter out would change the query's results.
+///
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class SqliteSubqueryToJoinRewriter(ISqlExpressionFactory sqlExpressionFactory) : ExpressionVisitor
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitExtension(Expression node)
+    {
+        if (node is ShapedQueryExpression shapedQuery)
+        {
+            return shapedQuery
+                .UpdateQueryExpression(Visit(shapedQuery.QueryExpression))
+                .UpdateShaperExpression(Visit(shapedQuery.ShaperExpression));
+        }
+
+        var visited = base.VisitExtension(node);
+
+        return visited is SelectExpression select ? TryFlattenJoins(select) : visited;
+    }
+
+    private Expression TryFlattenJoins(SelectExpression select)
+    {
+        List<TableExpressionBase>? newTables = null;
+        Dictionary<string, (IReadOnlyDictionary<string, SqlExpression> Map, bool IsLeftJoin)>? inlinedAliases = null;
+
+        for (var i = 0; i < select.Tables.Count; i++)
+        {
+            if (select.Tables[i] is not PredicateJoinExpressionBase { Table: SelectExpression inner } join
+                || join is not (InnerJoinExpression or LeftJoinExpression)
+                || !IsFilterOnlySubquery(inner)
+                || IsAliasReferencedElsewhere(select, inner.Alias!, i)
+                || JoinKeyReferencesSibling(select, join, i)
+                // Under a LEFT JOIN the projected columns must be made nullable; we can only do that for bare column projections.
+                || (join is LeftJoinExpression && inner.Projection.Any(p => p.Expression is not ColumnExpression))
+                // A predicate made purely of IS NOT NULL checks is an optional-entity existence test (table splitting), not a real
+                // filter; the containing query uses it to decide whether the entity is present, so keep it inside the subquery.
+                || (join is LeftJoinExpression && IsExistenceCheckOnly(inner.Predicate!)))
+            {
+                continue;
+            }
+
+            var projectionMap = inner.Projection.ToDictionary(p => p.Alias, p => p.Expression);
+            var inliner = new AliasInliningVisitor(inner.Alias!, projectionMap);
+
+            // The subquery's WHERE moves onto the join condition; both the existing join key and the filter are remapped from the
+            // subquery alias onto the underlying table's columns.
+            var newJoinPredicate = sqlExpressionFactory.AndAlso(
+                (SqlExpression)inliner.Visit(join.JoinPredicate),
+                (SqlExpression)inliner.Visit(inner.Predicate!));
+
+            newTables ??= [.. select.Tables];
+            newTables[i] = join is InnerJoinExpression
+                ? new InnerJoinExpression(inner.Tables[0], newJoinPredicate)
+                : new LeftJoinExpression(inner.Tables[0], newJoinPredicate);
+
+            inlinedAliases ??= [];
+            inlinedAliases[inner.Alias!] = (projectionMap, join is LeftJoinExpression);
+        }
+
+        if (newTables is null)
+        {
+            return select;
+        }
+
+        // Anything in the containing SELECT that referenced the removed subquery alias now points at the underlying table's columns.
+        var outerInliner = new MultiAliasInliningVisitor(inlinedAliases!);
+
+        return select.Update(
+            newTables,
+            (SqlExpression?)outerInliner.Visit(select.Predicate),
+            select.GroupBy.Select(g => (SqlExpression)outerInliner.Visit(g)).ToList(),
+            (SqlExpression?)outerInliner.Visit(select.Having),
+            select.Projection.Select(p => (ProjectionExpression)outerInliner.Visit(p)).ToList(),
+            select.Orderings.Select(o => (OrderingExpression)outerInliner.Visit(o)).ToList(),
+            (SqlExpression?)outerInliner.Visit(select.Offset),
+            (SqlExpression?)outerInliner.Visit(select.Limit));
+    }
+
+    // An "IS NOT NULL" check is a SqlUnaryExpression with a NotEqual operator; a predicate built only from these (AND-ed together)
+    // is an entity-existence test rather than a value filter.
+    private static bool IsExistenceCheckOnly(SqlExpression predicate)
+        => predicate switch
+        {
+            SqlUnaryExpression { OperatorType: ExpressionType.NotEqual } => true,
+            SqlBinaryExpression { OperatorType: ExpressionType.AndAlso } binary
+                => IsExistenceCheckOnly(binary.Left) && IsExistenceCheckOnly(binary.Right),
+            _ => false
+        };
+
+    private static bool IsFilterOnlySubquery(SelectExpression select)
+        => select is
+        {
+            Tables: [TableExpression],
+            Predicate: not null,
+            GroupBy: [],
+            Having: null,
+            Orderings: [],
+            Limit: null,
+            Offset: null,
+            IsDistinct: false
+        };
+
+    // Any reference to the subquery alias from another table in the FROM clause (a sibling join's condition, or a correlated
+    // subquery nested inside one) means that table depends on the subquery having filtered its rows first, so it can't be unwrapped.
+    // References from the projection, predicate or orderings are fine, since those are remapped onto the underlying columns.
+    private static bool IsAliasReferencedElsewhere(SelectExpression select, string alias, int currentIndex)
+    {
+        for (var i = 0; i < select.Tables.Count; i++)
+        {
+            if (i != currentIndex
+                && new AliasReferenceFindingVisitor(alias).ContainsReference(select.Tables[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // If this join's own condition references another sibling join's table (a correlated join chain), unwrapping it would change
+    // the join order and nullability semantics that chain relies on (e.g. keying off a preceding optional/LEFT JOIN), so leave it.
+    private static bool JoinKeyReferencesSibling(SelectExpression select, PredicateJoinExpressionBase join, int currentIndex)
+    {
+        for (var i = 0; i < select.Tables.Count; i++)
+        {
+            if (i != currentIndex
+                && select.Tables[i] is PredicateJoinExpressionBase otherJoin
+                && otherJoin.Table.Alias is { } siblingAlias
+                && new AliasReferenceFindingVisitor(siblingAlias).ContainsReference(join.JoinPredicate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class AliasReferenceFindingVisitor(string alias) : ExpressionVisitor
+    {
+        private bool _found;
+
+        public bool ContainsReference(Expression expression)
+        {
+            _found = false;
+            Visit(expression);
+            return _found;
+        }
+
+        public override Expression? Visit(Expression? node)
+        {
+            if (_found)
+            {
+                return node;
+            }
+
+            if (node is ColumnExpression column && column.TableAlias == alias)
+            {
+                _found = true;
+                return node;
+            }
+
+            return base.Visit(node);
+        }
+    }
+
+    private sealed class AliasInliningVisitor(string alias, IReadOnlyDictionary<string, SqlExpression> projectionMap)
+        : ExpressionVisitor
+    {
+        protected override Expression VisitExtension(Expression node)
+            => node is ColumnExpression column && column.TableAlias == alias && projectionMap.TryGetValue(column.Name, out var expr)
+                ? expr
+                : base.VisitExtension(node);
+    }
+
+    private sealed class MultiAliasInliningVisitor(
+        IReadOnlyDictionary<string, (IReadOnlyDictionary<string, SqlExpression> Map, bool IsLeftJoin)> inlinedAliases)
+        : ExpressionVisitor
+    {
+        protected override Expression VisitExtension(Expression node)
+        {
+            if (node is ColumnExpression column
+                && inlinedAliases.TryGetValue(column.TableAlias, out var entry)
+                && entry.Map.TryGetValue(column.Name, out var expr))
+            {
+                // Under a LEFT JOIN the unwrapped table's columns become nullable (no match yields NULL), so the reference that used
+                // to point at the subquery's already-nullable projection must be made nullable too.
+                return entry.IsLeftJoin && expr is ColumnExpression inlinedColumn ? inlinedColumn.MakeNullable() : expr;
+            }
+
+            return base.VisitExtension(node);
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -322,12 +322,8 @@ DELETE FROM "Order Details" AS "o"
 WHERE EXISTS (
     SELECT 1
     FROM "Orders" AS "o0"
-    INNER JOIN (
-        SELECT "o2"."OrderID", "o2"."ProductID"
-        FROM "Order Details" AS "o2"
-        WHERE "o2"."ProductID" > 0
-    ) AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
-    WHERE "o0"."OrderID" < 10250 AND "o1"."OrderID" = "o"."OrderID" AND "o1"."ProductID" = "o"."ProductID")
+    INNER JOIN "Order Details" AS "o2" ON "o0"."OrderID" = "o2"."OrderID" AND "o2"."ProductID" > 0
+    WHERE "o0"."OrderID" < 10250 AND "o2"."OrderID" = "o"."OrderID" AND "o2"."ProductID" = "o"."ProductID")
 """);
     }
 
@@ -1325,11 +1321,7 @@ SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
-    LEFT JOIN (
-        SELECT "o"."CustomerID"
-        FROM "Orders" AS "o"
-        WHERE "o"."OrderID" < 10300
-    ) AS "o0" ON "c"."CustomerID" = "o0"."CustomerID"
+    LEFT JOIN "Orders" AS "o" ON "c"."CustomerID" = "o"."CustomerID" AND "o"."OrderID" < 10300
     WHERE "c"."CustomerID" LIKE 'F%'
 ) AS "s"
 WHERE "c0"."CustomerID" = "s"."CustomerID"
@@ -1349,11 +1341,7 @@ SET "ContactName" = @p
 FROM (
     SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
-    LEFT JOIN (
-        SELECT "o"."CustomerID"
-        FROM "Orders" AS "o"
-        WHERE "o"."OrderID" < 10300
-    ) AS "o0" ON "c"."CustomerID" = "o0"."CustomerID"
+    LEFT JOIN "Orders" AS "o" ON "c"."CustomerID" = "o"."CustomerID" AND "o"."OrderID" < 10300
     WHERE "c"."CustomerID" LIKE 'F%'
 ) AS "s"
 WHERE "c0"."CustomerID" = "s"."CustomerID"
@@ -1467,13 +1455,9 @@ WHERE "c"."CustomerID" LIKE 'F%'
 UPDATE "Orders" AS "o1"
 SET "OrderDate" = NULL
 FROM (
-    SELECT "o0"."OrderID"
+    SELECT "o"."OrderID"
     FROM "Customers" AS "c"
-    INNER JOIN (
-        SELECT "o"."OrderID", "o"."CustomerID"
-        FROM "Orders" AS "o"
-        WHERE CAST(strftime('%Y', "o"."OrderDate") AS INTEGER) = 1997
-    ) AS "o0" ON "c"."CustomerID" = "o0"."CustomerID"
+    INNER JOIN "Orders" AS "o" ON "c"."CustomerID" = "o"."CustomerID" AND CAST(strftime('%Y', "o"."OrderDate") AS INTEGER) = 1997
     WHERE "c"."CustomerID" LIKE 'F%'
 ) AS "s"
 WHERE "o1"."OrderID" = "s"."OrderID"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -1092,13 +1092,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "c1"."BillingAddress_ZipCode"
+SELECT "c0"."BillingAddress_ZipCode"
 FROM "CustomerGroup" AS "c"
-LEFT JOIN (
-    SELECT "c0"."Id", "c0"."BillingAddress_ZipCode"
-    FROM "Customer" AS "c0"
-    WHERE "c0"."Id" > 5
-) AS "c1" ON "c"."Id" = "c1"."Id"
+LEFT JOIN "Customer" AS "c0" ON "c"."Id" = "c0"."Id" AND "c0"."Id" > 5
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -433,13 +433,9 @@ LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSqu
 
         AssertSql(
             """
-SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated", "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId", "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId"
+SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated", "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId", "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 LEFT JOIN "LocustLeaders" AS "l1" ON "f"."Id" = "l1"."LocustHordeId"
 ORDER BY "f"."Name", "f"."Id"
 """);
@@ -451,13 +447,9 @@ ORDER BY "f"."Name", "f"."Id"
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
 WHERE "g"."Nickname" <> 'Marcus'
 ORDER BY "g"."Nickname", "g"."SquadId"
 """);
@@ -474,13 +466,9 @@ FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname"
 LEFT JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
 LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+    SELECT "g0"."Nickname", "g0"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
     FROM "Gears" AS "g0"
-    LEFT JOIN (
-        SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-        FROM "Weapons" AS "w"
-        WHERE "w"."IsAutomatic"
-    ) AS "w0" ON "g0"."FullName" = "w0"."OwnerFullName"
+    LEFT JOIN "Weapons" AS "w" ON "g0"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic"
     WHERE "g0"."HasSoulPatch"
 ) AS "s0" ON "s"."Id" = "s0"."SquadId"
 ORDER BY "t"."Note", "g"."Nickname" DESC, "t"."Id", "g"."SquadId", "s0"."Nickname", "s0"."SquadId"
@@ -599,12 +587,8 @@ INNER JOIN (
             """
 SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
-WHERE "l0"."Name" IS NOT NULL
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
+WHERE "l"."Name" IS NOT NULL
 """);
     }
 
@@ -1047,16 +1031,12 @@ END
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Name", "w0"."IsAutomatic", "w0"."Id", "g0"."Nickname", "g0"."Rank", "g0"."SquadId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Name", "w"."IsAutomatic", "w"."Id", "g0"."Nickname", "g0"."Rank", "g0"."SquadId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Name", "w"."IsAutomatic", "w"."Id", "w"."OwnerFullName"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic"
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic"
 LEFT JOIN "Gears" AS "g0" ON "g"."Nickname" = "g0"."LeaderNickname" AND "g"."SquadId" = "g0"."LeaderSquadId"
 WHERE "g"."Discriminator" = 'Officer'
-ORDER BY "g"."FullName", "g"."Nickname", "g"."SquadId", "w0"."Id", "g0"."FullName", "g0"."Nickname"
+ORDER BY "g"."FullName", "g"."Nickname", "g"."SquadId", "w"."Id", "g0"."FullName", "g0"."Nickname"
 """);
     }
 
@@ -1066,15 +1046,11 @@ ORDER BY "g"."FullName", "g"."Nickname", "g"."SquadId", "w0"."Id", "g0"."FullNam
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
 WHERE "g"."Nickname" <> 'Marcus'
-ORDER BY "g"."Nickname", "g"."SquadId", "w0"."Name" DESC
+ORDER BY "g"."Nickname", "g"."SquadId", "w"."Name" DESC
 """);
     }
 
@@ -1279,18 +1255,14 @@ WHERE "g"."Discriminator" = 'Officer'
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "g1"."Nickname", "g1"."SquadId", "g1"."AssignedCityName", "g1"."CityOfBirthName", "g1"."Discriminator", "g1"."FullName", "g1"."HasSoulPatch", "g1"."LeaderNickname", "g1"."LeaderSquadId", "g1"."Rank"
+SELECT "g"."Nickname", "g"."SquadId", "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
-    FROM "Gears" AS "g0"
-    WHERE NOT ("g0"."HasSoulPatch")
-) AS "g1" ON "g"."Nickname" = "g1"."LeaderNickname" AND "g"."SquadId" = "g1"."LeaderSquadId"
+LEFT JOIN "Gears" AS "g0" ON "g"."Nickname" = "g0"."LeaderNickname" AND "g"."SquadId" = "g0"."LeaderSquadId" AND NOT ("g0"."HasSoulPatch")
 WHERE "g"."Discriminator" = 'Officer'
 ORDER BY (
     SELECT COUNT(*)
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName"), "g"."Nickname", "g"."SquadId", "g1"."Nickname"
+    WHERE "g"."FullName" = "w"."OwnerFullName"), "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 """);
     }
 
@@ -1305,13 +1277,9 @@ FROM "Weapons" AS "w"
 LEFT JOIN "Gears" AS "g" ON "w"."OwnerFullName" = "g"."FullName"
 LEFT JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
 LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "w1"."Id", "w1"."AmmunitionType", "w1"."IsAutomatic", "w1"."Name", "w1"."OwnerFullName", "w1"."SynergyWithId", "g0"."Rank", "g0"."FullName"
+    SELECT "g0"."Nickname", "g0"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId", "g0"."Rank", "g0"."FullName"
     FROM "Gears" AS "g0"
-    LEFT JOIN (
-        SELECT "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
-        FROM "Weapons" AS "w0"
-        WHERE NOT ("w0"."IsAutomatic")
-    ) AS "w1" ON "g0"."FullName" = "w1"."OwnerFullName"
+    LEFT JOIN "Weapons" AS "w0" ON "g0"."FullName" = "w0"."OwnerFullName" AND NOT ("w0"."IsAutomatic")
 ) AS "s0" ON "s"."Id" = "s0"."SquadId"
 ORDER BY "w"."Name", "w"."Id", "s0"."FullName" DESC, "s0"."Nickname", "s0"."SquadId", "s0"."Id"
 """);
@@ -1334,15 +1302,11 @@ FROM "Weapons" AS "w"
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "g1"."Nickname", "g1"."FullName", "g1"."SquadId"
+SELECT "g"."Nickname", "g"."SquadId", "g0"."Nickname", "g0"."FullName", "g0"."SquadId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."FullName", "g0"."SquadId", "g0"."LeaderNickname", "g0"."LeaderSquadId"
-    FROM "Gears" AS "g0"
-    WHERE NOT ("g0"."HasSoulPatch")
-) AS "g1" ON "g"."Nickname" = "g1"."LeaderNickname" AND "g"."SquadId" = "g1"."LeaderSquadId"
+LEFT JOIN "Gears" AS "g0" ON "g"."Nickname" = "g0"."LeaderNickname" AND "g"."SquadId" = "g0"."LeaderSquadId" AND NOT ("g0"."HasSoulPatch")
 WHERE "g"."Discriminator" = 'Officer' AND "g"."Nickname" <> 'Foo'
-ORDER BY "g"."Nickname", "g"."SquadId", "g1"."Nickname"
+ORDER BY "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 """);
     }
 
@@ -1431,13 +1395,9 @@ ORDER BY "g"."Nickname", "g"."SquadId"
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Name", "w0"."Id"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Name", "w"."Id"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Name", "w"."Id", "w"."OwnerFullName"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
 WHERE "g"."Nickname" <> 'Marcus'
 ORDER BY "g"."Nickname", "g"."SquadId"
 """);
@@ -1687,13 +1647,9 @@ ORDER BY "t"."Note"
 
         AssertSql(
             """
-SELECT "f"."Name", "l0"."ThreatLevel" AS "Threat"
+SELECT "f"."Name", "l"."ThreatLevel" AS "Threat"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."ThreatLevel"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 ORDER BY "f"."Name"
 """);
     }
@@ -1861,12 +1817,8 @@ WHERE ("t"."Note" <> 'K.I.A.' OR "t"."Note" IS NULL) AND "g"."SquadId" IN (
             """
 SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
-WHERE "l0"."Name" IS NOT NULL
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
+WHERE "l"."Name" IS NOT NULL
 """);
     }
 
@@ -1891,21 +1843,13 @@ GROUP BY "g0"."CityOfBirthName", "g0"."HasSoulPatch", "g0"."IsMarcus"
 
         AssertSql(
             """
-SELECT "g"."Nickname", "s"."Name", "g"."SquadId", "s"."Id", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId", "g1"."Nickname", "g1"."SquadId", "g1"."AssignedCityName", "g1"."CityOfBirthName", "g1"."Discriminator", "g1"."FullName", "g1"."HasSoulPatch", "g1"."LeaderNickname", "g1"."LeaderSquadId", "g1"."Rank"
+SELECT "g"."Nickname", "s"."Name", "g"."SquadId", "s"."Id", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId", "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
 FROM "Gears" AS "g"
 CROSS JOIN "Squads" AS "s"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
-LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
-    FROM "Gears" AS "g0"
-    WHERE NOT ("g0"."HasSoulPatch")
-) AS "g1" ON "s"."Id" = "g1"."SquadId"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
+LEFT JOIN "Gears" AS "g0" ON "s"."Id" = "g0"."SquadId" AND NOT ("g0"."HasSoulPatch")
 WHERE "g"."HasSoulPatch"
-ORDER BY "g"."Nickname", "s"."Id" DESC, "g"."SquadId", "w0"."Id", "g1"."Nickname"
+ORDER BY "g"."Nickname", "s"."Id" DESC, "g"."SquadId", "w"."Id", "g0"."Nickname"
 """);
     }
 
@@ -2158,13 +2102,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "g2"."Nickname", "g2"."SquadId", "g2"."AssignedCityName", "g2"."CityOfBirthName", "g2"."Discriminator", "g2"."FullName", "g2"."HasSoulPatch", "g2"."LeaderNickname", "g2"."LeaderSquadId", "g2"."Rank"
+SELECT "g"."Nickname", "g"."SquadId", "g1"."Nickname", "g1"."SquadId", "g1"."AssignedCityName", "g1"."CityOfBirthName", "g1"."Discriminator", "g1"."FullName", "g1"."HasSoulPatch", "g1"."LeaderNickname", "g1"."LeaderSquadId", "g1"."Rank"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "g1"."Nickname", "g1"."SquadId", "g1"."AssignedCityName", "g1"."CityOfBirthName", "g1"."Discriminator", "g1"."FullName", "g1"."HasSoulPatch", "g1"."LeaderNickname", "g1"."LeaderSquadId", "g1"."Rank"
-    FROM "Gears" AS "g1"
-    WHERE NOT ("g1"."HasSoulPatch")
-) AS "g2" ON "g"."Nickname" = "g2"."LeaderNickname" AND "g"."SquadId" = "g2"."LeaderSquadId"
+LEFT JOIN "Gears" AS "g1" ON "g"."Nickname" = "g1"."LeaderNickname" AND "g"."SquadId" = "g1"."LeaderSquadId" AND NOT ("g1"."HasSoulPatch")
 WHERE "g"."Discriminator" = 'Officer'
 ORDER BY (
     SELECT COUNT(*)
@@ -2173,7 +2113,7 @@ ORDER BY (
         SELECT "g0"."HasSoulPatch"
         FROM "Gears" AS "g0"
         WHERE "g0"."Nickname" = 'Marcus'
-        LIMIT 1), 0)), "g"."Nickname", "g"."SquadId", "g2"."Nickname"
+        LIMIT 1), 0)), "g"."Nickname", "g"."SquadId", "g1"."Nickname"
 """);
     }
 
@@ -2373,14 +2313,10 @@ ORDER BY "g"."Nickname"
 
         AssertSql(
             """
-SELECT "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
+SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "Factions" AS "f"
 LEFT JOIN "Cities" AS "c" ON "f"."CapitalName" = "c"."Name"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 WHERE "c"."Name" <> 'Foo' OR "c"."Name" IS NULL
 """);
     }
@@ -2679,13 +2615,9 @@ END
 
         AssertSql(
             """
-SELECT "g"."FullName" AS "GearName", "g1"."FullName" AS "OfficerName"
+SELECT "g"."FullName" AS "GearName", "g0"."FullName" AS "OfficerName"
 FROM "Gears" AS "g"
-INNER JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "g0"."FullName"
-    FROM "Gears" AS "g0"
-    WHERE "g0"."Discriminator" = 'Officer'
-) AS "g1" ON "g"."Nickname" = "g1"."Nickname" AND "g"."SquadId" = "g1"."SquadId"
+INNER JOIN "Gears" AS "g0" ON "g"."Nickname" = "g0"."Nickname" AND "g"."SquadId" = "g0"."SquadId" AND "g0"."Discriminator" = 'Officer'
 """);
     }
 
@@ -3367,12 +3299,8 @@ WHERE COALESCE((
 SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "Factions" AS "f"
 LEFT JOIN "Cities" AS "c" ON "f"."CapitalName" = "c"."Name"
-LEFT JOIN (
-    SELECT "l"."Name"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
-WHERE ("c"."Name" <> 'Foo' OR "c"."Name" IS NULL) AND ("l0"."Name" <> 'Bar' OR "l0"."Name" IS NULL)
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
+WHERE ("c"."Name" <> 'Foo' OR "c"."Name" IS NULL) AND ("l"."Name" <> 'Bar' OR "l"."Name" IS NULL)
 """);
     }
 
@@ -3414,19 +3342,11 @@ ORDER BY "g"."Nickname"
 
         AssertSql(
             """
-SELECT "g"."FullName", "g"."Nickname", "g"."SquadId", "w1"."Id", "w1"."AmmunitionType", "w1"."IsAutomatic", "w1"."Name", "w1"."OwnerFullName", "w1"."SynergyWithId", "w2"."Id", "w2"."AmmunitionType", "w2"."IsAutomatic", "w2"."Name", "w2"."OwnerFullName", "w2"."SynergyWithId"
+SELECT "g"."FullName", "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic"
-) AS "w1" ON "g"."FullName" = "w1"."OwnerFullName"
-LEFT JOIN (
-    SELECT "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
-    FROM "Weapons" AS "w0"
-    WHERE NOT ("w0"."IsAutomatic")
-) AS "w2" ON "g"."FullName" = "w2"."OwnerFullName"
-ORDER BY "g"."Rank", "g"."Nickname", "g"."SquadId", "w1"."OwnerFullName", "w1"."Id", "w2"."IsAutomatic"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic"
+LEFT JOIN "Weapons" AS "w0" ON "g"."FullName" = "w0"."OwnerFullName" AND NOT ("w0"."IsAutomatic")
+ORDER BY "g"."Rank", "g"."Nickname", "g"."SquadId", "w"."OwnerFullName", "w"."Id", "w0"."IsAutomatic"
 """);
     }
 
@@ -3572,12 +3492,8 @@ WHERE "c"."Name" = (
 SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "Factions" AS "f"
 LEFT JOIN "Cities" AS "c" ON "f"."CapitalName" = "c"."Name"
-LEFT JOIN (
-    SELECT "l"."Name"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
-WHERE ("c"."Name" <> 'Foo' OR "c"."Name" IS NULL) AND ("l0"."Name" <> 'Bar' OR "l0"."Name" IS NULL)
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
+WHERE ("c"."Name" <> 'Foo' OR "c"."Name" IS NULL) AND ("l"."Name" <> 'Bar' OR "l"."Name" IS NULL)
 """);
     }
 
@@ -4328,15 +4244,11 @@ WHERE EXISTS (
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "g1"."Nickname", "g1"."SquadId", "g1"."AssignedCityName", "g1"."CityOfBirthName", "g1"."Discriminator", "g1"."FullName", "g1"."HasSoulPatch", "g1"."LeaderNickname", "g1"."LeaderSquadId", "g1"."Rank"
+SELECT "g"."Nickname", "g"."SquadId", "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
-    FROM "Gears" AS "g0"
-    WHERE "g0"."Nickname" <> 'Dom'
-) AS "g1" ON "g"."Nickname" = "g1"."LeaderNickname" AND "g"."SquadId" = "g1"."LeaderSquadId"
+LEFT JOIN "Gears" AS "g0" ON "g"."Nickname" = "g0"."LeaderNickname" AND "g"."SquadId" = "g0"."LeaderSquadId" AND "g0"."Nickname" <> 'Dom'
 WHERE "g"."Discriminator" = 'Officer'
-ORDER BY "g"."Nickname", "g"."SquadId", "g1"."Nickname"
+ORDER BY "g"."Nickname", "g"."SquadId", "g0"."Nickname"
 """);
     }
 
@@ -4359,13 +4271,9 @@ WHERE "t"."Note" <> 'K.I.A.' OR "t"."Note" IS NULL
 
         AssertSql(
             """
-SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated", "l0"."ThreatLevel" AS "Threat"
+SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated", "l"."ThreatLevel" AS "Threat"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."ThreatLevel"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 ORDER BY "f"."Name"
 """);
     }
@@ -4596,14 +4504,10 @@ ORDER BY "g0"."FullName", "g0"."Nickname", "g0"."SquadId"
 
         AssertSql(
             """
-SELECT "f0"."Id", "f0"."CapitalName", "f0"."Discriminator", "f0"."Name", "f0"."ServerAddress", "f0"."CommanderName", "f0"."DeputyCommanderName", "f0"."Eradicated"
+SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "LocustLeaders" AS "l"
-LEFT JOIN (
-    SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
-    FROM "Factions" AS "f"
-    WHERE "f"."Name" = 'Swarm'
-) AS "f0" ON "l"."Name" = "f0"."CommanderName"
-WHERE "f0"."Eradicated" <> 1 OR "f0"."Eradicated" IS NULL
+LEFT JOIN "Factions" AS "f" ON "l"."Name" = "f"."CommanderName" AND "f"."Name" = 'Swarm'
+WHERE "f"."Eradicated" <> 1 OR "f"."Eradicated" IS NULL
 """);
     }
 
@@ -4664,14 +4568,10 @@ WHERE "g"."Nickname" <> "g0"."Nickname" OR "g"."SquadId" <> "g0"."SquadId"
 
         AssertSql(
             """
-SELECT "f0"."Id", "f0"."CapitalName", "f0"."Discriminator", "f0"."Name", "f0"."ServerAddress", "f0"."CommanderName", "f0"."DeputyCommanderName", "f0"."Eradicated"
+SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
 FROM "LocustLeaders" AS "l"
-INNER JOIN (
-    SELECT "f"."Id", "f"."CapitalName", "f"."Discriminator", "f"."Name", "f"."ServerAddress", "f"."CommanderName", "f"."DeputyCommanderName", "f"."Eradicated"
-    FROM "Factions" AS "f"
-    WHERE "f"."Name" = 'Swarm'
-) AS "f0" ON "l"."Name" = "f0"."CommanderName"
-WHERE "f0"."Eradicated" <> 1 OR "f0"."Eradicated" IS NULL
+INNER JOIN "Factions" AS "f" ON "l"."Name" = "f"."CommanderName" AND "f"."Name" = 'Swarm'
+WHERE "f"."Eradicated" <> 1 OR "f"."Eradicated" IS NULL
 """);
     }
 
@@ -4686,11 +4586,7 @@ FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch" AND (
     SELECT "w"."IsAutomatic"
     FROM "Weapons" AS "w"
-    INNER JOIN (
-        SELECT "w0"."Id"
-        FROM "Weapons" AS "w0"
-        WHERE "g"."FullName" = "w0"."OwnerFullName"
-    ) AS "w1" ON "w"."Id" = "w1"."Id"
+    INNER JOIN "Weapons" AS "w0" ON "w"."Id" = "w0"."Id" AND "g"."FullName" = "w0"."OwnerFullName"
     WHERE "g"."FullName" = "w"."OwnerFullName"
     ORDER BY "w"."Id"
     LIMIT 1)
@@ -4941,19 +4837,11 @@ LEFT JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
 
         AssertSql(
             """
-SELECT "g"."FullName", "g"."Nickname", "g"."SquadId", "w1"."Id", "w1"."AmmunitionType", "w1"."IsAutomatic", "w1"."Name", "w1"."OwnerFullName", "w1"."SynergyWithId", "w2"."Id", "w2"."AmmunitionType", "w2"."IsAutomatic", "w2"."Name", "w2"."OwnerFullName", "w2"."SynergyWithId"
+SELECT "g"."FullName", "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic"
-) AS "w1" ON "g"."FullName" = "w1"."OwnerFullName"
-LEFT JOIN (
-    SELECT "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
-    FROM "Weapons" AS "w0"
-    WHERE "w0"."IsAutomatic"
-) AS "w2" ON "g"."FullName" = "w2"."OwnerFullName"
-ORDER BY "g"."Nickname", "g"."SquadId", "w1"."Id"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic"
+LEFT JOIN "Weapons" AS "w0" ON "g"."FullName" = "w0"."OwnerFullName" AND "w0"."IsAutomatic"
+ORDER BY "g"."Nickname", "g"."SquadId", "w"."Id"
 """);
     }
 
@@ -5140,13 +5028,9 @@ ORDER BY "g"."Nickname", "g"."SquadId"
 
         AssertSql(
             """
-SELECT "f"."Name", "l0"."Name" AS "CommanderName"
+SELECT "f"."Name", "l"."Name" AS "CommanderName"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 ORDER BY "f"."Name"
 """);
     }
@@ -5243,13 +5127,9 @@ ORDER BY "g"."HasSoulPatch" DESC, "t"."Note"
 
         AssertSql(
             """
-SELECT "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
+SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 """);
     }
 
@@ -5496,13 +5376,9 @@ WHERE "c"."Location" = 'Unknown' AND (
             """
 @prm='1'
 
-SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
+SELECT "g"."Nickname", "g"."FullName", "w"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."OwnerFullName"
-    FROM "Weapons" AS "w"
-    WHERE "w"."Id" > @prm
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."Id" > @prm
 """);
     }
 
@@ -5512,15 +5388,11 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "m0"."Rating"
+SELECT "m"."Rating"
 FROM (
     SELECT 1
 ) AS "e"
-LEFT JOIN (
-    SELECT "m"."Rating"
-    FROM "Missions" AS "m"
-    WHERE "m"."Id" = -1
-) AS "m0" ON 1
+LEFT JOIN "Missions" AS "m" ON "m"."Id" = -1
 """);
     }
 
@@ -5616,13 +5488,9 @@ INNER JOIN (
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
 WHERE "g"."Nickname" <> 'Marcus'
 ORDER BY "g"."Nickname", "g"."SquadId"
 """);
@@ -5873,14 +5741,10 @@ END
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Gears" AS "g"
 INNER JOIN "Cities" AS "c" ON "g"."CityOfBirthName" = "c"."Name"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."Name" <> 'Lancer' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."Name" <> 'Lancer' OR "w"."Name" IS NULL)
 WHERE "c"."Name" IN ('Ephyra', 'Hanover')
 ORDER BY "g"."Nickname", "g"."SquadId"
 """);
@@ -6448,19 +6312,15 @@ ORDER BY "t"."Id", "g0"."Nickname", "g0"."SquadId", "g1"."Nickname"
 
         AssertSql(
             """
-SELECT "g0"."Nickname", "g0"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g0"."Nickname", "g0"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM (
     SELECT "g"."Nickname", "g"."SquadId", "g"."FullName"
     FROM "Gears" AS "g"
     ORDER BY "g"."Nickname"
     LIMIT 1
 ) AS "g0"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE NOT ("w"."IsAutomatic")
-) AS "w0" ON "g0"."FullName" = "w0"."OwnerFullName"
-ORDER BY "g0"."Nickname", "g0"."SquadId", "w0"."Id"
+LEFT JOIN "Weapons" AS "w" ON "g0"."FullName" = "w"."OwnerFullName" AND NOT ("w"."IsAutomatic")
+ORDER BY "g0"."Nickname", "g0"."SquadId", "w"."Id"
 """);
     }
 
@@ -6970,13 +6830,9 @@ FROM "Cities" AS "c"
             """
 @isAutomatic='True'
 
-SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
+SELECT "g"."Nickname", "g"."FullName", "w"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."OwnerFullName"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" = @isAutomatic
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic" = @isAutomatic
 """);
     }
 
@@ -7012,13 +6868,9 @@ WHERE "g"."Nickname" = 'Marcus'
 
         AssertSql(
             """
-SELECT "f"."Name", "l0"."ThreatLevel" AS "Threat"
+SELECT "f"."Name", "l"."ThreatLevel" AS "Threat"
 FROM "Factions" AS "f"
-LEFT JOIN (
-    SELECT "l"."Name", "l"."ThreatLevel"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "f"."CommanderName" = "l0"."Name"
+LEFT JOIN "LocustLeaders" AS "l" ON "f"."CommanderName" = "l"."Name" AND "l"."Discriminator" = 'LocustCommander'
 ORDER BY "f"."Name"
 """);
     }
@@ -7043,13 +6895,9 @@ INNER JOIN "Weapons" AS "w" ON "w"."SynergyWithId" IS NOT NULL
             """
 @isAutomatic='True'
 
-SELECT "g"."Nickname", "g"."FullName", "w0"."Id" IS NOT NULL AS "Collection"
+SELECT "g"."Nickname", "g"."FullName", "w"."Id" IS NOT NULL AS "Collection"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."OwnerFullName"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" <> @isAutomatic
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND "w"."IsAutomatic" <> @isAutomatic
 """);
     }
 
@@ -7346,13 +7194,9 @@ WHERE ("t"."Note" <> 'Foo' OR "t"."Note" IS NULL) AND "g"."Discriminator" = 'Off
 
         AssertSql(
             """
-SELECT "g"."Nickname", "g"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
+SELECT "g"."Nickname", "g"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-    FROM "Weapons" AS "w"
-    WHERE "w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL
-) AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
+LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName" AND ("w"."IsAutomatic" OR "w"."Name" <> 'foo' OR "w"."Name" IS NULL)
 WHERE "g"."Nickname" <> 'Marcus'
 ORDER BY "g"."Nickname", "g"."SquadId"
 """);
@@ -7666,13 +7510,9 @@ CROSS JOIN "Gears" AS "g0"
 SELECT "g"."FullName", "g"."Nickname", "g"."SquadId", "s"."FullName", "s"."Nickname", "s"."SquadId", "s"."Id", "s"."AmmunitionType", "s"."IsAutomatic", "s"."Name", "s"."OwnerFullName", "s"."SynergyWithId"
 FROM "Gears" AS "g"
 LEFT JOIN (
-    SELECT "g0"."FullName", "g0"."Nickname", "g0"."SquadId", "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId", "g0"."Rank", "g0"."LeaderNickname", "g0"."LeaderSquadId"
+    SELECT "g0"."FullName", "g0"."Nickname", "g0"."SquadId", "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId", "g0"."Rank", "g0"."LeaderNickname", "g0"."LeaderSquadId"
     FROM "Gears" AS "g0"
-    LEFT JOIN (
-        SELECT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
-        FROM "Weapons" AS "w"
-        WHERE "w"."Name" <> 'Bar' OR "w"."Name" IS NULL
-    ) AS "w0" ON "g0"."FullName" = "w0"."OwnerFullName"
+    LEFT JOIN "Weapons" AS "w" ON "g0"."FullName" = "w"."OwnerFullName" AND ("w"."Name" <> 'Bar' OR "w"."Name" IS NULL)
     WHERE "g0"."FullName" <> 'Foo'
 ) AS "s" ON "g"."Nickname" = "s"."LeaderNickname" AND "g"."SquadId" = "s"."LeaderSquadId"
 WHERE "g"."Discriminator" = 'Officer'
@@ -7861,14 +7701,10 @@ END = 'Tyrus'
 SELECT "f"."Name"
 FROM "Factions" AS "f"
 LEFT JOIN "LocustLeaders" AS "l" ON "f"."DeputyCommanderName" = "l"."Name"
-LEFT JOIN (
-    SELECT "l0"."Name", "l0"."ThreatLevel"
-    FROM "LocustLeaders" AS "l0"
-    WHERE "l0"."Discriminator" = 'LocustCommander'
-) AS "l1" ON "f"."CommanderName" = "l1"."Name"
+LEFT JOIN "LocustLeaders" AS "l0" ON "f"."CommanderName" = "l0"."Name" AND "l0"."Discriminator" = 'LocustCommander'
 WHERE CASE
     WHEN "l"."Name" IS NOT NULL THEN "l"."ThreatLevel"
-    ELSE "l1"."ThreatLevel"
+    ELSE "l0"."ThreatLevel"
 END = 4
 """);
     }
@@ -8274,18 +8110,14 @@ ORDER BY "g"."Nickname", "m"."Id"
 
         AssertSql(
             """
-SELECT 1, "l2"."Name", "l2"."Discriminator", "l2"."LocustHordeId", "l2"."ThreatLevel", "l2"."ThreatLevelByte", "l2"."ThreatLevelNullableByte", "l2"."DefeatedByNickname", "l2"."DefeatedBySquadId", "l2"."HighCommandId", "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
+SELECT 1, "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId", "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
 FROM "Factions" AS "f"
 CROSS JOIN (
     SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
     FROM "LocustLeaders" AS "l"
     WHERE "l"."Discriminator" = 'LocustCommander'
 ) AS "l0"
-LEFT JOIN (
-    SELECT "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId"
-    FROM "LocustLeaders" AS "l1"
-    WHERE "l1"."Discriminator" = 'LocustCommander'
-) AS "l2" ON "f"."CommanderName" = "l2"."Name"
+LEFT JOIN "LocustLeaders" AS "l1" ON "f"."CommanderName" = "l1"."Name" AND "l1"."Discriminator" = 'LocustCommander'
 """);
     }
 
@@ -8295,18 +8127,10 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "l2"."Name", "l2"."Discriminator", "l2"."LocustHordeId", "l2"."ThreatLevel", "l2"."ThreatLevelByte", "l2"."ThreatLevelNullableByte", "l2"."DefeatedByNickname", "l2"."DefeatedBySquadId", "l2"."HighCommandId", "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
+SELECT "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId", "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "Factions" AS "f"
-CROSS JOIN (
-    SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0"
-LEFT JOIN (
-    SELECT "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId"
-    FROM "LocustLeaders" AS "l1"
-    WHERE "l1"."Discriminator" = 'LocustCommander'
-) AS "l2" ON "f"."CommanderName" = "l2"."Name"
+INNER JOIN "LocustLeaders" AS "l" ON "l"."Discriminator" = 'LocustCommander'
+LEFT JOIN "LocustLeaders" AS "l1" ON "f"."CommanderName" = "l1"."Name" AND "l1"."Discriminator" = 'LocustCommander'
 """);
     }
 
@@ -8316,18 +8140,10 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "l2"."Name" = 'Queen Myrrah' AND "l2"."Name" IS NOT NULL, "l2"."Name", "l2"."Discriminator", "l2"."LocustHordeId", "l2"."ThreatLevel", "l2"."ThreatLevelByte", "l2"."ThreatLevelNullableByte", "l2"."DefeatedByNickname", "l2"."DefeatedBySquadId", "l2"."HighCommandId", "l0"."Name", "l0"."Discriminator", "l0"."LocustHordeId", "l0"."ThreatLevel", "l0"."ThreatLevelByte", "l0"."ThreatLevelNullableByte", "l0"."DefeatedByNickname", "l0"."DefeatedBySquadId", "l0"."HighCommandId"
+SELECT "l1"."Name" = 'Queen Myrrah' AND "l1"."Name" IS NOT NULL, "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId", "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "Factions" AS "f"
-CROSS JOIN (
-    SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0"
-LEFT JOIN (
-    SELECT "l1"."Name", "l1"."Discriminator", "l1"."LocustHordeId", "l1"."ThreatLevel", "l1"."ThreatLevelByte", "l1"."ThreatLevelNullableByte", "l1"."DefeatedByNickname", "l1"."DefeatedBySquadId", "l1"."HighCommandId"
-    FROM "LocustLeaders" AS "l1"
-    WHERE "l1"."Discriminator" = 'LocustCommander'
-) AS "l2" ON "f"."CommanderName" = "l2"."Name"
+INNER JOIN "LocustLeaders" AS "l" ON "l"."Discriminator" = 'LocustCommander'
+LEFT JOIN "LocustLeaders" AS "l1" ON "f"."CommanderName" = "l1"."Name" AND "l1"."Discriminator" = 'LocustCommander'
 """);
     }
 
@@ -8379,13 +8195,9 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT "s"."Id", "t0"."Id" AS "TagId"
+SELECT "s"."Id", "t"."Id" AS "TagId"
 FROM "Squads" AS "s"
-CROSS JOIN (
-    SELECT "t"."Id"
-    FROM "Tags" AS "t"
-    WHERE "t"."Note" = 'Marcus'' Tag'
-) AS "t0"
+INNER JOIN "Tags" AS "t" ON "t"."Note" = 'Marcus'' Tag'
 """);
     }
 
@@ -8824,13 +8636,9 @@ ORDER BY "g"."SquadId", "g"."Nickname"
 
         AssertSql(
             """
-SELECT "g"."FullName", "l0"."ThreatLevel"
+SELECT "g"."FullName", "l"."ThreatLevel"
 FROM "Gears" AS "g"
-LEFT JOIN (
-    SELECT "l"."ThreatLevel", "l"."DefeatedByNickname"
-    FROM "LocustLeaders" AS "l"
-    WHERE "l"."Discriminator" = 'LocustCommander'
-) AS "l0" ON "g"."Nickname" = "l0"."DefeatedByNickname"
+LEFT JOIN "LocustLeaders" AS "l" ON "g"."Nickname" = "l"."DefeatedByNickname" AND "l"."Discriminator" = 'LocustCommander'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -25,20 +25,12 @@ public class QueryFilterFuncletizationSqliteTest : QueryFilterFuncletizationTest
             """
 @ef_filter__Tenant='1'
 
-SELECT "d"."Id", "d"."Tenant", "d2"."Id", "d2"."DeDupeFilter1Id", "d2"."TenantX", "d3"."Id", "d3"."DeDupeFilter1Id", "d3"."Tenant"
+SELECT "d"."Id", "d"."Tenant", "d0"."Id", "d0"."DeDupeFilter1Id", "d0"."TenantX", "d1"."Id", "d1"."DeDupeFilter1Id", "d1"."Tenant"
 FROM "DeDupeFilter1" AS "d"
-LEFT JOIN (
-    SELECT "d0"."Id", "d0"."DeDupeFilter1Id", "d0"."TenantX"
-    FROM "DeDupeFilter2" AS "d0"
-    WHERE "d0"."TenantX" = @ef_filter__Tenant
-) AS "d2" ON "d"."Id" = "d2"."DeDupeFilter1Id"
-LEFT JOIN (
-    SELECT "d1"."Id", "d1"."DeDupeFilter1Id", "d1"."Tenant"
-    FROM "DeDupeFilter3" AS "d1"
-    WHERE "d1"."Tenant" = @ef_filter__Tenant
-) AS "d3" ON "d"."Id" = "d3"."DeDupeFilter1Id"
+LEFT JOIN "DeDupeFilter2" AS "d0" ON "d"."Id" = "d0"."DeDupeFilter1Id" AND "d0"."TenantX" = @ef_filter__Tenant
+LEFT JOIN "DeDupeFilter3" AS "d1" ON "d"."Id" = "d1"."DeDupeFilter1Id" AND "d1"."Tenant" = @ef_filter__Tenant
 WHERE "d"."Tenant" = @ef_filter__Tenant
-ORDER BY "d"."Id", "d2"."Id"
+ORDER BY "d"."Id", "d0"."Id"
 """);
     }
 


### PR DESCRIPTION
When a query filters a joined table (an optional navigation with a `Where`, a `SelectMany` with a predicate, etc.), EF currently emits a join over a subquery even when the subquery does nothing but filter a single table:

```sql
LEFT JOIN (
    SELECT "l0"."Id", "l0"."Name"
    FROM "LevelThree" AS "l0"
    WHERE "l0"."Id" > 5
) AS "l1" ON "l"."Id" = "l1"."OwnerId"
```

Since the filter references only the inner table, it can move onto the join condition and the subquery can go away:

```sql
LEFT JOIN "LevelThree" AS "l1" ON "l"."Id" = "l1"."OwnerId" AND "l1"."Id" > 5
```

This adds `SqliteSubqueryToJoinRewriter`, run from `SqliteQueryTranslationPostprocessor`, which does exactly that: rewrites a LEFT/INNER JOIN over a single-table filter subquery into a join over the table, folding the filter into the ON condition and inlining the subquery's projection.

### Where it deliberately does nothing

Working through the test suite surfaced several cases where folding the filter out would change results, so the rewrite skips them:

- **Another join references the subquery's alias** — a later join keying off this one (nested collection includes) relies on it having filtered its rows first.
- **The join key depends on a sibling join** — a correlated join chain (e.g. keying off a preceding optional/LEFT JOIN) relies on the current join order.
- **A LEFT JOIN projection isn't purely columns** — the projected columns must be made nullable under a LEFT JOIN, which only works for bare column references.
- **The predicate is only `IS NOT NULL` checks** — that's an optional-entity existence test (table splitting), not a value filter; the containing query uses it to decide whether the entity is present.

### Scope

This is implemented in the SQLite provider only. The underlying reasoning is provider-agnostic (it's about relational join semantics), so it could move to the relational layer to benefit all providers, but I kept it local to SQLite so it could be validated against the full SQLite functional suite. Happy to move it up if that's the preferred direction.

### Tests

Full SQLite functional suite passes: **38367 tests, 0 failures**. 97 query baselines lost their subqueries (net −334 lines in the affected test files, e.g. `GearsOfWarQuerySqliteTest` shrank noticeably). No data or nullability regressions — each skip condition above was added specifically because a test showed the rewrite was otherwise changing results.

Part of #33745
