### PR TITLE
Handle ranges spanning midnight when translating TimeOnly.IsBetween

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
@@ -76,13 +76,29 @@ public class SqlServerTimeOnlyMethodTranslator(ISqlExpressionFactory sqlExpressi
             var typeMapping = ExpressionExtensions.InferTypeMapping(instance, arguments[0], arguments[1]);
             instance = sqlExpressionFactory.ApplyTypeMapping(instance, typeMapping);
 
-            return sqlExpressionFactory.And(
-                sqlExpressionFactory.GreaterThanOrEqual(
-                    instance,
-                    sqlExpressionFactory.ApplyTypeMapping(arguments[0], typeMapping)),
-                sqlExpressionFactory.LessThan(
-                    instance,
-                    sqlExpressionFactory.ApplyTypeMapping(arguments[1], typeMapping)));
+            var start = sqlExpressionFactory.ApplyTypeMapping(arguments[0], typeMapping);
+            var end = sqlExpressionFactory.ApplyTypeMapping(arguments[1], typeMapping);
+
+            var isAfterStart = sqlExpressionFactory.GreaterThanOrEqual(instance, start);
+            var isBeforeEnd = sqlExpressionFactory.LessThan(instance, end);
+
+            // A range whose start is after its end wraps around midnight, and matches the times that are either after
+            // the start or before the end.
+            if (arguments is [SqlConstantExpression { Value: TimeOnly startValue }, SqlConstantExpression { Value: TimeOnly endValue }])
+            {
+                return startValue > endValue
+                    ? sqlExpressionFactory.OrElse(isAfterStart, isBeforeEnd)
+                    : sqlExpressionFactory.AndAlso(isAfterStart, isBeforeEnd);
+            }
+
+            // The bounds aren't known when translating, so both cases have to be handled in the SQL.
+            return sqlExpressionFactory.Case(
+                [
+                    new CaseWhenClause(
+                        sqlExpressionFactory.LessThanOrEqual(start, end),
+                        sqlExpressionFactory.AndAlso(isAfterStart, isBeforeEnd))
+                ],
+                sqlExpressionFactory.OrElse(isAfterStart, isBeforeEnd));
         }
 
         return null;

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerTimeOnlyMethodTranslator.cs
@@ -92,13 +92,13 @@ public class SqlServerTimeOnlyMethodTranslator(ISqlExpressionFactory sqlExpressi
             }
 
             // The bounds aren't known when translating, so both cases have to be handled in the SQL.
-            return sqlExpressionFactory.Case(
-                [
-                    new CaseWhenClause(
-                        sqlExpressionFactory.LessThanOrEqual(start, end),
-                        sqlExpressionFactory.AndAlso(isAfterStart, isBeforeEnd))
-                ],
-                sqlExpressionFactory.OrElse(isAfterStart, isBeforeEnd));
+            return sqlExpressionFactory.OrElse(
+                sqlExpressionFactory.AndAlso(
+                    sqlExpressionFactory.LessThanOrEqual(start, end),
+                    sqlExpressionFactory.AndAlso(isAfterStart, isBeforeEnd)),
+                sqlExpressionFactory.AndAlso(
+                    sqlExpressionFactory.GreaterThan(start, end),
+                    sqlExpressionFactory.OrElse(isAfterStart, isBeforeEnd)));
         }
 
         return null;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
