### PR TITLE
Format vector floats with the invariant culture

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerVectorTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerVectorTypeMapping.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -116,7 +117,7 @@ public class SqlServerVectorTypeMapping : RelationalTypeMapping
                 builder.Append(',');
             }
 
-            builder.Append(floats[i]);
+            builder.Append(floats[i].ToString("R", CultureInfo.InvariantCulture));
         }
 
         builder

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Storage;
@@ -479,6 +480,12 @@ public class SqlServerTypeMappingTest : RelationalTypeMappingTest
             new SqlServerVectorTypeMapping(3),
             SqlVector<float>.CreateNull(3),
             "Microsoft.Data.SqlTypes.SqlVector<float>.CreateNull(3)");
+
+    [Fact, UseCulture("de-DE")]
+    public virtual void GenerateSqlLiteral_formats_vector_floats_with_the_invariant_culture()
+        => Assert.Equal(
+            "CAST('[1.5,2.5]' AS VECTOR(2))",
+            new SqlServerVectorTypeMapping(2).GenerateSqlLiteral(new SqlVector<float>(new float[] { 1.5f, 2.5f })));
 
     [Fact]
     public virtual void Vector_default_provider_value_is_zero_vector_of_configured_dimensions()


### PR DESCRIPTION
…eMapping

- GenerateNonNullSqlLiteral appended each float via StringBuilder.Append(float), which formats with the current culture, so a vector literal such as CAST('[1.5,2.5]' AS VECTOR(2)) became CAST('[1,5,2,5]' AS VECTOR(2)) under cultures with a comma decimal separator (e.g. de-DE)
- Format each float with "R" and CultureInfo.InvariantCulture, matching FloatTypeMapping
- Add a test under a non-invariant culture

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

