### PR TITLE
Emit oldStored based on the old column in CSharpMigrationOperationGen…

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -640,7 +640,7 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("oldComputedColumnSql: ")
                     .Append(Code.Literal(operation.OldColumn.ComputedColumnSql));
 
-                if (operation.IsStored != null)
+                if (operation.OldColumn.IsStored != null)
                 {
                     builder
                         .AppendLine(",")

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -634,6 +634,37 @@ mb.AlterColumn<int>(
             });
 
     [Fact]
+    public void AlterColumnOperation_computed_to_non_computed_preserves_oldStored()
+        => Test(
+            new AlterColumnOperation
+            {
+                Name = "Id",
+                Table = "Post",
+                ClrType = typeof(int),
+                OldColumn =
+                {
+                    ComputedColumnSql = "1",
+                    IsStored = true
+                }
+            },
+            """
+mb.AlterColumn<int>(
+    name: "Id",
+    table: "Post",
+    nullable: false,
+    oldComputedColumnSql: "1",
+    oldStored: true);
+""",
+            o =>
+            {
+                Assert.Equal("Id", o.Name);
+                Assert.Equal("Post", o.Table);
+                Assert.Equal(typeof(int), o.ClrType);
+                Assert.Equal("1", o.OldColumn.ComputedColumnSql);
+                Assert.True(o.OldColumn.IsStored);
+            });
+
+    [Fact]
     public void AlterColumnOperation_DefaultValueSql()
         => Test(
             new AlterColumnOperation


### PR DESCRIPTION
…erator

- The oldStored: argument of a generated AlterColumn call was gated on operation.IsStored (the new column) while emitting operation.OldColumn.IsStored, so altering a column away from a stored computed column dropped oldStored: from the generated (and reverse) migration
- Gate on operation.OldColumn.IsStored to match the value being written
- Add a test covering alter from a stored computed column to a non-computed column

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

