### PR TITLE
Fix escaping of UNC project paths containing spaces

### DIFF
--- a/src/dotnet-ef/Exe.cs
+++ b/src/dotnet-ef/Exe.cs
@@ -111,15 +111,7 @@ internal static class Exe
                     default:
                         if (pendingBackslashes != 0)
                         {
-                            if (pendingBackslashes == 1)
-                            {
-                                builder.Append('\\');
-                            }
-                            else
-                            {
-                                builder.Append('\\', pendingBackslashes * 2);
-                            }
-
+                            builder.Append('\\', pendingBackslashes);
                             pendingBackslashes = 0;
                         }
 

--- a/test/dotnet-ef.Tests/ExeTest.cs
+++ b/test/dotnet-ef.Tests/ExeTest.cs
@@ -30,9 +30,15 @@ public class ExeTest
             + "\"Needs escaping\\\\\\\\\" "
             + "\"Needs \\\"escaping\\\"\" "
             + "\"Needs \\\\\\\"escaping\\\"\" "
-            + "\"Needs escaping\\\\\\\\too\"",
+            + "\"Needs escaping\\\\too\"",
             result);
     }
+
+    [Fact]
+    public void ToArguments_does_not_escape_UNC_prefix()
+        => Assert.Equal(
+            "\"\\\\FILESERVER\\DevShare\\Sample Solution\\Api Project.csproj\"",
+            ToArguments(["\\\\FILESERVER\\DevShare\\Sample Solution\\Api Project.csproj"]));
 
     private static string ToArguments(IReadOnlyList<string> args)
         => (string)typeof(Exe).GetMethod("ToArguments", BindingFlags.Static | BindingFlags.Public)!


### PR DESCRIPTION
Fixes #38675

`dotnet-ef` incorrectly escaped backslashes in UNC project paths when generating the `dotnet msbuild` argument list. As a result, paths starting with `\\FILESERVER` were passed as `\\\\FILESERVER`.

This change preserves the UNC prefix while continuing to quote paths containing spaces.

A regression test was added that fails before the fix and passes after it.

<!-- Please check whether the PR fulfills these requirements -->
- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
Summary of the changes

- Detail 1
- Detail 2

Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo