### PR TITLE
Scaffolding fails for a self-referencing many-to-many join table when both FKs yield the same navigation name

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -707,6 +707,10 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
                         singularizePluralizer: null,
                         uniquifier: NavigationUniquifier);
 
+                // The skip navigation is only added to the model below, so make the name visible to the right-hand
+                // side, which otherwise generates the same name when the join table references a single entity type.
+                leftExistingIdentifiers.Add(leftNavigationPropertyName);
+
                 var rightExistingIdentifiers = ExistingIdentifiers(rightEntityType);
                 var rightNavigationPropertyCandidateName =
                     _candidateNamingService.GetDependentEndCandidateNavigationPropertyName(fks[0]);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -2682,6 +2682,59 @@ public class RelationalScaffoldingModelFactoryTest
     }
 
     [Fact]
+    public void Scaffold_skip_navigation_for_many_to_many_join_table_self_ref_with_colliding_navigation_names()
+    {
+        var database = new DatabaseModel
+        {
+            Tables =
+            {
+                new DatabaseTable
+                {
+                    Name = "Products",
+                    Columns = { new DatabaseColumn { Name = "Id", StoreType = "int" } },
+                    PrimaryKey = new DatabasePrimaryKey { Columns = { new DatabaseColumnRef("Id") } }
+                },
+                new DatabaseTable
+                {
+                    Name = "RelatedProducts",
+                    Columns =
+                    {
+                        new DatabaseColumn { Name = "ProductGuid", StoreType = "int" },
+                        new DatabaseColumn { Name = "ProductId", StoreType = "int" }
+                    },
+                    PrimaryKey = new DatabasePrimaryKey
+                    {
+                        Columns = { new DatabaseColumnRef("ProductGuid"), new DatabaseColumnRef("ProductId") }
+                    },
+                    ForeignKeys =
+                    {
+                        new DatabaseForeignKey
+                        {
+                            Columns = { new DatabaseColumnRef("ProductGuid") },
+                            PrincipalColumns = { new DatabaseColumnRef("Id") },
+                            PrincipalTable = new DatabaseTableRef("Products"),
+                        },
+                        new DatabaseForeignKey
+                        {
+                            Columns = { new DatabaseColumnRef("ProductId") },
+                            PrincipalColumns = { new DatabaseColumnRef("Id") },
+                            PrincipalTable = new DatabaseTableRef("Products"),
+                        }
+                    }
+                }
+            }
+        };
+
+        var model = _factory.Create(database, new ModelReverseEngineerOptions());
+
+        var product = model.GetEntityTypes().Single(e => e.Name == "Product");
+        var skipNavigationNames = product.GetSkipNavigations().Select(n => n.Name).ToList();
+
+        Assert.Equal(2, skipNavigationNames.Count);
+        Assert.Equal(skipNavigationNames.Count, skipNavigationNames.Distinct().Count());
+    }
+
+    [Fact]
     public void Scaffold_skip_navigation_for_many_to_many_join_table_composite_fk()
     {
         var database = new DatabaseModel

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -2699,18 +2699,18 @@ public class RelationalScaffoldingModelFactoryTest
                     Name = "RelatedProducts",
                     Columns =
                     {
-                        new DatabaseColumn { Name = "ProductGuid", StoreType = "int" },
+                        new DatabaseColumn { Name = "Product_Id", StoreType = "int" },
                         new DatabaseColumn { Name = "ProductId", StoreType = "int" }
                     },
                     PrimaryKey = new DatabasePrimaryKey
                     {
-                        Columns = { new DatabaseColumnRef("ProductGuid"), new DatabaseColumnRef("ProductId") }
+                        Columns = { new DatabaseColumnRef("Product_Id"), new DatabaseColumnRef("ProductId") }
                     },
                     ForeignKeys =
                     {
                         new DatabaseForeignKey
                         {
-                            Columns = { new DatabaseColumnRef("ProductGuid") },
+                            Columns = { new DatabaseColumnRef("Product_Id") },
                             PrincipalColumns = { new DatabaseColumnRef("Id") },
                             PrincipalTable = new DatabaseTableRef("Products"),
                         },


### PR DESCRIPTION
- The name generated for the left skip navigation was neither added to the existing identifiers nor present in the model when the right name was generated, and the identifier list is shared by both ends when the join table references a single entity type, so the uniquifier produced the same name twice and AddSkipNavigation threw, failing the whole scaffolding operation
- Add the generated name to the identifiers so the right-hand side sees it
- Add a test for a self-referencing join table whose foreign keys yield the same candidate name

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

