### PR TITLE
Turn on Helix Job Monitor

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.dotnet.helix.jobmonitor": {
+      "version": "11.0.0-beta.26401.101",
+      "commands": [
+        "dotnet-helix-job-monitor"
+      ]
+    }
+  }
+}

--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -645,6 +645,9 @@ extends:
                   HelixAccessToken: $(_HelixAccessToken)
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                   DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
     - stage: validate
       displayName: Validate
       dependsOn: build

--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -673,8 +673,18 @@ extends:
           HelixMacOsArm64Result: $[ stageDependencies.build.Helix_macOS_ARM64.result ]
           HelixWindowsArm64Result: $[ stageDependencies.build.Helix_Windows_Arm64.result ]
           HelixUbuntuCosmosResult: $[ stageDependencies.build.Helix_Ubuntu_Cosmos.result ]
+          HelixJobMonitorResult: $[ stageDependencies.build.HelixJobMonitor.result ]
         steps:
           - pwsh: |
+              $helixJobMonitorResult = "$(HelixJobMonitorResult)"
+              Write-Host "Helix Job Monitor result: $helixJobMonitorResult"
+
+              if ($helixJobMonitorResult -ne 'Succeeded')
+              {
+                  Write-Error "Helix Job Monitor did not succeed: $helixJobMonitorResult."
+                  exit 1
+              }
+
               $groupResults = @{
                   Windows = @("$(WindowsResult)", "$(HelixWindowsResult)")
                   Linux = @("$(LinuxResult)", "$(HelixUbuntuResult)")

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -534,8 +534,18 @@ stages:
       HelixMacOsArm64Result: $[ stageDependencies.build.Helix_macOS_ARM64.result ]
       HelixWindowsArm64Result: $[ stageDependencies.build.Helix_Windows_Arm64.result ]
       HelixUbuntuCosmosResult: $[ stageDependencies.build.Helix_Ubuntu_Cosmos.result ]
+      HelixJobMonitorResult: $[ stageDependencies.build.HelixJobMonitor.result ]
     steps:
       - pwsh: |
+          $helixJobMonitorResult = "$(HelixJobMonitorResult)"
+          Write-Host "Helix Job Monitor result: $helixJobMonitorResult"
+
+          if ($helixJobMonitorResult -ne 'Succeeded')
+          {
+              Write-Error "Helix Job Monitor did not succeed: $helixJobMonitorResult."
+              exit 1
+          }
+
           $groupResults = @{
               Windows = @("$(WindowsResult)", "$(HelixWindowsResult)")
               Linux = @("$(LinuxResult)", "$(HelixUbuntuResult)")

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -509,6 +509,7 @@ stages:
                 env:
                   HelixAccessToken: $(_HelixAccessToken)
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    - template: /eng/common/core-templates/job/helix-job-monitor.yml
 - stage: validate
   displayName: Validate
   dependsOn: build

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,6 +8,7 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26401.101</MicrosoftDotNetArcadeSdkPackageVersion>
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26401.101</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26401.101</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26401.101</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>11.0.0-rc.1.26401.101</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsConfigurationPackageVersion>11.0.0-rc.1.26401.101</MicrosoftExtensionsConfigurationPackageVersion>
@@ -29,6 +30,7 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetHelixJobMonitorVersion>$(MicrosoftDotNetHelixJobMonitorPackageVersion)</MicrosoftDotNetHelixJobMonitorVersion>
     <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
     <MicrosoftExtensionsCachingMemoryVersion>$(MicrosoftExtensionsCachingMemoryPackageVersion)</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsConfigurationVersion>$(MicrosoftExtensionsConfigurationPackageVersion)</MicrosoftExtensionsConfigurationVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -68,6 +68,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5da2de22f7c6e2ebe7ed4c16c614b00183145d3c</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26401.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>5da2de22f7c6e2ebe7ed4c16c614b00183145d3c</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26401.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5da2de22f7c6e2ebe7ed4c16c614b00183145d3c</Sha>

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -11,6 +11,7 @@
     <DotNetCliVersion>$(NETCoreSdkVersion)</DotNetCliVersion>
 
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <EnableHelixJobMonitor Condition = "'$(SYSTEM_ACCESSTOKEN)' != ''">true</EnableHelixJobMonitor>
     <FailOnTestFailure>true</FailOnTestFailure>
     <SqlServerTests>$(RepoRoot)/test/EFCore.SqlServer.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.SqlServer.HierarchyId.Tests/*.csproj;$(RepoRoot)/test/EFCore.CrossStore.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.OData.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.AspNet.SqlServer.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.VisualBasic.FunctionalTests/*.vbproj;$(RepoRoot)/test/EFCore.FSharp.FunctionalTests/*.fsproj</SqlServerTests>
     <CosmosTests>$(RepoRoot)/test/EFCore.Cosmos.FunctionalTests/*.csproj</CosmosTests>


### PR DESCRIPTION
Enable Arcade's Helix Job Monitor for the public and internal test pipelines. Helix submission jobs can now release their agents after queueing work, while the monitor publishes test results and owns the final Helix status.