### PR TITLE
Return -1 from SQLite String.IndexOf(value, startIndex) when the valu…

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringMethodTranslator.cs
@@ -145,7 +145,7 @@ public class SqliteStringMethodTranslator(ISqlExpressionFactory sqlExpressionFac
         SqlExpression instance, SqlExpression argument, SqlExpression startIndex)
     {
         var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, argument);
-        instance = sqlExpressionFactory.Function(
+        var subString = sqlExpressionFactory.Function(
             "substr",
             [instance, sqlExpressionFactory.Add(startIndex, sqlExpressionFactory.Constant(1))],
             nullable: true,
@@ -153,20 +153,28 @@ public class SqliteStringMethodTranslator(ISqlExpressionFactory sqlExpressionFac
             typeof(string),
             instance.TypeMapping);
 
-        return sqlExpressionFactory.Add(
-            sqlExpressionFactory.Subtract(
-                sqlExpressionFactory.Function(
-                    "instr",
-                    [
-                        sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping),
-                        sqlExpressionFactory.ApplyTypeMapping(
-                            argument, argument.Type == typeof(char) ? CharTypeMapping.Default : stringTypeMapping)
-                    ],
-                    nullable: true,
-                    argumentsPropagateNullability: Statics.TrueArrays[2],
-                    typeof(int)),
-                sqlExpressionFactory.Constant(1)),
-            startIndex);
+        var indexInSubString = sqlExpressionFactory.Function(
+            "instr",
+            [
+                sqlExpressionFactory.ApplyTypeMapping(subString, stringTypeMapping),
+                sqlExpressionFactory.ApplyTypeMapping(
+                    argument, argument.Type == typeof(char) ? CharTypeMapping.Default : stringTypeMapping)
+            ],
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[2],
+            typeof(int));
+
+        // instr returns 0 when the value is not found, so guard against it to return -1 (as String.IndexOf does)
+        // rather than startIndex - 1.
+        return sqlExpressionFactory.Case(
+            [
+                new CaseWhenClause(
+                    sqlExpressionFactory.Equal(indexInSubString, sqlExpressionFactory.Constant(0)),
+                    sqlExpressionFactory.Constant(-1))
+            ],
+            sqlExpressionFactory.Add(
+                sqlExpressionFactory.Subtract(indexInSubString, sqlExpressionFactory.Constant(1)),
+                startIndex));
     }
 
     private SqlExpression TranslateReplace(SqlExpression instance, SqlExpression oldValue, SqlExpression newValue)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
@@ -196,7 +196,10 @@ WHERE instr("b"."String", @pattern) - 1 = 1
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE length("b"."String") > 2 AND (instr(substr("b"."String", 2 + 1), 'e') - 1) + 2 = 6
+WHERE length("b"."String") > 2 AND CASE
+    WHEN instr(substr("b"."String", 2 + 1), 'e') = 0 THEN -1
+    ELSE (instr(substr("b"."String", 2 + 1), 'e') - 1) + 2
+END = 6
 """);
     }
 
@@ -208,7 +211,10 @@ WHERE length("b"."String") > 2 AND (instr(substr("b"."String", 2 + 1), 'e') - 1)
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE length("b"."String") > 2 AND (instr(substr("b"."String", 2 + 1), 'e') - 1) + 2 = 6
+WHERE length("b"."String") > 2 AND CASE
+    WHEN instr(substr("b"."String", 2 + 1), 'e') = 0 THEN -1
+    ELSE (instr(substr("b"."String", 2 + 1), 'e') - 1) + 2
+END = 6
 """);
     }
 
@@ -222,7 +228,10 @@ WHERE length("b"."String") > 2 AND (instr(substr("b"."String", 2 + 1), 'e') - 1)
 
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE length("b"."String") > 2 AND (instr(substr("b"."String", @start + 1), 'e') - 1) + @start = 6
+WHERE length("b"."String") > 2 AND CASE
+    WHEN instr(substr("b"."String", @start + 1), 'e') = 0 THEN -1
+    ELSE (instr(substr("b"."String", @start + 1), 'e') - 1) + @start
+END = 6
 """);
     }
 
@@ -236,7 +245,26 @@ WHERE length("b"."String") > 2 AND (instr(substr("b"."String", @start + 1), 'e')
 
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE length("b"."String") > 2 AND (instr(substr("b"."String", @start + 1), 'e') - 1) + @start = 6
+WHERE length("b"."String") > 2 AND CASE
+    WHEN instr(substr("b"."String", @start + 1), 'e') = 0 THEN -1
+    ELSE (instr(substr("b"."String", @start + 1), 'e') - 1) + @start
+END = 6
+""");
+    }
+
+    [Fact]
+    public virtual async Task IndexOf_with_starting_position_returns_negative_one_when_not_found()
+    {
+        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(b => b.String.Length > 2 && b.String.IndexOf("qwxz", 2) == -1));
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE length("b"."String") > 2 AND CASE
+    WHEN instr(substr("b"."String", 2 + 1), 'qwxz') = 0 THEN -1
+    ELSE (instr(substr("b"."String", 2 + 1), 'qwxz') - 1) + 2
+END = -1
 """);
     }
 


### PR DESCRIPTION
…e is not found

- The translation computed (instr(substr(...)) - 1) + startIndex, which yields startIndex - 1 instead of -1 when instr returns 0 (the value is not found), so IndexOf produced a wrong non-negative result
- Wrap the result in a CASE that returns -1 when instr is 0, matching String.IndexOf
- Add a test for the not-found case and update the affected SQL baselines

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

