### PR TITLE
Emit explicit element type for nullable value type arrays in CSharpHe…

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -689,6 +689,12 @@ public class CSharpHelper : ICSharpHelper
             {
                 builder.Append(" object");
             }
+            else if (Nullable.GetUnderlyingType(type) != null)
+            {
+                // Elements are emitted as their underlying type, so an implicitly-typed array would be inferred as
+                // the non-nullable type; emit the element type explicitly to keep the array type correct.
+                builder.Append(' ').Append(Reference(type));
+            }
 
             if (vertical)
             {

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -97,6 +97,18 @@ public class CSharpHelperTest
             "new byte[] { 1, 2 }");
 
     [Fact]
+    public void Literal_works_when_nullable_value_type_array()
+        => Literal_works(
+            new int?[] { 1, 2 },
+            "new int?[] { 1, 2 }");
+
+    [Fact]
+    public void Literal_works_when_nullable_value_type_array_with_null_element()
+        => Literal_works(
+            new int?[] { 1, null, 3 },
+            "new int?[] { 1, null, 3 }");
+
+    [Fact]
     public void Literal_works_when_empty_list()
         => Literal_works(
             new List<string>(),


### PR DESCRIPTION
…lper

- A non-empty array literal is normally emitted as an implicitly-typed array (new[] { ... }), but nullable value type elements are rendered as their underlying type, so the array is inferred as the non-nullable type (e.g. int[] instead of int?[]), producing code that does not compile
- Emit the element type explicitly for nullable value type arrays, matching the existing handling for byte and object arrays
- Add tests for nullable value type arrays with and without null elements

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