@@ -125,13 +125,73 @@ WHERE DATEADD(minute, CAST(3.0E0 AS int), [b].[TimeOnly]) = '15:33:10'
             """
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
+WHERE [b].[TimeOnly] >= '14:00:00' AND [b].[TimeOnly] < '16:00:00'
+""");
+    }
+
+    [Fact]
+    public virtual async Task IsBetween_spanning_midnight_with_parameters()
+    {
+        var start = new TimeOnly(15, 0, 0);
+        var end = new TimeOnly(14, 0, 0);
+
+        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(start, end)));
+
+        AssertSql(
+            """
+@start='15:00' (DbType = Time)
+@end='14:00' (DbType = Time)
+
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
 WHERE CASE
-    WHEN [b].[TimeOnly] >= '14:00:00' THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END & CASE
-    WHEN [b].[TimeOnly] < '16:00:00' THEN CAST(1 AS bit)
+    WHEN @start <= @end THEN CASE
+        WHEN [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    WHEN [b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
+""");
+    }
+
+    [Fact]
+    public virtual async Task IsBetween_with_parameters()
+    {
+        var start = new TimeOnly(14, 0, 0);
+        var end = new TimeOnly(16, 0, 0);
+
+        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(start, end)));
+
+        AssertSql(
+            """
+@start='14:00' (DbType = Time)
+@end='16:00' (DbType = Time)
+
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE CASE
+    WHEN @start <= @end THEN CASE
+        WHEN [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    WHEN [b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(1 AS bit)
+""");
+    }
+
+    [Fact]
+    public virtual async Task IsBetween_spanning_midnight()
+    {
+        await AssertQuery(
+            ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(new TimeOnly(15, 0, 0), new TimeOnly(14, 0, 0))));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE [b].[TimeOnly] >= '15:00:00' OR [b].[TimeOnly] < '14:00:00'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
@@ -132,26 +132,19 @@ WHERE [b].[TimeOnly] >= '14:00:00' AND [b].[TimeOnly] < '16:00:00'
     [Fact]
     public virtual async Task IsBetween_spanning_midnight_with_parameters()
     {
-        var start = new TimeOnly(15, 0, 0);
-        var end = new TimeOnly(14, 0, 0);
+        var start = new TimeOnly(16, 0, 0);
+        var end = new TimeOnly(12, 0, 0);
 
         await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(start, end)));
 
         AssertSql(
             """
-@start='15:00' (DbType = Time)
-@end='14:00' (DbType = Time)
+@start='16:00' (DbType = Time)
+@end='12:00' (DbType = Time)
 
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE CASE
-    WHEN @start <= @end THEN CASE
-        WHEN [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end THEN CAST(1 AS bit)
-        ELSE CAST(0 AS bit)
-    END
-    WHEN [b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END = CAST(1 AS bit)
+WHERE (@start <= @end AND [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end) OR (@start > @end AND ([b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end))
 """);
     }
 
@@ -170,14 +163,7 @@ END = CAST(1 AS bit)
 
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE CASE
-    WHEN @start <= @end THEN CASE
-        WHEN [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end THEN CAST(1 AS bit)
-        ELSE CAST(0 AS bit)
-    END
-    WHEN [b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END = CAST(1 AS bit)
+WHERE (@start <= @end AND [b].[TimeOnly] >= @start AND [b].[TimeOnly] < @end) OR (@start > @end AND ([b].[TimeOnly] >= @start OR [b].[TimeOnly] < @end))
 """);
     }
 
@@ -185,13 +171,13 @@ END = CAST(1 AS bit)
     public virtual async Task IsBetween_spanning_midnight()
     {
         await AssertQuery(
-            ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(new TimeOnly(15, 0, 0), new TimeOnly(14, 0, 0))));
+            ss => ss.Set<BasicTypesEntity>().Where(b => b.TimeOnly.IsBetween(new TimeOnly(16, 0, 0), new TimeOnly(12, 0, 0))));
 
         AssertSql(
             """
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE [b].[TimeOnly] >= '15:00:00' OR [b].[TimeOnly] < '14:00:00'
+WHERE [b].[TimeOnly] >= '16:00:00' OR [b].[TimeOnly] < '12:00:00'
 """);
     }
 


### PR DESCRIPTION
- The translation always emitted "time >= start AND time < end", but TimeOnly.IsBetween treats a range whose start is after its end as wrapping around midnight and then matches times that are either after the start or before the end, so queries such as IsBetween(23:00, 01:00) matched no rows at all
- Emit the OR form for constant bounds that wrap, and decide in SQL when the bounds are not constants
- Add tests for wrapping and non-wrapping bounds, as constants and as parameters

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

