### PR TITLE
Avoid doubling an existing @ prefix in GenerateParameterName(StringBu…

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -82,7 +82,14 @@ public class RelationalSqlGenerationHelper : ISqlGenerationHelper
     /// <param name="builder">The <see cref="StringBuilder" /> to write generated string to.</param>
     /// <param name="name">The candidate name for the parameter.</param>
     public virtual void GenerateParameterName(StringBuilder builder, string name)
-        => builder.Append('@').Append(name);
+    {
+        if (!name.StartsWith('@'))
+        {
+            builder.Append('@');
+        }
+
+        builder.Append(name);
+    }
 
     /// <summary>
     ///     Generates a valid parameter placeholder name for the given candidate name.

--- a/test/EFCore.Relational.Tests/Storage/RelationalSqlGenerationHelperTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalSqlGenerationHelperTest.cs
@@ -10,6 +10,26 @@ public class RelationalSqlGenerationHelperTest
         => Assert.Equal("@name", CreateSqlGenerationHelper().GenerateParameterName("name"));
 
     [Fact]
+    public void GenerateParameterName_does_not_double_an_existing_prefix()
+        => Assert.Equal("@name", CreateSqlGenerationHelper().GenerateParameterName("@name"));
+
+    [Fact]
+    public void GenerateParameterName_to_StringBuilder_writes_parameter_name()
+    {
+        var builder = new StringBuilder();
+        CreateSqlGenerationHelper().GenerateParameterName(builder, "name");
+        Assert.Equal("@name", builder.ToString());
+    }
+
+    [Fact]
+    public void GenerateParameterName_to_StringBuilder_does_not_double_an_existing_prefix()
+    {
+        var builder = new StringBuilder();
+        CreateSqlGenerationHelper().GenerateParameterName(builder, "@name");
+        Assert.Equal("@name", builder.ToString());
+    }
+
+    [Fact]
     public void Default_BatchCommandSeparator_is_semicolon()
         => Assert.Equal(";", CreateSqlGenerationHelper().StatementTerminator);
 


### PR DESCRIPTION


- The StringBuilder overload of ISqlGenerationHelper.GenerateParameterName always prepended '@', so a name that already started with '@' became '@@name', unlike the string overload which guards against this
- Only prepend '@' when the name does not already start with it, matching the string overload
- Add tests for the StringBuilder overload

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

