### PR TITLE
Escape Unicode line separators in CSharpHelper string and char literals

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -364,6 +364,9 @@ public class CSharpHelper : ICSharpHelper
                 .Replace("\n", @"\n")
                 .Replace("\r", @"\r")
                 .Replace("\"", "\\\"")
+                .Replace(((char)0x2028).ToString(), "\\u2028")
+                .Replace(((char)0x2029).ToString(), "\\u2029")
+                .Replace(((char)0x0085).ToString(), "\\u0085")
                 .Insert(0, '"')
                 .Append('"')
                 .ToString()
@@ -402,6 +405,9 @@ public class CSharpHelper : ICSharpHelper
                 '\n' => @"\n",
                 '\r' => @"\r",
                 '\'' => @"\'",
+                (char)0x2028 => "\\u2028",
+                (char)0x2029 => "\\u2029",
+                (char)0x0085 => "\\u0085",
                 _ => value.ToString()
             }
             + "\'";

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -79,7 +79,7 @@ public class CSharpHelperTest
     }
 
     [Fact]
-    public void Literal_escapes_unicode_line_and_paragraph_separators_in_string()
+    public void Literal_escapes_unicode_newline_characters_in_string()
     {
         // U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR) and U+0085 (NEXT LINE) are treated as
         // new-line characters by the C# compiler, so leaving them unescaped produces code that does not compile.

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -79,6 +79,24 @@ public class CSharpHelperTest
     }
 
     [Fact]
+    public void Literal_escapes_unicode_line_and_paragraph_separators_in_string()
+    {
+        // U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR) and U+0085 (NEXT LINE) are treated as
+        // new-line characters by the C# compiler, so leaving them unescaped produces code that does not compile.
+        Assert.Equal("\"a\\u2028b\"", new CSharpHelper(TypeMappingSource).Literal("a" + (char)0x2028 + "b"));
+        Assert.Equal("\"a\\u2029b\"", new CSharpHelper(TypeMappingSource).Literal("a" + (char)0x2029 + "b"));
+        Assert.Equal("\"a\\u0085b\"", new CSharpHelper(TypeMappingSource).Literal("a" + (char)0x0085 + "b"));
+    }
+
+    [Fact]
+    public void Literal_escapes_unicode_line_and_paragraph_separators_in_char()
+    {
+        Assert.Equal("'\\u2028'", new CSharpHelper(TypeMappingSource).Literal((char)0x2028));
+        Assert.Equal("'\\u2029'", new CSharpHelper(TypeMappingSource).Literal((char)0x2029));
+        Assert.Equal("'\\u0085'", new CSharpHelper(TypeMappingSource).Literal((char)0x0085));
+    }
+
+    [Fact]
     public void Literal_works_when_empty_ByteArray()
         => Literal_works(
             Array.Empty<byte>(),


### PR DESCRIPTION
- Escape U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR) and U+0085 (NEXT LINE) using their backslash-u escape sequences in Literal(string) and Literal(char)
- The C# compiler treats these code points as new-line characters, so emitting them raw produced generated code that failed to compile (CS1010: Newline in constant)
- Add tests covering the three separators for both string and char literals

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

